### PR TITLE
LineGraphFull documentation fixes

### DIFF
--- a/doc/lineGraph/pgr_lineGraphFull.rst
+++ b/doc/lineGraph/pgr_lineGraphFull.rst
@@ -26,6 +26,7 @@ pgr_lineGraphFull, converts original directed graph to a directed line graph by 
 A possible application of the resulting graph is "routing with two edge restrictions":
   - Setting a cost of using the vertex when routing between edges on the connecting edge
   - Forbid the routing between two edges by removing the connecting edge
+
 This is possible because each of the intersections (vertices) in the original graph are now complete graphs that have a new edge for each possible turn across that intersection.
 
 Characteristics

--- a/doc/lineGraph/pgr_lineGraphFull.rst
+++ b/doc/lineGraph/pgr_lineGraphFull.rst
@@ -130,20 +130,54 @@ In the transformed graph, all of the edges from the original graph are still pre
 Example for creating table that identifies transformed vertices
 -----------------------------------------------------------------------------
  
-The vertices in the transformed graph are each created by splitting up the vertices in the original graph. Unless a vertex in the original graph is a leaf vertex, it will generate more than one vertex in the transformed graph. One of the newly created vertices in the transformed graph will have the same vertex-id as the vertex that it was created from in the original graph, but the rest of the newly created vertices will have negative vertex ids. Following is an example of how to generate a table that maps the ids of the newly created vertices with the original vertex that they were created from.
+The vertices in the transformed graph are each created by splitting up the vertices in the original graph. Unless a vertex in the original graph is a leaf vertex, it will generate more than one vertex in the transformed graph. One of the newly created vertices in the transformed graph will be given the same vertex-id as the vertex that it was created from in the original graph, but the rest of the newly created vertices will have negative vertex ids. Following is an example of how to generate a table that maps the ids of the newly created vertices with the original vertex that they were created from
+
+The first step is to store your results graph into a table and then create the vertex mapping table with one row for each distinct vertex id in the results graph.
 
 .. literalinclude:: doc-pgr_lineGraphFull.queries
    :start-after: -- q2
    :end-before: -- q3
+
+Next, we set the original_id of all of the vertices in the results graph that were given the same vertex id as the vertex that it was created from in the original graph.
+
+.. literalinclude:: doc-pgr_lineGraphFull.queries
+   :start-after: -- q3
+   :end-before: -- q4
+
+Then, we cross reference all of the other newly created vertices that do not have the same original_id and set thier original_id values. 
+
+.. literalinclude:: doc-pgr_lineGraphFull.queries
+   :start-after: -- q4
+   :end-before: -- q5
+
+The only vertices left that have not been mapped are a few of the leaf vertices from the original graph. The following sql completes the mapping for these leaf vertices (in the case of this example graph there are no leaf vertices but this is nessessary for larger graphs).
+
+.. literalinclude:: doc-pgr_lineGraphFull.queries
+   :start-after: -- q5
+   :end-before: -- q6
+
+Now our vertex mapping table is complete:
+
+.. literalinclude:: doc-pgr_lineGraphFull.queries
+   :start-after: -- q6
+   :end-before: -- q7
 
 Example for running a dijkstra's shortest path with turn penalties
 -----------------------------------------------------------------------------
 
 One use case for this graph transformation is to be able to run a shortest path search that takes into account the cost or limitation of turning. Below is an example of running a dijkstra's shortest path from vertex 2 to vertex 8 in the original graph, while adding a turn penalty cost of 100 to the turn from edge 4 to edge -7.
 
+First we must increase set the cost of making the turn to 100:
+
 .. literalinclude:: doc-pgr_lineGraphFull.queries
-   :start-after: -- q3
-   :end-before: -- q4
+   :start-after: -- q7
+   :end-before: -- q8
+
+Then we must run a dijkstra's shortest path search using all of the vertices in the new graph that were created from vertex 2 as the starting point, and all of the vertices in the new graph that were created from vertex 8 as the ending point.
+
+.. literalinclude:: doc-pgr_lineGraphFull.queries
+   :start-after: -- q8
+   :end-before: -- q9
 
 Normally the shortest path from vertex 2 to vertex 8 would have an aggregate cost of 2, but since there is a large penalty for making the turn needed to get this cost, the route goes through vertex 6 to avoid this turn.
 

--- a/doc/queries/doc-pgr_lineGraphFull.queries
+++ b/doc/queries/doc-pgr_lineGraphFull.queries
@@ -8,7 +8,7 @@ SELECT * FROM pgr_lineGraphFull(
       FROM edge_table
       WHERE id IN (4,7,8,10)'
 );
- seq | source | target | cost | edge 
+ seq | source | target | cost | edge
 -----+--------+--------+------+------
    1 |     -1 |      5 |    1 |    4
    2 |      2 |     -1 |    0 |    0
