### PR TITLE
Remove unnecessary instructions and change names of PostGIS functions

### DIFF
--- a/core/sql/routing_topology.sql
+++ b/core/sql/routing_topology.sql
@@ -79,7 +79,7 @@ BEGIN
 			
     FOR _r IN EXECUTE 'SELECT ' || quote_ident(gid_cname) || ' AS id,'
 	    || ' ST_StartPoint('|| quote_ident(geo_cname) ||') AS source,'
-            || ' ST_EndtPoint('|| quote_ident(geo_cname) ||') as target'
+            || ' ST_EndPoint('|| quote_ident(geo_cname) ||') as target'
 	    || ' FROM ' || quote_ident(geom_table) || ' WHERE ' || quote_ident(geo_cname) || ' IS NOT NULL '
     LOOP
         


### PR DESCRIPTION
PostGIS has begun a transition from the existing naming convention to an SQL-MM-centric convention. As a result, most of the functions that you know and love have been renamed using the standard spatial type (ST) prefix. Previous functions are still available, though are not listed in this document where updated functions are equivalent. The non ST_ functions not listed in this documentation are deprecated and will be removed in a future release so STOP USING THEM.
