### PR TITLE
Fix spelling errors

### DIFF
--- a/doc/src/tutorial/custom_query.rst
+++ b/doc/src/tutorial/custom_query.rst
@@ -121,9 +121,9 @@ When the columns required have the default names this can be used (pgr_func is t
 
 .. code-block:: sql
 
-        pgr_func('edge_table')        -- when tolerance is not requiered
-	pgr_func('edge_table',0.001)  -- when tolerance is requiered
-        -- s_in_rule, s_out_rule, st_in_rules, t_out_rules are requiered
+        pgr_func('edge_table')        -- when tolerance is not required
+	pgr_func('edge_table',0.001)  -- when tolerance is required
+        -- s_in_rule, s_out_rule, st_in_rules, t_out_rules are required
 	SELECT pgr_analyzeOneway('edge_table', ARRAY['', 'B', 'TF'], ARRAY['', 'B', 'FT'], 
 					       ARRAY['', 'B', 'FT'], ARRAY['', 'B', 'TF']) 
 

--- a/src/allpairs/src/johnson_driver.cpp
+++ b/src/allpairs/src/johnson_driver.cpp
@@ -57,7 +57,7 @@ do_pgr_johnson(
   std::ostringstream log;
   try {
     if (total_tuples == 1) {
-      log << "Requiered: more than one tuple\n";
+      log << "Required: more than one tuple\n";
       (*return_tuples) = NULL;
       (*return_count) = 0;
       *err_msg = strdup(log.str().c_str());

--- a/src/common/src/postgres_connection.c
+++ b/src/common/src/postgres_connection.c
@@ -38,7 +38,7 @@ pgr_send_error(int errcode) {
             elog(ERROR, "Unexpected point(s) with same pid but different edge/fraction/side combination found.");
             break;
         case 2:
-            elog(ERROR, "Internal: Unexpected missmatch count and sequence number on results");
+            elog(ERROR, "Internal: Unexpected mismatch count and sequence number on results");
             break;
         default:
             elog(ERROR, "Unknown exception");

--- a/src/dijkstra/src/dijkstraVia_driver.cpp
+++ b/src/dijkstra/src/dijkstraVia_driver.cpp
@@ -183,7 +183,7 @@ do_pgr_dijkstraViaVertex(
     try {
 
         if (total_tuples == 1) {
-            log << "Requiered: more than one tuple\n";
+            log << "Required: more than one tuple\n";
             (*return_tuples) = NULL;
             (*return_count) = 0;
             *err_msg = strdup(log.str().c_str());

--- a/src/driving_distance/src/boost_interface_drivedist.cpp
+++ b/src/driving_distance/src/boost_interface_drivedist.cpp
@@ -140,7 +140,7 @@ do_pgr_driving_distance(
 
         log << "Returning number of tuples" << path.size() << "\n";
         if (path.empty()) {
-            log << "NOTICE: it shoud have at least the one for it self";
+            log << "NOTICE: it should have at least the one for it self";
             *err_msg = strdup(log.str().c_str());
             *ret_path = noResult(path_count, (*ret_path));
             return;

--- a/src/mainpage.dox
+++ b/src/mainpage.dox
@@ -56,7 +56,7 @@ Step by Step processing
 ~~~~{.c}
     git remote -v
 ~~~~
-   - Now you shoud have something like this:
+   - Now you should have something like this:
 ~~~~{.c}
 origin  https://github.com/acountName/pgrouting (fetch)
 origin  https://github.com/acountName/pgrouting (push)

--- a/src/withPoints/src/pgr_withPoints.cpp
+++ b/src/withPoints/src/pgr_withPoints.cpp
@@ -261,7 +261,7 @@ create_new_edges(
             }
         }
         if (points_on_edge.empty()) {
-            log << "For some reason we didnt find a point belonging to the edge, must be an error\n";
+            log << "For some reason we didn't find a point belonging to the edge, must be an error\n";
             return false;
         }
 #if 0

--- a/tools/template/src/function1_driver.cpp
+++ b/tools/template/src/function1_driver.cpp
@@ -66,7 +66,7 @@ do_pgr_MY_FUNCTION_NAME(
     try {
 
         if (total_tuples == 1) {
-            log << "Requiered: more than one tuple\n";
+            log << "Required: more than one tuple\n";
             (*return_tuples) = NULL;
             (*return_count) = 0;
             *err_msg = strdup(log.str().c_str());


### PR DESCRIPTION
Fix spelling errors reported by the lintian QA tool for the Debian package build.

Changes proposed in this pull request:
- missmatch -> mismatch
- requiered -> required
- shoud     -> should
- didnt     -> didn't

@pgRouting/admins