### PR TITLE
Flow Family of functions official on pgRouting

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,29 @@
 pgRouting 3.0.0 Release Notes
 -------------------------------------------------------------------------------
 
+*Proposed moved to official on pgRouting*
+
+* Flow Family
+  * pgr_pushRelabel(one to one)
+  * pgr_pushRelabel(one to many)
+  * pgr_pushRelabel(many to one)
+  * pgr_pushRelabel(many to many)
+  * pgr_edmondsKarp(one to one)
+  * pgr_edmondsKarp(one to many)
+  * pgr_edmondsKarp(many to one)
+  * pgr_edmondsKarp(many to many)
+  * pgr_boykovKolmogorov (one to one)
+  * pgr_boykovKolmogorov (one to many)
+  * pgr_boykovKolmogorov (many to one)
+  * pgr_boykovKolmogorov (many to many)
+  * pgr_maxCardinalityMatching
+  * pgr_maxFlow
+  * pgr_edgeDisjointPaths(one to one)
+  * pgr_edgeDisjointPaths(one to many)
+  * pgr_edgeDisjointPaths(many to one)
+  * pgr_edgeDisjointPaths(many to many)
+
+
 *Moved to legacy*
 
 * Experimental functions

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-6797-dedc9d4 release/3.0
+6802-1fb14b2 release/3.0

--- a/doc/bdDijkstra/pgr_bdDijkstra.rst
+++ b/doc/bdDijkstra/pgr_bdDijkstra.rst
@@ -184,18 +184,22 @@ The extra ``start_vid`` and ``end_vid`` in the result is used to distinguish to 
    :start-after: -- q5
    :end-before: -- q6
 
+Parameters
+-------------------------------------------------------------------------------
 
+.. include:: pgr_dijkstra.rst
+    :start-after: pgr_dijkstra_parameters_start
+    :end-before: pgr_dijkstra_parameters_end
 
-Description of the Signatures
+Inner query
 -------------------------------------------------------------------------------
 
 .. include:: pgRouting-concepts.rst
     :start-after: basic_edges_sql_start
     :end-before: basic_edges_sql_end
 
-.. include:: pgr_dijkstra.rst
-    :start-after: pgr_dijkstra_parameters_start
-    :end-before: pgr_dijkstra_parameters_end
+Result Columns
+-------------------------------------------------------------------------------
 
 .. include:: pgRouting-concepts.rst
     :start-after: return_path_start

--- a/doc/bdDijkstra/pgr_bdDijkstraCost.rst
+++ b/doc/bdDijkstra/pgr_bdDijkstraCost.rst
@@ -172,18 +172,22 @@ The extra ``start_vid`` and ``end_vid`` in the result is used to distinguish to 
    :start-after: -- q5
    :end-before: -- q6
 
+Parameters
+-------------------------------------------------------------------------------
 
+.. include:: pgr_dijkstra.rst
+    :start-after: pgr_dijkstra_parameters_start
+    :end-before: pgr_dijkstra_parameters_end
 
-Description of the Signatures
+Inner query
 -------------------------------------------------------------------------------
 
 .. include::  pgRouting-concepts.rst
     :start-after: basic_edges_sql_start
     :end-before: basic_edges_sql_end
 
-.. include:: pgr_dijkstra.rst
-    :start-after: pgr_dijkstra_parameters_start
-    :end-before: pgr_dijkstra_parameters_end
+Result Columns
+-------------------------------------------------------------------------------
 
 .. include::  pgRouting-concepts.rst
     :start-after: return_cost_start

--- a/doc/dijkstra/pgr_dijkstra.rst
+++ b/doc/dijkstra/pgr_dijkstra.rst
@@ -211,23 +211,15 @@ The extra ``start_vid`` and ``end_vid`` in the result is used to distinguish to 
    :start-after: -- q5
    :end-before: -- q6
 
-Description of the Signatures
+Parameters
 -------------------------------------------------------------------------------
-
-.. include:: pgRouting-concepts.rst
-    :start-after: basic_edges_sql_start
-    :end-before: basic_edges_sql_end
-
 
 .. pgr_dijkstra_parameters_start
 
-Description of the parameters of the signatures
-...............................................................................
-
 ============== ================== ======== =================================================
-Column         Type               Default     Description
+Parameter      Type               Default     Description
 ============== ================== ======== =================================================
-**sql**        ``TEXT``                    SQL query as described above.
+**edges_sql**  ``TEXT``                    Inner SQL query as described bellow.
 **start_vid**  ``BIGINT``                  Identifier of the starting vertex of the path.
 **start_vids** ``ARRAY[BIGINT]``           Array of identifiers of starting vertices.
 **end_vid**    ``BIGINT``                  Identifier of the ending vertex of the path.
@@ -238,6 +230,18 @@ Column         Type               Default     Description
 
 .. pgr_dijkstra_parameters_end
 
+Inner query
+-------------------------------------------------------------------------------
+
+edges_sql
+...............................................................................
+
+.. include:: pgRouting-concepts.rst
+    :start-after: basic_edges_sql_start
+    :end-before: basic_edges_sql_end
+
+Return Columns
+-------------------------------------------------------------------------------
 
 .. include:: pgRouting-concepts.rst
     :start-after: return_path_start

