### PR TITLE
[WIP] Full implementation of pgr_minCostMaxFlow

### DIFF
--- a/include/c_types/pgr_costFlow_t.h
+++ b/include/c_types/pgr_costFlow_t.h
@@ -56,7 +56,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 typedef struct {
-  int64_t id;
+  int64_t edge_id;
   int64_t source;
   int64_t target;
   int64_t capacity;

--- a/include/costFlow/pgr_minCostMaxFlow.hpp
+++ b/include/costFlow/pgr_minCostMaxFlow.hpp
@@ -226,7 +226,7 @@ PgrCostFlowGraph::get_flow_edges() const {
             edge.target = get_vertex_id((*e).m_target);
             edge.flow = capacity[*e] - residual_capacity[*e];
             edge.residual_capacity = residual_capacity[*e];
-            edge.cost = weight[*e];
+            edge.cost = weight[*e] * edge.flow;
             if (flow_edges.size() == 0)
                 edge.agg_cost = edge.cost;
             else

--- a/sql/costFlow/minCostMaxFlow.sql
+++ b/sql/costFlow/minCostMaxFlow.sql
@@ -49,3 +49,49 @@ RETURNS SETOF RECORD AS
 '$libdir/${PGROUTING_LIBRARY_NAME}', 'minCostMaxFlow_many_to_many'
 LANGUAGE c IMMUTABLE STRICT;
 
+------------------------
+--    ONE TO MANY
+------------------------
+
+CREATE OR REPLACE FUNCTION pgr_minCostMaxFlow(
+    edges_sql TEXT,                 -- edges_sql
+    sources BIGINT,                 -- source
+    targets ANYARRAY)               -- targets
+  RETURNS FLOAT AS
+  $BODY$
+        SELECT * 
+        FROM pgr_minCostMaxFlow(_pgr_get_statement($1), ARRAY[$2]::BIGINT[], $3::BIGINT[], only_cost := false);
+  $BODY$
+  LANGUAGE SQL VOLATILE;
+
+------------------------
+--    MANY TO ONE 
+------------------------
+
+CREATE OR REPLACE FUNCTION pgr_minCostMaxFlow(
+    edges_sql TEXT,                 -- edges_sql
+    sources ANYARRAY,               -- sources
+    targets BIGINT)                 -- target
+  RETURNS FLOAT AS
+  $BODY$
+        SELECT *
+        FROM pgr_minCostMaxFlow(_pgr_get_statement($1), $2::BIGINT[], ARRAY[$3]::BIGINT[], only_cost := false);
+  $BODY$
+  LANGUAGE SQL VOLATILE;
+
+------------------------
+--    ONE TO ONE 
+------------------------
+
+CREATE OR REPLACE FUNCTION pgr_minCostMaxFlow(
+    edges_sql TEXT,                 -- edges_sql
+    sources BIGINT,                 -- source
+    targets BIGINT)                 -- target
+  RETURNS FLOAT AS
+  $BODY$
+        SELECT * 
+        FROM pgr_minCostMaxFlow(_pgr_get_statement($1), ARRAY[$2]::BIGINT[], ARRAY[$3]::BIGINT[], only_cost := false);
+  $BODY$
+  LANGUAGE SQL VOLATILE;
+
+

--- a/sql/costFlow/minCostMaxFlow.sql
+++ b/sql/costFlow/minCostMaxFlow.sql
@@ -42,8 +42,8 @@ CREATE OR REPLACE FUNCTION pgr_minCostMaxFlow(
     OUT target BIGINT,              -- end vertex
     OUT flow BIGINT,                -- flow
     OUT residual_capacity BIGINT,   -- residual capacity
-    OUT cost float,                 -- cost
-    OUT agg_cost float)             -- total cost
+    OUT cost FLOAT,                 -- cost
+    OUT agg_cost FLOAT)             -- total cost
 
 RETURNS SETOF RECORD AS
 '$libdir/${PGROUTING_LIBRARY_NAME}', 'minCostMaxFlow_many_to_many'

--- a/sql/costFlow/minCostMaxFlow.sql
+++ b/sql/costFlow/minCostMaxFlow.sql
@@ -56,8 +56,18 @@ LANGUAGE c IMMUTABLE STRICT;
 CREATE OR REPLACE FUNCTION pgr_minCostMaxFlow(
     edges_sql TEXT,                 -- edges_sql
     sources BIGINT,                 -- source
-    targets ANYARRAY)               -- targets
-  RETURNS FLOAT AS
+    targets ANYARRAY,               -- targets
+    only_cost BOOLEAN DEFAULT false,
+        OUT seq INTEGER,            -- seq
+    OUT edge BIGINT,                -- edge_id
+    OUT source BIGINT,              -- start vertex
+    OUT target BIGINT,              -- end vertex
+    OUT flow BIGINT,                -- flow
+    OUT residual_capacity BIGINT,   -- residual capacity
+    OUT cost FLOAT,                 -- cost
+    OUT agg_cost FLOAT)             -- total cost
+
+  RETURNS SETOF RECORD AS
   $BODY$
         SELECT * 
         FROM pgr_minCostMaxFlow(_pgr_get_statement($1), ARRAY[$2]::BIGINT[], $3::BIGINT[], only_cost := false);
