### PR TITLE
fixed pgr_pointsAsPolygon breaking when comparing strings in WHERE clause

### DIFF
--- a/pgtap/common/hasnt_v2_signatures.sql
+++ b/pgtap/common/hasnt_v2_signatures.sql
@@ -30,7 +30,7 @@ SELECT hasnt_function('pgr_ksp',ARRAY['text', 'integer', 'integer', 'integer', '
 SELECT hasnt_function('pgr_drivingdistance',ARRAY['text', 'integer', 'double precision', 'boolean', 'boolean']);
 SELECT hasnt_function('pgr_bdastar',ARRAY['text', 'integer', 'integer', 'boolean', 'boolean']);
 SELECT hasnt_function('pgr_bddijkstra',ARRAY['text', 'integer', 'integer', 'boolean', 'boolean']);
-SELECT hasnt_function('pgr_tsp',ARRAY['(double precision[]', 'integer', 'integer']);
+SELECT hasnt_function('pgr_tsp',ARRAY['double precision[]', 'integer', 'integer']);
 
 -- deprecated functions
 SELECT hasnt_function('pgr_kdijkstracost');

--- a/sql/alpha_shape/alpha_shape.sql
+++ b/sql/alpha_shape/alpha_shape.sql
@@ -59,7 +59,7 @@ CREATE OR REPLACE FUNCTION pgr_pointsAsPolygon(query varchar, alpha float8 DEFAU
 		geoms := array[]::geometry[];
 		i := 1;
 
-		FOR vertex_result IN EXECUTE 'SELECT x, y FROM pgr_alphashape('''|| query || ''', ' || alpha || ')'
+		FOR vertex_result IN EXECUTE 'SELECT x, y FROM pgr_alphashape('''|| REPLACE(query, E'\'', E'\'\'') || ''', ' || alpha || ')'
 		LOOP
 			x[i] = vertex_result.x;
 			y[i] = vertex_result.y;


### PR DESCRIPTION
Fixes #1192 .

Changes proposed in this pull request:
- Replace single quotes in the query passed to `pgr_pointsAsPolygon()` with escaped quotes, stopping a failure if a string comparison is specified in its `WHERE` clause in the subsequent call to `pgr_alphaShape()`

@pgRouting/admins
