### PR TITLE
Fixed #336 by initializing GraphDefinition class member variables (for develop_2_1_0 branch)

### DIFF
--- a/src/trsp/src/GraphDefinition.cpp
+++ b/src/trsp/src/GraphDefinition.cpp
@@ -10,8 +10,15 @@
 // -------------------------------------------------------------------------
 GraphDefinition::GraphDefinition(void)
 {
+    m_lStartEdgeId = -1;
+    m_lEndEdgeId = 0;
+    m_dStartpart = 0.0;
+    m_dEndPart = 0.0;
+    m_dCost = NULL;
     m_bIsturnRestrictOn = false;
     m_bIsGraphConstructed = false;
+    parent = NULL;
+    init();
 }
 
 // -------------------------------------------------------------------------


### PR DESCRIPTION
This commit fixes #336 (pgr_trsp on windows returns no route).
I send this pull request also for develop_2_1_0 branch, because after executing `git cherry-pick 8ddc530`,
I encountered some conflict (tab to 4 white spaces .etc).
(See #402 for `master` branch pull request.)