--- a/doc/dijkstra/pgr_dijkstraCost.rst
+++ b/doc/dijkstra/pgr_dijkstraCost.rst
@@ -208,17 +208,23 @@ This signature performs a Dijkstra from each ``start_vid`` in  ``start_vids`` to
    :end-before: --q6
 
 
+Parameters
+-------------------------------------------------------------------------------
 
-Description of the Signatures
+.. include:: pgr_dijkstra.rst
+    :start-after: pgr_dijkstra_parameters_start
+    :end-before: pgr_dijkstra_parameters_end
+
+
+Inner query
 -------------------------------------------------------------------------------
 
 .. include:: pgRouting-concepts.rst
     :start-after: basic_edges_sql_start
     :end-before: basic_edges_sql_end
 
-.. include:: pgr_dijkstra.rst
-    :start-after: pgr_dijkstra_parameters_start
-    :end-before: pgr_dijkstra_parameters_end
+Return Columns
+-------------------------------------------------------------------------------
 
 .. include:: pgRouting-concepts.rst
     :start-after: return_cost_start

--- a/doc/dijkstraTRSP/pgr_dijkstraTRSP.rst
+++ b/doc/dijkstraTRSP/pgr_dijkstraTRSP.rst
@@ -111,17 +111,23 @@ This signature finds the shortest path from one ``start_vid`` to one ``end_vid``
    :end-before: -- q3
 
 
+Parameters
+-------------------------------------------------------------------------------
 
-Description of the Signatures
+.. include:: pgr_dijkstra.rst
+    :start-after: pgr_dijkstra_parameters_start
+    :end-before: pgr_dijkstra_parameters_end
+
+
+Inner query
 -------------------------------------------------------------------------------
 
 .. include:: pgRouting-concepts.rst
     :start-after: basic_edges_sql_start
     :end-before: basic_edges_sql_end
 
-.. include:: pgr_dijkstra.rst
-    :start-after: pgr_dijkstra_parameters_start
-    :end-before: pgr_dijkstra_parameters_end
+Return Columns
+-------------------------------------------------------------------------------
 
 .. include:: pgRouting-concepts.rst
     :start-after: return_path_start

--- a/doc/max_flow/flow-family.rst
+++ b/doc/max_flow/flow-family.rst
@@ -7,28 +7,22 @@
     Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-.. _maxFlow:
-
 Flow - Family of functions
 ===================================
 
 .. index from here
 
-* :ref:`pgr_maxFlow` - Only the Max flow calculation using Push and Relabel algorithm.
-* :ref:`pgr_BoykovKolmogorov` - Boykov and Kolmogorov with details of flow on edges.
-* :ref:`pgr_EdmondsKarp` - Edmonds and Karp algorithm with details of flow on edges.
-* :ref:`pgr_PushRelabel` - Push and relabel algorithm with details of flow on edges.
+* :doc:`pgr_maxFlow` - Only the Max flow calculation using Push and Relabel algorithm.
+* :doc:`pgr_boykovKolmogorov` - Boykov and Kolmogorov with details of flow on edges.
+* :doc:`pgr_edmondsKarp` - Edmonds and Karp algorithm with details of flow on edges.
+* :doc:`pgr_pushRelabel` - Push and relabel algorithm with details of flow on edges.
 * Applications
 
-  * :ref:`pgr_edgeDisjointPaths` - Calculates edge disjoint paths between two groups of vertices.
-  * :ref:`pgr_maxCardinalityMatch` - Calculates a maximum cardinality matching in a graph.
+  * :doc:`pgr_edgeDisjointPaths` - Calculates edge disjoint paths between two groups of vertices.
+  * :doc:`pgr_maxCardinalityMatch` - Calculates a maximum cardinality matching in a graph.
 
 .. index to here
 
-
-.. include:: proposed.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
 
 .. toctree::
     :hidden:
@@ -73,7 +67,7 @@ Flow Functions General Information
 
 
 
-Problem definition
+Adcanced Documentation
 ------------------------
 
 A flow network is a directed graph where each edge has a capacity and a flow.
@@ -118,9 +112,9 @@ Given:
 
 Then:
 
-     :math:`pgr\_maxFlow(edges\_sql, source, sink) = \boldsymbol{\Phi}`
+- :math:`pgr\_maxFlow(edges\_sql, source, sink) = \boldsymbol{\Phi}`
 
-     :math:`\boldsymbol{\Phi} = {(id_i, edge\_id_i, source_i, target_i, flow_i, residual\_capacity_i)}`
+- :math:`\boldsymbol{\Phi} = {(id_i, edge\_id_i, source_i, target_i, flow_i, residual\_capacity_i)}`
 
 Where:
 

--- a/doc/max_flow/pgr_boykovKolmogorov.rst
+++ b/doc/max_flow/pgr_boykovKolmogorov.rst
@@ -10,7 +10,7 @@
 
 .. _pgr_boykovKolmogorov:
 
-pgr_boykovKolmogorov - Proposed
+pgr_boykovKolmogorov
 ============================================
 
 
