### PR TITLE
Include math.h for ceil() to fix build failure.

### DIFF
--- a/src/vrp_basic/src/VRP_Solver.h
+++ b/src/vrp_basic/src/VRP_Solver.h
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <map>
 #include <utility>
 #include <string>
+#include <math.h>
 
 #define MAXIMUM_TRY 15
 #define TOTAL_NUMBER_OF_SEARCH 15


### PR DESCRIPTION
Fixes build failure of pgRouting 2.2.3:
```
src/vrp_basic/src/VRP_Solver.cpp: In member function 'bool CVRPSolver::updateTourCosts(CTourInfo&)':
src/vrp_basic/src/VRP_Solver.cpp:760:59: error: 'ceil' was not declared in this scope
  vecStartTimes.push_back(static_cast<int>(ceil(dTravelTime)));
                                                           ^
```

Changes proposed in this pull request:
- Restore `#include <math.h>` that was removed in 2.2.3

@pgRouting/admins