### PR TITLE
fix tsp internal variable type to double.

### DIFF
--- a/src/tsp/src/tsp.h
+++ b/src/tsp/src/tsp.h
@@ -23,7 +23,7 @@
 #define _TSP_H
 
 // define the type of object for the distance matrix
-#define DTYPE float
+#define DTYPE double
 
 #include "postgres.h"
 #include "dijkstra.h" 

--- a/src/tsp/src/tsplib.c
+++ b/src/tsp/src/tsplib.c
@@ -168,8 +168,9 @@ typedef struct tspstruct {
 int findEulerianPath(TSP *tsp)
 {
     int *mst, *arc;    
-    int d, i, j, k, l, a;
+    int i, j, k, l, a;
     int n, *iorder, *jorder;
+    DTYPE d;
     DTYPE maxd;
     DTYPE *dist;
     DTYPE *dis;


### PR DESCRIPTION
This fix will support tsp distance variables < 1.0 case (#159).
I confirmed that all test passed on Ubuntu12.04x86/Windows7x64(winnie-rc1)/MacOSX.

The reported query and its result was as follows.

<pre>
pgrouting-workshop=# SELECT * FROM pgr_tsp('{{0,0.0239288164765725,0.0257979665805287,0.031582558789943},{0.0239288164765725,0,0.0211958716829549,0.0379751989289084},{0.0257979665805287,0.0211958716829549,0,0.0180511085745426},{0.031582558789943,0.0379751989289084,0.0180511085745426,0}}'::float8[], 1);
 seq | id 
-----+----
   0 |  1
   1 |  3
   2 |  2
   3 |  0
(4 rows)
</pre>
