### PR TITLE
Commented out apsp_johnson '-fno-delete-null-pointer-checks' flag for Mac OSX build

### DIFF
--- a/src/apsp_johnson/src/CMakeLists.txt
+++ b/src/apsp_johnson/src/CMakeLists.txt
@@ -1,6 +1,9 @@
-## FIXME: The following patch is required by apsp_johnson_boost_wrapper.cpp.
-## With -fdelete-null-pointer-checks optimization, the assignments
-## to Edge bundled properties doesn't occur.
-#SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-delete-null-pointer-checks")
+# FIXME: The following patch is required by apsp_johnson_boost_wrapper.cpp.
+# With -fdelete-null-pointer-checks optimization, the assignments
+# to Edge bundled properties doesn't occur.
+
+if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-delete-null-pointer-checks")
+endif()
 
 ADD_LIBRARY(apsp_johnson OBJECT apsp_johnson.c apsp_johnson_boost_wrapper.cpp)


### PR DESCRIPTION
This fix will support Xcode 5.1 clang build on Mac OSX (#258).
I confirmed that all test work correctly on Mac OSX.
And I think that the following notice(original comment) in "src/apsp_johnson/src/CMakeLists.txt" should be fixed in C/C++ source level.

<pre>
# FIXME: The following patch is required by apsp_johnson_boost_wrapper.cpp.
# With -fdelete-null-pointer-checks optimization, the assignments
# to Edge bundled properties doesn't occur.
</pre>
