### PR TITLE
Remove is_same.hpp include because it is not used and generates install error

### DIFF
--- a/core/src/edge_visitors.hpp
+++ b/core/src/edge_visitors.hpp
@@ -6,7 +6,6 @@
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/limits.hpp>
-#include <boost/graph/detail/is_same.hpp>
 
 namespace boost 
 {


### PR DESCRIPTION
I had this issue installing on ubuntu quantal:

<pre>
$ make
Scanning dependencies of target routing
[ 16%] Building C object core/src/CMakeFiles/routing.dir/dijkstra.o
[ 33%] Building C object core/src/CMakeFiles/routing.dir/astar.o
[ 50%] Building C object core/src/CMakeFiles/routing.dir/shooting_star.o
[ 66%] Building CXX object core/src/CMakeFiles/routing.dir/boost_wrapper.o
[ 83%] Building CXX object core/src/CMakeFiles/routing.dir/astar_boost_wrapper.o
[100%] Building CXX object core/src/CMakeFiles/routing.dir/shooting_star_boost_wrapper.o
In file included from /home/jperelli/pgrouting/core/src/shooting_star_search.hpp:28:0,
                 from /home/jperelli/pgrouting/core/src/shooting_star_boost_wrapper.cpp:30:
/home/jperelli/pgrouting/core/src/edge_visitors.hpp:9:42: error fatal: boost/graph/detail/is_same.hpp: No existe el archivo o el directorio
compilación terminada.
make[2]: *** [core/src/CMakeFiles/routing.dir/shooting_star_boost_wrapper.o] Error 1
make[1]: *** [core/src/CMakeFiles/routing.dir/all] Error 2
make: *** [all] Error 2
</pre>


And I deleted this line, because of this comment:
"edit edge_visitors.hpp and delete the line that includes is_same.hpp.  it's not really used anyways." (http://http-lists-osgeo-org-pipermail-pgrouting-users.974093.n3.nabble.com/pgrouting-users-How-to-install-pgRouting-on-Mac-OSX-10-7-with-PostgreSQL-9-0-td3409053.html)

Then it compiled ok.