@@ -30,11 +30,6 @@ Synopsis
 * Renamed 2.5.0, Previous name pgr_maxFlowBoykovKolmogorov
 * New in 2.3.0
 
-.. include:: proposed.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
-
-
 .. include::  flow-family.rst
     :start-after: characteristics_start
     :end-before: characteristics_end
@@ -46,16 +41,16 @@ Signature Summary
 
 .. code-block:: none
 
-    pgr_boykovKolmogorov(edges_sql, source,  target) - Proposed
-    pgr_boykovKolmogorov(edges_sql, sources, target) - Proposed
-    pgr_boykovKolmogorov(edges_sql, source,  targets) - Proposed
-    pgr_boykovKolmogorov(edges_sql, sources, targets) - Proposed
+    pgr_boykovKolmogorov(edges_sql, source,  target)
+    pgr_boykovKolmogorov(edges_sql, sources, target)
+    pgr_boykovKolmogorov(edges_sql, source,  targets)
+    pgr_boykovKolmogorov(edges_sql, sources, targets)
     RETURNS SET OF (seq, edge, start_vid, end_vid, flow, residual_capacity)
     OR EMPTY SET
 
 
 .. index::
-    single: boykovKolmogorov(One to One) - Proposed
+    single: boykovKolmogorov(One to One)
 
 One to One
 .....................................................................
@@ -76,7 +71,7 @@ Calculates the flow on the graph edges that maximizes the flow from the `source`
 
 
 .. index::
-    single: boykovKolmogorov(One to Many) - Proposed
+    single: boykovKolmogorov(One to Many)
 
 One to Many
 .....................................................................
@@ -97,7 +92,7 @@ Calculates the flow on the graph edges that maximizes the flow from the `source`
 
 
 .. index::
-    single: boykovKolmogorov(Many to One) - Proposed
+    single: boykovKolmogorov(Many to One)
 
 Many to One
 .....................................................................
@@ -118,7 +113,7 @@ Calculates the flow on the graph edges that maximizes the flow from all of the `
 
 
 .. index::
-    single: boykovKolmogorov(Many to Many) - Proposed
+    single: boykovKolmogorov(Many to Many)
 
 Many to Many
 .....................................................................
@@ -137,18 +132,25 @@ Calculates the flow on the graph edges that maximizes the flow from all of the `
    :start-after: -- q4
    :end-before: -- q5
 
-Description of the Signatures
+Parameters
 --------------------------------------------------------
-
-.. include:: pgRouting-concepts.rst
-    :start-after: flow_edges_sql_start
-    :end-before: flow_edges_sql_end
-
 
 .. include::  ./pgr_maxFlow.rst
     :start-after: pgr_flow_parameters_start
     :end-before: pgr_flow_parameters_end
 
+Inner query
+--------------------------------------------------------
+
+edges_sql
+...........................................................
+
+.. include:: pgRouting-concepts.rst
+    :start-after: flow_edges_sql_start
+    :end-before: flow_edges_sql_end
+
+Result Columns
+--------------------------------------------------------
 
 .. include:: pgRouting-concepts.rst
     :start-after: result_flow_start
@@ -158,7 +160,7 @@ Description of the Signatures
 See Also
 --------
 
-* :ref:`maxFlow`, :ref:`pgr_pushRelabel <pgr_pushRelabel>`, :ref:`pgr_EdmondsKarp <pgr_edmondsKarp>`
+* :doc:`flow-family`, :doc:`pgr_pushRelabel`, :doc:`pgr_edmondsKarp`
 * http://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html
 
 .. rubric:: Indices and tables

--- a/doc/max_flow/pgr_edgeDisjointPaths.rst
+++ b/doc/max_flow/pgr_edgeDisjointPaths.rst
@@ -8,12 +8,10 @@
    ****************************************************************************
 
 
-.. _pgr_edgeDisjointPaths:
-
-pgr_edgeDisjointPaths - Proposed
+pgr_edgeDisjointPaths
 ==========================================
 
-Name
+Synopsis
 -------------------------------------------------------------------------------
 
 ``pgr_edgeDisjointPaths`` — Calculates edge disjoint paths between two groups of vertices.
@@ -26,20 +24,12 @@ Name
 
 .. Rubric:: Availability: 2.3.0
 
-.. include:: proposed.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
-
-
-
-Synopsis
--------------------------------------------------------------------------------
 
 Calculates the edge disjoint paths between two groups of vertices.
 Utilizes underlying maximum flow algorithms to calculate the paths.
 
 Characteristics:
-----------------
+...............................................................................
 
 The main characterics are:
   - Calculates the edge disjoint paths between any two groups of vertices.
@@ -49,28 +39,25 @@ The main characterics are:
   - Uses :ref:`pgr_boykovKolmogorov` to calculate the paths.
 
 Signature Summary
------------------
+-------------------------------------------------------------------------------
 
 .. code-block:: none
 
     pgr_edgeDisjointPaths(edges_sql, start_vid, end_vid)
