### PR TITLE
Added Driving distance delta function

### DIFF
--- a/core/sql/matching.sql
+++ b/core/sql/matching.sql
@@ -284,7 +284,7 @@ BEGIN
 	    IF rc THEN query := query || ', reverse_cost'; 
 	    END IF;				
 				
-	    query := query || ' from '||quote_ident(tbl)||' where setsrid(''''BOX3D('||ST_X(ST_PointN(line, i-1))-distance2*2||' '
+	    query := query || ' from '||quote_ident(tbl)||' where ST_SetSRID(''''BOX3D('||ST_X(ST_PointN(line, i-1))-distance2*2||' '
 				||ST_Y(ST_PointN(line, i-1))-distance2*2||', '||ST_X(ST_PointN(line, i))+distance2*2||' '
 				||ST_Y(ST_PointN(line, i))+distance2*2||')''''::BOX3D, '||srid||')&&the_geom'', '
 				|| points[i-1] ||', '||	points[i-2] ||', '''||dir||''', '''||rc||'''), '
@@ -411,7 +411,7 @@ BEGIN
 	    IF rc THEN query := query || ', reverse_cost'; 
 	    END IF;
 	    
-	    query := query || ' from '||quote_ident(tbl)||' where setsrid(''''BOX3D('||ST_X(ST_PointN(line, i-1))-distance2*2||' '
+	    query := query || ' from '||quote_ident(tbl)||' where ST_SetSRID(''''BOX3D('||ST_X(ST_PointN(line, i-1))-distance2*2||' '
 				||ST_Y(ST_PointN(line, i-1))-distance2*2||', '||ST_X(ST_PointN(line, i))+distance2*2||' '
 				||ST_Y(ST_PointN(line, i))+distance2*2||')''''::BOX3D, '||srid||')&&the_geom'', '
 				|| points[i-1] ||', '||	points[i-2] ||', '''||dir||''', '''||rc||''')';

--- a/core/sql/matching.sql
+++ b/core/sql/matching.sql
@@ -19,7 +19,7 @@ DECLARE
     
 BEGIN
 
-    FOR row IN EXECUTE 'select getsrid(the_geom) as srid from '||tbl||' where gid = (select min(gid) from '||tbl||')' LOOP
+    FOR row IN EXECUTE 'select ST_SRID(the_geom) as srid from '||tbl||' where gid = (select min(gid) from '||tbl||')' LOOP
     END LOOP;
 	srid:= row.srid;
     
@@ -79,7 +79,7 @@ DECLARE
     
 BEGIN
 
-    FOR row IN EXECUTE 'select getsrid(the_geom) as srid from '||tbl||' where gid = (select min(gid) from '||tbl||')' LOOP
+    FOR row IN EXECUTE 'select ST_SRID(the_geom) as srid from '||tbl||' where gid = (select min(gid) from '||tbl||')' LOOP
     END LOOP;
 	srid:= row.srid;
 
@@ -155,7 +155,7 @@ DECLARE
     srid integer;
 BEGIN
 
-    FOR row IN EXECUTE 'select getsrid(the_geom) as srid from '||tbl||' where gid = (select min(gid) from '||tbl||')' LOOP
+    FOR row IN EXECUTE 'select ST_SRID(the_geom) as srid from '||tbl||' where gid = (select min(gid) from '||tbl||')' LOOP
     END LOOP;
 	srid:= row.srid;
 
@@ -231,7 +231,7 @@ DECLARE
     
 BEGIN
 
-    FOR row IN EXECUTE 'select getsrid(the_geom) as srid from '||tbl||' where gid = (select min(gid) from '||tbl||')' LOOP
+    FOR row IN EXECUTE 'select ST_SRID(the_geom) as srid from '||tbl||' where gid = (select min(gid) from '||tbl||')' LOOP
     END LOOP;
 	srid:= row.srid;
 
@@ -353,7 +353,7 @@ DECLARE
 
 BEGIN
 
-    FOR row IN EXECUTE 'select getsrid(the_geom) as srid from '||tbl||' where gid = (select min(gid) from '||tbl||')' LOOP
+    FOR row IN EXECUTE 'select ST_SRID(the_geom) as srid from '||tbl||' where gid = (select min(gid) from '||tbl||')' LOOP
     END LOOP;
 	srid:= row.srid;
 
@@ -517,7 +517,7 @@ DECLARE
     
 BEGIN
 
-    FOR row IN EXECUTE 'select getsrid(the_geom) as srid from '||tbl||' where gid = (select min(gid) from '||tbl||')' LOOP
+    FOR row IN EXECUTE 'select ST_SRID(the_geom) as srid from '||tbl||' where gid = (select min(gid) from '||tbl||')' LOOP
     END LOOP;
 	srid:= row.srid;
 

--- a/core/sql/routing_core_wrappers.sql
+++ b/core/sql/routing_core_wrappers.sql
@@ -293,7 +293,7 @@ BEGIN
 	
 	id :=0;
 	FOR rec IN EXECUTE
-	    'select srid(the_geom) from ' ||
+	    'select ST_SRID(the_geom) as srid from ' ||
 	    quote_ident(geom_table) || ' limit 1'
 	LOOP
 	END LOOP;
@@ -496,7 +496,7 @@ BEGIN
 	
 	id :=0;
 	FOR rec IN EXECUTE
-	    'select srid(the_geom) from ' ||
+	    'select ST_SRID(the_geom) as srid from ' ||
 	    quote_ident(geom_table) || ' limit 1'
 	LOOP
 	END LOOP;
@@ -683,7 +683,7 @@ BEGIN
 	
 	id :=0;
 	FOR rec IN EXECUTE
-	    'select srid(the_geom) from ' ||
+	    'select ST_SRID(the_geom) as srid from ' ||
 	    quote_ident(geom_table) || ' limit 1'
 	LOOP
 	END LOOP;
@@ -870,7 +870,7 @@ BEGIN
 	
 	id :=0;
 	FOR rec IN EXECUTE
-	    'select srid(the_geom) from ' ||
+	    'select ST_SRID(the_geom) as srid from ' ||
 	    quote_ident(geom_table) || ' limit 1'
 	LOOP
 	END LOOP;
@@ -1043,7 +1043,7 @@ BEGIN
 	
 	id :=0;
 	FOR rec IN EXECUTE
-	    'select srid(the_geom) from ' ||
+	    'select ST_SRID(the_geom) as srid from ' ||
 	    quote_ident(geom_table) || ' limit 1'
 	LOOP
 	END LOOP;

--- a/core/sql/routing_core_wrappers.sql
+++ b/core/sql/routing_core_wrappers.sql
@@ -51,12 +51,12 @@ BEGIN
                 ' SET the_geom = NULL';
 
 	EXECUTE 'UPDATE ' || quote_ident(vertices_table) || 
-                ' SET the_geom = startPoint(geometryn(m.the_geom, 1)) FROM ' ||
+                ' SET the_geom = ST_StartPoint(ST_GeometryN(m.the_geom, 1)) FROM ' ||
                  quote_ident(geom_table) || 
                 ' m where geom_id = m.source';
 
 	EXECUTE 'UPDATE ' || quote_ident(vertices_table) || 
-                ' set the_geom = endPoint(geometryn(m.the_geom, 1)) FROM ' || 
+                ' set the_geom = ST_EndPoint(ST_GeometryN(m.the_geom, 1)) FROM ' || 
                 quote_ident(geom_table) || 
                 ' m where geom_id = m.target_id AND ' || 
                 quote_ident(vertices_table) || 
@@ -88,7 +88,7 @@ BEGIN
 	END;
 
 	EXECUTE 'UPDATE ' || quote_ident(geom_table) || 
-              '_edges SET cost = (SELECT sum( length( g.the_geom ) ) FROM ' || 
+              '_edges SET cost = (SELECT sum( ST_Length( g.the_geom ) ) FROM ' || 
               quote_ident(geom_table) || 
               ' g WHERE g.edge_id = id GROUP BY id)';
 
@@ -300,7 +300,7 @@ BEGIN
 	srid := rec.srid;
 	
 	FOR rec IN EXECUTE 
-            'select x(startpoint(the_geom)) as source_x from ' || 
+            'select ST_X(ST_StartPoint(the_geom)) as source_x from ' || 
             quote_ident(geom_table) || ' where source = ' || 
             sourceid ||  ' or target='||sourceid||' limit 1'
         LOOP
@@ -308,7 +308,7 @@ BEGIN
 	source_x := rec.source_x;
 	
 	FOR rec IN EXECUTE 
-            'select y(startpoint(the_geom)) as source_y from ' || 
+            'select ST_Y(ST_StartPoint(the_geom)) as source_y from ' || 
             quote_ident(geom_table) || ' where source = ' || 
             sourceid ||  ' or target='||sourceid||' limit 1'
         LOOP
@@ -317,7 +317,7 @@ BEGIN
 	source_y := rec.source_y;
 
 	FOR rec IN EXECUTE 
-            'select x(startpoint(the_geom)) as target_x from ' ||
+            'select ST_X(ST_StartPoint(the_geom)) as target_x from ' ||
             quote_ident(geom_table) || ' where source = ' || 
             targetid ||  ' or target='||targetid||' limit 1'
         LOOP
@@ -326,7 +326,7 @@ BEGIN
 	target_x := rec.target_x;
 	
 	FOR rec IN EXECUTE 
-            'select y(startpoint(the_geom)) as target_y from ' || 
+            'select ST_Y(ST_StartPoint(the_geom)) as target_y from ' || 
             quote_ident(geom_table) || ' where source = ' || 
             targetid ||  ' or target='||targetid||' limit 1'
         LOOP
@@ -503,7 +503,7 @@ BEGIN
 	srid := rec.srid;
 	
 	FOR rec IN EXECUTE 
-            'select x(startpoint(the_geom)) as source_x from ' || 
+            'select ST_X(ST_StartPoint(the_geom)) as source_x from ' || 
             quote_ident(geom_table) || ' where source = ' || 
             sourceid || ' or target='||sourceid||' limit 1'
         LOOP
@@ -511,7 +511,7 @@ BEGIN
 	source_x := rec.source_x;
 	
 	FOR rec IN EXECUTE 
-            'select y(startpoint(the_geom)) as source_y from ' || 
+            'select ST_Y(ST_StartPoint(the_geom)) as source_y from ' || 
             quote_ident(geom_table) || ' where source = ' || 
             sourceid ||  ' or target='||sourceid||' limit 1'
         LOOP
@@ -520,7 +520,7 @@ BEGIN
 	source_y := rec.source_y;
 
 	FOR rec IN EXECUTE 
-            'select x(startpoint(the_geom)) as target_x from ' ||
+            'select ST_X(ST_StartPoint(the_geom)) as target_x from ' ||
             quote_ident(geom_table) || ' where source = ' || 
             targetid ||  ' or target='||targetid||' limit 1'
         LOOP
@@ -529,7 +529,7 @@ BEGIN
 	target_x := rec.target_x;
 	
 	FOR rec IN EXECUTE 
-            'select y(startpoint(the_geom)) as target_y from ' || 
+            'select ST_Y(ST_StartPoint(the_geom)) as target_y from ' || 
             quote_ident(geom_table) || ' where source = ' || 
             targetid ||  ' or target='||targetid||' limit 1'
         LOOP
@@ -690,7 +690,7 @@ BEGIN
 	srid := rec.srid;
 
 	FOR rec IN EXECUTE 
-            'select x(startpoint(the_geom)) as source_x from ' || 
+            'select ST_X(ST_StartPoint(the_geom)) as source_x from ' || 
             quote_ident(geom_table) || ' where source = ' || 
             sourceid ||  ' or target='||sourceid||' limit 1'
         LOOP
@@ -698,7 +698,7 @@ BEGIN
 	source_x := rec.source_x;
 	
 	FOR rec IN EXECUTE 
-            'select y(startpoint(the_geom)) as source_y from ' || 
+            'select ST_Y(ST_StartPoint(the_geom)) as source_y from ' || 
             quote_ident(geom_table) || ' where source = ' || 
             sourceid ||  ' or target='||sourceid||' limit 1'
         LOOP
@@ -707,7 +707,7 @@ BEGIN
 	source_y := rec.source_y;
 
 	FOR rec IN EXECUTE 
-            'select x(startpoint(the_geom)) as target_x from ' ||
+            'select ST_X(ST_StartPoint(the_geom)) as target_x from ' ||
             quote_ident(geom_table) || ' where source = ' || 
             targetid ||  ' or target='||targetid||' limit 1'
         LOOP
@@ -716,7 +716,7 @@ BEGIN
 	target_x := rec.target_x;
 	
 	FOR rec IN EXECUTE 
-            'select y(startpoint(the_geom)) as target_y from ' || 
+            'select ST_Y(ST_StartPoint(the_geom)) as target_y from ' || 
             quote_ident(geom_table) || ' where source = ' || 
             targetid ||  ' or target='||targetid||' limit 1'
         LOOP
@@ -1050,14 +1050,14 @@ BEGIN
 	srid := rec.srid;
 	
 	FOR rec IN EXECUTE 
-            'select x(startpoint(the_geom)) as source_x from ' || 
+            'select ST_X(ST_StartPoint(the_geom)) as source_x from ' || 
             quote_ident(geom_table) || ' where gid = '||sourceid
         LOOP
 	END LOOP;
 	source_x := rec.source_x;
 	
 	FOR rec IN EXECUTE 
-            'select y(startpoint(the_geom)) as source_y from ' || 
+            'select ST_Y(ST_StartPoint(the_geom)) as source_y from ' || 
             quote_ident(geom_table) || ' where gid = ' ||sourceid
         LOOP
 	END LOOP;
@@ -1065,7 +1065,7 @@ BEGIN
 	source_y := rec.source_y;
 
 	FOR rec IN EXECUTE 
-            'select x(startpoint(the_geom)) as target_x from ' ||
+            'select ST_X(ST_StartPoint(the_geom)) as target_x from ' ||
             quote_ident(geom_table) || ' where gid = ' ||targetid
         LOOP
 	END LOOP;
@@ -1073,7 +1073,7 @@ BEGIN
 	target_x := rec.target_x;
 	
 	FOR rec IN EXECUTE 
-            'select y(startpoint(the_geom)) as target_y from ' || 
+            'select ST_Y(ST_StartPoint(the_geom)) as target_y from ' || 
             quote_ident(geom_table) || ' where gid = ' ||targetid
         LOOP
 	END LOOP;

--- a/core/sql/routing_core_wrappers.sql
+++ b/core/sql/routing_core_wrappers.sql
@@ -363,7 +363,7 @@ BEGIN
 	IF rc THEN query := query || ' , reverse_cost ';  
 	END IF;
 	  
-	query := query || 'FROM ' || quote_ident(geom_table) || ' where setSRID(''''BOX3D('||
+	query := query || 'FROM ' || quote_ident(geom_table) || ' where ST_SetSRID(''''BOX3D('||
           ll_x-delta||' '||ll_y-delta||','||ur_x+delta||' '||
           ur_y+delta||')''''::BOX3D, ' || srid || ') && the_geom'', ' || 
           quote_literal(sourceid) || ' , ' || 
