### PR TITLE
Fix bogus uses of extern "C"

### DIFF
--- a/src/bd_astar/src/bdastar.h
+++ b/src/bd_astar/src/bdastar.h
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
 
   int bdastar_wrapper(edge_astar_t *edges, size_t count, int maxnode,
@@ -39,7 +39,7 @@ extern "C"
                   bool directed, bool has_reverse_cost,
                   path_element_t **path, size_t *path_count, char **err_msg);
 #ifdef __cplusplus
-extern "C"
+}
 #endif
 
 #endif

--- a/src/pickDeliver/src/pdp.h
+++ b/src/pickDeliver/src/pdp.h
@@ -53,7 +53,7 @@ typedef struct  {
 
 
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
 int64_t Solver(Customer *c,
         size_t total_tuples,
@@ -64,6 +64,6 @@ int64_t Solver(Customer *c,
         size_t *length_results);
 
 #ifdef __cplusplus
-extern "C"
+}
 #endif
 

--- a/src/vrp_basic/src/VRP.h
+++ b/src/vrp_basic/src/VRP.h
@@ -70,7 +70,7 @@ typedef struct vrp_result_element
 
 
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
 
 int find_vrp_solution(vrp_vehicles_t *vehicles, size_t vehicle_count, 
@@ -80,7 +80,7 @@ int find_vrp_solution(vrp_vehicles_t *vehicles, size_t vehicle_count,
 					  vrp_result_element_t **result, size_t *result_count, char **err_msg);
 
 #ifdef __cplusplus
-extern "C"
+}
 #endif
 
 #endif

--- a/src/vrppdtw/src/pdp.h
+++ b/src/vrppdtw/src/pdp.h
@@ -168,12 +168,12 @@ typedef struct PathElement {
 
 
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
 int Solver(customer *c, int total_tuples, int vehicle_count, int capacity , char **msg, path_element **results, int *length_results);
 
 #ifdef __cplusplus
-extern "C"
+}
 #endif
 
 


### PR DESCRIPTION
Fixes #653.

Changes proposed in this pull request:
- Fix bogus uses of extern "C" in headers that are meant to be C++ compatible.

@pgRouting/admins