@@ -67,12 +77,21 @@ CREATE OR REPLACE FUNCTION pgr_minCostMaxFlow(
 ------------------------
 --    MANY TO ONE 
 ------------------------
-
 CREATE OR REPLACE FUNCTION pgr_minCostMaxFlow(
     edges_sql TEXT,                 -- edges_sql
     sources ANYARRAY,               -- sources
-    targets BIGINT)                 -- target
-  RETURNS FLOAT AS
+    targets BIGINT,                 -- target
+    only_cost BOOLEAN DEFAULT false,
+        OUT seq INTEGER,            -- seq
+    OUT edge BIGINT,                -- edge_id
+    OUT source BIGINT,              -- start vertex
+    OUT target BIGINT,              -- end vertex
+    OUT flow BIGINT,                -- flow
+    OUT residual_capacity BIGINT,   -- residual capacity
+    OUT cost FLOAT,                 -- cost
+    OUT agg_cost FLOAT)             -- total cost
+
+  RETURNS SETOF RECORD AS
   $BODY$
         SELECT *
         FROM pgr_minCostMaxFlow(_pgr_get_statement($1), $2::BIGINT[], ARRAY[$3]::BIGINT[], only_cost := false);
@@ -82,16 +101,23 @@ CREATE OR REPLACE FUNCTION pgr_minCostMaxFlow(
 ------------------------
 --    ONE TO ONE 
 ------------------------
-
 CREATE OR REPLACE FUNCTION pgr_minCostMaxFlow(
     edges_sql TEXT,                 -- edges_sql
     sources BIGINT,                 -- source
-    targets BIGINT)                 -- target
-  RETURNS FLOAT AS
+    targets BIGINT,                 -- target
+    only_cost BOOLEAN DEFAULT false,
+        OUT seq INTEGER,            -- seq
+    OUT edge BIGINT,                -- edge_id
+    OUT source BIGINT,              -- start vertex
+    OUT target BIGINT,              -- end vertex
+    OUT flow BIGINT,                -- flow
+    OUT residual_capacity BIGINT,   -- residual capacity
+    OUT cost FLOAT,                 -- cost
+    OUT agg_cost FLOAT)             -- total cost
+
+  RETURNS SETOF RECORD AS
   $BODY$
         SELECT * 
         FROM pgr_minCostMaxFlow(_pgr_get_statement($1), ARRAY[$2]::BIGINT[], ARRAY[$3]::BIGINT[], only_cost := false);
   $BODY$
   LANGUAGE SQL VOLATILE;
-
-

