### PR TITLE
TSP with fixed source & destination

### DIFF
--- a/extra/tsp/sql/routing_tsp.sql
+++ b/extra/tsp/sql/routing_tsp.sql
@@ -25,3 +25,11 @@ CREATE OR REPLACE FUNCTION tsp(sql text, ids varchar, source integer)
         RETURNS SETOF path_result
         AS '$libdir/librouting_tsp'
         LANGUAGE 'C' IMMUTABLE STRICT;
+        
+-----------------------------------------------------------------------
+-- Support for TSP where source and destination are defined
+-----------------------------------------------------------------------     
+CREATE OR REPLACE FUNCTION tsp(sql text, ids varchar, source integer, dest integer)
+        RETURNS SETOF path_result
+        AS '$libdir/librouting_tsp'
+        LANGUAGE 'C' IMMUTABLE STRICT;             

--- a/extra/tsp/src/tsp.h
+++ b/extra/tsp/src/tsp.h
@@ -39,6 +39,9 @@ extern "C"
   int find_tsp_solution(int num, float dist[MAX_TOWNS][MAX_TOWNS], 
 			int p_ids[MAX_TOWNS], int source, float* fit, 
 			char* err_msg);
+  int find_tspd_solution(int num, float dist[MAX_TOWNS][MAX_TOWNS], 
+			int p_ids[MAX_TOWNS], int source, int dest, float* fit, 
+			char* err_msg);				
 #ifdef __cplusplus
 }
 #endif

--- a/extra/tsp/src/tsp_solver.cpp
+++ b/extra/tsp/src/tsp_solver.cpp
@@ -36,6 +36,7 @@ using namespace std;
 float DISTANCE[MAX_TOWNS][MAX_TOWNS];
 int ids[MAX_TOWNS];
 int source_id;
+int dest_id;
 int cnum;
 
 boolean tsp_score(population *pop, entity *entity)
@@ -61,6 +62,35 @@ boolean tsp_score(population *pop, entity *entity)
       
   return TRUE;
 }
+
+boolean tspd_score(population *pop, entity *entity)
+{
+  int           k;
+  float         dist;
+  int           cur_allele, prev_allele;
+      
+  entity->fitness = 0.0;
+  dist = 0.0;
+
+  // Loop over alleles in chromosome.
+  for (k = 1; k < pop->len_chromosomes; k++)
+    {
+      cur_allele = ((int *)entity->chromosome[0])[k];
+      prev_allele = ((int *)entity->chromosome[0])[k-1];
+      dist += DISTANCE[cur_allele][prev_allele];
+    }
+                                  
+  entity->fitness = 1/dist*100; 
+  if(ids[((int *)entity->chromosome[0])[0]] != source_id){
+    entity->fitness /= 10;
+  }  
+  //ensure last node is dest  
+  if(ids[((int *)entity->chromosome[0])[pop->len_chromosomes-1]] != dest_id){
+    entity->fitness /= 10; 
+  }   
+      
+  return TRUE;
+}
                                             
 boolean tsp_seed(population *pop, entity *adam)
 {
@@ -83,6 +113,39 @@ boolean tsp_seed(population *pop, entity *adam)
   tmp = data[0];
   data[0] = data[s];
   data[s] = tmp;
+						    
+  return TRUE;
+}
+
+boolean tspd_seed(population *pop, entity *adam)
+{
+  int           i,s,t,tmp;
+  int           *data;
+    
+  data = (int *)adam->chromosome[0];
+      
+  for (i=0; i<pop->len_chromosomes; i++)
+  {
+    data[i] = i;
+  }
+		      
+  for (i=0; i<pop->len_chromosomes; i++)
+  {
+    if(ids[data[i]] == source_id)
+      s = i;
+    if(ids[data[i]] == dest_id)
+      t = i; 
+  }
+	
+  //swap start to top				      
+  tmp = data[0];
+  data[0] = data[s];
+  data[s] = tmp;
+  
+  //swap dest to end
+  tmp = data[pop->len_chromosomes-1];
+  data[pop->len_chromosomes-1] = data[t];
+  data[t] = tmp;
 						    
   return TRUE;
 }