@@ -567,7 +567,7 @@ BEGIN
 	IF rc THEN query := query || ' , reverse_cost ';
 	END IF;
 	  
-	query := query || 'FROM ' || quote_ident(geom_table) || ' where setSRID(''''BOX3D('||
+	query := query || 'FROM ' || quote_ident(geom_table) || ' where ST_SetSRID(''''BOX3D('||
           ll_x-delta||' '||ll_y-delta||','||ur_x+delta||' '||
           ur_y+delta||')''''::BOX3D, ' || srid || ') && the_geom'', ' || 
           quote_literal(sourceid) || ' , ' || 
@@ -752,7 +752,7 @@ BEGIN
 	IF rc THEN query := query || ' , reverse_cost ';
 	END IF;
 
-	query := query || ' FROM ' || quote_ident(geom_table) || ' where setSRID(''''BOX3D('||
+	query := query || ' FROM ' || quote_ident(geom_table) || ' where ST_SetSRID(''''BOX3D('||
           ll_x-delta||' '||ll_y-delta||','||ur_x+delta||' '||
           ur_y+delta||')''''::BOX3D, ' || srid || ') && the_geom'', ' || 
           quote_literal(sourceid) || ' , ' || 
@@ -886,7 +886,7 @@ BEGIN
 	END IF;
 	   
 	query := query || 'FROM ' || 