@@ -41,112 +41,113 @@ SELECT * FROM pgr_lineGraphFull(
 (28 rows)
 
 -- q2
-// Generate the Line Graph Full result table
-CREATE TABLE result2 AS SELECT * FROM pgr_lineGraphFull(
+CREATE TABLE lineGraph_edges AS SELECT * FROM pgr_lineGraphFull(
     $$SELECT id, source, target, cost, reverse_cost
     FROM edge_table WHERE id IN (4,7,8,10)$$
 );
-
-// Create a table for mapping the new vertices to the original vertices
-CREATE TABLE result2_vertices_pgr AS
+SELECT 28
+CREATE TABLE lineGraph_vertices AS
 SELECT *, NULL::BIGINT AS original_id
-FROM (SELECT source AS id FROM result2
+FROM (SELECT source AS id FROM lineGraph_edges
     UNION
-    SELECT target FROM result2) as foo
+    SELECT target FROM lineGraph_edges) as foo
 ORDER BY id;
-
-// Populate the vertex mapping table
-UPDATE result2_vertices_pgr AS r
+SELECT 16
+-- q3
+UPDATE lineGraph_vertices AS r
   SET original_id = v.id
   FROM edge_table_vertices_pgr AS v
   WHERE v.id = r.id;
-
+UPDATE 5
+-- q4
 WITH
 a AS (SELECT e.id, e.original_id
-       FROM result2_vertices_pgr AS e
+       FROM lineGraph_vertices AS e
        WHERE original_id IS NOT NULL),
 b AS (SELECT *
-        FROM result2
+        FROM lineGraph_edges
         WHERE cost = 0 and source IN (SELECT id FROM a)),
 c AS (SELECT *
         FROM b
-        JOIN result2_vertices_pgr
+        JOIN lineGraph_vertices
         ON(source = id)),
 d AS (SELECT c.source, v.original_id
         FROM c
-        JOIN result2_vertices_pgr as v
+        JOIN lineGraph_vertices as v
         ON (target=v.id)),
 e AS (SELECT DISTINCT c.target, c.original_id
         FROM c
-        JOIN result2_vertices_pgr AS r
+        JOIN lineGraph_vertices AS r
         ON(target = r.id AND r.original_id IS NULL))
-UPDATE result2_vertices_pgr
+UPDATE lineGraph_vertices
   SET original_id = e.original_id
   FROM e
   WHERE e.target = id;
-
+UPDATE 8
 WITH
 a AS (SELECT e.id, e.original_id
-        FROM result2_vertices_pgr AS e
+        FROM lineGraph_vertices AS e
         WHERE original_id IS NOT NULL),
 b AS (SELECT *
-        FROM result2
+        FROM lineGraph_edges
         WHERE cost = 0 and target IN (SELECT id FROM a)),
 c AS (SELECT *
         FROM b
-        JOIN result2_vertices_pgr
+        JOIN lineGraph_vertices
         ON(target = id)),
 d AS (SELECT c.target, v.original_id
         FROM c
-        JOIN result2_vertices_pgr as v
+        JOIN lineGraph_vertices as v
         ON (source=v.id)),
 e AS (SELECT DISTINCT c.source, c.original_id
         FROM c
-        JOIN result2_vertices_pgr AS r
+        JOIN lineGraph_vertices AS r
         ON(source = r.id AND r.original_id IS NULL))
-UPDATE result2_vertices_pgr
+UPDATE lineGraph_vertices
   SET original_id = e.original_id
   FROM e
   WHERE e.source = id;
-
+UPDATE 3
+-- q5
 WITH
 a AS (SELECT id
-        FROM result2_vertices_pgr
+        FROM lineGraph_vertices
         WHERE original_id IS NULL),
 b AS (SELECT source,edge
-        FROM result2
+        FROM lineGraph_edges
         WHERE source IN (SELECT id FROM a)),
 c AS (SELECT id,source
         FROM edge_table
         WHERE id IN (SELECT edge FROM b))
-UPDATE result2_vertices_pgr AS d
+UPDATE lineGraph_vertices AS d
   SET original_id = (SELECT source
                        FROM c
                        WHERE c.id = (SELECT edge
                                        FROM b
                                        WHERE b.source = d.id))
   WHERE id IN (SELECT id FROM a);
-
+UPDATE 0
 WITH
 a AS (SELECT id
-        FROM result2_vertices_pgr
+        FROM lineGraph_vertices
         WHERE original_id IS NULL),
 b AS (SELECT target,edge
-        FROM result2
+        FROM lineGraph_edges
         WHERE target IN (SELECT id FROM a)),
 c AS (SELECT id,target
         FROM edge_table
         WHERE id IN (SELECT edge FROM b))
-UPDATE result2_vertices_pgr AS d
+UPDATE lineGraph_vertices AS d
   SET original_id = (SELECT target
                        FROM c
                        WHERE c.id = (SELECT edge
                                        FROM b
                                        WHERE b.target = d.id))
   WHERE id IN (SELECT id FROM a);
-
-SELECT * FROM result2_vertices_pgr;
- id  | original_id 
+UPDATE 0
+-- q6
+SELECT * FROM lineGraph_vertices;
+ id  | original_id
 -----+-------------
    2 |           2
    5 |           5
@@ -166,27 +167,24 @@ SELECT * FROM result2_vertices_pgr;
   -6 |           5
 (16 rows)
 
--- q3
-// Set the cost of turning from edge 5 to edge -8 to 100
-UPDATE result2
+-- q7
+UPDATE lineGraph_edges
   SET cost = 100
   WHERE source IN (SELECT target
-                     FROM result2
+                     FROM lineGraph_edges
                      WHERE edge = 4) AND target IN (SELECT source
-                                                      FROM result2
+                                                      FROM lineGraph_edges
                                                       WHERE edge = -7);
-
-// Run a dijkstra's shortest path search using all of the vertices
-// created from vertex 3 in the original graph as the starting point
-// and all of the vertices created from vertex 5 as the ending point
+UPDATE 1
+-- q8
 SELECT * FROM
   (SELECT * FROM
-    (SELECT * FROM pgr_dijkstra($$SELECT seq AS id, * FROM result2$$,
-      (SELECT array_agg(id) FROM result2_vertices_pgr where original_id = 2),
-      (SELECT array_agg(id) FROM result2_vertices_pgr where original_id = 8)
+    (SELECT * FROM pgr_dijkstra($$SELECT seq AS id, * FROM lineGraph_edges$$,
+      (SELECT array_agg(id) FROM lineGraph_vertices where original_id = 2),
+      (SELECT array_agg(id) FROM lineGraph_vertices where original_id = 8)
     )) as a
   WHERE start_vid = 2 AND end_vid = 8 AND (cost != 0 OR edge = -1)) as b;
- seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost 
+ seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
 -----+----------+-----------+---------+------+------+------+----------
   29 |        2 |         2 |       8 |   -1 |    1 |    1 |        0
   31 |        4 |         2 |       8 |   -4 |    5 |    1 |        1
@@ -195,6 +193,6 @@ SELECT * FROM
   36 |        9 |         2 |       8 |    8 |   -1 |    0 |        4
 (5 rows)
 
--- q4
+-- q9
 ROLLBACK;
 ROLLBACK

--- a/doc/queries/doc-pgr_lineGraphFull.queries
+++ b/doc/queries/doc-pgr_lineGraphFull.queries
@@ -61,89 +61,99 @@ UPDATE lineGraph_vertices AS r
 UPDATE 5
 -- q4
 WITH
-a AS (SELECT e.id, e.original_id
+unassignedVertices
+  AS (SELECT e.id, e.original_id
        FROM lineGraph_vertices AS e
        WHERE original_id IS NOT NULL),
-b AS (SELECT *
+edgesWithUnassignedSource
+  AS (SELECT *
         FROM lineGraph_edges
-        WHERE cost = 0 and source IN (SELECT id FROM a)),
-c AS (SELECT *
-        FROM b
+        WHERE cost = 0 and source IN (SELECT id FROM unassignedVertices)),
+edgesWithUnassignedSourcePlusVertices
+  AS (SELECT *
+        FROM edgesWithUnassignedSource
         JOIN lineGraph_vertices
         ON(source = id)),
-d AS (SELECT c.source, v.original_id
-        FROM c
-        JOIN lineGraph_vertices as v
-        ON (target=v.id)),
-e AS (SELECT DISTINCT c.target, c.original_id
-        FROM c
+verticesFromEdgesWithUnassignedSource
+  AS (SELECT DISTINCT edgesWithUnassignedSourcePlusVertices.target,
+                      edgesWithUnassignedSourcePlusVertices.original_id
+        FROM edgesWithUnassignedSourcePlusVertices
         JOIN lineGraph_vertices AS r
         ON(target = r.id AND r.original_id IS NULL))
 UPDATE lineGraph_vertices
-  SET original_id = e.original_id
-  FROM e
-  WHERE e.target = id;
+  SET original_id = verticesFromEdgesWithUnassignedSource.original_id
+  FROM verticesFromEdgesWithUnassignedSource
+  WHERE verticesFromEdgesWithUnassignedSource.target = id;
 UPDATE 8
 WITH
-a AS (SELECT e.id, e.original_id
+unassignedVertices
+  AS (SELECT e.id, e.original_id
         FROM lineGraph_vertices AS e
         WHERE original_id IS NOT NULL),
-b AS (SELECT *
+edgesWithUnassignedTarget
+  AS (SELECT *
         FROM lineGraph_edges
-        WHERE cost = 0 and target IN (SELECT id FROM a)),
-c AS (SELECT *
-        FROM b
+        WHERE cost = 0 and target IN (SELECT id FROM unassignedVertices)),
+edgesWithUnassignedTargetPlusVertices
+  AS (SELECT *
+        FROM edgesWithUnassignedTarget
         JOIN lineGraph_vertices
         ON(target = id)),
-d AS (SELECT c.target, v.original_id
-        FROM c
-        JOIN lineGraph_vertices as v
-        ON (source=v.id)),
-e AS (SELECT DISTINCT c.source, c.original_id
-        FROM c
+verticesFromEdgesWithUnassignedTarget
+  AS (SELECT DISTINCT edgesWithUnassignedTargetPlusVertices.source,
+                     edgesWithUnassignedTargetPlusVertices.original_id
+        FROM edgesWithUnassignedTargetPlusVertices
         JOIN lineGraph_vertices AS r
         ON(source = r.id AND r.original_id IS NULL))
 UPDATE lineGraph_vertices
-  SET original_id = e.original_id
-  FROM e
-  WHERE e.source = id;
+  SET original_id = verticesFromEdgesWithUnassignedTarget.original_id
+  FROM verticesFromEdgesWithUnassignedTarget
+  WHERE verticesFromEdgesWithUnassignedTarget.source = id;
 UPDATE 3
 -- q5
 WITH
-a AS (SELECT id
+unassignedVertexIds
+  AS (SELECT id
         FROM lineGraph_vertices
         WHERE original_id IS NULL),
-b AS (SELECT source,edge
+edgesWithUnassignedSource
+  AS (SELECT source,edge
         FROM lineGraph_edges
-        WHERE source IN (SELECT id FROM a)),
-c AS (SELECT id,source
+        WHERE source IN (SELECT id FROM unassignedVertexIds)),
+originalEdgesWithUnassignedSource
+  AS (SELECT id,source
         FROM edge_table
-        WHERE id IN (SELECT edge FROM b))
+        WHERE id IN (SELECT edge FROM edgesWithUnassignedSource))
 UPDATE lineGraph_vertices AS d
   SET original_id = (SELECT source
-                       FROM c
-                       WHERE c.id = (SELECT edge
-                                       FROM b
-                                       WHERE b.source = d.id))
-  WHERE id IN (SELECT id FROM a);
+                       FROM originalEdgesWithUnassignedSource
+                       WHERE originalEdgesWithUnassignedSource.id =
+                         (SELECT edge
+                            FROM edgesWithUnassignedSource
+                            WHERE edgesWithUnassignedSource.source = d.id))
+  WHERE id IN (SELECT id FROM unassignedVertexIds);
 UPDATE 0
 WITH
-a AS (SELECT id
+unassignedVertexIds
+  AS (SELECT id
         FROM lineGraph_vertices
         WHERE original_id IS NULL),
-b AS (SELECT target,edge
+edgesWithUnassignedTarget
+  AS (SELECT target,edge
         FROM lineGraph_edges
-        WHERE target IN (SELECT id FROM a)),
-c AS (SELECT id,target
+        WHERE target IN (SELECT id FROM unassignedVertexIds)),
+originalEdgesWithUnassignedTarget
+  AS (SELECT id,target
         FROM edge_table
-        WHERE id IN (SELECT edge FROM b))
+        WHERE id IN (SELECT edge FROM edgesWithUnassignedTarget))
 UPDATE lineGraph_vertices AS d
   SET original_id = (SELECT target
-                       FROM c
-                       WHERE c.id = (SELECT edge
-                                       FROM b
-                                       WHERE b.target = d.id))
-  WHERE id IN (SELECT id FROM a);
+                       FROM originalEdgesWithUnassignedTarget
+                       WHERE originalEdgesWithUnassignedTarget.id =
+                         (SELECT edge
+                            FROM edgesWithUnassignedTarget
+                            WHERE edgesWithUnassignedTarget.target = d.id))
+  WHERE id IN (SELECT id FROM unassignedVertexIds);
 UPDATE 0
 -- q6
 SELECT * FROM lineGraph_vertices;
@@ -182,7 +192,7 @@ SELECT * FROM
     (SELECT * FROM pgr_dijkstra($$SELECT seq AS id, * FROM lineGraph_edges$$,
       (SELECT array_agg(id) FROM lineGraph_vertices where original_id = 2),
       (SELECT array_agg(id) FROM lineGraph_vertices where original_id = 8)
-    )) as a
+    )) as shortestPaths
   WHERE start_vid = 2 AND end_vid = 8 AND (cost != 0 OR edge = -1)) as b;
  seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
 -----+----------+-----------+---------+------+------+------+----------

--- a/test/lineGraph/doc-pgr_lineGraphFull.result
+++ b/test/lineGraph/doc-pgr_lineGraphFull.result
@@ -61,89 +61,99 @@ UPDATE lineGraph_vertices AS r
 UPDATE 5
 -- q4
 WITH
-a AS (SELECT e.id, e.original_id
+unassignedVertices
+  AS (SELECT e.id, e.original_id
        FROM lineGraph_vertices AS e
        WHERE original_id IS NOT NULL),
-b AS (SELECT *
+edgesWithUnassignedSource
+  AS (SELECT *
         FROM lineGraph_edges
-        WHERE cost = 0 and source IN (SELECT id FROM a)),
-c AS (SELECT *
-        FROM b
+        WHERE cost = 0 and source IN (SELECT id FROM unassignedVertices)),
+edgesWithUnassignedSourcePlusVertices
+  AS (SELECT *
+        FROM edgesWithUnassignedSource
         JOIN lineGraph_vertices
         ON(source = id)),
-d AS (SELECT c.source, v.original_id
-        FROM c
-        JOIN lineGraph_vertices as v
-        ON (target=v.id)),
-e AS (SELECT DISTINCT c.target, c.original_id
-        FROM c
+verticesFromEdgesWithUnassignedSource
+  AS (SELECT DISTINCT edgesWithUnassignedSourcePlusVertices.target,
+                      edgesWithUnassignedSourcePlusVertices.original_id
+        FROM edgesWithUnassignedSourcePlusVertices
         JOIN lineGraph_vertices AS r
         ON(target = r.id AND r.original_id IS NULL))
 UPDATE lineGraph_vertices
-  SET original_id = e.original_id
-  FROM e
-  WHERE e.target = id;
+  SET original_id = verticesFromEdgesWithUnassignedSource.original_id
+  FROM verticesFromEdgesWithUnassignedSource
+  WHERE verticesFromEdgesWithUnassignedSource.target = id;
 UPDATE 8
 WITH
-a AS (SELECT e.id, e.original_id
+unassignedVertices
+  AS (SELECT e.id, e.original_id
         FROM lineGraph_vertices AS e
         WHERE original_id IS NOT NULL),
-b AS (SELECT *
+edgesWithUnassignedTarget
+  AS (SELECT *
         FROM lineGraph_edges
-        WHERE cost = 0 and target IN (SELECT id FROM a)),
-c AS (SELECT *
-        FROM b
+        WHERE cost = 0 and target IN (SELECT id FROM unassignedVertices)),
+edgesWithUnassignedTargetPlusVertices
+  AS (SELECT *
+        FROM edgesWithUnassignedTarget
         JOIN lineGraph_vertices
         ON(target = id)),
-d AS (SELECT c.target, v.original_id
-        FROM c
-        JOIN lineGraph_vertices as v
-        ON (source=v.id)),
-e AS (SELECT DISTINCT c.source, c.original_id
-        FROM c
+verticesFromEdgesWithUnassignedTarget
+  AS (SELECT DISTINCT edgesWithUnassignedTargetPlusVertices.source,
+                     edgesWithUnassignedTargetPlusVertices.original_id
+        FROM edgesWithUnassignedTargetPlusVertices
         JOIN lineGraph_vertices AS r
         ON(source = r.id AND r.original_id IS NULL))
 UPDATE lineGraph_vertices
-  SET original_id = e.original_id
-  FROM e
-  WHERE e.source = id;
+  SET original_id = verticesFromEdgesWithUnassignedTarget.original_id
+  FROM verticesFromEdgesWithUnassignedTarget
+  WHERE verticesFromEdgesWithUnassignedTarget.source = id;
 UPDATE 3
 -- q5
 WITH
-a AS (SELECT id
+unassignedVertexIds
+  AS (SELECT id
         FROM lineGraph_vertices
         WHERE original_id IS NULL),
-b AS (SELECT source,edge
+edgesWithUnassignedSource
+  AS (SELECT source,edge
         FROM lineGraph_edges
-        WHERE source IN (SELECT id FROM a)),
-c AS (SELECT id,source
+        WHERE source IN (SELECT id FROM unassignedVertexIds)),
+originalEdgesWithUnassignedSource
+  AS (SELECT id,source
         FROM edge_table
-        WHERE id IN (SELECT edge FROM b))
+        WHERE id IN (SELECT edge FROM edgesWithUnassignedSource))
 UPDATE lineGraph_vertices AS d
   SET original_id = (SELECT source
-                       FROM c
-                       WHERE c.id = (SELECT edge
-                                       FROM b
-                                       WHERE b.source = d.id))
-  WHERE id IN (SELECT id FROM a);
+                       FROM originalEdgesWithUnassignedSource
+                       WHERE originalEdgesWithUnassignedSource.id =
+                         (SELECT edge
+                            FROM edgesWithUnassignedSource
+                            WHERE edgesWithUnassignedSource.source = d.id))
+  WHERE id IN (SELECT id FROM unassignedVertexIds);
 UPDATE 0
 WITH
-a AS (SELECT id
+unassignedVertexIds
+  AS (SELECT id
         FROM lineGraph_vertices
         WHERE original_id IS NULL),
-b AS (SELECT target,edge
+edgesWithUnassignedTarget
+  AS (SELECT target,edge
         FROM lineGraph_edges
-        WHERE target IN (SELECT id FROM a)),
-c AS (SELECT id,target
+        WHERE target IN (SELECT id FROM unassignedVertexIds)),
+originalEdgesWithUnassignedTarget
+  AS (SELECT id,target
         FROM edge_table
-        WHERE id IN (SELECT edge FROM b))
+        WHERE id IN (SELECT edge FROM edgesWithUnassignedTarget))
 UPDATE lineGraph_vertices AS d
   SET original_id = (SELECT target
-                       FROM c
-                       WHERE c.id = (SELECT edge
-                                       FROM b
-                                       WHERE b.target = d.id))
-  WHERE id IN (SELECT id FROM a);
+                       FROM originalEdgesWithUnassignedTarget
+                       WHERE originalEdgesWithUnassignedTarget.id =
+                         (SELECT edge
+                            FROM edgesWithUnassignedTarget
+                            WHERE edgesWithUnassignedTarget.target = d.id))
+  WHERE id IN (SELECT id FROM unassignedVertexIds);
 UPDATE 0
 -- q6
 SELECT * FROM lineGraph_vertices;
@@ -182,7 +192,7 @@ SELECT * FROM
     (SELECT * FROM pgr_dijkstra($$SELECT seq AS id, * FROM lineGraph_edges$$,
       (SELECT array_agg(id) FROM lineGraph_vertices where original_id = 2),
       (SELECT array_agg(id) FROM lineGraph_vertices where original_id = 8)
-    )) as a
+    )) as shortestPaths
   WHERE start_vid = 2 AND end_vid = 8 AND (cost != 0 OR edge = -1)) as b;
  seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
 -----+----------+-----------+---------+------+------+------+----------

--- a/test/lineGraph/doc-pgr_lineGraphFull.result
+++ b/test/lineGraph/doc-pgr_lineGraphFull.result
@@ -4,44 +4,195 @@ SET client_min_messages TO NOTICE;
 SET
 -- q1
 SELECT * FROM pgr_lineGraphFull(
-    'SELECT id, source, target, cost FROM edge_table'
+    'SELECT id, source, target, cost, reverse_cost
+      FROM edge_table
+      WHERE id IN (4,7,8,10)'
 );
  seq | source | target | cost | edge
 -----+--------+--------+------+------
-   1 |      1 |      2 |    1 |    1
-   2 |     -1 |      5 |    1 |    4
-   3 |      2 |     -1 |    0 |    0
-   4 |     -2 |     -7 |    1 |    8
-   5 |     -3 |     10 |    1 |   10
-   6 |      5 |     -2 |    0 |    0
-   7 |      5 |     -3 |    0 |    0
-   8 |     -4 |     -2 |    0 |    0
-   9 |     -4 |     -3 |    0 |    0
-  10 |      3 |      6 |    1 |    5
-  11 |     -5 |      9 |    1 |    9
-  12 |     -6 |     11 |    1 |   11
-  13 |      6 |     -5 |    0 |    0
-  14 |      6 |     -6 |    0 |    0
-  15 |     -7 |     -5 |    0 |    0
-  16 |     -7 |     -6 |    0 |    0
-  17 |      7 |      8 |    1 |    6
-  18 |     -8 |     -4 |    1 |    7
-  19 |      8 |     -8 |    0 |    0
-  20 |     -9 |    -15 |    1 |   15
-  21 |      9 |     -9 |    0 |    0
-  22 |    -10 |     -9 |    0 |    0
-  23 |    -11 |    -14 |    1 |   12
-  24 |    -12 |     13 |    1 |   14
-  25 |     10 |    -11 |    0 |    0
-  26 |     10 |    -12 |    0 |    0
-  27 |    -13 |     12 |    1 |   13
-  28 |     11 |    -13 |    0 |    0
-  29 |    -14 |    -13 |    0 |    0
-  30 |      4 |    -10 |    1 |   16
-  31 |     14 |     15 |    1 |   17
-  32 |     16 |     17 |    1 |   18
-(32 rows)
+   1 |     -1 |      5 |    1 |    4
+   2 |      2 |     -1 |    0 |    0
+   3 |     -2 |      2 |    1 |   -4
+   4 |     -3 |      8 |    1 |   -7
+   5 |     -4 |      6 |    1 |    8
+   6 |     -5 |     10 |    1 |   10
+   7 |      5 |     -2 |    0 |    0
+   8 |      5 |     -3 |    0 |    0
+   9 |      5 |     -4 |    0 |    0
+  10 |      5 |     -5 |    0 |    0
+  11 |     -6 |     -2 |    0 |    0
+  12 |     -6 |     -3 |    0 |    0
+  13 |     -6 |     -4 |    0 |    0
+  14 |     -6 |     -5 |    0 |    0
+  15 |     -7 |     -2 |    0 |    0
+  16 |     -7 |     -3 |    0 |    0
+  17 |     -7 |     -4 |    0 |    0
+  18 |     -7 |     -5 |    0 |    0
+  19 |     -8 |     -2 |    0 |    0
+  20 |     -8 |     -3 |    0 |    0
+  21 |     -8 |     -4 |    0 |    0
+  22 |     -8 |     -5 |    0 |    0
+  23 |     -9 |     -6 |    1 |    7
+  24 |      8 |     -9 |    0 |    0
+  25 |    -10 |     -7 |    1 |   -8
+  26 |      6 |    -10 |    0 |    0
+  27 |    -11 |     -8 |    1 |  -10
+  28 |     10 |    -11 |    0 |    0
+(28 rows)
 
 -- q2
+CREATE TABLE lineGraph_edges AS SELECT * FROM pgr_lineGraphFull(
+    $$SELECT id, source, target, cost, reverse_cost
+    FROM edge_table WHERE id IN (4,7,8,10)$$
+);
+SELECT 28
+CREATE TABLE lineGraph_vertices AS
+SELECT *, NULL::BIGINT AS original_id
+FROM (SELECT source AS id FROM lineGraph_edges
+    UNION
+    SELECT target FROM lineGraph_edges) as foo
+ORDER BY id;
+SELECT 16
+-- q3
+UPDATE lineGraph_vertices AS r
+  SET original_id = v.id
+  FROM edge_table_vertices_pgr AS v
+  WHERE v.id = r.id;
+UPDATE 5
+-- q4
+WITH
+a AS (SELECT e.id, e.original_id
+       FROM lineGraph_vertices AS e
+       WHERE original_id IS NOT NULL),
+b AS (SELECT *
+        FROM lineGraph_edges
+        WHERE cost = 0 and source IN (SELECT id FROM a)),
+c AS (SELECT *
+        FROM b
+        JOIN lineGraph_vertices
+        ON(source = id)),
+d AS (SELECT c.source, v.original_id
+        FROM c
+        JOIN lineGraph_vertices as v
+        ON (target=v.id)),
+e AS (SELECT DISTINCT c.target, c.original_id
+        FROM c
+        JOIN lineGraph_vertices AS r
+        ON(target = r.id AND r.original_id IS NULL))
+UPDATE lineGraph_vertices
+  SET original_id = e.original_id
+  FROM e
+  WHERE e.target = id;
+UPDATE 8
+WITH
+a AS (SELECT e.id, e.original_id
+        FROM lineGraph_vertices AS e
+        WHERE original_id IS NOT NULL),
+b AS (SELECT *
+        FROM lineGraph_edges
+        WHERE cost = 0 and target IN (SELECT id FROM a)),
+c AS (SELECT *
+        FROM b
+        JOIN lineGraph_vertices
+        ON(target = id)),
+d AS (SELECT c.target, v.original_id
+        FROM c
+        JOIN lineGraph_vertices as v
+        ON (source=v.id)),
+e AS (SELECT DISTINCT c.source, c.original_id
+        FROM c
+        JOIN lineGraph_vertices AS r
+        ON(source = r.id AND r.original_id IS NULL))
+UPDATE lineGraph_vertices
+  SET original_id = e.original_id
+  FROM e
+  WHERE e.source = id;
+UPDATE 3
+-- q5
+WITH
+a AS (SELECT id
+        FROM lineGraph_vertices
+        WHERE original_id IS NULL),
+b AS (SELECT source,edge
+        FROM lineGraph_edges
+        WHERE source IN (SELECT id FROM a)),
+c AS (SELECT id,source
+        FROM edge_table
+        WHERE id IN (SELECT edge FROM b))
+UPDATE lineGraph_vertices AS d
+  SET original_id = (SELECT source
+                       FROM c
+                       WHERE c.id = (SELECT edge
+                                       FROM b
+                                       WHERE b.source = d.id))
+  WHERE id IN (SELECT id FROM a);
+UPDATE 0
+WITH
+a AS (SELECT id
+        FROM lineGraph_vertices
+        WHERE original_id IS NULL),
+b AS (SELECT target,edge
+        FROM lineGraph_edges
+        WHERE target IN (SELECT id FROM a)),
+c AS (SELECT id,target
+        FROM edge_table
+        WHERE id IN (SELECT edge FROM b))
+UPDATE lineGraph_vertices AS d
+  SET original_id = (SELECT target
+                       FROM c
+                       WHERE c.id = (SELECT edge
+                                       FROM b
+                                       WHERE b.target = d.id))
+  WHERE id IN (SELECT id FROM a);
+UPDATE 0
+-- q6
+SELECT * FROM lineGraph_vertices;
+ id  | original_id
+-----+-------------
+   2 |           2
+   5 |           5
+   6 |           6
+   8 |           8
+  10 |          10
+ -11 |          10
+ -10 |           6
+  -9 |           8
+  -5 |           5
+  -4 |           5
+  -3 |           5
+  -2 |           5
+  -1 |           2
+  -8 |           5
+  -7 |           5
+  -6 |           5
+(16 rows)
+
+-- q7
+UPDATE lineGraph_edges
+  SET cost = 100
+  WHERE source IN (SELECT target
+                     FROM lineGraph_edges
+                     WHERE edge = 4) AND target IN (SELECT source
+                                                      FROM lineGraph_edges
+                                                      WHERE edge = -7);
+UPDATE 1
+-- q8
+SELECT * FROM
+  (SELECT * FROM
+    (SELECT * FROM pgr_dijkstra($$SELECT seq AS id, * FROM lineGraph_edges$$,
+      (SELECT array_agg(id) FROM lineGraph_vertices where original_id = 2),
+      (SELECT array_agg(id) FROM lineGraph_vertices where original_id = 8)
+    )) as a
+  WHERE start_vid = 2 AND end_vid = 8 AND (cost != 0 OR edge = -1)) as b;
+ seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
+-----+----------+-----------+---------+------+------+------+----------
+  29 |        2 |         2 |       8 |   -1 |    1 |    1 |        0
+  31 |        4 |         2 |       8 |   -4 |    5 |    1 |        1
+  33 |        6 |         2 |       8 |  -10 |   25 |    1 |        2
+  35 |        8 |         2 |       8 |   -3 |    4 |    1 |        3
+  36 |        9 |         2 |       8 |    8 |   -1 |    0 |        4
+(5 rows)
+
+-- q9
 ROLLBACK;
 ROLLBACK

--- a/test/lineGraph/doc-pgr_lineGraphFull.test.sql
+++ b/test/lineGraph/doc-pgr_lineGraphFull.test.sql
@@ -1,6 +1,136 @@
 
 \echo -- q1
 SELECT * FROM pgr_lineGraphFull(
-    'SELECT id, source, target, cost FROM edge_table'
+    'SELECT id, source, target, cost, reverse_cost
+      FROM edge_table
+      WHERE id IN (4,7,8,10)'
 );
+
 \echo -- q2
+CREATE TABLE lineGraph_edges AS SELECT * FROM pgr_lineGraphFull(
+    $$SELECT id, source, target, cost, reverse_cost
+    FROM edge_table WHERE id IN (4,7,8,10)$$
+);
+
+CREATE TABLE lineGraph_vertices AS
+SELECT *, NULL::BIGINT AS original_id
+FROM (SELECT source AS id FROM lineGraph_edges
+    UNION
+    SELECT target FROM lineGraph_edges) as foo
+ORDER BY id;
+
+\echo -- q3
+UPDATE lineGraph_vertices AS r
+  SET original_id = v.id
+  FROM edge_table_vertices_pgr AS v
+  WHERE v.id = r.id;
+
+\echo -- q4
+WITH
+a AS (SELECT e.id, e.original_id
+       FROM lineGraph_vertices AS e
+       WHERE original_id IS NOT NULL),
+b AS (SELECT *
+        FROM lineGraph_edges
+        WHERE cost = 0 and source IN (SELECT id FROM a)),
+c AS (SELECT *
+        FROM b
+        JOIN lineGraph_vertices
+        ON(source = id)),
+d AS (SELECT c.source, v.original_id
+        FROM c
+        JOIN lineGraph_vertices as v
+        ON (target=v.id)),
+e AS (SELECT DISTINCT c.target, c.original_id
+        FROM c
+        JOIN lineGraph_vertices AS r
+        ON(target = r.id AND r.original_id IS NULL))
+UPDATE lineGraph_vertices
+  SET original_id = e.original_id
+  FROM e
+  WHERE e.target = id;
+
+WITH
+a AS (SELECT e.id, e.original_id
+        FROM lineGraph_vertices AS e
+        WHERE original_id IS NOT NULL),
+b AS (SELECT *
+        FROM lineGraph_edges
+        WHERE cost = 0 and target IN (SELECT id FROM a)),
+c AS (SELECT *
+        FROM b
+        JOIN lineGraph_vertices
+        ON(target = id)),
+d AS (SELECT c.target, v.original_id
+        FROM c
+        JOIN lineGraph_vertices as v
+        ON (source=v.id)),
+e AS (SELECT DISTINCT c.source, c.original_id
+        FROM c
+        JOIN lineGraph_vertices AS r
+        ON(source = r.id AND r.original_id IS NULL))
+UPDATE lineGraph_vertices
+  SET original_id = e.original_id
+  FROM e
+  WHERE e.source = id;
+
+\echo -- q5
+WITH
+a AS (SELECT id
+        FROM lineGraph_vertices
+        WHERE original_id IS NULL),
+b AS (SELECT source,edge
+        FROM lineGraph_edges
+        WHERE source IN (SELECT id FROM a)),
+c AS (SELECT id,source
+        FROM edge_table
+        WHERE id IN (SELECT edge FROM b))
+UPDATE lineGraph_vertices AS d
+  SET original_id = (SELECT source
+                       FROM c
+                       WHERE c.id = (SELECT edge
+                                       FROM b
+                                       WHERE b.source = d.id))
+  WHERE id IN (SELECT id FROM a);
+
+WITH
+a AS (SELECT id
+        FROM lineGraph_vertices
+        WHERE original_id IS NULL),
+b AS (SELECT target,edge
+        FROM lineGraph_edges
+        WHERE target IN (SELECT id FROM a)),
+c AS (SELECT id,target
+        FROM edge_table
+        WHERE id IN (SELECT edge FROM b))
+UPDATE lineGraph_vertices AS d
+  SET original_id = (SELECT target
+                       FROM c
+                       WHERE c.id = (SELECT edge
+                                       FROM b
+                                       WHERE b.target = d.id))
+  WHERE id IN (SELECT id FROM a);
+
+\echo -- q6
+SELECT * FROM lineGraph_vertices;
+
+\echo -- q7
+UPDATE lineGraph_edges
+  SET cost = 100
+  WHERE source IN (SELECT target
+                     FROM lineGraph_edges
+                     WHERE edge = 4) AND target IN (SELECT source
+                                                      FROM lineGraph_edges
+                                                      WHERE edge = -7);
+
+\echo -- q8
+SELECT * FROM
+  (SELECT * FROM
+    (SELECT * FROM pgr_dijkstra($$SELECT seq AS id, * FROM lineGraph_edges$$,
+      (SELECT array_agg(id) FROM lineGraph_vertices where original_id = 2),
+      (SELECT array_agg(id) FROM lineGraph_vertices where original_id = 8)
+    )) as a
+  WHERE start_vid = 2 AND end_vid = 8 AND (cost != 0 OR edge = -1)) as b;
+
+\echo -- q9
+


### PR DESCRIPTION
This PR fixes an issue where the lineGraphFull documentation queries were not being generated. It also includes many changes to the wording and structure of the lineGraphFull documentation as well as the queries themselves to make them more readable.

@pgRouting/admins