-    pgr_edgeDisjointPaths(edges_sql, start_vid, end_vid, directed)
-    pgr_edgeDisjointPaths(edges_sql, start_vid, end_vids, directed)
-    pgr_edgeDisjointPaths(edges_sql, start_vids, end_vid, directed)
-    pgr_edgeDisjointPaths(edges_sql, start_vids, end_vids, directed)
+    pgr_edgeDisjointPaths(edges_sql, start_vid, end_vid [, directed])
+    pgr_edgeDisjointPaths(edges_sql, start_vid, end_vids [, directed])
+    pgr_edgeDisjointPaths(edges_sql, start_vids, end_vid [, directed])
+    pgr_edgeDisjointPaths(edges_sql, start_vids, end_vids [, directed])
 
     RETURNS SET OF (seq, path_id, path_seq, [start_vid,] [end_vid,] node, edge, cost, agg_cost)
     OR EMPTY SET
 
 
-Signatures
-----------
-
 .. index::
-    single: edgeDisjointPaths(Minimal Use) - Proposed
+    single: edgeDisjointPaths(Minimal Use)
 
 Minimal use
-.................
+...............................................................................
 
 .. code-block:: none
 
@@ -87,10 +74,10 @@ The minimal use is for a **directed** graph from one ``start_vid`` to one ``end_
    :end-before: -- q2
 
 .. index::
-    single: edgeDisjointPaths(One to One) - Proposed
+    single: edgeDisjointPaths(One to One)
 
 One to One
-.......................................
+...............................................................................
 
 This signature finds the set of dijoint paths from one ``start_vid`` to one ``end_vid``:
   -  on a **directed** graph when ``directed`` flag is missing or is set to ``true``.
@@ -111,10 +98,10 @@ This signature finds the set of dijoint paths from one ``start_vid`` to one ``en
 
 
 .. index::
-    single: edgeDisjointPaths(One to Many) - Proposed
+    single: edgeDisjointPaths(One to Many)
 
 One to Many
-.......................................
+...............................................................................
 
 This signature finds the sset of disjoint paths  from the ``start_vid`` to each one of the ``end_vid`` in ``end_vids``:
   - on a **directed** graph when ``directed`` flag is missing or is set to ``true``.
@@ -140,10 +127,10 @@ This signature finds the sset of disjoint paths  from the ``start_vid`` to each 
 
 
 .. index::
-    single: edgeDisjointPaths(Many to One) - Proposed
+    single: edgeDisjointPaths(Many to One)
 
 Many to One
-.......................................
+...............................................................................
 
 This signature finds the set of disjoint paths from each one of the ``start_vid`` in ``start_vids`` to the ``end_vid``:
   - on a **directed** graph when ``directed`` flag is missing or is set to ``true``.
@@ -166,10 +153,10 @@ This signature finds the set of disjoint paths from each one of the ``start_vid`
 
 
 .. index::
-    single: edgeDisjointPaths(Many to Many) - Proposed
+    single: edgeDisjointPaths(Many to Many)
 
 Many to Many
-.......................................
+...............................................................................
 
 This signature finds the set of disjoint paths from each one of the ``start_vid`` in ``start_vids`` to each one of the ``end_vid`` in ``end_vids``:
   - on a **directed** graph when ``directed`` flag is missing or is set to ``true``.
@@ -191,18 +178,25 @@ This signature finds the set of disjoint paths from each one of the ``start_vid`
 
 
 
-Description of the Signatures
-----------------------------------------------
-
-.. include:: pgRouting-concepts.rst
-    :start-after: basic_edges_sql_start
-    :end-before: basic_edges_sql_end
-
+Parameters
+-------------------------------------------------------------------------------
 
 .. include:: pgr_dijkstra.rst
     :start-after: pgr_dijkstra_parameters_start
     :end-before: pgr_dijkstra_parameters_end
 
+Inner query
+-------------------------------------------------------------------------------
+
+edges_sql
+...............................................................................
+
+.. include:: pgRouting-concepts.rst
+    :start-after: basic_edges_sql_start
+    :end-before: basic_edges_sql_end
+
+Return Columns
+-------------------------------------------------------------------------------
 
 .. include:: pgRouting-concepts.rst
     :start-after: return_path_start
@@ -211,7 +205,7 @@ Description of the Signatures
 See Also
 --------
 
-* :ref:`maxFlow`
+* :doc:`flow-family`
 
 .. rubric:: Indices and tables
 

--- a/doc/max_flow/pgr_edmondsKarp.rst
+++ b/doc/max_flow/pgr_edmondsKarp.rst
@@ -10,7 +10,7 @@
 
 .. _pgr_edmondsKarp:
 
-pgr_edmondsKarp - Proposed
+pgr_edmondsKarp
 ============================================
 
 
@@ -30,10 +30,6 @@ Synopsis
 * Renamed 2.5.0, Previous name pgr_maxFlowEdmondsKarp
 * New in 2.3.0
 
-.. include:: proposed.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
-
 
 .. include::  flow-family.rst
     :start-after: characteristics_start
@@ -46,17 +42,17 @@ Signature Summary
 
 .. code-block:: none
 
