### PR TITLE
No Contrib When Use Extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,16 +170,13 @@ execute_process(
   OUTPUT_VARIABLE SHARE_DIR)
 
 if(SHARE_DIR)
-  # Always install in "contrib" directory of PostgreSQL
-  set(CONTRIB_DIR "${SHARE_DIR}/contrib/pgrouting-${PGROUTING_VERSION_MAJOR}.${PGROUTING_VERSION_MINOR}")
-  message(STATUS "Contrib directory for SQL files is set to ${CONTRIB_DIR}")
-
   # Install as extension if supported by the version of PostgreSQL
   if(USE_PG_EXTENSION)
     set(SHARE_DIR "${SHARE_DIR}/extension")
     message(STATUS "Extension directory for SQL files is set to ${SHARE_DIR}")
-  #else(USE_PG_EXTENSION)
-  #  set(SHARE_DIR "/usr/share/pgrouting")
+  else(USE_PG_EXTENSION)
+    set(CONTRIB_DIR "${SHARE_DIR}/contrib/pgrouting-${PGROUTING_VERSION_MAJOR}.${PGROUTING_VERSION_MINOR}")
+    message(STATUS "Contrib directory for SQL files is set to ${CONTRIB_DIR}")
   endif(USE_PG_EXTENSION)
 else(SHARE_DIR)
   message(FATAL_ERROR "pg_config --sharedir failed to return a value. Please check your PostgreSQL installation!")
@@ -347,22 +344,24 @@ endif(UNIX)
 
 install(FILES ${LIBS_TO_INSTALL}  DESTINATION ${LIB_DIR})
 
-install(FILES
+if(USE_PG_EXTENSION)
+  install(FILES
     "${CMAKE_BINARY_DIR}/lib/pgrouting--${PGROUTING_VERSION_STRING}.sql"
     "${CMAKE_BINARY_DIR}/lib/pgrouting.control"
     "${CMAKE_BINARY_DIR}/lib/pgrouting_legacy.sql"
     DESTINATION "${SHARE_DIR}")
-
-# The following probably could be done better
-# The idea is to also have a "pgrouting-x.x" directory in PostgreSQL contrib
-configure_file("${CMAKE_BINARY_DIR}/lib/pgrouting--${PGROUTING_VERSION_STRING}.sql"
+else(USE_PG_EXTENSION)
+  # The following probably could be done better
+  # The idea is to also have a "pgrouting-x.x" directory in PostgreSQL contrib
+  configure_file("${CMAKE_BINARY_DIR}/lib/pgrouting--${PGROUTING_VERSION_STRING}.sql"
     "${CMAKE_BINARY_DIR}/lib/pgrouting.sql" COPYONLY)
 
-install(FILES
+  install(FILES
     "${CMAKE_BINARY_DIR}/lib/pgrouting.sql"
     "${CMAKE_BINARY_DIR}/lib/pgrouting.control"
     "${CMAKE_BINARY_DIR}/lib/pgrouting_legacy.sql"
     DESTINATION "${CONTRIB_DIR}")
+endif(USE_PG_EXTENSION)
 
 # TODO: The following probably should be done better
 if(WITH_DD)
@@ -372,12 +371,14 @@ if(WITH_DD)
   configure_file("${PGROUTING_SOURCE_DIR}/src/driving_distance/sql/routing_dd_legacy.sql"
       "${CMAKE_BINARY_DIR}/lib/pgrouting_dd_legacy.sql" COPYONLY)
 
-  install(FILES
-      "${CMAKE_BINARY_DIR}/lib/pgrouting_dd_legacy.sql"
-      DESTINATION "${SHARE_DIR}")
-
-  install(FILES
-      "${CMAKE_BINARY_DIR}/lib/pgrouting_dd_legacy.sql"
-      DESTINATION "${CONTRIB_DIR}")
+    if(USE_PG_EXTENSION)
+      install(FILES
+	"${CMAKE_BINARY_DIR}/lib/pgrouting_dd_legacy.sql"
+	DESTINATION "${SHARE_DIR}")
+    else(USE_PG_EXTENSION)
+      install(FILES
+	"${CMAKE_BINARY_DIR}/lib/pgrouting_dd_legacy.sql"
+	DESTINATION "${CONTRIB_DIR}")
+    endif(USE_PG_EXTENSION)
 endif(WITH_DD)
 


### PR DESCRIPTION
Don't install to ${SHAREDIR}/contrib when USE EXTENSION is true to fit
in with PostgreSQL's directory structure. (pg_routing in the only thing
in ${SHAREDIR}/contrib on 9.1+.)

We're using this on Gentoo and so far I haven't gotten any reports about
this breaking anything.