### PR TITLE
Added alpha argument with default 0 (use optimal alpha value)

### DIFF
--- a/src/driving_distance/sql/routing_dd.sql
+++ b/src/driving_distance/sql/routing_dd.sql
@@ -31,7 +31,7 @@ CREATE OR REPLACE FUNCTION pgr_drivingDistance(sql text, source_id integer, dist
 -- The sql should return vertex ids and x,y values. Return ordered
 -- vertex ids. 
 -----------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION pgr_alphashape(sql text, OUT x float8, OUT y float8)
+CREATE OR REPLACE FUNCTION pgr_alphashape(sql text, alpha float8 DEFAULT 0, OUT x float8, OUT y float8)
     RETURNS SETOF record
     AS '$libdir/librouting_dd', 'alphashape'
     LANGUAGE c IMMUTABLE STRICT;
@@ -40,7 +40,7 @@ CREATE OR REPLACE FUNCTION pgr_alphashape(sql text, OUT x float8, OUT y float8)
 -- Draws an alpha shape around given set of points.
 -- ** This should be rewritten as an aggregate. **
 ----------------------------------------------------------
-CREATE OR REPLACE FUNCTION pgr_pointsAsPolygon(query varchar)
+CREATE OR REPLACE FUNCTION pgr_pointsAsPolygon(query varchar, alpha float8 DEFAULT 0)
 	RETURNS geometry AS
 	$$
 	DECLARE
@@ -55,7 +55,7 @@ CREATE OR REPLACE FUNCTION pgr_pointsAsPolygon(query varchar)
 		i := 1;								     
 		q := 'SELECT ST_GeometryFromText(''POLYGON((';
 
-		FOR path_result IN EXECUTE 'SELECT x, y FROM pgr_alphashape('''|| query || ''')' 
+		FOR path_result IN EXECUTE 'SELECT x, y FROM pgr_alphashape('''|| query || ''', ' || alpha || ')' 
 		LOOP
 			x[i] = path_result.x;
 			y[i] = path_result.y;

--- a/src/driving_distance/src/alpha.c
+++ b/src/driving_distance/src/alpha.c
@@ -169,7 +169,7 @@ fetch_vertex(HeapTuple *tuple, TupleDesc *tupdesc,
   target_vertex->y = DatumGetFloat8(binval);
 }
 
-static int compute_alpha_shape(char* sql, vertex_t **res, int *res_count) 
+static int compute_alpha_shape(char* sql, float8 alpha, vertex_t **res, int *res_count)
 {
 
   int SPIcode;
@@ -273,7 +273,7 @@ static int compute_alpha_shape(char* sql, vertex_t **res, int *res_count)
   profstop("extract", prof_extract);
   profstart(prof_alpha);
 
-  ret = alpha_shape(vertices, total_tuples, res, res_count, &err_msg);
+  ret = alpha_shape(vertices, total_tuples, alpha, res, res_count, &err_msg);
 
   profstop("alpha", prof_alpha);
   profstart(prof_store);
@@ -315,7 +315,7 @@ Datum alphashape(PG_FUNCTION_ARGS)
       oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
 
       ret = compute_alpha_shape(text2char(PG_GETARG_TEXT_P(0)), 
-                                &res, &res_count);
+                                PG_GETARG_FLOAT8(1), &res, &res_count);
 
       /* total number of tuples to be returned */
       DBG("Conting tuples number\n");

--- a/src/driving_distance/src/alpha.h
+++ b/src/driving_distance/src/alpha.h
@@ -39,7 +39,7 @@ extern "C"
 {
 #endif
                                                                      
-  int alpha_shape(vertex_t *vertices, unsigned int count, 
+  int alpha_shape(vertex_t *vertices, unsigned int count, double alpha,
                   vertex_t **res, int *res_count, char **err_msg);
 
 #ifdef __cplusplus

--- a/src/driving_distance/src/alpha_drivedist.cpp
+++ b/src/driving_distance/src/alpha_drivedist.cpp
@@ -119,7 +119,7 @@ alpha_edges( const Alpha_shape_2&  A,
 }
 
 
-int alpha_shape(vertex_t *vertices, unsigned int count, 
+int alpha_shape(vertex_t *vertices, unsigned int count, double alpha,
                 vertex_t **res, int *res_count, char **err_msg)
 {
   std::list<Point> points;
@@ -147,7 +147,11 @@ int alpha_shape(vertex_t *vertices, unsigned int count,
   Alpha_shape_2::Face_iterator fit;
   Alpha_shape_2::Face_handle face;
   
-  A.set_alpha(*A.find_optimal_alpha(1)*6); 
+  if (alpha <= 0.0)
+  {
+    alpha = *A.find_optimal_alpha(1);
+  }
+  A.set_alpha(alpha);
 
   alpha_edges( A, std::back_inserter(segments));
 


### PR DESCRIPTION
This fix will enable pgr_alphashape/pgr_pointsAsPolygon to set arbitrary alpha value.
If specified alpha value equals 0 (default), then optimal alpha value is used.

This fix is related to issue #235, but independent from pull request #236(hole polygon case).
So, the following image's alpha = "0.0001" shows invalid result because of hole polygon case.

![pass_alpha](https://f.cloud.github.com/assets/629923/2301593/6c79890c-a14e-11e3-82c0-e99219148d84.png)