--- a/sql/costFlow/minCostMaxFlow_Cost.sql
+++ b/sql/costFlow/minCostMaxFlow_Cost.sql
@@ -42,3 +42,48 @@ CREATE OR REPLACE FUNCTION pgr_minCostMaxFlow_Cost(
   $BODY$
   LANGUAGE SQL VOLATILE;
 
+------------------------
+--    ONE TO MANY
+------------------------
+
+CREATE OR REPLACE FUNCTION pgr_minCostMaxFlow_Cost(
+    edges_sql TEXT,                 -- edges_sql
+    sources BIGINT,                 -- source
+    targets ANYARRAY)               -- targets
+  RETURNS FLOAT AS
+  $BODY$
+        SELECT cost
+        FROM pgr_minCostMaxFlow(_pgr_get_statement($1), ARRAY[$2]::BIGINT[], $3::BIGINT[], only_cost := true);
+  $BODY$
+  LANGUAGE SQL VOLATILE;
+
+------------------------
+--    MANY TO ONE 
+------------------------
+
+CREATE OR REPLACE FUNCTION pgr_minCostMaxFlow_Cost(
+    edges_sql TEXT,                 -- edges_sql
+    sources ANYARRAY,               -- sources
+    targets BIGINT)                 -- target
+  RETURNS FLOAT AS
+  $BODY$
+        SELECT cost
+        FROM pgr_minCostMaxFlow(_pgr_get_statement($1), $2::BIGINT[], ARRAY[$3]::BIGINT[], only_cost := true);
+  $BODY$
+  LANGUAGE SQL VOLATILE;
+
+------------------------
+--    ONE TO ONE 
+------------------------
+
+CREATE OR REPLACE FUNCTION pgr_minCostMaxFlow_Cost(
+    edges_sql TEXT,                 -- edges_sql
+    sources BIGINT,                 -- source
+    targets BIGINT)                 -- target
+  RETURNS FLOAT AS
+  $BODY$
+        SELECT cost
+        FROM pgr_minCostMaxFlow(_pgr_get_statement($1), ARRAY[$2]::BIGINT[], ARRAY[$3]::BIGINT[], only_cost := true);
+  $BODY$
+  LANGUAGE SQL VOLATILE;
+

--- a/src/common/edges_input.c
+++ b/src/common/edges_input.c
@@ -555,7 +555,7 @@ get_edges_costFlow(
             for (t = 0; t < ntuples; t++) {
                 HeapTuple tuple = tuptable->vals[t];
                 fetch_costFlow_edge(&tuple, &tupdesc, info,
-                                    &default_id, 0, 0,
+                                    &default_id, -1, 0,
                                     &(*edges)[total_tuples - ntuples + t],
                                     &valid_edges,
                                     true);

--- a/src/common/edges_input.c
+++ b/src/common/edges_input.c
@@ -105,9 +105,9 @@ void fetch_costFlow_edge(
         size_t *valid_edges,
         bool normal) {
     if (column_found(info[0].colNumber)) {
-        edge->id = pgr_SPI_getBigInt(tuple, tupdesc, info[0]);
+        edge->edge_id = pgr_SPI_getBigInt(tuple, tupdesc, info[0]);
     } else {
-        edge->id = *default_id;
+        edge->edge_id = *default_id;
         ++(*default_id);
     }
 

--- a/src/common/edges_input.c
+++ b/src/common/edges_input.c
@@ -555,7 +555,7 @@ get_edges_costFlow(
             for (t = 0; t < ntuples; t++) {
                 HeapTuple tuple = tuptable->vals[t];
                 fetch_costFlow_edge(&tuple, &tupdesc, info,
-                                    &default_id, -1, 0,
+                                    &default_id, 0, 0,
                                     &(*edges)[total_tuples - ntuples + t],
                                     &valid_edges,
                                     true);

--- a/src/costFlow/minCostMaxFlow.c
+++ b/src/costFlow/minCostMaxFlow.c
@@ -55,6 +55,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "c_common/time_msg.h"
 /* for functions to get edges information */
 #include "c_common/edges_input.h"
+/* for functions to get array input */
+#include "c_common/arrays_input.h"
 
 #include "drivers/costFlow/minCostMaxFlow_driver.h"  // the link to the C++ code of the function
 
@@ -83,7 +85,7 @@ process(
         pgr_get_bigIntArray(&size_source_verticesArr, starts);
 
     size_t size_sink_verticesArr = 0;
-    int64_t* sink_vertices =
+    int64_t* sink_vertices = 
         pgr_get_bigIntArray(&size_sink_verticesArr, ends);
 
     PGR_DBG("Load data");

--- a/src/costFlow/minCostMaxFlow.c
+++ b/src/costFlow/minCostMaxFlow.c
@@ -245,8 +245,8 @@ PGDLLEXPORT Datum minCostMaxFlow_many_to_many(PG_FUNCTION_ARGS) {
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].target);
         values[4] = Int64GetDatum(result_tuples[funcctx->call_cntr].flow);
         values[5] = Int64GetDatum(result_tuples[funcctx->call_cntr].residual_capacity);
-        values[6] = Int64GetDatum(result_tuples[funcctx->call_cntr].cost);
-        values[7] = Int64GetDatum(result_tuples[funcctx->call_cntr].agg_cost);
+        values[6] = Float8GetDatum(result_tuples[funcctx->call_cntr].cost);
+        values[7] = Float8GetDatum(result_tuples[funcctx->call_cntr].agg_cost);
         /**********************************************************************/
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);

--- a/src/costFlow/minCostMaxFlow.c
+++ b/src/costFlow/minCostMaxFlow.c
@@ -154,7 +154,7 @@ process(
 /*                                                                            */
 /******************************************************************************/
 
-PGDLLEXPORT Datum minCostMaxFlow(PG_FUNCTION_ARGS) {
+PGDLLEXPORT Datum minCostMaxFlow_many_to_many(PG_FUNCTION_ARGS) {
     FuncCallContext     *funcctx;
     TupleDesc           tuple_desc;
 


### PR DESCRIPTION
Many to many works now.
```reverse_capacity``` DEFAULT ```-1```
```reverse_cost``` DEFAULT ```0```
### All the new functions
```
 function pgr_mincostmaxflow_cost(text,anyarray,anyarray)
 function pgr_mincostmaxflow_cost(text,anyarray,bigint)
 function pgr_mincostmaxflow_cost(text,bigint,anyarray)
 function pgr_mincostmaxflow_cost(text,bigint,bigint)
 function pgr_mincostmaxflow(text,anyarray,anyarray,boolean)
 function pgr_mincostmaxflow(text,anyarray,bigint,boolean)
 function pgr_mincostmaxflow(text,bigint,anyarray,boolean)
 function pgr_mincostmaxflow(text,bigint,bigint,boolean)
```

### Tasks
- [x] Change ```id``` to ```edge_id``` in ```pgr_costFlow_t.h```
- [x] Create pgr_costFlowGraph.hpp file.
- [x] Create pgr_minCostMaxFlow.hpp file.
- [x] One to one version.
- [x] One to many version.
- [x] Many to one version.
- [ ] Documentation tests.
- [ ] Unit tests.
@pgRouting/admins
