### PR TITLE
bdDijkstra to official

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -32,6 +32,20 @@ pgRouting 3.0.0 Release Notes
   * pgr_bdAstarCostMatrix(many to one)
   * pgr_bdAstarCostMatrix(many to many)
 
+* bdDijkstra Family
+
+  * pgr_bdDijkstra(one to many)
+  * pgr_bdDijkstra(many to one)
+  * pgr_bdDijkstra(many to many)
+  * pgr_bdDijkstraCost(one to one)
+  * pgr_bdDijkstraCost(one to many)
+  * pgr_bdDijkstraCost(many to one)
+  * pgr_bdDijkstraCost(many to many)
+  * pgr_bdDijkstraCostMatrix(one to one)
+  * pgr_bdDijkstraCostMatrix(one to many)
+  * pgr_bdDijkstraCostMatrix(many to one)
+  * pgr_bdDijkstraCostMatrix(many to many)
+
 * Flow Family
 
   * pgr_pushRelabel(one to one)

--- a/doc/bdDijkstra/pgr_bdDijkstra.rst
+++ b/doc/bdDijkstra/pgr_bdDijkstra.rst
@@ -19,8 +19,20 @@ pgr_bdDijkstra
 
 .. rubric:: Availability:
 
-* pgr_bdDijkstra(one to one) 2.0.0, Signature changed 2.4.0
-* pgr_bdDijkstra(other signatures) 2.5.0
+* Proposed on v2.5.0 and Official on v3.0.0:
+
+  * pgr_bdDijkstra(One to Many)
+  * pgr_bdDijkstra(Many to One)
+  * pgr_bdDijkstra(Many to Many)
+
+* Signature change on v2.4.0
+
+  * pgr_bdDijkstra(One to One)
+
+* New on v2.0.0:
+
+  * pgr_astar(One to One)
+
 
 Signatures
 -------------------------------------------------------------------------------
@@ -29,25 +41,15 @@ Signatures
 
 .. code-block:: none
 
-    pgr_bdDijkstra(edges_sql, start_vid,  end_vid)
-    pgr_bdDijkstra(edges_sql, start_vid, end_vid, directed)
-    RETURNS SET OF (seq, path_seq, node, edge, cost, agg_cost)
-    OR EMPTY SET
-
-.. include:: proposed.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
-
-.. code-block:: none
-
-    pgr_bdDijkstra(edges_sql, start_vid, end_vids, directed)
-    pgr_bdDijkstra(edges_sql, start_vids, end_vid, directed)
-    pgr_bdDijkstra(edges_sql, start_vids, end_vids, directed)
+    pgr_bdDijkstra(edges_sql, start_vid, end_vid [, directed])
+    pgr_bdDijkstra(edges_sql, start_vid, end_vids [, directed])
+    pgr_bdDijkstra(edges_sql, start_vids, end_vid [, directed])
+    pgr_bdDijkstra(edges_sql, start_vids, end_vids [, directed])
 
     RETURNS SET OF (seq, path_seq [, start_vid] [, end_vid], node, edge, cost, agg_cost)
     OR EMPTY SET
 
-..rubric:: Minimal signature
+.. rubric:: Minimal signature
 
 .. code-block:: none
 
@@ -70,8 +72,9 @@ One to One
 
 .. code-block:: none
 
-    pgr_bdDijkstra(edges_sql, start_vid, end_vid, directed)
-    RETURNS SET OF (seq, path_seq, node, edge, cost, agg_cost) or EMPTY SET
+    pgr_bdDijkstra(edges_sql, start_vid, end_vid [, directed])
+    RETURNS SET OF (seq, path_seq, node, edge, cost, agg_cost)
+    OR EMPTY SET
 
 This signature finds the shortest path from one ``start_vid`` to one ``end_vid``:
 
@@ -92,8 +95,9 @@ One to many
 
 .. code-block:: none
 
-    pgr_bdDijkstra(edges_sql, start_vid, end_vids, directed)
-    RETURNS SET OF (seq, path_seq, end_vid, node, edge, cost, agg_cost) or EMPTY SET
+    pgr_bdDijkstra(edges_sql, start_vid, end_vids [, directed])
+    RETURNS SET OF (seq, path_seq, end_vid, node, edge, cost, agg_cost)
+    OR EMPTY SET
 
 This signature finds the shortest path from one ``start_vid`` to each ``end_vid`` in ``end_vids``:
 
