### PR TITLE
Fix 'expection' typo, replace with 'exception'.

### DIFF
--- a/src/allpairs/src/floydWarshall_driver.cpp
+++ b/src/allpairs/src/floydWarshall_driver.cpp
@@ -88,7 +88,7 @@ do_pgr_floydWarshall(
 #endif
     return;
   } catch ( ... ) {
-    log << "Caught unknown expection!\n";
+    log << "Caught unknown exception!\n";
     *err_msg = strdup(log.str().c_str());
     *postgres_rows = NULL;
     *result_tuple_count = 0;

--- a/src/allpairs/src/johnson_driver.cpp
+++ b/src/allpairs/src/johnson_driver.cpp
@@ -95,7 +95,7 @@ do_pgr_johnson(
       *err_msg = strdup(log.str().c_str());
     #endif
   } catch ( ... ) {
-    log << "Caught unknown expection!\n";
+    log << "Caught unknown exception!\n";
     *err_msg = strdup(log.str().c_str());
   }
 }

--- a/src/alpha_shape/src/alpha_drivedist.cpp
+++ b/src/alpha_shape/src/alpha_drivedist.cpp
@@ -294,7 +294,7 @@ int alpha_shape(vertex_t *vertices, size_t count, double alpha,
 
   return EXIT_SUCCESS;
     } catch ( ... ) {
-        *err_msg = strdup("Caught unknown expection!");
+        *err_msg = strdup("Caught unknown exception!");
     }
         return -1;
 

--- a/src/dijkstra/src/dijkstraVia_driver.cpp
+++ b/src/dijkstra/src/dijkstraVia_driver.cpp
@@ -232,7 +232,7 @@ do_pgr_dijkstraViaVertex(
         *err_msg = strdup(log.str().c_str());
 #endif
     } catch ( ... ) {
-        log << "Caught unknown expection!\n";
+        log << "Caught unknown exception!\n";
         *err_msg = strdup(log.str().c_str());
     }
 }

--- a/src/dijkstra/src/many_to_many_dijkstra_driver.cpp
+++ b/src/dijkstra/src/many_to_many_dijkstra_driver.cpp
@@ -119,7 +119,7 @@ do_pgr_many_to_many_dijkstra(
 
         return;
     } catch ( ... ) {
-        log << "Caught unknown expection!\n";
+        log << "Caught unknown exception!\n";
         *err_msg = strdup(log.str().c_str());
         return;
     }

--- a/src/dijkstra/src/many_to_one_dijkstra_driver.cpp
+++ b/src/dijkstra/src/many_to_one_dijkstra_driver.cpp
@@ -114,7 +114,7 @@ do_pgr_many_to_one_dijkstra(
 
         return;
     } catch ( ... ) {
-        log << "Caught unknown expection!\n";
+        log << "Caught unknown exception!\n";
         *err_msg = strdup(log.str().c_str());
         return;
     }

--- a/src/dijkstra/src/one_to_many_dijkstra_driver.cpp
+++ b/src/dijkstra/src/one_to_many_dijkstra_driver.cpp
@@ -106,8 +106,8 @@ do_pgr_one_to_many_dijkstra(
 
     return;
   } catch ( ... ) {
-      log << "Caught unknown expection!\n";
-      *err_msg = strdup("Caught unknown expection!\n");
+      log << "Caught unknown exception!\n";
+      *err_msg = strdup("Caught unknown exception!\n");
       return;
   }
 }

--- a/src/dijkstra/src/one_to_one_dijkstra_driver.cpp
+++ b/src/dijkstra/src/one_to_one_dijkstra_driver.cpp
@@ -108,7 +108,7 @@ do_pgr_one_to_one_dijkstra(
 
       return;
   } catch ( ... ) {
-      log << "Caught unknown expection!\n";
+      log << "Caught unknown exception!\n";
       *err_msg = strdup(log.str().c_str());
       return;
   }

--- a/src/driving_distance/src/boost_interface_drivedist.cpp
+++ b/src/driving_distance/src/boost_interface_drivedist.cpp
@@ -90,7 +90,7 @@ do_pgr_driving_many_to_dist(
         return;
 
     } catch ( ... ) {
-        *err_msg = strdup("Caught unknown expection!");
+        *err_msg = strdup("Caught unknown exception!");
         *ret_path = noResult(path_count, (*ret_path));
         return;
     }

