### PR TITLE
PostGIS 2.x requires ST_GeometryFromText?

### DIFF
--- a/extra/driving_distance/sql/routing_dd_wrappers.sql
+++ b/extra/driving_distance/sql/routing_dd_wrappers.sql
@@ -40,7 +40,7 @@ BEGIN
      id :=0;
 									     
      i := 1;								     
-     q := 'select 1 as gid, GeometryFromText(''POLYGON((';
+     q := 'select 1 as gid, ST_GeometryFromText(''POLYGON((';
      
      FOR path_result IN EXECUTE 'select x, y from alphashape('''|| 
          query || ''')' LOOP


### PR DESCRIPTION
I'm not sure if this is the correct fix to this but it worked for me. points_as_polygon tries to call GeometryFromText instead of ST_GeometryFromText.

Running:

    select points_as_polygon('select id,x,y from ...');

I received:

    ERROR:  function geometryfromtext(unknown, integer) does not exist
    LINE 1: select 1 as gid, GeometryFromText('POLYGON((1589842.23558516...

Rebuilding the function with this change resolved the error.