### PR TITLE
Include stdlib.h for srand() and rand() to fix build failure

### DIFF
--- a/src/vrp_basic/src/VRP_Solver.h
+++ b/src/vrp_basic/src/VRP_Solver.h
@@ -29,6 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <utility>
 #include <string>
 #include <math.h>
+#include <stdlib.h>
 
 #define MAXIMUM_TRY 15
 #define TOTAL_NUMBER_OF_SEARCH 15


### PR DESCRIPTION
Some platforms require `stdlib.h` for `rand()` and `srand()` while others include `stdlib.h` implicitly, so always include to be safe.