@@ -120,8 +124,9 @@ Many to One
 
 .. code-block:: none
 
-    pgr_bdDijkstra(edges_sql, start_vids, end_vid, directed)
-    RETURNS SET OF (seq, path_seq, start_vid, node, edge, cost, agg_cost) or EMPTY SET
+    pgr_bdDijkstra(edges_sql, start_vids, end_vid [, directed])
+    RETURNS SET OF (seq, path_seq, start_vid, node, edge, cost, agg_cost)
+    OR EMPTY SET
 
 This signature finds the shortest path from each ``start_vid`` in  ``start_vids`` to one ``end_vid``:
 
@@ -148,8 +153,9 @@ Many to Many
 
 .. code-block:: none
 
-    pgr_bdDijkstra(edges_sql, start_vids, end_vids, directed)
-    RETURNS SET OF (seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost) or EMPTY SET
+    pgr_bdDijkstra(edges_sql, start_vids, end_vids [, directed])
+    RETURNS SET OF (seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)
+    OR EMPTY SET
 
 This signature finds the shortest path from each ``start_vid`` in  ``start_vids`` to each ``end_vid`` in ``end_vids``:
 

--- a/doc/bdDijkstra/pgr_bdDijkstra.rst
+++ b/doc/bdDijkstra/pgr_bdDijkstra.rst
@@ -31,7 +31,7 @@ pgr_bdDijkstra
 
 * New on v2.0.0:
 
-  * pgr_astar(One to One)
+  * pgr_bdDijkstra(One to One)
 
 
 Signatures

--- a/doc/bdDijkstra/pgr_bdDijkstraCost.rst
+++ b/doc/bdDijkstra/pgr_bdDijkstraCost.rst
@@ -7,7 +7,7 @@
     Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-pgr_bdDijkstraCost - Proposed
+pgr_bdDijkstraCost
 ===============================================================================
 
 ``pgr_bdDijkstraCost`` — Returns the shortest path(s)'s cost using Bidirectional Dijkstra algorithm.
@@ -17,11 +17,10 @@ pgr_bdDijkstraCost - Proposed
 
    Boost Graph Inside
 
-.. rubric:: Availability: 2.5.0
+.. rubric:: Availability:
 
-.. include:: proposed.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+* Official on v3.0.0
+* Proposed on v2.5.0
 
 Signatures
 -------------------------------------------------------------------------------
@@ -77,9 +76,9 @@ This signature finds the shortest path from one ``start_vid`` to one ``end_vid``
    :end-before: -- q3
 
 .. index::
-    single: bdDijkstraCost(One to Many) - Proposed
+    single: bdDijkstraCost(One to Many)
 
-One to many
+One to Many
 ...............................................................................
 
 .. code-block:: none
@@ -105,7 +104,7 @@ where the starting vertex is fixed, and stop when all ``end_vids`` are reached.
    :end-before: -- q4
 
 .. index::
-    single: bdDijkstraCost(Many to One) - Proposed
+    single: bdDijkstraCost(Many to One)
 
 Many to One
 ...............................................................................
@@ -134,7 +133,7 @@ where the ending vertex is fixed.
 
 
 .. index::
-    single: bdDijkstraCost(Many to Many) - Proposed
+    single: bdDijkstraCost(Many to Many)
 
 Many to Many
 ...............................................................................

--- a/doc/costMatrix/pgr_bdDijkstraCostMatrix.rst
+++ b/doc/costMatrix/pgr_bdDijkstraCostMatrix.rst
@@ -7,7 +7,7 @@
     Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-pgr_bdDijkstraCostMatrix - proposed
+pgr_bdDijkstraCostMatrix
 ===============================================================================
 
 Name
@@ -21,11 +21,11 @@ Name
 
    Boost Graph Inside
 
-.. rubric:: Availability: 2.5.0
+.. rubric:: Availability:
 
-.. include:: proposed.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+* Official on v3.0.0
+* Proposed on v2.5.0
+
 
 Synopsis
 -------------------------------------------------------------------------------
