### PR TITLE
[doc] Typo corrections

### DIFF
--- a/doc/dijkstra/pgr_dijkstra.rst
+++ b/doc/dijkstra/pgr_dijkstra.rst
@@ -175,7 +175,7 @@ Parameters
 ============== ================== ======== =================================================
 Parameter      Type               Default     Description
 ============== ================== ======== =================================================
-**edges_sql**  ``TEXT``                    Inner SQL query as described bellow.
+**edges_sql**  ``TEXT``                    Inner SQL query as described below.
 **start_vid**  ``BIGINT``                  Identifier of the starting vertex of the path.
 **start_vids** ``ARRAY[BIGINT]``           Array of identifiers of starting vertices.
 **end_vid**    ``BIGINT``                  Identifier of the ending vertex of the path.

--- a/doc/topology/pgr_extractVertices.rst
+++ b/doc/topology/pgr_extractVertices.rst
@@ -42,7 +42,7 @@ Parameters
 ============== ==================  =================================================
 Parameter      Type                Description
 ============== ==================  =================================================
-**Edges SQL**  ``TEXT``            Inner SQL query as described bellow.
+**Edges SQL**  ``TEXT``            Inner SQL query as described below.
 ============== ==================  =================================================
 
 Inner Query


### PR DESCRIPTION
This PR fixes the typo `bellow` to `below` in `pgr_dijkstra.rst` and `pgr_extractVertices.rst`.

@pgRouting/admins
