### PR TITLE
Small adjustments to FindPostgreSQL.cmake

### DIFF
--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -85,7 +85,7 @@ else(POSTGRESQL_INCLUDE_DIR AND POSTGRESQL_LIBRARIES AND POSTGRESQL_EXECUTABLE)
 
     find_path(POSTGRESQL_INCLUDE_DIR postgres.h
         ${T_POSTGRESQL_INCLUDE_DIR}
-
+        /usr/pgsql-*/include/server
         /usr/include/server
         /usr/include/pgsql/server
         /usr/local/include/pgsql/server


### PR DESCRIPTION
Small adjustments to FindPostgreSQL.cmake, needed if installation is performed based on instructions here: https://www.postgresql.org/download/linux/redhat/

Fixes # .

Changes proposed in this pull request:
- added to FindPostgreSQL.cmake the custom path of an installation performed following PostgreSQL instructions

@pgRouting/admins