--- a/src/driving_distance/src/withPoints_dd_driver.cpp
+++ b/src/driving_distance/src/withPoints_dd_driver.cpp
@@ -178,7 +178,7 @@ do_pgr_many_withPointsDD(
         return 0;
 
     } catch ( ... ) {
-        *err_msg = strdup("Caught unknown expection!");
+        *err_msg = strdup("Caught unknown exception!");
         return 1000;
     }
 
@@ -316,7 +316,7 @@ do_pgr_withPointsDD(
 #endif
         return 0;
     } catch ( ... ) {
-        log << "Caught unknown expection!\n";
+        log << "Caught unknown exception!\n";
         *err_msg = strdup(log.str().c_str());
     }
     return 1000;

--- a/src/ksp/src/ksp_driver.cpp
+++ b/src/ksp/src/ksp_driver.cpp
@@ -102,7 +102,7 @@ int  do_pgr_ksp(
 #endif
         return EXIT_SUCCESS;
     } catch ( ... ) {
-        *err_msg = strdup("Caught unknown expection!");
+        *err_msg = strdup("Caught unknown exception!");
         return -1;
     }
 }

--- a/src/ksp/src/withPoints_ksp_driver.cpp
+++ b/src/ksp/src/withPoints_ksp_driver.cpp
@@ -166,7 +166,7 @@ do_pgr_withPointsKsp(
 #endif
         return 0;
     } catch ( ... ) {
-        log << "Caught unknown expection!\n";
+        log << "Caught unknown exception!\n";
         *err_msg = strdup(log.str().c_str());
     }
     return 1000;

--- a/src/withPoints/src/many_to_many_withPoints_driver.cpp
+++ b/src/withPoints/src/many_to_many_withPoints_driver.cpp
@@ -201,7 +201,7 @@ do_pgr_many_to_many_withPoints(
 #endif
         return 0;
     } catch ( ... ) {
-        log << "Caught unknown expection!\n";
+        log << "Caught unknown exception!\n";
         *err_msg = strdup(log.str().c_str());
         return 1000;
     }

--- a/src/withPoints/src/many_to_one_withPoints_driver.cpp
+++ b/src/withPoints/src/many_to_one_withPoints_driver.cpp
@@ -164,7 +164,7 @@ do_pgr_many_to_one_withPoints(
 #endif
         return 0;
     } catch ( ... ) {
-        log << "Caught unknown expection!\n";
+        log << "Caught unknown exception!\n";
         *err_msg = strdup(log.str().c_str());
         return 1000;
     }

--- a/src/withPoints/src/one_to_many_withPoints_driver.cpp
+++ b/src/withPoints/src/one_to_many_withPoints_driver.cpp
@@ -189,7 +189,7 @@ do_pgr_one_to_many_withPoints(
 #endif
         return 0;
     } catch ( ... ) {
-        log << "Caught unknown expection!\n";
+        log << "Caught unknown exception!\n";
         *err_msg = strdup(log.str().c_str());
         return 1000;
     }

--- a/src/withPoints/src/one_to_one_withPoints_driver.cpp
+++ b/src/withPoints/src/one_to_one_withPoints_driver.cpp
@@ -169,7 +169,7 @@ do_pgr_withPoints(
 #endif
         return 0;
     } catch ( ... ) {
-        log << "Caught unknown expection!\n";
+        log << "Caught unknown exception!\n";
         *err_msg = strdup(log.str().c_str());
     }
     return 1000;

--- a/tools/template/src/function1_driver.cpp
+++ b/tools/template/src/function1_driver.cpp
@@ -123,7 +123,7 @@ do_pgr_MY_FUNCTION_NAME(
         *err_msg = strdup(log.str().c_str());
 #endif
     } catch ( ... ) {
-        log << "Caught unknown expection!\n";
+        log << "Caught unknown exception!\n";
         *err_msg = strdup(log.str().c_str());
     }
 }


### PR DESCRIPTION
The spelling error was reported by the lintian QA tool for the most recent Debian package build.

@pgRouting/admins

