### PR TITLE
Free heap allocations

### DIFF
--- a/core/src/astar.c
+++ b/core/src/astar.c
@@ -459,7 +459,7 @@ shortest_path_astar(PG_FUNCTION_ARGS)
   int                  call_cntr;
   int                  max_calls;
   TupleDesc            tuple_desc;
-  path_element_t      *path;
+  path_element_t      *path = 0;
   
   /* stuff done only on the first call of the function */
   if (SRF_IS_FIRSTCALL())
@@ -577,6 +577,7 @@ shortest_path_astar(PG_FUNCTION_ARGS)
     }
   else    /* do when there is no more left */
     {
+      if (path) free(path);
       profstop("store", prof_store);
       profstop("total", prof_total);
 #ifdef PROFILE

--- a/core/src/dijkstra.c
+++ b/core/src/dijkstra.c
@@ -359,7 +359,7 @@ shortest_path(PG_FUNCTION_ARGS)
   int                  call_cntr;
   int                  max_calls;
   TupleDesc            tuple_desc;
-  path_element_t      *path;
+  path_element_t      *path = 0;
 
   /* stuff done only on the first call of the function */
   if (SRF_IS_FIRSTCALL())
@@ -457,6 +457,7 @@ shortest_path(PG_FUNCTION_ARGS)
     }
   else    /* do when there is no more left */
     {
+      if (path) free(path);
       SRF_RETURN_DONE(funcctx);
     }
 }

--- a/core/src/shooting_star.c
+++ b/core/src/shooting_star.c
@@ -452,7 +452,7 @@ shortest_path_shooting_star(PG_FUNCTION_ARGS)
   int                  call_cntr;
   int                  max_calls;
   TupleDesc            tuple_desc;
-  path_element_t      *path;
+  path_element_t      *path = 0;
   
   /* stuff done only on the first call of the function */
   if (SRF_IS_FIRSTCALL())
@@ -559,6 +559,7 @@ shortest_path_shooting_star(PG_FUNCTION_ARGS)
     }
   else    /* do when there is no more left */
     {
+      if (path) free(path);
       SRF_RETURN_DONE(funcctx);
     }
 }

--- a/extra/driving_distance/src/alpha.c
+++ b/extra/driving_distance/src/alpha.c
@@ -292,7 +292,7 @@ Datum alphashape(PG_FUNCTION_ARGS)
   int                  call_cntr;
   int                  max_calls;
   TupleDesc            tuple_desc;
-  vertex_t     *res;
+  vertex_t     *res = 0;
                     
   /* stuff done only on the first call of the function */
   if (SRF_IS_FIRSTCALL())
@@ -385,6 +385,7 @@ Datum alphashape(PG_FUNCTION_ARGS)
     }
   else    /* do when there is no more left */
     {
+      if (res) free(res);
       profstop("store", prof_store);
       profstop("total", prof_total);
 #ifdef PROFILE

--- a/extra/driving_distance/src/drivedist.c
+++ b/extra/driving_distance/src/drivedist.c
@@ -375,7 +375,7 @@ driving_distance(PG_FUNCTION_ARGS)
   int                  call_cntr;
   int                  max_calls;
   TupleDesc            tuple_desc;
-  path_element_t      *path;
+  path_element_t      *path = 0;
 
   /* stuff done only on the first call of the function */
   if (SRF_IS_FIRSTCALL()) {
@@ -473,6 +473,7 @@ driving_distance(PG_FUNCTION_ARGS)
     SRF_RETURN_NEXT(funcctx, result);
   }
   else {    /* do when there is no more left */
+    if (path) free(path);
     profstop("store", prof_store);
     profstop("total", prof_total);
 #ifdef PROFILE


### PR DESCRIPTION
Fixes memory leak that occurs when calculating many routes in the same db session.

I've only tested the solution with the Shortest Path A* solver but have applied the fix to the other algorithms since they are more or less copy paste code.