-           quote_ident(geom_table) || ' where setSRID(''''BOX3D('||ll_x||' '||
+           quote_ident(geom_table) || ' where ST_SetSRID(''''BOX3D('||ll_x||' '||
            ll_y||','||ur_x||' '||ur_y||')''''::BOX3D, ' || srid || 
 	   ') && the_geom'', ' || quote_literal(sourceid) || ' , ' || 
            quote_literal(targetid) || ' , '''||text(dir)||''', '''||text(rc)||''' ),'  ||
@@ -1110,7 +1110,7 @@ BEGIN
 	IF rc THEN query := query || ' , reverse_cost ';  
 	END IF;
 	  
-	query := query || 'FROM ' || quote_ident(geom_table) || ' where setSRID(''''BOX3D('||
+	query := query || 'FROM ' || quote_ident(geom_table) || ' where ST_SetSRID(''''BOX3D('||
           ll_x-delta||' '||ll_y-delta||','||ur_x+delta||' '||
           ur_y+delta||')''''::BOX3D, ' || srid || ') && the_geom'', ' || 
           quote_literal(sourceid) || ' , ' || 

--- a/extra/driving_distance/sql/routing_dd_wrappers.sql
+++ b/extra/driving_distance/sql/routing_dd_wrappers.sql
@@ -96,9 +96,9 @@ BEGIN
      q := 'SELECT gid, the_geom FROM points_as_polygon(''SELECT a.vertex_id::integer AS id, b.x1::double precision AS x, b.y1::double precision AS y'||
      ' FROM driving_distance(''''''''SELECT gid AS id,source::integer,target::integer, '||cost||'::double precision AS cost, '||
      reverse_cost||'::double precision as reverse_cost FROM '||
