### PR TITLE
Modified OS X installation description to Homebrew

### DIFF
--- a/doc/src/installation/index.rst
+++ b/doc/src/installation/index.rst
@@ -49,10 +49,16 @@ RHEL/CentOS/Fedora
 * Fedora RPM's: https://admin.fedoraproject.org/pkgdb/acls/name/pgRouting
 
 
-OSX
+OS X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-See `builds from KingChaos <http://www.kyngchaos.com/software/postgres>`_.
+.. See `builds from KingChaos <http://www.kyngchaos.com/software/postgres>`_.
+
+* Homebrew
+
+.. code-block:: bash
+
+	brew install pgrouting
 
 
 Build from Source


### PR DESCRIPTION
I commented out KingChaos ver 1.0.5 binary link and added ver 2.0 Homebrew installation instruction.

https://github.com/mxcl/homebrew/blob/master/Library/Formula/pgrouting.rb