@@ -37,8 +37,7 @@ Signature Summary
 
 .. code-block:: none
 
-    pgr_bdDijkstraCostMatrix(edges_sql, start_vids)
-    pgr_bdDijkstraCostMatrix(edges_sql, start_vids, directed)
+    pgr_bdDijkstraCostMatrix(edges_sql, start_vids [, directed])
     RETURNS SET OF (start_vid, end_vid, agg_cost)
 
 
@@ -47,7 +46,7 @@ Signatures
 -------------------------------------------------------------------------------
 
 .. index::
-    single: bdDijkstraCostMatrix(Minimal Use) - Proposed
+    single: bdDijkstraCostMatrix(Minimal Use)
 
 Minimal Signature
 ...............................................................................
@@ -70,14 +69,14 @@ The minimal signature:
 
 
 .. index::
-    single: bdDijkstraCostMatrix(Complete Signature) - Proposed
+    single: bdDijkstraCostMatrix(Complete Signature)
 
 Complete Signature
 ...............................................................................
 
 .. code-block:: none
 
-    pgr_bdDijkstraCostMatrix(edges_sql, start_vids, directed:=true)
+    pgr_bdDijkstraCostMatrix(edges_sql, start_vids [, directed])
     RETURNS SET OF (start_vid, end_vid, agg_cost)
 
 

--- a/doc/src/proposed.rst
+++ b/doc/src/proposed.rst
@@ -36,13 +36,6 @@ As part of the :doc:`dijkstra-family`
 
 .. rubric:: Families
 
-:doc:`bdDijkstra-family`
-
-.. include:: bdDijkstra-family.rst
-   :start-after: index from here
-   :end-before: index to here
-
-
 :doc:`withPoints-family`
 
 .. include:: withPoints-family.rst
@@ -72,7 +65,6 @@ As part of the :doc:`dijkstra-family`
 .. toctree::
     :hidden:
 
-    bdDijkstra-family
     withPoints-family
     cost-category
     costMatrix-category

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -75,6 +75,20 @@ pgRouting 3.0.0 Release Notes
   * pgr_bdAstarCostMatrix(many to one)
   * pgr_bdAstarCostMatrix(many to many)
 
+* bdDijkstra Family
+
+  * pgr_bdDijkstra(one to many)
+  * pgr_bdDijkstra(many to one)
+  * pgr_bdDijkstra(many to many)
+  * pgr_bdDijkstraCost(one to one)
+  * pgr_bdDijkstraCost(one to many)
+  * pgr_bdDijkstraCost(many to one)
+  * pgr_bdDijkstraCost(many to many)
+  * pgr_bdDijkstraCostMatrix(one to one)
+  * pgr_bdDijkstraCostMatrix(one to many)
+  * pgr_bdDijkstraCostMatrix(many to one)
+  * pgr_bdDijkstraCostMatrix(many to many)
+
 * Flow Family
 
   * pgr_pushRelabel(one to one)

--- a/doc/src/routingFunctions.rst
+++ b/doc/src/routingFunctions.rst
@@ -33,8 +33,11 @@ Routing Functions
    :start-after: index from here
    :end-before: index to here
 
+:doc:`bdDijkstra-family`
 
-:doc:`pgr_bdDijkstra` - Bi-directional Dijkstra Shortest Path
+.. include:: bdDijkstra-family.rst
+   :start-after: index from here
+   :end-before: index to here
 
 
 :doc:`dijkstra-family`
@@ -73,7 +76,7 @@ Routing Functions
     allpairs-family
     aStar-family
     bdAstar-family
-    pgr_bdDijkstra
+    bdDijkstra-family
     dijkstra-family
     flow-family
     pgr_KSP