-     table_name||' WHERE setsrid(''''''''''''''''BOX3D('||
+     table_name||' WHERE ST_SetSRID(''''''''''''''''BOX3D('||
      x-distance||' '||y-distance||', '||x+distance||' '||y+distance||')''''''''''''''''::BOX3D, '||srid||') && the_geom  '''''''', (SELECT id FROM find_node_by_nearest_link_within_distance(''''''''POINT('||x||' '||y||')'''''''','||distance/10||','''''''''||table_name||''''''''')),'||
-     distance||',true,true) a, (SELECT * FROM '||table_name||' WHERE setsrid(''''''''BOX3D('||
+     distance||',true,true) a, (SELECT * FROM '||table_name||' WHERE ST_SetSRID(''''''''BOX3D('||
      x-distance||' '||y-distance||', '||x+distance||' '||y+distance||')''''''''::BOX3D, '||srid||')&&the_geom) b WHERE a.vertex_id = b.source'')';
 
      RAISE NOTICE 'Query: %', q;

--- a/extra/driving_distance/sql/routing_dd_wrappers.sql
+++ b/extra/driving_distance/sql/routing_dd_wrappers.sql
@@ -178,10 +178,14 @@ BEGIN
 
 
      q := 'SELECT gid, the_geom FROM points_as_polygon(''SELECT a.vertex_id::integer AS id, b.x1::double precision AS x, b.y1::double precision AS y'||
-     ' FROM driving_distance(''''''''SELECT gid AS id,source::integer,target::integer, length::double precision AS cost, reverse_cost::double precision FROM '||
-     table_name||' WHERE ST_SetSRID(''''''''''''''''BOX3D('||
+     ' FROM driving_distance(''''''''SELECT gid AS id,source::integer,target::integer, length::double precision AS cost ';
+
+     IF has_reverse_cost THEN q := q || ', reverse_cost::double precision ';
+     END IF;
+
+     q := q || ' FROM '||table_name||' WHERE ST_SetSRID(''''''''''''''''BOX3D('||
      source_x-delta||' '||source_y-delta||', '||source_x+delta||' '||source_y+delta||')''''''''''''''''::BOX3D, '||srid||') && the_geom  '''''''', '||source_id||', '||
