### PR TITLE
library type specification to build under Mac OSX

### DIFF
--- a/src/astar/src/astar_boost_wrapper.cpp
+++ b/src/astar/src/astar_boost_wrapper.cpp
@@ -140,8 +140,9 @@ boost_astar(edge_astar_t *edges, unsigned int count,
 
   graph_t graph(num_nodes);
 
-  property_map<graph_t, edge_weight_t>::type weightmap = get(edge_weight, 
-							     graph);
+  // interfers with APPLE build, can it just be commented out?
+  //property_map<graph_t, edge_weight_t>::type weightmap = get(edge_weight, 
+  //							     graph);
 
   for (std::size_t j = 0; j < count; ++j)
   {

--- a/src/dijkstra/src/boost_wrapper.cpp
+++ b/src/dijkstra/src/boost_wrapper.cpp
@@ -60,7 +60,8 @@ boost_dijkstra(edge_t *edges, unsigned int count, int start_vertex, int end_vert
 
     graph_t graph(num_nodes);
 
-    property_map<graph_t, edge_weight_t>::type weightmap = get(edge_weight, graph);
+    // commented out to fix APPLE build, is it needed?
+    //property_map<graph_t, edge_weight_t>::type weightmap = get(edge_weight, graph);
 
     for (std::size_t j = 0; j < count; ++j)
     {

--- a/src/driving_distance/src/CMakeLists.txt
+++ b/src/driving_distance/src/CMakeLists.txt
@@ -1,7 +1,16 @@
 SET(LIBRARY_OUTPUT_PATH ../../../lib/)
 LINK_LIBRARIES(${CGAL_LIBRARIES} ${GMP_LIBRARIES} ${BOOST_THREAD_LIBRARIES})
-ADD_LIBRARY(routing_dd SHARED alpha.c alpha_drivedist.cpp alpha.h boost_drivedist.cpp drivedist.c drivedist.h)
+
+ADD_LIBRARY(routing_dd ${LIBRARY_MODE_TARGET} alpha.c alpha_drivedist.cpp alpha.h boost_drivedist.cpp drivedist.c drivedist.h)
+
 IF(WIN32)
   SET_TARGET_PROPERTIES(routing_dd PROPERTIES COMPILE_FLAGS "-DBOOST_THREAD_USE_LIB -DBoost_USE_STATIC_LIBS -DBOOST_USE_WINDOWS_H")
 ENDIF(WIN32)
+
+if(APPLE)
+    set_target_properties(routing_dd
+        PROPERTIES
+        LINK_FLAGS "-bundle_loader ${POSTGRESQL_EXECUTABLE} -bundle")
+endif(APPLE)
+
 INSTALL(TARGETS routing_dd DESTINATION ${LIBRARY_INSTALL_PATH})

--- a/src/driving_distance/src/boost_drivedist.cpp
+++ b/src/driving_distance/src/boost_drivedist.cpp
@@ -85,8 +85,8 @@ boost_dijkstra_dist(edge_t *edges, unsigned int count, int source_vertex_id,
   
   graph_t graph( num_nodes );
   
-  property_map<graph_t, edge_weight_t>::type weightmap = 
-    get(edge_weight, graph);
+  //property_map<graph_t, edge_weight_t>::type weightmap = 
+  //  get(edge_weight, graph);
   
   for (std::size_t j = 0; j < count; ++j)
     {

--- a/src/ksp/src/CMakeLists.txt
+++ b/src/ksp/src/CMakeLists.txt
@@ -5,7 +5,7 @@ if(WIN32)
   include_directories(${POSTGRESQL_INCLUDE_DIR}/port/win32)
 endif(WIN32)
 
-add_library(routing_ksp SHARED BaseGraph.cpp BaseGraph.h BasePath.cpp BasePath.h DijkstraShortestPathAlg.cpp DijkstraShortestPathAlg.h DynamicGraph.h Graph.cpp GraphElements.h Graph.h HeaderTest.cpp TGraph.h TPath.h YenTopKShortestPathsAlg.cpp YenTopKShortestPathsAlg.h ksp.c KSPDriver.cpp KSPGraph.h KSPGraph.cpp )
+add_library(routing_ksp ${LIBRARY_MODE_TARGET} BaseGraph.cpp BaseGraph.h BasePath.cpp BasePath.h DijkstraShortestPathAlg.cpp DijkstraShortestPathAlg.h DynamicGraph.h Graph.cpp GraphElements.h Graph.h HeaderTest.cpp TGraph.h TPath.h YenTopKShortestPathsAlg.cpp YenTopKShortestPathsAlg.h ksp.c KSPDriver.cpp KSPGraph.h KSPGraph.cpp )
 
 if(WIN32)
   if(MSVC)
@@ -16,7 +16,7 @@ if(WIN32)
   endif(MSVC)
 endif(WIN32)
 if(APPLE)
-  set_target_properties(routing
+  set_target_properties(routing_ksp
     PROPERTIES
     LINK_FLAGS "-bundle_loader ${POSTGRESQL_EXECUTABLE} -bundle")
 endif(APPLE)

--- a/src/tsp/src/CMakeLists.txt
+++ b/src/tsp/src/CMakeLists.txt
@@ -5,10 +5,10 @@ if(WIN32)
     include_directories(${POSTGRESQL_INCLUDE_DIR}/port/win32)
 endif(WIN32)
 
-add_library(routing_tsp SHARED tsp.c tsp.h tsplib.c)
+add_library(routing_tsp ${LIBRARY_MODE_TARGET} tsp.c tsp.h tsplib.c)
 
 if(APPLE)
-    set_target_properties(routing
+    set_target_properties(routing_tsp
         PROPERTIES
         LINK_FLAGS "-bundle_loader ${POSTGRESQL_EXECUTABLE} -bundle")
 endif(APPLE)


### PR DESCRIPTION
These changes mostly solve issues building under OSX using current boost and postgresql. The remaining issue is that librouting_tsp and librouting_ksp are built as static libraries (.a) rather than dynamic (.so), so the create extension command in postgresql complains that it can't find the files. I haven't been able to figure out how cmake decides to do this.