-    pgr_edmondsKarp(edges_sql, source,  target) - Proposed
-    pgr_edmondsKarp(edges_sql, sources, target) - Proposed
-    pgr_edmondsKarp(edges_sql, source,  targets) - Proposed
-    pgr_edmondsKarp(edges_sql, sources, targets) - Proposed
+    pgr_edmondsKarp(edges_sql, source,  target)
+    pgr_edmondsKarp(edges_sql, sources, target)
+    pgr_edmondsKarp(edges_sql, source,  targets)
+    pgr_edmondsKarp(edges_sql, sources, targets)
     RETURNS SET OF (seq, edge, start_vid, end_vid, flow, residual_capacity)
     OR EMPTY SET
 
 
 
 .. index::
-    single: edmondsKarp(One to One) - Proposed
+    single: edmondsKarp(One to One)
 
 One to One
 .....................................................................
@@ -77,7 +73,7 @@ Calculates the flow on the graph edges that maximizes the flow from the `source`
 
 
 .. index::
-    single: edmondsKarp(One to Many) - Proposed
+    single: edmondsKarp(One to Many)
 
 One to Many
 .....................................................................
@@ -98,7 +94,7 @@ Calculates the flow on the graph edges that maximizes the flow from the `source`
 
 
 .. index::
-    single: edmondsKarp(Many to One) - Proposed
+    single: edmondsKarp(Many to One)
 
 Many to One
 .....................................................................
@@ -119,7 +115,7 @@ Calculates the flow on the graph edges that maximizes the flow from all of the `
 
 
 .. index::
-    single: edmondsKarp(Many to Many) - Proposed
+    single: edmondsKarp(Many to Many)
 
 Many to Many
 .....................................................................
@@ -138,18 +134,25 @@ Calculates the flow on the graph edges that maximizes the flow from all of the `
    :start-after: -- q4
    :end-before: -- q5
 
-Description of the Signatures
+Parameters
 --------------------------------------------------------
-
-.. include:: pgRouting-concepts.rst
-    :start-after: flow_edges_sql_start
-    :end-before: flow_edges_sql_end
-
 
 .. include::  ./pgr_maxFlow.rst
     :start-after: pgr_flow_parameters_start
     :end-before: pgr_flow_parameters_end
 
+Inner query
+--------------------------------------------------------
+
+edges_sql
+...........................................................
+
+.. include:: pgRouting-concepts.rst
+    :start-after: flow_edges_sql_start
+    :end-before: flow_edges_sql_end
+
+Result Columns
+--------------------------------------------------------
 
 .. include:: pgRouting-concepts.rst
     :start-after: result_flow_start
@@ -159,7 +162,7 @@ Description of the Signatures
 See Also
 --------
 
-* :ref:`maxFlow`, :ref:`pgr_boykovKolmogorov <pgr_boykovKolmogorov>`, :ref:`pgr_PushRelabel <pgr_pushRelabel>`
+* :doc:`flow-family`, :doc:`pgr_boykovKolmogorov`, :doc:`pgr_pushRelabel`
 * http://www.boost.org/libs/graph/doc/edmonds_karp_max_flow.html
 * https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm
 

--- a/doc/max_flow/pgr_maxCardinalityMatch.rst
+++ b/doc/max_flow/pgr_maxCardinalityMatch.rst
@@ -7,9 +7,7 @@
     Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-.. _pgr_maxCardinalityMatch:
-
-pgr_maxCardinalityMatch - Proposed
+pgr_maxCardinalityMatch
 ============================================================
 
 
@@ -17,11 +15,6 @@ Synopsis
 ------------------------------------------------------------
 
 ``pgr_maxCardinalityMatch`` — Calculates a maximum cardinality matching in a graph.
-
-.. include:: proposed.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
-
 
 .. figure:: images/boost-inside.jpeg
    :target: http://www.boost.org/libs/graph/doc/maximum_matching.html
@@ -45,7 +38,7 @@ Synopsis
 * The graph can be **directed** or **undirected**.
 * Running time: :math:`O( E*V * \alpha(E,V))`
 
-    * :math:`\alpha(E,V)` is the inverse of the `Ackermann function`_.
+  * :math:`\alpha(E,V)` is the inverse of the `Ackermann function`_.
 
 
 .. _Ackermann function: https://en.wikipedia.org/wiki/Ackermann_function
@@ -55,15 +48,15 @@ Signature Summary
 
 .. code-block:: none
 
-    pgr_MaximumCardinalityMatching(edges_sql) - Proposed
-    pgr_MaximumCardinalityMatching(edges_sql, directed) - Proposed
+    pgr_MaximumCardinalityMatching(edges_sql)
+    pgr_MaximumCardinalityMatching(edges_sql, directed)
 
     RETURNS SET OF (seq, edge_id, source, target)
         OR EMPTY SET
 
 
 .. index::
-    single: MaximumCardinalityMatching(Minimal Use) - Proposed
+    single: MaximumCardinalityMatching(Minimal Use)
 
 
 
@@ -84,7 +77,7 @@ The minimal use calculates one possible maximum cardinality matching on a **dire
    :end-before: -- q2
 
 .. index::
-    single: MaximumCardinalityMatching(Complete Signature) - Proposed
+    single: MaximumCardinalityMatching(Complete Signature)
 
 Complete signature
 .............................................
