### PR TITLE
Fixing petite bug in contractGraph.c

### DIFF
--- a/src/contraction/src/contractGraph.c
+++ b/src/contraction/src/contractGraph.c
@@ -185,7 +185,7 @@ contractGraph(PG_FUNCTION_ARGS) {
         HeapTuple   tuple;
         Datum       result;
         Datum       *values;
-        char        *nulls;
+        bool        *nulls;
         int16 typlen;
         size_t      call_cntr = funcctx->call_cntr;
 


### PR DESCRIPTION
Changes proposed in this pull request:
- This commit fixes a petite bug in contractGraph.c file in contraction directory.  
- Replaced `char` in `char *nulls;` with `bool` on line number 188

@pgRouting/admins