@@ -272,6 +335,87 @@ find_tsp_solution(int num, float dist[MAX_TOWNS][MAX_TOWNS],
                 NULL,   /* GAdata_ref_incrementor data_ref_incrementor */
                 tsp_score,/* GAevaluate           evaluate */
                 tsp_seed, /* GAseed               seed */
+                NULL,     /* GAadapt              adapt */
+                ga_select_one_randomrank,/* GAselect_one     select_one */
+                ga_select_two_randomrank,/* GAselect_two     select_two */
+                tsp_mutate,    /* GAmutate        mutate */
+                tsp_crossover, /* GAcrossover     crossover */
+                NULL,          /* GAreplace       replace */
+                NULL           /* vpointer        User data */
+                );
+
+      ga_population_set_parameters(
+               pop,                     /* population      *pop */
+               GA_SCHEME_DARWIN,        /* const ga_scheme_type     scheme */
+               GA_ELITISM_PARENTS_DIE,  /* const ga_elitism_type   elitism */
+               0.5,                     /* optimal double  crossover */
+               0.4,                     /* optimal double  mutation */
+               0.0                      /* unused  double  migration */
+               );
+
+      ga_evolution(
+              pop,              /* population  *pop */
+              num*4             /* const int   max_generations */
+              );
+
+      
+      if(score < ga_get_entity_from_rank(pop,0)->fitness)
+        {
+          score = ga_get_entity_from_rank(pop,0)->fitness;
+          *fit = score;
+      
+          for(int l=0; l<cnum; l++)
+            { 
+              p_ids[l] = ids[
+                             ((int *)ga_get_entity_from_rank(pop,0)->
+                              chromosome[0])[l]];
+            }
+        }
+      
+    }  
+  
+  return EXIT_SUCCESS;
+}
+
+int 
+find_tspd_solution(int num, float dist[MAX_TOWNS][MAX_TOWNS], 
+                  int p_ids[MAX_TOWNS], int source, int dest,
+                  float *fit, char* err_msg)
+{
+  int i,j;
+  population    *pop=NULL;              /* Population of solutions. */
+  float         score = 0.0;            /* Best score */
+
+  source_id = source;
+  dest_id = dest;
+  cnum=num;
+  
+  for(i=0;i<cnum;i++)
+    {
+      ids[i] = p_ids[i];
+
+      for(j=0;j<cnum;j++)
+        {
+          DISTANCE[i][j]=dist[i][j];
+        }
+    }
+  
+  random_init();
+
+  for (int ss=0; ss<15; ss++) //use seed 15 times
+    {
+      if (pop) ga_extinction(pop);
+      random_seed(ss);
+      pop = ga_genesis_integer(
+                num*4,  /* const int              population_size */
+                1,      /* const int              num_chromo */
+                cnum,   /* const int              len_chromo */
+                NULL,   /* GAgeneration_hook      generation_hook */
+                NULL,   /* GAiteration_hook       iteration_hook */
+                NULL,   /* GAdata_destructor      data_destructor */
+                NULL,   /* GAdata_ref_incrementor data_ref_incrementor */
+                tspd_score,/* GAevaluate           evaluate */
+                tspd_seed, /* GAseed               seed */
                 NULL,     /* GAadapt              adapt */
                 ga_select_one_randomrank,/* GAselect_one     select_one */
                 ga_select_two_randomrank,/* GAselect_two     select_two */


### PR DESCRIPTION
Extending TSP solver to support the case where both the source and
destination nodes are specified. 

I'm not sure if this case is covered somewhere already, but I didn't see a way to do it. I needed to solve TSP for multiple locations between a fixed start and end point. My solution is fairly trivial, I simply added new seed (tspd_seed) and score (tspd_score) functions to tsp_solver to handle the case where a destination is specified. There is probably a cleaner way to do this, but my C programming skills are limited. 