@@ -105,11 +98,23 @@ The complete signature calculates one possible maximum cardinality matching.
 
 
 
-Description of the Signatures
+Parameters
 --------------------------------------------------------
 
+============== ================== ======== =========================================
+Parameter         Type            Default       Description
+============== ================== ======== =========================================
+**edges_sql**     ``TEXT``                 SQL query as described above.
+**directed**   ``BOOLEAN``        ``true`` Determines the type of the graph.
+                                           - When ``true`` Graph is considered `Directed`
+                                           - When ``false`` the graph is considered as `Undirected`.
 
-Description of the SQL query
+============== ================== ======== =========================================
+
+Inner query
+--------------------------------------------------------
+
+edges_sql
 ...........................................................
 
 :edges_sql: an SQL query, which should return a set of rows with the following columns:
@@ -126,21 +131,11 @@ Column                Type                  Description
 
 Where:
 
-  - :ANY-INTEGER: SMALLINT, INTEGER, BIGINT
-  - :ANY-NUMERIC: SMALLINT, INTEGER, BIGINT, REAL, DOUBLE PRECISION
+:ANY-INTEGER: SMALLINT, INTEGER, BIGINT
+:ANY-NUMERIC: SMALLINT, INTEGER, BIGINT, REAL FLOAT
 
-Description of the parameters of the signatures
-...........................................................
-
-================= ====================== =================================================
-Column            Type                   Description
-================= ====================== =================================================
-**edges_sql**     ``TEXT``               SQL query as described above.
-**directed**      ``BOOLEAN``            (optional) Determines the type of the graph. Default TRUE.
-================= ====================== =================================================
-
-Description of the Result
-...........................................................
+Result Columns
+--------------------------------------------------------
 
 =====================  ====================  =================================================
 Column                 Type                  Description
@@ -154,7 +149,7 @@ Column                 Type                  Description
 See Also
 --------
 
-* :ref:`maxFlow`
+* :doc:`flow-family`
 * http://www.boost.org/libs/graph/doc/maximum_matching.html
 * https://en.wikipedia.org/wiki/Matching_%28graph_theory%29
 * https://en.wikipedia.org/wiki/Ackermann_function

--- a/doc/max_flow/pgr_maxFlow.rst
+++ b/doc/max_flow/pgr_maxFlow.rst
@@ -9,7 +9,7 @@
 
 .. _pgr_maxFlow:
 
-pgr_maxFlow - Proposed
+pgr_maxFlow
 ============================================
 
 
@@ -25,10 +25,6 @@ Synopsis
    Boost Graph Inside
 
 .. Rubric:: Availability: 2.4.0
-
-.. include:: proposed.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
 
 
 .. rubric:: Characteristics
@@ -56,7 +52,7 @@ Signature Summary
 
 
 .. index::
-    single: maxFlow(One to One) - Proposed
+    single: maxFlow(One to One)
 
 One to One
 .....................................................................
@@ -76,7 +72,7 @@ Calculates the maximum flow from the `source` to the `target`.
 
 
 .. index::
-    single: maxFlow(One to Many) - Proposed
+    single: maxFlow(One to Many)
 
 One to Many
 .....................................................................
@@ -96,7 +92,7 @@ Calculates the maximum flow from the `source` to all of the `targets`.
 
 
 .. index::
-    single: maxFlow(Many to One) - Proposed
+    single: maxFlow(Many to One)
 
 Many to One
 .....................................................................
@@ -116,7 +112,7 @@ Calculates the maximum flow from all the `sources` to the `target`.
 
 
 .. index::
-    single: maxFlow(Many to Many) - Proposed
+    single: maxFlow(Many to Many)
 
 Many to Many
 .....................................................................
@@ -134,19 +130,11 @@ Calculates the maximum flow from all of the `sources` to all of the `targets`.
    :start-after: -- q4
    :end-before: -- q5
 
-Description of the Signatures
+
+Parameters
 --------------------------------------------------------
 
-
-.. include:: pgRouting-concepts.rst
-    :start-after: flow_edges_sql_start
-    :end-before: flow_edges_sql_end
-
-
 .. pgr_flow_parameters_start
-
-Description of the Parameters of the Flow Signatures
-...............................................................................
 
 ============== ================== ======== =================================================
 Column         Type               Default     Description
@@ -160,10 +148,19 @@ Column         Type               Default     Description
 
 .. pgr_flow_parameters_end
 
+Inner query
+--------------------------------------------------------
+
+edges_sql
+...........................................................
+
+.. include:: pgRouting-concepts.rst
+    :start-after: flow_edges_sql_start
+    :end-before: flow_edges_sql_end
 
 
-Description of the return value
-.....................................................................
+Return Columns
+--------------------------------------------------------
 
 ====================== =================================================
 Type                   Description
@@ -174,7 +171,7 @@ Type                   Description
 See Also
 --------
 
-* :ref:`maxFlow`
+* :doc:`flow-family`
 * http://www.boost.org/libs/graph/doc/push_relabel_max_flow.html
 * https://en.wikipedia.org/wiki/Push%E2%80%93relabel_maximum_flow_algorithm
 