--- a/sql/bdDijkstra/_bdDijkstra.sql
+++ b/sql/bdDijkstra/_bdDijkstra.sql
@@ -26,9 +26,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 -- bdDijkstra MANY TO MANY
 CREATE OR REPLACE FUNCTION _pgr_bdDijkstra(
-    edges_sql TEXT,
-    start_vids ANYARRAY,
-    end_vids ANYARRAY,
+    TEXT, -- edges_sql
+    ANYARRAY, -- start_vids
+    ANYARRAY, -- end_vids
     directed BOOLEAN DEFAULT true,
     only_cost BOOLEAN DEFAULT false,
     OUT seq INTEGER,

--- a/sql/bdDijkstra/bdDijkstra.sql
+++ b/sql/bdDijkstra/bdDijkstra.sql
@@ -26,9 +26,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 -- ONE TO ONE
 CREATE OR REPLACE FUNCTION pgr_bdDijkstra(
-    edges_sql TEXT,
-    start_vid BIGINT,
-    end_vid BIGINT,
+    TEXT, -- edges_sql
+    BIGINT, -- start_vid
+    BIGINT, -- end_vid
     directed BOOLEAN DEFAULT true,
     OUT seq INTEGER,
     OUT path_seq INTEGER,
@@ -47,9 +47,9 @@ ROWS 1000;
 
 -- ONE TO MANY
 CREATE OR REPLACE FUNCTION pgr_bdDijkstra(
-    edges_sql TEXT,
-    start_vid BIGINT,
-    end_vids ANYARRAY,
+    TEXT, -- edges_sql
+    BIGINT, -- start_vid
+    ANYARRAY, -- end_vids
     directed BOOLEAN DEFAULT TRUE,
     OUT seq INTEGER,
     OUT path_seq INTEGER,
@@ -70,9 +70,9 @@ ROWS 1000;
 
 -- MANY TO ONE
 CREATE OR REPLACE FUNCTION pgr_bdDijkstra(
-    edges_sql TEXT,
-    start_vids ANYARRAY,
-    end_vid BIGINT,
+    TEXT, -- edges_sql
+    ANYARRAY, -- start_vids
+    BIGINT, -- end_vid
     directed BOOLEAN DEFAULT TRUE,
     OUT seq INTEGER,
     OUT path_seq INTEGER,
@@ -94,9 +94,9 @@ ROWS 1000;
 
 -- MANY TO MANY
 CREATE OR REPLACE FUNCTION pgr_bdDijkstra(
-    edges_sql TEXT,
-    start_vids ANYARRAY,
-    end_vids ANYARRAY,
+    TEXT, -- edges_sql
+    ANYARRAY, -- start_vids
+    ANYARRAY, -- end_vids
     directed BOOLEAN DEFAULT TRUE,
     OUT seq INTEGER,
     OUT path_seq INTEGER,

--- a/sql/bdDijkstra/bdDijkstraCost.sql
+++ b/sql/bdDijkstra/bdDijkstraCost.sql
@@ -26,9 +26,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 CREATE OR REPLACE FUNCTION pgr_bdDijkstraCost(
-    edges_sql TEXT,
-    BIGINT,
-    BIGINT,
+    TEXT, -- edges_sql
+    BIGINT, -- start_vid
+    BIGINT, -- end_vid
     directed BOOLEAN DEFAULT TRUE,
     OUT start_vid BIGINT,
     OUT end_vid BIGINT,
@@ -44,9 +44,9 @@ ROWS 1000;
 
 -- ONE TO MANY
 CREATE OR REPLACE FUNCTION pgr_bdDijkstraCost(
-    edges_sql TEXT,
-    BIGINT,
-    end_vids ANYARRAY,
+    TEXT, -- edges_sql
+    BIGINT, -- start_vid
+    end_vids ANYARRAY, -- end_vids
     directed BOOLEAN DEFAULT TRUE,
     OUT start_vid BIGINT,
     OUT end_vid BIGINT,
@@ -63,9 +63,9 @@ ROWS 1000;
 
 -- MANY TO ONE
 CREATE OR REPLACE FUNCTION pgr_bdDijkstraCost(
-    edges_sql TEXT,
-    start_vids ANYARRAY,
-    BIGINT,
+    edges_sql TEXT, -- edges_sql
+    start_vids ANYARRAY, -- start_vids
+    BIGINT, -- end_vid
     directed BOOLEAN DEFAULT TRUE,
     OUT start_vid BIGINT,
     OUT end_vid BIGINT,
@@ -83,9 +83,9 @@ ROWS 1000;
 
 -- MANY TO MANY
 CREATE OR REPLACE FUNCTION pgr_bdDijkstraCost(
-    edges_sql TEXT,
-    start_vids ANYARRAY,
-    end_vids ANYARRAY,
+    TEXT, -- edges_sql
+    ANYARRAY, -- start_vids
+    ANYARRAY, -- end_vids
     directed BOOLEAN DEFAULT TRUE,
     OUT start_vid BIGINT,
     OUT end_vid BIGINT,
@@ -98,3 +98,8 @@ $BODY$
 LANGUAGE SQL VOLATILE STRICT
 COST 100
 ROWS 1000;
+
+COMMENT ON FUNCTION pgr_bdDijkstraCost(TEXT, BIGINT, BIGINT, BOOLEAN) IS 'pgr_bdDijkstraCost(One to One)';
+COMMENT ON FUNCTION pgr_bdDijkstraCost(TEXT, ANYARRAY, BIGINT, BOOLEAN) IS 'pgr_bdDijkstraCost(Many to One)';
+COMMENT ON FUNCTION pgr_bdDijkstraCost(TEXT, BIGINT, ANYARRAY, BOOLEAN) IS 'pgr_bdDijkstraCost(One to Many)';
+COMMENT ON FUNCTION pgr_bdDijkstraCost(TEXT, ANYARRAY, ANYARRAY, BOOLEAN) IS 'pgr_bdDijkstraCost(Many to Many)';

--- a/sql/costMatrix/bdDijkstraCostMatrix.sql
+++ b/sql/costMatrix/bdDijkstraCostMatrix.sql
@@ -25,11 +25,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ********************************************************************PGR-GNU*/
 
 
---  BIDIRECTIONAL DIJKSTRA Matrix
+CREATE OR REPLACE FUNCTION pgr_bdDijkstraCostMatrix(
+    TEXT, -- edges_sql
+    ANYARRAY, -- vids
+    directed BOOLEAN DEFAULT true,
 
-
-CREATE OR REPLACE FUNCTION pgr_bdDijkstraCostMatrix(edges_sql TEXT, vids ANYARRAY, directed BOOLEAN DEFAULT true,
-    OUT start_vid BIGINT, OUT end_vid BIGINT, OUT agg_cost float)
+    OUT start_vid BIGINT,
+    OUT end_vid BIGINT,
+    OUT agg_cost FLOAT)
 RETURNS SETOF RECORD AS
 $BODY$
     SELECT a.start_vid, a.end_vid, a.agg_cost
@@ -39,5 +42,4 @@ LANGUAGE sql VOLATILE
 COST 100
 ROWS 1000;
 
-
-
+COMMENT ON FUNCTION pgr_bdDijkstraCostMatrix(TEXT, ANYARRAY, BOOLEAN) IS 'pgr_bdDijkstraCostMatrix(edges_sql, vids [, directed:=true])';


### PR DESCRIPTION
To view the proposed documentation with this PR: (Note: this links will not be permanent)
[Index](https://cvvergara.github.io/pgr/en/index.html#routing-functions) has the [Bidirectional Dijkstra family](https://cvvergara.github.io/pgr/en/bdDijkstra-family.html) that include:
* [pgr_bdDijkstra](https://cvvergara.github.io/pgr/en/pgr_bdDijkstra.html)
* [pgr_bdDijkstraCost](https://cvvergara.github.io/pgr/en/pgr_bdDijkstraCost.html)
* [pgr_bdDijkstraCostMatrix](https://cvvergara.github.io/pgr/en/pgr_bdDijkstraCostMatrix.html)

--------------
Changes committed:

* Updating NEWS and release notes
	modified:   NEWS
	modified:   doc/src/release_notes.rst

* Updating availability
	modified:   doc/bdDijkstra/pgr_bdDijkstra.rst
	modified:   doc/bdDijkstra/pgr_bdDijkstraCost.rst
	modified:   doc/costMatrix/pgr_bdDijkstraCostMatrix.rst

* Moving from proposed to Official
	modified:   doc/src/proposed.rst
	modified:   doc/src/routingFunctions.rst

* Adding coments on function & standarizing signatures
	modified:   sql/bdDijkstra/_bdDijkstra.sql
	modified:   sql/bdDijkstra/bdDijkstra.sql
	modified:   sql/bdDijkstra/bdDijkstraCost.sql
	modified:   sql/costMatrix/bdDijkstraCostMatrix.sql



@pgRouting/admins
