### PR TITLE
correct online documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Postgresql 9.1+
 
 ## USAGE
 
-See online documentation: http://docs.pgrouting.org/en/2.2/doc/index.html
+See online documentation: http://docs.pgrouting.org/2.2/en/doc/index.html
 
 
 ## LICENSE


### PR DESCRIPTION
Fixes Readme.md online documentation link

@pgRouting/admins

http://docs.pgrouting.org/2.2/en/doc/index.html instead of http://docs.pgrouting.org/en/2.2/doc/index.html