--- a/doc/max_flow/pgr_pushRelabel.rst
+++ b/doc/max_flow/pgr_pushRelabel.rst
@@ -10,7 +10,7 @@
 
 .. _pgr_pushRelabel:
 
-pgr_pushRelabel - Proposed
+pgr_pushRelabel
 ============================================
 
 
@@ -30,10 +30,6 @@ Synopsis
 * Renamed 2.5.0, Previous name pgr_maxFlowPushRelabel
 * New in 2.3.0
 
-.. include:: proposed.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
-
 .. include::  flow-family.rst
     :start-after: characteristics_start
     :end-before: characteristics_end
@@ -45,16 +41,16 @@ Signature Summary
 
 .. code-block:: none
 
-    pgr_pushRelabel(edges_sql, source,  target) - Proposed
-    pgr_pushRelabel(edges_sql, sources, target) - Proposed
-    pgr_pushRelabel(edges_sql, source,  targets) - Proposed
-    pgr_pushRelabel(edges_sql, sources, targets) - Proposed
+    pgr_pushRelabel(edges_sql, source,  target)
+    pgr_pushRelabel(edges_sql, sources, target)
+    pgr_pushRelabel(edges_sql, source,  targets)
+    pgr_pushRelabel(edges_sql, sources, targets)
     RETURNS SET OF (seq, edge, start_vid, end_vid, flow, residual_capacity)
     OR EMPTY SET
 
 
 .. index::
-    single: pushRelabel(One to One) - Proposed
+    single: pushRelabel(One to One)
 
 One to One
 .....................................................................
@@ -75,7 +71,7 @@ Calculates the flow on the graph edges that maximizes the flow from the `source`
 
 
 .. index::
-    single: pushRelabel(One to Many) - Proposed
+    single: pushRelabel(One to Many)
 
 One to Many
 .....................................................................
@@ -96,7 +92,7 @@ Calculates the flow on the graph edges that maximizes the flow from the `source`
 
 
 .. index::
-    single: pushRelabel(Many to One) - Proposed
+    single: pushRelabel(Many to One)
 
 Many to One
 .....................................................................
@@ -117,7 +113,7 @@ Calculates the flow on the graph edges that maximizes the flow from all of the `
 
 
 .. index::
-    single: pushRelabel(Many to Many) - Proposed
+    single: pushRelabel(Many to Many)
 
 Many to Many
 .....................................................................
@@ -136,28 +132,35 @@ Calculates the flow on the graph edges that maximizes the flow from all of the `
    :start-after: -- q4
    :end-before: -- q5
 
-Description of the Signatures
+Parameters
 --------------------------------------------------------
-
-.. include:: pgRouting-concepts.rst
-    :start-after: flow_edges_sql_start
-    :end-before: flow_edges_sql_end
-
 
 .. include::  ./pgr_maxFlow.rst
     :start-after: pgr_flow_parameters_start
     :end-before: pgr_flow_parameters_end
 
+Inner query
+--------------------------------------------------------
+
+edges_sql
+...........................................................
 
 .. include:: pgRouting-concepts.rst
-    :start-after: result_flow_start
-    :end-before: result_flow_end
+    :start-after: flow_edges_sql_start
+    :end-before: flow_edges_sql_end
+
+Result Columns
+--------------------------------------------------------
+
+.. include:: pgRouting-concepts.rst
+   :start-after: result_flow_start
+   :end-before: result_flow_end
 
 
 See Also
 --------
 
-* :ref:`maxFlow`, :ref:`pgr_boykovKolmogorov <pgr_boykovKolmogorov>`, :ref:`pgr_edmondsKarp <pgr_edmondsKarp>`
+* :doc:`flow-family`, :doc:`pgr_boykovKolmogorov`, :doc:`pgr_edmondsKarp`
 * http://www.boost.org/libs/graph/doc/push_relabel_max_flow.html
 * https://en.wikipedia.org/wiki/Push%E2%80%93relabel_maximum_flow_algorithm
 

--- a/doc/src/pgRouting-concepts.rst
+++ b/doc/src/pgRouting-concepts.rst
@@ -156,10 +156,11 @@ Where:
 
 .. where_definition_ends
 
-.. basic_edges_sql_start
 
 Description of the edges_sql query for dijkstra like functions
 ...............................................................................
+
+.. basic_edges_sql_start
 
 :edges_sql: an SQL query, which should return a set of rows with the following columns:
 
@@ -184,8 +185,8 @@ Where:
 :ANY-INTEGER: SMALLINT, INTEGER, BIGINT
 :ANY-NUMERICAL: SMALLINT, INTEGER, BIGINT, REAL, FLOAT
 
-
 .. basic_edges_sql_end
+
 
 .. no_id_edges_sql_start
 
@@ -274,10 +275,11 @@ Where:
 
 .. xy_edges_sql_end
 
-.. flow_edges_sql_start
 
 Description of the edges_sql query for Max-flow like functions
 ...............................................................................
+
+.. flow_edges_sql_start
 
 :edges_sql: an SQL query, which should return a set of rows with the following columns:
 
@@ -391,10 +393,10 @@ Column         Type       Description
 
 
 
-.. result_flow_start
-
 Description of the Return Values
 .....................................................................
