### PR TITLE
implicit cast for via_path integer to text

### DIFF
--- a/sql/trsp/trsp_V2.2.sql
+++ b/sql/trsp/trsp_V2.2.sql
@@ -105,7 +105,7 @@ BEGIN
             $6 || $$
         )
         SELECT ROW_NUMBER() OVER() AS id,
-            _pgr_array_reverse(array_prepend(target_id, string_to_array(via_path, ',')::INTEGER[])) AS path,
+            _pgr_array_reverse(array_prepend(target_id, string_to_array(via_path::text, ',')::INTEGER[])) AS path,
             to_cost AS cost
         FROM old_restrictions;
     $$;


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- I have faced the issue with SQL queries for a string to array conversion for integer values. I have updated this setting in my local server and its working fine. decided to push and make a pull request for this.
-
-

@pgRouting/admins
