### PR TITLE
Update pgrouting_topology.sql

### DIFF
--- a/src/common/sql/pgrouting_topology.sql
+++ b/src/common/sql/pgrouting_topology.sql
@@ -1,4 +1,3 @@
-
 /*
 .. function:: pgr_pointToId(point geometry, tolerance double precision,vname text,srid integer)
 
@@ -278,7 +277,7 @@ BEGIN
 
   
   BEGIN 
-    sql = 'select * from '||pgr_quote_ident(tabname)||' WHERE true'||rows_where ||' limit 1';
+    sql = 'SELECT count(*) FROM '||pgr_quote_ident(tabname)||' WHERE true'||rows_where ||' LIMIT 1';
     EXECUTE sql into i;
     sql = 'select count(*) from '||pgr_quote_ident(tabname)||' WHERE (' || gname || ' IS NOT NULL AND '||
 		idname||' IS NOT NULL)=false '||rows_where;


### PR DESCRIPTION
In sql file src/common/sql/pgrouting_topology.sql  at lines 281 and 282.
 
 sql = 'select * from '||pgr_quote_ident(tabname)||' WHERE true'||rows_where ||' limit 1';
 EXECUTE sql into i;

Variable i is declared as integer so the select * from ... cause a SQLSTATE  22P02 error 

At line 281, the select should be SELECT count(*) instead of SELECT * 