-     distance||',true,true) a, (SELECT * FROM '||table_name||' WHERE ST_SetSRID(''''''''BOX3D('||
+     distance||','||directed||','||has_reverse_cost||') a, (SELECT * FROM '||table_name||' WHERE ST_SetSRID(''''''''BOX3D('||
      source_x-delta||' '||source_y-delta||', '||source_x+delta||' '||source_y+delta||')''''''''::BOX3D, '||srid||')&&the_geom) b WHERE a.vertex_id = b.source'')';
 
 

--- a/extra/driving_distance/sql/routing_dd_wrappers.sql
+++ b/extra/driving_distance/sql/routing_dd_wrappers.sql
@@ -40,7 +40,7 @@ BEGIN
      id :=0;
 									     
      i := 1;								     
-     q := 'select 1 as gid, GeometryFromText(''POLYGON((';
+     q := 'select 1 as gid, ST_GeometryFromText(''POLYGON((';
      
      FOR path_result IN EXECUTE 'select x, y from alphashape('''|| 
          query || ''')' LOOP

--- a/extra/tsp/sql/routing_tsp_wrappers.sql
+++ b/extra/tsp/sql/routing_tsp_wrappers.sql
@@ -36,9 +36,9 @@ DECLARE
 
 BEGIN
 	prev := -1;
-	FOR path_result IN EXECUTE 'SELECT vertex_id FROM tsp(''select distinct source::integer as source_id, x(startpoint(the_geom)), y(startpoint(the_geom)) from ' ||
+	FOR path_result IN EXECUTE 'SELECT vertex_id FROM tsp(''select distinct source::integer as source_id, ST_X(ST_StartPoint(the_geom)), ST_Y(ST_StartPoint(the_geom)) from ' ||
 		quote_ident(geom_table) || ' where source in (' || 
-                ids || ')  UNION select distinct target as source_id, x(endpoint(the_geom)), y(endpoint(the_geom)) from tsp_test where target in ('||ids||')'', '''|| ids  ||''', '|| source  ||')' LOOP
+                ids || ')  UNION select distinct target as source_id, ST_X(ST_EndPoint(the_geom)), ST_Y(ST_EndPoint(the_geom)) from tsp_test where target in ('||ids||')'', '''|| ids  ||''', '|| source  ||')' LOOP
 
                 v_id = path_result.vertex_id;
         RETURN NEXT v_id;
@@ -74,7 +74,7 @@ BEGIN
 	prev := source;
 	FOR path_result IN EXECUTE 'SELECT vertex_id FROM tsp(''select distinct source::integer as source_id, x1::double precision as x, y1::double precision as y from ' ||
 	  quote_ident(geom_table) || ' where source in (' || 
-          ids || ') UNION select distinct target as source_id, x(endpoint(the_geom)), y(endpoint(the_geom)) from tsp_test where target in ('||ids||')'', '''|| ids  ||''', '|| source  ||')' LOOP
+          ids || ') UNION select distinct target as source_id, ST_X(ST_EndPoint(the_geom)), ST_Y(ST_EndPoint(the_geom)) from tsp_test where target in ('||ids||')'', '''|| ids  ||''', '|| source  ||')' LOOP
 
                 v_id = path_result.vertex_id;
 		
@@ -177,9 +177,9 @@ BEGIN
 	
 	id :=0;
 	prev := source;
-	FOR path_result IN EXECUTE 'SELECT vertex_id FROM tsp(''select distinct source::integer as source_id, x(startpoint(the_geom)), y(startpoint(the_geom)) from ' ||
+	FOR path_result IN EXECUTE 'SELECT vertex_id FROM tsp(''select distinct source::integer as source_id, ST_X(ST_StartPoint(the_geom)), ST_Y(ST_StartPoint(the_geom)) from ' ||
 	   quote_ident(geom_table) || ' where source in (' || 
-           ids || ') UNION select distinct target as source_id, x(endpoint(the_geom)), y(endpoint(the_geom)) from tsp_test where target in ('||ids||')'', '''|| ids  ||''', '|| source  ||')' LOOP
+           ids || ') UNION select distinct target as source_id, ST_X(ST_EndPoint(the_geom)), ST_Y(ST_EndPoint(the_geom)) from tsp_test where target in ('||ids||')'', '''|| ids  ||''', '|| source  ||')' LOOP
 
                 v_id = path_result.vertex_id;
 		
@@ -228,13 +228,13 @@ BEGIN
 	prev := source;
 	
 	query := 'SELECT vertex_id FROM tsp(''select distinct source::integer as source_id, '||
-		    'x(startpoint(the_geom)), y(startpoint(the_geom))';
+		    'ST_X(ST_StartPoint(the_geom)), ST_Y(ST_StartPoint(the_geom))';
 		    
 	IF rc THEN query := query || ' , reverse_cost ';
 	END IF;
 
 	query := query || ' from ' || quote_ident(geom_table) || ' where source in (' || 
-           ids || ') UNION select distinct target as source_id, x(endpoint(the_geom)), y(endpoint(the_geom))';
+           ids || ') UNION select distinct target as source_id, ST_X(ST_EndPoint(the_geom)), ST_Y(ST_EndPoint(the_geom))';
         
         IF rc THEN query := query || ' , reverse_cost ';
 	END IF;


### PR DESCRIPTION
First of all, this pull request depends on #72 "Adapt PostGIS function calls to the standard spatial type (ST) prefix syntax", because there is no other way to make the code work with newer PostGIS versions.

(I'm sorry, but there's no better way to add a pull request that depends on another one)

---------------------------------------------------------------------------------------------------------
**Description:**
I added a [driving_distance_delta function](https://github.com/daniel-j-h/pgrouting/blob/driving-distance-delta/extra/driving_distance/sql/routing_dd_wrappers.sql), in order to solve the following issues with the already existing one (extra/driving_distance/sql/routing_dd_wrappers.sql):

* Inconsistent API: You had to pass coordinates instead of an id; unlike the shortest path delta functions or the normal driving distance function.

* Unexpected behavior: The function didn't respect the 'directed' and 'has_reverse_cost' arguments; instead it delegated with 'true', 'true' - no matter the actual arguments.

* Delta dependency: The delta for resolving the coordinates to an id depended on the delta of the driving distance.

* No documentation: Not even in the source code.

---------------------------------------------------------------------------------------------------------
**Further notes:**

* The old driving distance delta function is still available; because I didn't want to break your working code; the new function returns the same and you can use it e.g. in combination with ST_AsGeoJSON(the_geom) to get a GeoJSON polygon.

* For now it assumes length as the cost column - like all other shortest path delta functions. Maybe there should be a driving_distance_delta_cc with the cost column as parameter; or you could just create a view in which you alias your specific column.