### PR TITLE
Part fix for PostgreSQL 9.6 compile issue #549. Replace heap_formtupl…

### DIFF
--- a/#.gitignore#
+++ b/#.gitignore#
@@ -1,0 +1,10 @@
+# default build directory
+build
+src/turnRestricted
+.DS_Store
+.vagrant
+issues
+tools/vagrant/packaging.sh
+*.mo
+.directory
+notUsed

--- a/src/allpairs/src/floydWarshall.c
+++ b/src/allpairs/src/floydWarshall.c
@@ -190,7 +190,7 @@ floydWarshall(PG_FUNCTION_ARGS) {
         nulls[2] = ' ';
         /*********************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/allpairs/src/johnson.c
+++ b/src/allpairs/src/johnson.c
@@ -183,7 +183,7 @@ johnson(PG_FUNCTION_ARGS) {
 
         /*********************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/alpha_shape/src/alpha.c
+++ b/src/alpha_shape/src/alpha.c
@@ -387,7 +387,7 @@ Datum alphashape(PG_FUNCTION_ARGS)
 	
       PGR_DBG("Heap making\n");
 
-      tuple = heap_formtuple(tuple_desc, values, nulls);
+      tuple = heap_form_tuple(tuple_desc, values, nulls);
 
       PGR_DBG("Datum making\n");
 

--- a/src/astar/src/astarManyToMany.c
+++ b/src/astar/src/astarManyToMany.c
@@ -275,7 +275,7 @@ astarManyToMany(PG_FUNCTION_ARGS) {
 
         /*******************************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/astar/src/astarManyToOne.c
+++ b/src/astar/src/astarManyToOne.c
@@ -266,7 +266,7 @@ astarManyToOne(PG_FUNCTION_ARGS) {
 
         /*******************************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/astar/src/astarOneToMany.c
+++ b/src/astar/src/astarOneToMany.c
@@ -265,7 +265,7 @@ astarOneToMany(PG_FUNCTION_ARGS) {
 
         /*******************************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/astar/src/astarOneToOne.c
+++ b/src/astar/src/astarOneToOne.c
@@ -254,7 +254,7 @@ astarOneToOne(PG_FUNCTION_ARGS) {
         values[5] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
         /*******************************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/bd_astar/src/bdastar.c
+++ b/src/bd_astar/src/bdastar.c
@@ -475,7 +475,7 @@ bidir_astar_shortest_path(PG_FUNCTION_ARGS)
 
       PGR_DBG("Heap making\n");
 
-      tuple = heap_formtuple(tuple_desc, values, nulls);
+      tuple = heap_form_tuple(tuple_desc, values, nulls);
 
       PGR_DBG("Datum making\n");
 

--- a/src/bd_dijkstra/src/bdsp.c
+++ b/src/bd_dijkstra/src/bdsp.c
@@ -405,7 +405,7 @@ bidir_dijkstra_shortest_path(PG_FUNCTION_ARGS)
       values[3] = Float8GetDatum(path[call_cntr].cost);
       nulls[3] = ' ';
 
-      tuple = heap_formtuple(tuple_desc, values, nulls);
+      tuple = heap_form_tuple(tuple_desc, values, nulls);
 
       // make the tuple into a datum 
       result = HeapTupleGetDatum(tuple);

--- a/src/dijkstra/src/dijkstraVia.c
+++ b/src/dijkstra/src/dijkstraVia.c
@@ -221,7 +221,7 @@ dijkstraVia(PG_FUNCTION_ARGS) {
 
         /*******************************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/dijkstra/src/many_to_many_dijkstra.c
+++ b/src/dijkstra/src/many_to_many_dijkstra.c
@@ -233,7 +233,7 @@ many_to_many_dijkstra(PG_FUNCTION_ARGS) {
         values[7] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
         /*********************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/dijkstra/src/many_to_one_dijkstra.c
+++ b/src/dijkstra/src/many_to_one_dijkstra.c
@@ -225,7 +225,7 @@ many_to_one_dijkstra(PG_FUNCTION_ARGS) {
         values[6] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
         /*********************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/dijkstra/src/one_to_many_dijkstra.c
+++ b/src/dijkstra/src/one_to_many_dijkstra.c
@@ -225,7 +225,7 @@ one_to_many_dijkstra(PG_FUNCTION_ARGS) {
         values[6] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
         /*********************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/dijkstra/src/one_to_one_dijkstra.c
+++ b/src/dijkstra/src/one_to_one_dijkstra.c
@@ -218,7 +218,7 @@ one_to_one_dijkstra(PG_FUNCTION_ARGS) {
         values[5] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
         /**********************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/driving_distance/src/drivedist.c
+++ b/src/driving_distance/src/drivedist.c
@@ -174,7 +174,7 @@ driving_distance(PG_FUNCTION_ARGS) {
       values[3] = Float8GetDatum(ret_path[call_cntr].cost);
       values[4] = Float8GetDatum(ret_path[call_cntr].agg_cost);
 
-      tuple = heap_formtuple(tuple_desc, values, nulls);
+      tuple = heap_form_tuple(tuple_desc, values, nulls);
 
       /* make the tuple into a datum */
       result = HeapTupleGetDatum(tuple);

--- a/src/driving_distance/src/many_to_dist_driving_distance.c
+++ b/src/driving_distance/src/many_to_dist_driving_distance.c
@@ -176,7 +176,7 @@ driving_many_to_dist(PG_FUNCTION_ARGS) {
         values[4] = Float8GetDatum(ret_path[call_cntr].cost);
         values[5] = Float8GetDatum(ret_path[call_cntr].agg_cost);
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
 
         /* make the tuple into a datum */
         result = HeapTupleGetDatum(tuple);

--- a/src/driving_distance/src/many_to_dist_withPointsDD.c
+++ b/src/driving_distance/src/many_to_dist_withPointsDD.c
@@ -251,7 +251,7 @@ many_withPointsDD(PG_FUNCTION_ARGS) {
         values[4] = Float8GetDatum(result_tuples[call_cntr].cost);
         values[5] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
 
         /* make the tuple into a datum */
         result = HeapTupleGetDatum(tuple);

--- a/src/driving_distance/src/withPoints_dd.c
+++ b/src/driving_distance/src/withPoints_dd.c
@@ -258,7 +258,7 @@ withPoints_dd(PG_FUNCTION_ARGS) {
         values[4] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
         /*******************************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/ksp/src/withPoints_ksp.c
+++ b/src/ksp/src/withPoints_ksp.c
@@ -269,7 +269,7 @@ withPoints_ksp(PG_FUNCTION_ARGS) {
         values[6] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
         /*******************************************************************************/
 
-        tuple =heap_formtuple(tuple_desc, values, nulls);
+        tuple =heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/pickDeliver/src/pdp.c
+++ b/src/pickDeliver/src/pdp.c
@@ -152,7 +152,7 @@ vrppdtw(PG_FUNCTION_ARGS) {
         values[1] = Int64GetDatum(results[call_cntr].rid);
         values[2] = Int64GetDatum(results[call_cntr].nid);
         values[3] = Float8GetDatum(results[call_cntr].cost);
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
 
         /* make the tuple into a datum */
         result = HeapTupleGetDatum(tuple);

--- a/src/shooting_star/src/shooting_star.c
+++ b/src/shooting_star/src/shooting_star.c
@@ -555,7 +555,7 @@ shortest_path_shooting_star(PG_FUNCTION_ARGS)
       values[3] = Float8GetDatum(path[call_cntr].cost);
       nulls[3] = ' ';
   
-      tuple = heap_formtuple(tuple_desc, values, nulls);
+      tuple = heap_form_tuple(tuple_desc, values, nulls);
   
       /* make the tuple into a datum */
       result = HeapTupleGetDatum(tuple);

--- a/src/trsp/src/trsp.c
+++ b/src/trsp/src/trsp.c
@@ -326,7 +326,7 @@ turn_restrict_shortest_path_vertex(PG_FUNCTION_ARGS)
         values[3] = Float8GetDatum(path[call_cntr].cost);
         nulls[3] = ' ';
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
 
         // make the tuple into a datum 
         result = HeapTupleGetDatum(tuple);
@@ -475,7 +475,7 @@ turn_restrict_shortest_path_edge(PG_FUNCTION_ARGS)
         values[3] = Float8GetDatum(path[call_cntr].cost);
         nulls[3] = ' ';
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
 
         // make the tuple into a datum 
         result = HeapTupleGetDatum(tuple);

--- a/src/tsp/src/OBSOLETE/tsp.c
+++ b/src/tsp/src/OBSOLETE/tsp.c
@@ -516,7 +516,7 @@ tsp(PG_FUNCTION_ARGS)
 
       DBG("Heap making");
 
-      tuple = heap_formtuple(tuple_desc, values, nulls);
+      tuple = heap_form_tuple(tuple_desc, values, nulls);
 
       DBG("Datum making");
 

--- a/src/tsp/src/tsp2.c
+++ b/src/tsp/src/tsp2.c
@@ -314,7 +314,7 @@ tsp_matrix(PG_FUNCTION_ARGS)
 
         PGR_DBG("Heap making");
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
 
         PGR_DBG("Datum making");
 

--- a/src/tsp/src/xyd_tsp.c
+++ b/src/tsp/src/xyd_tsp.c
@@ -195,7 +195,7 @@ xyd_tsp(PG_FUNCTION_ARGS) {
         values[3] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
         /**********************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/vrp_basic/src/VRP.c
+++ b/src/vrp_basic/src/VRP.c
@@ -883,7 +883,7 @@ vrp(PG_FUNCTION_ARGS)
 
 		// PGR_DBG("Heap making\n");
 		//elog(NOTICE,"Result %d %d %d", call_cntr, path[call_cntr].order_id, max_calls);
-		tuple = heap_formtuple(tuple_desc, values, nulls);
+		tuple = heap_form_tuple(tuple_desc, values, nulls);
 
 		//PGR_DBG("Datum making\n");
 

--- a/src/vrppdtw/src/pdp.c
+++ b/src/vrppdtw/src/pdp.c
@@ -452,7 +452,7 @@ vrppdtw(PG_FUNCTION_ARGS)
                 nulls[2] = ' ';
                 values[3] = Int32GetDatum(results[call_cntr].cost);
                 nulls[3] = ' ';
-                tuple = heap_formtuple(tuple_desc, values, nulls);
+                tuple = heap_form_tuple(tuple_desc, values, nulls);
 
                 /* make the tuple into a datum */
                 result = HeapTupleGetDatum(tuple);

--- a/src/withPoints/src/many_to_many_withPoints.c
+++ b/src/withPoints/src/many_to_many_withPoints.c
@@ -269,7 +269,7 @@ many_to_many_withPoints(PG_FUNCTION_ARGS) {
         values[7] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
         /*******************************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/withPoints/src/many_to_one_withPoints.c
+++ b/src/withPoints/src/many_to_one_withPoints.c
@@ -256,7 +256,7 @@ many_to_one_withPoints(PG_FUNCTION_ARGS) {
         values[6] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
         /*******************************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/withPoints/src/one_to_many_withPoints.c
+++ b/src/withPoints/src/one_to_many_withPoints.c
@@ -312,7 +312,7 @@ one_to_many_withPoints(PG_FUNCTION_ARGS) {
         values[6] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
         /*******************************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/src/withPoints/src/one_to_one_withPoints.c
+++ b/src/withPoints/src/one_to_one_withPoints.c
@@ -296,7 +296,7 @@ one_to_one_withPoints(PG_FUNCTION_ARGS) {
         values[5] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
         /*******************************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {

--- a/tools/template/src/function1.c
+++ b/tools/template/src/function1.c
@@ -235,7 +235,7 @@ MY_FUNCTION_NAME(PG_FUNCTION_ARGS) {
         values[7] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
         /*******************************************************************************/
 
-        tuple = heap_formtuple(tuple_desc, values, nulls);
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
         SRF_RETURN_NEXT(funcctx, result);
     } else {


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
heap_formtuple should have been removed ages ago and replaced with heap_form_tuple.
heap_formtuple was deprecated in 2008 and finally removed in PostgreSQL 9.6 develop

@pgRouting/admins

…e with heap_form_tuple.  Refer to http://www.postgresql.org/message-id/CAM3SWZTXu9LfUx7SR3XN+s2Dos+1Y+pP3E0qgGb5h1Ei89GUEw@mail.gmail.com . heap_formtuple was deprecated in 2008 and removed in PostgreSQL 9.6