### PR TITLE
Extract vertices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,6 @@ matrix:
       env: POSTGRESQL_VERSION=9.4   PG_USER=postgres DOCUMENTATION=OFF
 
     - os: linux
-      env: POSTGRESQL_VERSION=9.3   PG_USER=postgres DOCUMENTATION=OFF
-
-    - os: linux
       env: POSTGRESQL_VERSION=9.6   PG_USER=postgres DOCUMENTATION=ON
 
 

--- a/doc/queries/CMakeLists.txt
+++ b/doc/queries/CMakeLists.txt
@@ -63,6 +63,7 @@ SET(LOCAL_FILES
     doc-pgr_primDFS.queries
     doc-pgr_primBFS.queries
     doc-pgr_randomSpanTree.queries
+    doc-pgr_extractVertices.queries
     )
 
 foreach (f ${LOCAL_FILES})

--- a/doc/queries/doc-pgr_extractVertices.queries
+++ b/doc/queries/doc-pgr_extractVertices.queries
@@ -1,0 +1,50 @@
+BEGIN;
+BEGIN
+SET client_min_messages TO NOTICE;
+SET
+--q1
+SELECT  * FROM pgr_extractVertices('SELECT source, target, the_geom FROM edge_table');
+ id |       x        |  y  |                  the_geom
+----+----------------+-----+--------------------------------------------
+  1 |              2 |   0 | 010100000000000000000000400000000000000000
+  2 |              2 |   1 | 01010000000000000000000040000000000000F03F
+  3 |              3 |   1 | 01010000000000000000000840000000000000F03F
+  4 |              4 |   1 | 01010000000000000000001040000000000000F03F
+  5 |              2 |   2 | 010100000000000000000000400000000000000040
+  6 |              3 |   2 | 010100000000000000000008400000000000000040
+  7 |              0 |   2 | 010100000000000000000000000000000000000040
+  8 |              1 |   2 | 0101000000000000000000F03F0000000000000040
+  9 |              4 |   2 | 010100000000000000000010400000000000000040
+ 10 |              2 |   3 | 010100000000000000000000400000000000000840
+ 11 |              3 |   3 | 010100000000000000000008400000000000000840
+ 12 |              4 |   3 | 010100000000000000000010400000000000000840
+ 13 |              2 |   4 | 010100000000000000000000400000000000001040
+ 14 |            0.5 | 3.5 | 0101000000000000000000E03F0000000000000C40
+ 15 | 1.999999999999 | 3.5 | 010100000068EEFFFFFFFFFF3F0000000000000C40
+ 16 |            3.5 | 2.3 | 01010000000000000000000C406666666666660240
+ 17 |            3.5 |   4 | 01010000000000000000000C400000000000001040
+(17 rows)
+
+--q1.1
+--q2
+SELECT  * FROM pgr_extractVertices('SELECT source, target FROM edge_table WHERE id < 5');
+ id | x | y | the_geom
+----+---+---+----------
+  1 |   |   |
+  2 |   |   |
+  3 |   |   |
+  4 |   |   |
+  5 |   |   |
+(5 rows)
+
+--q2.1
+--q3
+DROP IF EXISTS edge_table_vertices_pgr;
+ERROR:  syntax error at or near "IF"
+LINE 1: DROP IF EXISTS edge_table_vertices_pgr;
+             ^
+SELECT  * INTO edge_table_vertices_pgr FROM pgr_extractVertices('SELECT source, target, the_geom FROM edge_table');
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+--q3.1
+ROLLBACK;
+ROLLBACK

