### PR TITLE
Fix compiling issues with musl libc

### DIFF
--- a/src/common/src/pgr_assert.cpp
+++ b/src/common/src/pgr_assert.cpp
@@ -15,7 +15,7 @@
 #include <stdlib.h>
 #include <stddef.h>
 
-#ifdef __linux__
+#ifdef __GLIBC__
 #include <execinfo.h>
 #endif
 
@@ -24,7 +24,7 @@
 
 
 std::string get_backtrace() {
-#ifdef __linux__
+#ifdef __GLIBC__
         void *trace[16];
         int i, trace_size = 0;
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Replace `__linux__` with `__GLIBC__` for glibc-specific headers and functions.

@pgRouting/admins