+
+.. result_flow_start
 
 =====================  ====================  =================================================
 Column                 Type                  Description

--- a/doc/src/proposed.rst
+++ b/doc/src/proposed.rst
@@ -55,11 +55,6 @@ As part of the :ref:`dijkstra`
    :start-after: index from here
    :end-before: index to here
 
-:ref:`maxFlow`
-
-.. include:: flow-family.rst
-   :start-after: index from here
-   :end-before: index to here
 
 :ref:`withPoints`
 
@@ -94,7 +89,6 @@ As part of the :ref:`dijkstra`
     bdAstar-family
     bdDijkstra-family
     withPoints-family
-
     cost-category
     costMatrix-category
     KSP-category
@@ -154,7 +148,6 @@ Experimental Functions
   :hidden:
 
   contraction-family
-  flow-family
   components-family
   pgr_gsoc_vrppdtw
   pgr_vrpOneDepot

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -47,6 +47,29 @@ To see the full list of changes check the list of `Git commits <https://github.c
 pgRouting 3.0.0 Release Notes
 -------------------------------------------------------------------------------
 
+.. rubric:: Proposed moved to official on pgRouting
+
+* Flow Family
+  * pgr_pushRelabel(one to one)
+  * pgr_pushRelabel(one to many)
+  * pgr_pushRelabel(many to one)
+  * pgr_pushRelabel(many to many)
+  * pgr_edmondsKarp(one to one)
+  * pgr_edmondsKarp(one to many)
+  * pgr_edmondsKarp(many to one)
+  * pgr_edmondsKarp(many to many)
+  * pgr_boykovKolmogorov (one to one)
+  * pgr_boykovKolmogorov (one to many)
+  * pgr_boykovKolmogorov (many to one)
+  * pgr_boykovKolmogorov (many to many)
+  * pgr_maxCardinalityMatching
+  * pgr_maxFlow
+  * pgr_edgeDisjointPaths(one to one)
+  * pgr_edgeDisjointPaths(one to many)
+  * pgr_edgeDisjointPaths(many to one)
+  * pgr_edgeDisjointPaths(many to many)
+
+
 .. rubric:: Moved to legacy
 
 * Experimental functions

--- a/doc/src/routingFunctions.rst
+++ b/doc/src/routingFunctions.rst
@@ -36,6 +36,12 @@ Routing Functions
    :start-after: index from here
    :end-before: index to here
 
+:doc:`flow-family`
+
+.. include:: flow-family.rst
+   :start-after: index from here
+   :end-before: index to here
+
 :ref:`pgr_ksp` - K-Shortest Path
 
 :ref:`pgr_trsp<trsp>` - Turn Restriction Shortest Path (TRSP)
@@ -61,6 +67,7 @@ Routing Functions
     pgr_bdAstar
     pgr_bdDijkstra
     dijkstra-family
+    flow-family
     pgr_KSP
     pgr_trsp
     TSP-family

--- a/doc/src/sampledata.rst
+++ b/doc/src/sampledata.rst
@@ -55,7 +55,7 @@ To be able to execute the sample queries, run the following SQL commands to crea
 
 .. rubric:: Categories
 
-- Used with the :ref:`maxFlow` functions.
+- Used with the :doc:`flow-family` functions.
 
 .. literalinclude:: ../../tools/testers/sampledata.sql
    :start-after: --RESTRICTIONS END


### PR DESCRIPTION
This PR makes the flow family of functions official on pgRouting
its on the main page:
https://cvvergara.github.io/pgr/en/index.html
No longer as proposed:
https://cvvergara.github.io/pgr/en/proposed.html
Main page of flow family of functions
https://cvvergara.github.io/pgr/en/flow-family.html
On the functions like [pgr_maxFlow](https://cvvergara.github.io/pgr/en/pgr_maxFlow.html) the *page* button shows: (this is a proposed standard for the page button)
        Synopsis
        Signature Summary
        Parameters
        Inner query
        Return Columns
        See Also


Changes to be committed:
* Updating news about the change
	modified:   ../NEWS
	modified:   src/release_notes.rst
* Updating the documentation & standarizing it
	modified:   max_flow/flow-family.rst
	modified:   max_flow/pgr_boykovKolmogorov.rst
	modified:   max_flow/pgr_edgeDisjointPaths.rst
	modified:   max_flow/pgr_edmondsKarp.rst
	modified:   max_flow/pgr_maxCardinalityMatch.rst
	modified:   max_flow/pgr_maxFlow.rst
	modified:   max_flow/pgr_pushRelabel.rst
* Some side effects of the standarization
	modified:   bdDijkstra/pgr_bdDijkstra.rst
	modified:   bdDijkstra/pgr_bdDijkstraCost.rst
	modified:   dijkstra/pgr_dijkstra.rst
	modified:   dijkstra/pgr_dijkstraCost.rst
	modified:   dijkstraTRSP/pgr_dijkstraTRSP.rst
	modified:   src/pgRouting-concepts.rst
	modified:   src/sampledata.rst
* Is no longer proposed
	modified:   src/proposed.rst
* Is part of the routing functions
	modified:   src/routingFunctions.rst

@pgRouting/admins