--- a/doc/queries/doc-pgr_extractVertices.queries
+++ b/doc/queries/doc-pgr_extractVertices.queries
@@ -39,12 +39,33 @@ SELECT  * FROM pgr_extractVertices('SELECT source, target FROM edge_table WHERE 
 
 --q2.1
 --q3
-DROP IF EXISTS edge_table_vertices_pgr;
-ERROR:  syntax error at or near "IF"
-LINE 1: DROP IF EXISTS edge_table_vertices_pgr;
-             ^
-SELECT  * INTO edge_table_vertices_pgr FROM pgr_extractVertices('SELECT source, target, the_geom FROM edge_table');
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+DROP TABLE IF EXISTS edge_table_vertices_pgr;
+DROP TABLE
+SELECT  * INTO edge_table_vertices_pgr
+FROM pgr_extractVertices('SELECT source, target, the_geom FROM edge_table');
+SELECT 17
+SELECT * FROM edge_table_vertices_pgr;
+ id |       x        |  y  |                  the_geom
+----+----------------+-----+--------------------------------------------
+  1 |              2 |   0 | 010100000000000000000000400000000000000000
+  2 |              2 |   1 | 01010000000000000000000040000000000000F03F
+  3 |              3 |   1 | 01010000000000000000000840000000000000F03F
+  4 |              4 |   1 | 01010000000000000000001040000000000000F03F
+  5 |              2 |   2 | 010100000000000000000000400000000000000040
+  6 |              3 |   2 | 010100000000000000000008400000000000000040
+  7 |              0 |   2 | 010100000000000000000000000000000000000040
+  8 |              1 |   2 | 0101000000000000000000F03F0000000000000040
+  9 |              4 |   2 | 010100000000000000000010400000000000000040
+ 10 |              2 |   3 | 010100000000000000000000400000000000000840
+ 11 |              3 |   3 | 010100000000000000000008400000000000000840
+ 12 |              4 |   3 | 010100000000000000000010400000000000000840
+ 13 |              2 |   4 | 010100000000000000000000400000000000001040
+ 14 |            0.5 | 3.5 | 0101000000000000000000E03F0000000000000C40
+ 15 | 1.999999999999 | 3.5 | 010100000068EEFFFFFFFFFF3F0000000000000C40
+ 16 |            3.5 | 2.3 | 01010000000000000000000C406666666666660240
+ 17 |            3.5 |   4 | 01010000000000000000000C400000000000001040
+(17 rows)
+
 --q3.1
 ROLLBACK;
 ROLLBACK

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -64,11 +64,9 @@ Pgrouting Concepts
 :doc:`topology-functions`
 ===============================================================================
 
--  :doc:`pgr_createTopology` -  to create a topology based on the geometry.
--  :doc:`pgr_createVerticesTable` - to reconstruct the vertices table based on the source and target information.
--  :doc:`pgr_analyzeGraph`  - to analyze the edges and vertices of the edge table.
--  :doc:`pgr_analyzeOneWay` - to analyze directionality of the edges.
--  :doc:`pgr_nodeNetwork`  -to create nodes to a not noded edge table.
+.. include:: topology-functions.rst
+   :start-after: topology_index_start
+   :end-before: topology_index_end
 
 .. toctree::
    :hidden:

--- a/doc/src/proposed.rst
+++ b/doc/src/proposed.rst
@@ -79,6 +79,12 @@ Stable Proposed Functions
     KSP-category
 
 
+:doc:`topology-functions`
+
+.. include:: topology-functions.rst
+   :start-after: topology_proposed_start
+   :end-before: topology_proposed_end
+
 .. _proposed:
 
 Experimental Functions

--- a/doc/src/release_notes.back.rst
+++ b/doc/src/release_notes.back.rst
@@ -1,0 +1,773 @@
+..
+   ****************************************************************************
+    pgRouting Manual
+    Copyright(c) pgRouting Contributors
+
+    This documentation is licensed under a Creative Commons Attribution-Share
+    Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
+   ****************************************************************************
+
+Release Notes
+===============================================================================
+
+To see the full list of changes check the list of `Git commits <https://github.com/pgRouting/pgrouting/commits>`_ on Github.
+
+.. rubric:: Table of contents
+
+.. changelog start
+
+* :ref:`changelog_3_0_0`
+* :ref:`changelog_2_6_0`
+* :ref:`changelog_2_5_5`
+* :ref:`changelog_2_5_4`
+* :ref:`changelog_2_5_3`
+* :ref:`changelog_2_5_2`
+* :ref:`changelog_2_5_1`
+* :ref:`changelog_2_5_0`
+* :ref:`changelog_2_4_2`
+* :ref:`changelog_2_4_1`
+* :ref:`changelog_2_4_0`
+* :ref:`changelog_2_3_2`
+* :ref:`changelog_2_3_1`
+* :ref:`changelog_2_3_0`
+* :ref:`changelog_2_2_4`
+* :ref:`changelog_2_2_3`
+* :ref:`changelog_2_2_2`
+* :ref:`changelog_2_2_1`
+* :ref:`changelog_2_2_0`
+* :ref:`changelog_2_1_0`
+* :ref:`changelog_2_0_1`
+* :ref:`changelog_2_0_0`
+* :ref:`changelog_1_x`
+
+.. changelog end
+
+.. _changelog_3_0_0:
+
+pgRouting 3.0.0 Release Notes
+-------------------------------------------------------------------------------
+.. _changelog_2_5_5:
+
+pgRouting 2.5.5 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed milestone for 2.5.5 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.5.5%22%20>`_ on Github.
+
+.. rubric:: Bug fixes
+
+* Fixes driving distance when vertex is not part of the graph
+* Fixes windows test
+* Fixes build for python3 and perl5
+
+.. _changelog_2_5_4:
+
+.. rubric:: New Experimental functions
+
+* Prim family
+
+  * pgr_prim
+  * pgr_primDD
+  * pgr_primDFS
+  * pgr_primBFS
+
+* Kruskal family
+
+  * pgr_kruskal
+  * pgr_kruskalDD
+  * pgr_kruskalDFS
+  * pgr_kruskalBFS
+
+.. rubric:: Proposed moved to official on pgRouting
+
+* aStar Family
+
+  * pgr_aStar(one to many)
+  * pgr_aStar(many to one)
+  * pgr_aStar(many to many)
+  * pgr_aStarCost(one to one)
+  * pgr_aStarCost(one to many)
+  * pgr_aStarCost(many to one)
+  * pgr_aStarCost(many to many)
+  * pgr_aStarCostMatrix(one to one)
+  * pgr_aStarCostMatrix(one to many)
+  * pgr_aStarCostMatrix(many to one)
+  * pgr_aStarCostMatrix(many to many)
+
+* bdAstar Family
+
+  * pgr_bdAstar(one to many)
+  * pgr_bdAstar(many to one)
+  * pgr_bdAstar(many to many)
+  * pgr_bdAstarCost(one to one)
+  * pgr_bdAstarCost(one to many)
+  * pgr_bdAstarCost(many to one)
+  * pgr_bdAstarCost(many to many)
+  * pgr_bdAstarCostMatrix(one to one)
+  * pgr_bdAstarCostMatrix(one to many)
+  * pgr_bdAstarCostMatrix(many to one)
+  * pgr_bdAstarCostMatrix(many to many)
+
+* bdDijkstra Family
+
+  * pgr_bdDijkstra(one to many)
+  * pgr_bdDijkstra(many to one)
+  * pgr_bdDijkstra(many to many)
+  * pgr_bdDijkstraCost(one to one)
+  * pgr_bdDijkstraCost(one to many)
+  * pgr_bdDijkstraCost(many to one)
+  * pgr_bdDijkstraCost(many to many)
+  * pgr_bdDijkstraCostMatrix(one to one)
+  * pgr_bdDijkstraCostMatrix(one to many)
+  * pgr_bdDijkstraCostMatrix(many to one)
+  * pgr_bdDijkstraCostMatrix(many to many)
+
+* Flow Family
+
+  * pgr_pushRelabel(one to one)
+  * pgr_pushRelabel(one to many)
+  * pgr_pushRelabel(many to one)
+  * pgr_pushRelabel(many to many)
+  * pgr_edmondsKarp(one to one)
+  * pgr_edmondsKarp(one to many)
+  * pgr_edmondsKarp(many to one)
+  * pgr_edmondsKarp(many to many)
+  * pgr_boykovKolmogorov (one to one)
+  * pgr_boykovKolmogorov (one to many)
+  * pgr_boykovKolmogorov (many to one)
+  * pgr_boykovKolmogorov (many to many)
+  * pgr_maxCardinalityMatching
+  * pgr_maxFlow
+  * pgr_edgeDisjointPaths(one to one)
+  * pgr_edgeDisjointPaths(one to many)
+  * pgr_edgeDisjointPaths(many to one)
+  * pgr_edgeDisjointPaths(many to many)
+
+
+
+.. rubric:: Moved to legacy
+
+* Experimental functions
+
+  * pgr_labelGraph  -  Use the components family of functions instead.
+  * Max flow - functions were renamed on v2.5.0
+
+    * pgr_maxFlowPushRelabel
+    * pgr_maxFlowBoykovKolmogorov
+    * pgr_maxFlowEdmondsKarp
+    * pgr_maximumcardinalitymatching
+
+.. _changelog_2_6_0:
+
+pgRouting 2.6.0 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed milestone for 2.6.0 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.6.0%22%20>`_ on Github.
+
+
+.. rubric:: New fexperimental functions
+
+*  pgr_lineGraphFull
+
+.. rubric:: Bug fixes
+
+* Fix pgr_trsp(text,integer,double precision,integer,double precision,boolean,boolean[,text])
+
+  * without restrictions
+
+    * calls pgr_dijkstra when both end points have a fraction IN (0,1)
+    * calls pgr_withPoints when at least one fraction NOT IN (0,1)
+
+  * with restrictions
+
+    * calls original trsp code
+
+.. rubric:: Internal code
+
+* Cleaned the internal code of trsp(text,integer,integer,boolean,boolean [, text])
+
+  * Removed the use of pointers
+  * Internal code can accept BIGINT
+
+* Cleaned the internal code of withPoints
+
+
+.. _changelog_2_5_3:
+
+pgRouting 2.5.3 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed milestone for 2.5.3 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.5.3%22%20>`_ on Github.
+
+.. rubric:: Bug fixes
+
+* Fix for postgresql 11: Removed a compilation error when compiling with postgreSQL
+
+.. _changelog_2_5_2:
+
+pgRouting 2.5.2 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed milestone for 2.5.2 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.5.2%22%20>`_ on Github.
+
+.. rubric:: Bug fixes
+
+* Fix for postgresql 10.1: Removed a compiler condition
+
+
+.. _changelog_2_5_1:
+
+pgRouting 2.5.1 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed milestone for 2.5.1 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.5.1%22%20>`_ on Github.
+
+.. rubric:: Bug fixes
+
+* Fixed prerequisite minimum version of: cmake
+
+
+.. _changelog_2_5_0:
+
+pgRouting 2.5.0 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed issues for 2.5.0 <https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.5.0%22+is%3Aclosed>`_ on Github.
+
+
+.. rubric:: enhancement:
+
+* pgr_version is now on SQL language
+
+.. rubric:: Breaking change on:
+
+* pgr_edgeDisjointPaths:
+
+  * Added path_id, cost and agg_cost columns on the result
+  * Parameter names changed
+  * The many version results are the union of the one to one version
+
+.. rubric:: New Signatures:
+
+* pgr_bdAstar(one to one)
+
+.. rubric:: New Proposed functions
+
+* pgr_bdAstar(one to many)
+* pgr_bdAstar(many to one)
+* pgr_bdAstar(many to many)
+* pgr_bdAstarCost(one to one)
+* pgr_bdAstarCost(one to many)
+* pgr_bdAstarCost(many to one)
+* pgr_bdAstarCost(many to many)
+* pgr_bdAstarCostMatrix
+* pgr_bdDijkstra(one to many)
+* pgr_bdDijkstra(many to one)
+* pgr_bdDijkstra(many to many)
+* pgr_bdDijkstraCost(one to one)
+* pgr_bdDijkstraCost(one to many)
+* pgr_bdDijkstraCost(many to one)
+* pgr_bdDijkstraCost(many to many)
+* pgr_bdDijkstraCostMatrix
+* pgr_lineGraph
+* pgr_lineGraphFull
+* pgr_connectedComponents
+* pgr_strongComponents
+* pgr_biconnectedComponents
+* pgr_articulationPoints
+* pgr_bridges
+* pgr_minCostMaxFlow
+* pgr_minCostMaxFlow_Cost
+* pgr_directedChPP
+* pgr_directedChPP_Cost
+
+.. rubric:: Deprecated Signatures
+
+* pgr_bdastar - use pgr_bdAstar instead
+
+.. rubric:: Renamed Functions
+
+* pgr_maxFlowPushRelabel - use pgr_pushRelabel instead
+* pgr_maxFlowEdmondsKarp -use pgr_edmondsKarp instead
+* pgr_maxFlowBoykovKolmogorov - use pgr_boykovKolmogorov instead
+* pgr_maximumCardinalityMatching - use pgr_maxCardinalityMatch instead
+
+.. rubric:: Deprecated function
+
+* pgr_pointToEdgeNode
+
+
+.. _changelog_2_4_2:
+
+pgRouting 2.4.2 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed milestone for 2.4.2 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.4.2%22%20>`_ on Github.
+
+.. rubric:: Improvement
+
+* Works for postgreSQL 10
+
+.. rubric:: Bug fixes
+
+* Fixed: Unexpected error column "cname"
+* Replace __linux__ with __GLIBC__ for glibc-specific headers and functions
+
+
+
+.. _changelog_2_4_1:
+
+pgRouting 2.4.1 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed milestone for 2.4.1 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.4.1%22%20>`_ on Github.
+
+.. rubric:: Bug fixes
+
+* Fixed compiling error on macOS
+* Condition error on pgr_withPoints
+
+.. _changelog_2_4_0:
+
+pgRouting 2.4.0 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed issues for 2.4.0 <https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.4.0%22+is%3Aclosed>`_ on Github.
+
+.. rubric:: New Signatures
+
+* pgr_bdDijkstra
+
+
+.. rubric:: New Proposed Signatures
+
+* pgr_maxFlow
+* pgr_astar(one to many)
+* pgr_astar(many to one)
+* pgr_astar(many to many)
+* pgr_astarCost(one to one)
+* pgr_astarCost(one to many)
+* pgr_astarCost(many to one)
+* pgr_astarCost(many to many)
+* pgr_astarCostMatrix
+
+.. rubric:: Deprecated Signatures
+
+* pgr_bddijkstra - use pgr_bdDijkstra instead
+
+.. rubric:: Deprecated Functions
+
+* pgr_pointsToVids
+
+.. rubric:: Bug fixes
+
+* Bug fixes on proposed functions
+
+  * pgr_withPointsKSP: fixed ordering
+
+* TRSP original code is used with no changes on the compilation warnings
+
+.. _changelog_2_3_2:
+
+pgRouting 2.3.2 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed issues for 2.3.2 <https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.3.2%22+is%3Aclosed>`_ on Github.
+
+.. rubric:: Bug Fixes
+
+* Fixed pgr_gsoc_vrppdtw crash when all orders fit on one truck.
+* Fixed pgr_trsp:
+
+  * Alternate code is not executed when the point is in reality a vertex
+  * Fixed ambiguity on seq
+
+
+.. _changelog_2_3_1:
+
+pgRouting 2.3.1 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed issues for 2.3.1 <https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.3.1%22+is%3Aclosed>`_ on Github.
+
+.. rubric:: Bug Fixes
+
+* Leaks on proposed max_flow functions
+* Regression error on pgr_trsp
+* Types discrepancy on pgr_createVerticesTable
+
+
+.. _changelog_2_3_0:
+
+pgRouting 2.3.0 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed issues for 2.3.0 <https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.3.0%22+is%3Aclosed>`_ on Github.
+
+.. rubric:: New Signatures
+
+* pgr_TSP
+* pgr_aStar
+
+.. rubric:: New Functions
+
+* pgr_eucledianTSP
+
+
+.. rubric:: New Proposed functions
+
+* pgr_dijkstraCostMatrix
+* pgr_withPointsCostMatrix
+* pgr_maxFlowPushRelabel(one to one)
+* pgr_maxFlowPushRelabel(one to many)
+* pgr_maxFlowPushRelabel(many to one)
+* pgr_maxFlowPushRelabel(many to many)
+* pgr_maxFlowEdmondsKarp(one to one)
+* pgr_maxFlowEdmondsKarp(one to many)
+* pgr_maxFlowEdmondsKarp(many to one)
+* pgr_maxFlowEdmondsKarp(many to many)
+* pgr_maxFlowBoykovKolmogorov (one to one)
+* pgr_maxFlowBoykovKolmogorov (one to many)
+* pgr_maxFlowBoykovKolmogorov (many to one)
+* pgr_maxFlowBoykovKolmogorov (many to many)
+* pgr_maximumCardinalityMatching
+* pgr_edgeDisjointPaths(one to one)
+* pgr_edgeDisjointPaths(one to many)
+* pgr_edgeDisjointPaths(many to one)
+* pgr_edgeDisjointPaths(many to many)
+* pgr_contractGraph
+
+
+.. rubric:: Deprecated Signatures
+
+* pgr_tsp - use pgr_TSP or pgr_eucledianTSP instead
+* pgr_astar - use pgr_aStar instead
+
+
+.. rubric:: Deprecated Functions
+
+* pgr_flip_edges
+* pgr_vidsToDmatrix
+* pgr_pointsToDMatrix
+* pgr_textToPoints
+
+
+
+.. _changelog_2_2_4:
+
+pgRouting 2.2.4 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed issues for 2.2.4 <https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.2.4%22+is%3Aclosed>`_ on Github.
+
+.. rubric:: Bug Fixes
+
+* Bogus uses of extern "C"
+* Build error on Fedora 24 + GCC 6.0
+* Regression error pgr_nodeNetwork
+
+.. _changelog_2_2_3:
+
+pgRouting 2.2.3 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed issues for 2.2.3 <https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.2.3%22+is%3Aclosed>`_ on Github.
+
+.. rubric:: Bug Fixes
+
+* Fixed compatibility issues with PostgreSQL 9.6.
+
+.. _changelog_2_2_2:
+
+pgRouting 2.2.2 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed issues for 2.2.2 <https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.2.2%22+is%3Aclosed>`_ on Github.
+
+.. rubric:: Bug Fixes
+
+* Fixed regression error on pgr_drivingDistance
+
+
+.. _changelog_2_2_1:
+
+pgRouting 2.2.1 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed issues for 2.2.1 <https://github.com/pgRouting/pgrouting/issues?q=milestone%3A2.2.1+is%3Aclosed>`_ on Github.
+
+.. rubric:: Bug Fixes
+
+* Server crash fix on pgr_alphaShape
+* Bug fix on With Points family of functions
+
+
+.. _changelog_2_2_0:
+
+pgRouting 2.2.0 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed issues for 2.2.0 <https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.2.0%22+is%3Aclosed>`_ on Github.
+
+
+.. rubric:: Improvements
+
+- pgr_nodeNetwork
+
+  - Adding a row_where and outall optional parameters
+
+- Signature fix
+
+  - pgr_dijkstra  -- to match what is documented
+
+
+.. rubric:: New Functions
+
+- pgr_floydWarshall
+- pgr_Johnson
+- pgr_dijkstraCost(one to one)
+- pgr_dijkstraCost(one to many)
+- pgr_dijkstraCost(many to one)
+- pgr_dijkstraCost(many to many)
+
+.. rubric:: Proposed functionality
+
+- pgr_withPoints(one to one)
+- pgr_withPoints(one to many)
+- pgr_withPoints(many to one)
+- pgr_withPoints(many to many)
+- pgr_withPointsCost(one to one)
+- pgr_withPointsCost(one to many)
+- pgr_withPointsCost(many to one)
+- pgr_withPointsCost(many to many)
+- pgr_withPointsDD(single vertex)
+- pgr_withPointsDD(multiple vertices)
+- pgr_withPointsKSP
+- pgr_dijkstraVia
+
+
+.. rubric:: Deprecated functions:
+
+- pgr_apspWarshall  use pgr_floydWarshall instead
+- pgr_apspJohnson   use pgr_Johnson instead
+- pgr_kDijkstraCost use pgr_dijkstraCost instead
+- pgr_kDijkstraPath use pgr_dijkstra instead
+
+.. rubric:: Renamed and deprecated function
+
+- pgr_makeDistanceMatrix renamed to _pgr_makeDistanceMatrix
+
+
+.. _changelog_2_1_0:
+
+pgRouting 2.1.0 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed issues for 2.1.0 <https://github.com/pgRouting/pgrouting/issues?q=is%3Aissue+milestone%3A%22Release+2.1.0%22+is%3Aclosed>`_ on Github.
+
+.. rubric:: New Signatures
+
+- pgr_dijkstra(one to many)
+- pgr_dijkstra(many to one)
+- pgr_dijkstra(many to many)
+- pgr_drivingDistance(multiple vertices)
+
+.. rubric:: Refactored
+
+- pgr_dijkstra(one to one)
+- pgr_ksp
+- pgr_drivingDistance(single vertex)
+
+.. rubric:: Improvements
+
+- pgr_alphaShape function now can generate better (multi)polygon with holes and alpha parameter.
+
+.. rubric:: Proposed functionality
+
+- Proposed functions from Steve Woodbridge, (Classified as Convenience by the author.)
+
+  - pgr_pointToEdgeNode - convert a point geometry to a vertex_id based on closest edge.
+  - pgr_flipEdges - flip the edges in an array of geometries so the connect end to end.
+  - pgr_textToPoints - convert a string of x,y;x,y;... locations into point geometries.
+  - pgr_pointsToVids - convert an array of point geometries into vertex ids.
+  - pgr_pointsToDMatrix - Create a distance matrix from an array of points.
+  - pgr_vidsToDMatrix - Create a distance matrix from an array of vertix_id.
+  - pgr_vidsToDMatrix - Create a distance matrix from an array of vertix_id.
+
+- Added proposed functions from GSoc Projects:
+
+  - pgr_vrppdtw
+  - pgr_vrponedepot
+
+.. rubric:: Deprecated functions
+
+- pgr_getColumnName
+- pgr_getTableName
+- pgr_isColumnCndexed
+- pgr_isColumnInTable
+- pgr_quote_ident
+- pgr_versionless
+- pgr_startPoint
+- pgr_endPoint
+- pgr_pointToId
+
+.. rubric:: No longer supported
+
+- Removed the 1.x legacy functions
+
+.. rubric:: Bug Fixes
+
+- Some bug fixes in other functions
+
+
+.. rubric:: Refactoring Internal Code
+
+- A C and C++ library for developer was created
+
+  - encapsulates postgreSQL related functions
+  - encapsulates Boost.Graph graphs
+
+    - Directed Boost.Graph
+    - Undirected Boost.graph.
+
+  - allow any-integer in the id's
+  - allow any-numerical on the cost/reverse_cost columns
+
+- Instead of generating many libraries:
+  - All functions are encapsulated in one library
+  - The library has the prefix 2-1-0
+
+
+
+.. _changelog_2_0_1:
+
+pgRouting 2.0.1 Release Notes
+-------------------------------------------------------------------------------
+
+Minor bug fixes.
+
+.. rubric:: Bug Fixes
+
+* No track of the bug fixes were kept.
+
+
+.. _changelog_2_0_0:
+
+pgRouting 2.0.0 Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed issues for 2.0.0 <https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.0.0%22+is%3Aclosed>`_ on Github.
+
+With the release of pgRouting 2.0.0 the library has abandoned backwards compatibility to :ref:`pgRouting 1.x <changelog_1_x>` releases.
+The main Goals for this release are:
+
+* Major restructuring of pgRouting.
+* Standardization of the function naming
+* Preparation of the project for future development.
+
+As a result of this effort:
+
+* pgRouting has a simplified structure
+* Significant new functionality has being added
+* Documentation has being integrated
+* Testing has being integrated
+* And made it easier for multiple developers to make contributions.
+
+
+.. rubric:: Important Changes
+
+* Graph Analytics - tools for detecting and fixing connection some problems in a graph
+* A collection of useful utility functions
+* Two new All Pairs Short Path algorithms (pgr_apspJohnson, pgr_apspWarshall)
+* Bi-directional Dijkstra and A-star search algorithms (pgr_bdAstar, pgr_bdDijkstra)
+* One to many nodes search (pgr_kDijkstra)
+* K alternate paths shortest path (pgr_ksp)
+* New TSP solver that simplifies the code and the build process (pgr_tsp), dropped "Gaul Library" dependency
+* Turn Restricted shortest path (pgr_trsp) that replaces Shooting Star
+* Dropped support for Shooting Star
+* Built a test infrastructure that is run before major code changes are checked in
+* Tested and fixed most all of the outstanding bugs reported against 1.x that existing in the 2.0-dev code base.
+* Improved build process for Windows
+* Automated testing on Linux and Windows platforms trigger by every commit
+* Modular library design
+* Compatibility with PostgreSQL 9.1 or newer
+* Compatibility with PostGIS 2.0 or newer
+* Installs as PostgreSQL EXTENSION
+* Return types re factored and unified
+* Support for table SCHEMA in function parameters
+* Support for ``st_`` PostGIS function prefix
+* Added ``pgr_`` prefix to functions and types
+* Better documentation: http://docs.pgrouting.org
+* shooting_star is discontinued
+
+
+
+.. _changelog_1_x:
+
+pgRouting 1.x Release Notes
+-------------------------------------------------------------------------------
+
+To see the issues closed by this release see the `Git closed issues for 1.x <https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+1.x%22+is%3Aclosed>`_ on Github.
+The following release notes have been copied from the previous ``RELEASE_NOTES`` file and are kept as a reference.
+
+
+Changes for release 1.05
+...............................................................................
+
+* Bug fixes
+
+
+Changes for release 1.03
+...............................................................................
+
+* Much faster topology creation
+* Bug fixes
+
+
+Changes for release 1.02
+...............................................................................
+
+* Shooting* bug fixes
+* Compilation problems solved
+
+
+Changes for release 1.01
+...............................................................................
+
+* Shooting* bug fixes
+
+
+Changes for release 1.0
+...............................................................................
+
+* Core and extra functions are separated
+* Cmake build process
+* Bug fixes
+
+
+Changes for release 1.0.0b
+...............................................................................
+
+* Additional SQL file with more simple names for wrapper functions
+* Bug fixes
+
+
+Changes for release 1.0.0a
+...............................................................................
+
+* Shooting* shortest path algorithm for real road networks
+* Several SQL bugs were fixed
+
+
+Changes for release 0.9.9
+...............................................................................
+
+* PostgreSQL 8.2 support
+* Shortest path functions return empty result if they could not find any path
+
+
+Changes for release 0.9.8
+...............................................................................
+
+* Renumbering scheme was added to shortest path functions
+* Directed shortest path functions were added
+* routing_postgis.sql was modified to use dijkstra in TSP search

--- a/doc/topology/CMakeLists.txt
+++ b/doc/topology/CMakeLists.txt
@@ -5,6 +5,7 @@ SET(LOCAL_FILES
     pgr_nodeNetwork.rst
     pgr_analyzeOneWay.rst
     pgr_createVerticesTable.rst
+    pgr_extractVertices.rst
     topology-functions.rst
     )
 

--- a/doc/topology/pgr_extractVertices.rst
+++ b/doc/topology/pgr_extractVertices.rst
@@ -1,0 +1,103 @@
+..
+   ****************************************************************************
+    pgRouting Manual
+    Copyright(c) pgRouting Contributors
+
+    This documentation is licensed under a Creative Commons Attribution-Share
+    Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
+   ****************************************************************************
+
+pgr_extractVertices -- Proposed
+===============================================================================
+
+``pgr_extractVertices`` — Extracts the vertices information based on the source and target.
+
+.. rubric:: Availability
+
+* New on v3.0.0
+
+Description
+-------------------------------------------------------------------------------
+
+Extracts the vertex information of the edges of a graph
+
+Signatures
+-------------------------------------------------------------------------------
+
+.. code-block:: sql
+
+   pgr_extractVertices(Edges SQL)
+   RETURNS SETOF (id, x, y, the_geom)
+
+:Example: Extracting the vertex information
+
+.. literalinclude:: doc-pgr_extractVertices.queries
+   :start-after: --q1
+   :end-before: --q1.1
+
+
+Parameters
+-------------------------------------------------------------------------------
+
+============== ==================  =================================================
+Parameter      Type                Description
+============== ==================  =================================================
+**Edges SQL**  ``TEXT``            Inner SQL query as described bellow.
+============== ==================  =================================================
+
+Inner Query
+-------------------------------------------------------------------------------
+
+.. rubric:: Edges SQL
+
+================= =================== =================================================
+Column            Type                Description
+================= =================== =================================================
+**source**        ``ANY-INTEGER``     Identifier of the first end point vertex of the edge.
+**target**        ``ANY-INTEGER``     Identifier of the second end point vertex of the edge.
+**the_geom**      ``LINESTRING``      (Optional) Geometry of the edge
+================= =================== =================================================
+
+
+Return Columns
+-------------------------------------------------------------------------------
+
+================= =============== =================================================
+Column            Type                Description
+================= =============== =================================================
+**id**            ``BIGINT``      Identifier of the first end point vertex of the edge.
+**x**             ``FLOAT``       X value of the POINT geometry
+                                  - `NULL` When no LINESTRING geometry is provided
+**y**             ``FLOAT``       Y value of the POINT geometry
+                                  - `NULL` When no LINESTRING geometry is provided
+**the_geom**      ``POINT``       Geometry of the POINT
+                                  - `NULL` When no LINESTRING geometry is provided
+================= =============== =================================================
+
+
+Additional Examples
+-------------------------------------------------------------------------------
+
+:Example 1: Extracting the vertex information without geometry for the first :math:`4` edges
+
+.. literalinclude:: doc-pgr_extractVertices.queries
+   :start-after: --q2
+   :end-before: --q2.1
+
+:Example 2: Creating a vertices table
+
+.. literalinclude:: doc-pgr_extractVertices.queries
+   :start-after: --q2
+   :end-before: --q2.1
+
+
+See Also
+-------------------------------------------------------------------------------
+
+* :doc:`topology-functions`  for an overview of a topology for routing algorithms.
+* :doc:`pgr_createVerticesTable` to create a topology based on the geometry.
+
+.. rubric:: Indices and tables
+
+* :ref:`genindex`
+* :ref:`search`

--- a/doc/topology/topology-functions.rst
+++ b/doc/topology/topology-functions.rst
@@ -14,16 +14,29 @@ The pgRouting's topology of a network, represented with an edge table with sourc
 Depending on the algorithm, you can create a topology or just reconstruct the vertices table, You can analyze the topology,
 We also provide a function to node an unoded network.
 
+.. topology_index_start
+
 -  :doc:`pgr_createTopology` -  to create a topology based on the geometry.
 -  :doc:`pgr_createVerticesTable` - to reconstruct the vertices table based on the source and target information.
 -  :doc:`pgr_analyzeGraph`  - to analyze the edges and vertices of the edge table.
 -  :doc:`pgr_analyzeOneWay` - to analyze directionality of the edges.
 -  :doc:`pgr_nodeNetwork`  -to create nodes to a not noded edge table.
 
+.. topology_index_end
+
+.. rubric:: Proposed
+
+.. topology_proposed_start
+
+-  :doc:`pgr_extractVertices` - Extracts vertices information based on the source and target.
+
+.. topology_proposed_end
+
 .. toctree::
   :hidden:
 
   pgr_createTopology
+  pgr_extractVertices
   pgr_createVerticesTable
   pgr_analyzeGraph
   pgr_analyzeOneWay

--- a/pgtap/topology/extractVertices/edge-cases.sql
+++ b/pgtap/topology/extractVertices/edge-cases.sql
@@ -1,0 +1,67 @@
+\i setup.sql
+
+SELECT plan(4);
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+--
+PREPARE query_1 AS
+SELECT * FROM pgr_extractVertices(
+    'SELECT source, target, the_geom
+    FROM edge_table WHERE id > 18'
+);
+
+PREPARE query_2 AS
+SELECT *
+FROM pgr_extractVertices(
+    'SELECT source, target
+     FROM edge_table WHERE id > 18'
+);
+
+SELECT is_empty('query_1', 'No_edge -> No answer');
+SELECT is_empty('query_2', 'No_edge -> No answer');
+
+
+--
+PREPARE query_3 AS
+SELECT count(*)
+FROM pgr_extractVertices(
+    'SELECT source, target, the_geom
+    FROM edge_table'
+);
+
+SELECT set_eq('query_3',
+    $$VALUES (17)$$,
+    '3: Number of vertices extracted');
+
+--
+PREPARE query_4 AS
+SELECT id
+FROM pgr_extractVertices(
+    'SELECT source, target, the_geom
+    FROM edge_table'
+);
+
+SELECT bag_has('query_4',
+$$VALUES
+(1),
+(2),
+(3),
+(4),
+(5),
+(6),
+(7),
+(8),
+(9),
+(10),
+(11),
+(12),
+(14),
+(15),
+(16),
+(17)$$,
+'4: query result');
+
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/topology/extractVertices/innerQuery.sql
+++ b/pgtap/topology/extractVertices/innerQuery.sql
@@ -1,0 +1,24 @@
+\i setup.sql
+
+SELECT plan(10);
+
+CREATE OR REPLACE FUNCTION style_id_s_t(fn TEXT, rest_sql TEXT)
+RETURNS SETOF TEXT AS
+$BODY$
+BEGIN
+
+--with the_geom
+RETURN QUERY SELECT test_anyInteger(fn, rest_sql,
+    ARRAY['id', 'source', 'target', 'the_geom'],
+    'source');
+RETURN QUERY SELECT test_anyInteger(fn, rest_sql,
+    ARRAY['id', 'source', 'target', 'the_geom'],
+    'target');
+END;
+$BODY$
+LANGUAGE plpgsql;
+
+SELECT style_id_s_t('pgr_extractVertices', ')');
+
+SELECT finish();
+ROLLBACK;

--- a/pgtap/topology/extractVertices/no_crash_test.sql
+++ b/pgtap/topology/extractVertices/no_crash_test.sql
@@ -1,0 +1,52 @@
+\i setup.sql
+
+SELECT plan(17);
+
+PREPARE edges AS
+SELECT source, target, the_geom  FROM edge_table;
+
+PREPARE edges1 AS
+SELECT source, target  FROM edge_table;
+
+SELECT isnt_empty('edges', 'Should be not empty to tests be meaningful');
+
+
+CREATE OR REPLACE FUNCTION test_function()
+RETURNS SETOF TEXT AS
+$BODY$
+DECLARE
+params TEXT[];
+subs TEXT[];
+BEGIN
+    -- with geometry
+    params = ARRAY[
+    '$$SELECT source, target, the_geom  FROM edge_table$$'
+    ]::TEXT[];
+
+    subs = ARRAY[
+    'NULL'
+    ]::TEXT[];
+
+    RETURN query SELECT * FROM no_crash_test('pgr_extractVertices', params, subs);
+
+    params[1] := '$$edges$$';
+    RETURN query SELECT * FROM no_crash_test('pgr_extractVertices', params, subs);
+
+    -- no geometry
+    params = ARRAY[
+    '$$SELECT source, target  FROM edge_table$$'
+    ]::TEXT[];
+
+    RETURN query SELECT * FROM no_crash_test('pgr_extractVertices', params, subs);
+
+    params[1] := '$$edges1$$';
+    RETURN query SELECT * FROM no_crash_test('pgr_extractVertices', params, subs);
+
+END
+$BODY$
+LANGUAGE plpgsql VOLATILE;
+
+
+SELECT * FROM test_function();
+
+ROLLBACK;

--- a/pgtap/topology/extractVertices/types-check.sql
+++ b/pgtap/topology/extractVertices/types-check.sql
@@ -1,0 +1,32 @@
+\i setup.sql
+
+SELECT plan(5);
+
+----------------------------------
+-- tests for all
+-- prefix:  pgr_extractvertices
+----------------------------------
+
+SELECT has_function('pgr_extractvertices');
+SELECT has_function('pgr_extractvertices',    ARRAY['text']);
+SELECT function_returns('pgr_extractvertices', ARRAY['text'], 'setof record');
+
+-- pgr_extractvertices
+-- parameter names
+SELECT set_eq(
+    $$SELECT  proargnames from pg_proc where proname = 'pgr_extractvertices'$$,
+    $$SELECT  '{"","id","x","y","the_geom"}'::TEXT[] $$
+);
+
+PREPARE fn_types AS
+SELECT ARRAY[25,20,701,701,oid] FROM pg_type WHERE typname = 'geometry';
+
+-- parameter types
+SELECT set_eq(
+    $$SELECT  proallargtypes from pg_proc where proname = 'pgr_extractvertices'$$,
+    $$fn_types$$
+);
+
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/sql/topology/CMakeLists.txt
+++ b/sql/topology/CMakeLists.txt
@@ -5,6 +5,7 @@ SET(LOCAL_FILES
     analyzeOneway.sql
     createverticestable.sql
     nodeNetwork.sql
+    extractVertices.sql
     )
 
 foreach (f ${LOCAL_FILES})

--- a/sql/topology/extractVertices.sql
+++ b/sql/topology/extractVertices.sql
@@ -1,0 +1,115 @@
+/*PGR-GNU*****************************************************************
+File: extractVertices.sql
+
+Copyright (c) 2018 Celia Virginia Vergara Castillo
+Mail: vicky_vergara@hotmail.com
+
+------
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; WITHout even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along WITH this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+********************************************************************PGR-GNU*/
+
+---------------------------
+-- pgr_extractVertices
+---------------------------
+
+
+CREATE OR REPLACE FUNCTION pgr_extractVertices(
+    TEXT,  -- SQL inner query (required)
+
+    OUT id BIGINT,
+    OUT x FLOAT,
+    OUT y FLOAT,
+    OUT the_geom geometry
+)
+RETURNS SETOF RECORD AS
+$BODY$
+DECLARE
+    edges_sql TEXT;
+    quoted TEXT;
+    query TEXT;
+    has_geom BOOLEAN := TRUE;
+    fnName TEXT;
+
+BEGIN
+    fnName = 'pgr_extractVertices';
+    RAISE DEBUG 'PROCESSING: %(''%'')', fnName, edges_sql;
+
+    BEGIN
+        quoted = '.*' || $1 || '.*as';
+        query = format($$
+            SELECT regexp_replace(regexp_replace(statement, %1$L,'','i'),';$','') FROM pg_prepared_statements WHERE name = %2$L$$,
+            quoted, $1);
+        EXECUTE query INTO edges_sql;
+
+        EXCEPTION WHEN OTHERS
+            THEN edges_sql := $1;
+    END;
+
+    IF edges_SQL IS NULL THEN
+        edges_sql := $1;
+    END IF;
+
+    BEGIN
+        query = 'SELECT the_geom FROM ('||edges_sql||' ) AS __a__ limit 1';
+        EXECUTE query;
+
+        EXCEPTION WHEN OTHERS THEN
+            has_geom := FALSE;
+    END;
+
+    IF has_geom THEN
+        query := $q$
+        SELECT DISTINCT source, ST_X(geom), ST_Y(geom), geom FROM (
+            SELECT source, ST_startpoint(the_geom) AS geom
+            FROM ( $q$ || edges_sql || $q$) AS __a__
+
+            UNION
+            SELECT target, ST_endpoint(the_geom)
+            FROM ( $q$ || edges_sql || $q$) AS __b__ ) AS __c__ $q$;
+    ELSE
+        query := $q$
+        SELECT DISTINCT source, NULL::FLOAT, NULL::FLOAT, NULL::geometry FROM (
+            SELECT source
+            FROM ( $q$ || edges_sql || $q$) AS a
+
+            UNION
+            SELECT target
+            FROM ( $q$ || edges_sql || $q$) AS b ) AS c $q$;
+    END IF;
+
+    RAISE DEBUG 'query %', query;
+    RETURN QUERY EXECUTE query;
+
+    EXCEPTION WHEN OTHERS THEN
+    RAISE EXCEPTION '%', SQLERRM
+        USING HINT = 'Please check query: '|| $1;
+
+END;
+$BODY$
+LANGUAGE plpgsql VOLATILE STRICT;
+
+
+-- COMMENTS
+
+
+COMMENT ON FUNCTION pgr_extractVertices(TEXT)
+IS 'pgr_extractVertices
+- Parameters
+    - Edges SQL with columns: source, target [, the_geom]
+- Documentation:
+- ${PGROUTING_DOC_LINK}/pgr_extractVertices.html
+';

--- a/test/topology/doc-pgr_extractVertices.result
+++ b/test/topology/doc-pgr_extractVertices.result
@@ -1,0 +1,50 @@
+BEGIN;
+BEGIN
+SET client_min_messages TO NOTICE;
+SET
+--q1
+SELECT  * FROM pgr_extractVertices('SELECT source, target, the_geom FROM edge_table');
+ id |       x        |  y  |                  the_geom
+----+----------------+-----+--------------------------------------------
+  1 |              2 |   0 | 010100000000000000000000400000000000000000
+  2 |              2 |   1 | 01010000000000000000000040000000000000F03F
+  3 |              3 |   1 | 01010000000000000000000840000000000000F03F
+  4 |              4 |   1 | 01010000000000000000001040000000000000F03F
+  5 |              2 |   2 | 010100000000000000000000400000000000000040
+  6 |              3 |   2 | 010100000000000000000008400000000000000040
+  7 |              0 |   2 | 010100000000000000000000000000000000000040
+  8 |              1 |   2 | 0101000000000000000000F03F0000000000000040
+  9 |              4 |   2 | 010100000000000000000010400000000000000040
+ 10 |              2 |   3 | 010100000000000000000000400000000000000840
+ 11 |              3 |   3 | 010100000000000000000008400000000000000840
+ 12 |              4 |   3 | 010100000000000000000010400000000000000840
+ 13 |              2 |   4 | 010100000000000000000000400000000000001040
+ 14 |            0.5 | 3.5 | 0101000000000000000000E03F0000000000000C40
+ 15 | 1.999999999999 | 3.5 | 010100000068EEFFFFFFFFFF3F0000000000000C40
+ 16 |            3.5 | 2.3 | 01010000000000000000000C406666666666660240
+ 17 |            3.5 |   4 | 01010000000000000000000C400000000000001040
+(17 rows)
+
+--q1.1
+--q2
+SELECT  * FROM pgr_extractVertices('SELECT source, target FROM edge_table WHERE id < 5');
+ id | x | y | the_geom
+----+---+---+----------
+  1 |   |   |
+  2 |   |   |
+  3 |   |   |
+  4 |   |   |
+  5 |   |   |
+(5 rows)
+
+--q2.1
+--q3
+DROP IF EXISTS edge_table_vertices_pgr;
+ERROR:  syntax error at or near "IF"
+LINE 1: DROP IF EXISTS edge_table_vertices_pgr;
+             ^
+SELECT  * INTO edge_table_vertices_pgr FROM pgr_extractVertices('SELECT source, target, the_geom FROM edge_table');
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+--q3.1
+ROLLBACK;
+ROLLBACK

--- a/test/topology/doc-pgr_extractVertices.result
+++ b/test/topology/doc-pgr_extractVertices.result
@@ -39,12 +39,33 @@ SELECT  * FROM pgr_extractVertices('SELECT source, target FROM edge_table WHERE 
 
 --q2.1
 --q3
-DROP IF EXISTS edge_table_vertices_pgr;
-ERROR:  syntax error at or near "IF"
-LINE 1: DROP IF EXISTS edge_table_vertices_pgr;
-             ^
-SELECT  * INTO edge_table_vertices_pgr FROM pgr_extractVertices('SELECT source, target, the_geom FROM edge_table');
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+DROP TABLE IF EXISTS edge_table_vertices_pgr;
+DROP TABLE
+SELECT  * INTO edge_table_vertices_pgr
+FROM pgr_extractVertices('SELECT source, target, the_geom FROM edge_table');
+SELECT 17
+SELECT * FROM edge_table_vertices_pgr;
+ id |       x        |  y  |                  the_geom
+----+----------------+-----+--------------------------------------------
+  1 |              2 |   0 | 010100000000000000000000400000000000000000
+  2 |              2 |   1 | 01010000000000000000000040000000000000F03F
+  3 |              3 |   1 | 01010000000000000000000840000000000000F03F
+  4 |              4 |   1 | 01010000000000000000001040000000000000F03F
+  5 |              2 |   2 | 010100000000000000000000400000000000000040
+  6 |              3 |   2 | 010100000000000000000008400000000000000040
+  7 |              0 |   2 | 010100000000000000000000000000000000000040
+  8 |              1 |   2 | 0101000000000000000000F03F0000000000000040
+  9 |              4 |   2 | 010100000000000000000010400000000000000040
+ 10 |              2 |   3 | 010100000000000000000000400000000000000840
+ 11 |              3 |   3 | 010100000000000000000008400000000000000840
+ 12 |              4 |   3 | 010100000000000000000010400000000000000840
+ 13 |              2 |   4 | 010100000000000000000000400000000000001040
+ 14 |            0.5 | 3.5 | 0101000000000000000000E03F0000000000000C40
+ 15 | 1.999999999999 | 3.5 | 010100000068EEFFFFFFFFFF3F0000000000000C40
+ 16 |            3.5 | 2.3 | 01010000000000000000000C406666666666660240
+ 17 |            3.5 |   4 | 01010000000000000000000C400000000000001040
+(17 rows)
+
 --q3.1
 ROLLBACK;
 ROLLBACK

--- a/test/topology/doc-pgr_extractVertices.test.sql
+++ b/test/topology/doc-pgr_extractVertices.test.sql
@@ -1,0 +1,13 @@
+\echo --q1
+SELECT  * FROM pgr_extractVertices('SELECT source, target, the_geom FROM edge_table');
+\echo --q1.1
+
+\echo --q2
+SELECT  * FROM pgr_extractVertices('SELECT source, target FROM edge_table WHERE id < 5');
+\echo --q2.1
+
+\echo --q3
+DROP IF EXISTS edge_table_vertices_pgr;
+SELECT  * INTO edge_table_vertices_pgr FROM pgr_extractVertices('SELECT source, target, the_geom FROM edge_table');
+\echo --q3.1
+

--- a/test/topology/doc-pgr_extractVertices.test.sql
+++ b/test/topology/doc-pgr_extractVertices.test.sql
@@ -7,7 +7,9 @@ SELECT  * FROM pgr_extractVertices('SELECT source, target FROM edge_table WHERE 
 \echo --q2.1
 
 \echo --q3
-DROP IF EXISTS edge_table_vertices_pgr;
-SELECT  * INTO edge_table_vertices_pgr FROM pgr_extractVertices('SELECT source, target, the_geom FROM edge_table');
+DROP TABLE IF EXISTS edge_table_vertices_pgr;
+SELECT  * INTO edge_table_vertices_pgr
+FROM pgr_extractVertices('SELECT source, target, the_geom FROM edge_table');
+SELECT * FROM edge_table_vertices_pgr;
 \echo --q3.1
 

--- a/test/topology/test.conf
+++ b/test/topology/test.conf
@@ -12,21 +12,20 @@
             doc-pgr_createVerticesTable
             doc-pgr_analyzeGraph
             nodeNetwork-any
+            doc-pgr_extractVertices
             )],
 
         'documentation' => [qw(
             doc-pgr_analyzeGraph
             doc-pgr_createTopology
             doc-pgr_createVerticesTable
+            doc-pgr_extractVertices
             )],
 
         'dummyStorage' => [qw(
             )]
 
     },
-# 'vpg-vpgis' => {}, # for version specific tests
-# '8-1' => {}, # for pg 8.x and postgis 1.x
-# '9.2-2.1' => {}, # for pg 9.2 and postgis 2.1
 );
 
 1;


### PR DESCRIPTION
While fixing pgr_createVerticesTable
I came up with the idea that the user must be the one controlling the table creation.
So extract vertices, does basically the same stuff, but without so much checking that had to go on for safety reasons because of the table creation.
This function needs the source and target columns of an edge table, optionally also the geometry
It also based on an inner query.




@pgRouting/admins
