### PR TITLE
Added ORDER BY to creating topology

### DIFF
--- a/src/common/sql/pgrouting_topology.sql
+++ b/src/common/sql/pgrouting_topology.sql
@@ -1,4 +1,3 @@
-
 /*
 .. function:: pgr_pointToId(point geometry, tolerance double precision,vname text,srid integer)
 
@@ -302,6 +301,7 @@ BEGIN
         || ' PGR_EndPoint('   || gname || ') AS target'
         || ' FROM '  || pgr_quote_ident(tabname)
         || ' WHERE ' || gname || ' IS NOT NULL AND ' || idname||' IS NOT NULL '||rows_where
+        || ' ORDER BY ' || idname
     LOOP
 
         rowcount := rowcount + 1;


### PR DESCRIPTION
Added ORDER BY to creating topology in order to return the same node numbers when topology run on same dataset multiple times.  Appears to return the same numbers each time now... .
