### PR TITLE
Fixed #336 by initializing GraphDefinition class member variables

### DIFF
--- a/src/trsp/src/GraphDefinition.cpp
+++ b/src/trsp/src/GraphDefinition.cpp
@@ -2,8 +2,15 @@
 
 GraphDefinition::GraphDefinition(void)
 {
+	m_lStartEdgeId = -1;
+	m_lEndEdgeId = 0;
+	m_dStartpart = 0.0;
+	m_dEndPart = 0.0;
+	m_dCost = NULL;
 	m_bIsturnRestrictOn = false;
 	m_bIsGraphConstructed = false;
+	parent = NULL;
+	init();
 }
 
 GraphDefinition::~GraphDefinition(void)


### PR DESCRIPTION
This commit fixes #336 (pgr_trsp on windows returns no route).
I send this pull request for `master` branch, because #336 is a bug and it should be fixed also in v2.0.1 release.
To fix the issue on `develop_2_1_0` branch, I think that using `git cherry-pick 8ddc530` will be enough.