### PR TITLE
Fix build with libboost >= 1.47. Closes #45

### DIFF
--- a/core/src/edge_visitors.hpp
+++ b/core/src/edge_visitors.hpp
@@ -6,7 +6,12 @@
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/limits.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION <= 14700
 #include <boost/graph/detail/is_same.hpp>
+#else
+#include <boost/type_traits/is_same.hpp>
+#endif
 
 namespace boost 
 {


### PR DESCRIPTION
Uses BOOST_VERSION switch as suggested by @sanak in #45 but changes the condition to start using type_traits in clude with 1.47.00, to allow building with future patch-level releases in 1.46 
