### PR TITLE
Null pointer dereference with astar when no viable route found

### DIFF
--- a/src/astar/src/astar_boost_wrapper.cpp
+++ b/src/astar/src/astar_boost_wrapper.cpp
@@ -287,6 +287,7 @@ try {
     *err_msg = (char *) "Unknown exception caught!";
     return -1;
  }
- return -1;
+ *err_msg = (char *) "No path found";
+ return 0;
 }
 

--- a/src/common/sql/pgrouting_utilities.sql
+++ b/src/common/sql/pgrouting_utilities.sql
@@ -203,7 +203,7 @@ COMMENT ON FUNCTION pgr_isColumnInTable(text,text) IS 'args: tab,col  -returns t
 	  	 when column "col" is not indexed
 
 */
-CREATE OR REPLACE FUNCTION public.pgr_isColumnIndexed(tab text, col text)
+CREATE OR REPLACE FUNCTION pgr_isColumnIndexed(tab text, col text)
 RETURNS boolean AS
 $BODY$
 DECLARE


### PR DESCRIPTION
err_msg isn't populated when there is no possible trace from source->target. When a return of -1 occurs, this causes a crash. It shouldn't be returning -1, however, as this is not an error condition.
