### PR TITLE
fix edge case for tsp when there is one or two nodes

### DIFF
--- a/include/tsp/pgr_tsp.hpp
+++ b/include/tsp/pgr_tsp.hpp
@@ -504,6 +504,7 @@ template < typename MATRIX >
 void
 TSP<MATRIX>::swapClimb() {
     invariant();
+    if (!(n > 2)) return;
     pgassert(n > 2);
 
     //    auto first = std::rand() % n;
@@ -537,6 +538,8 @@ TSP<MATRIX>::annealing(
         bool randomize,
         double time_limit) {
     invariant();
+    if (!(n > 2)) return;
+
     clock_t start_time(clock());
 
     if (randomize) {


### PR DESCRIPTION
Fixes an assertion problem on TSP
```

ERROR:  AssertFailedException: n > 2 at /home/vicky/pgRouting/pgrouting/include/tsp/pgr_tsp.hpp:572
*** Execution path***
[bt]/usr/lib/postgresql/10/lib/libpgrouting-3.0.so(_Z13get_backtraceB5cxx11v+0x40) [0x7f4acea4712c]
[bt]/usr/lib/postgresql/10/lib/libpgrouting-3.0.so(_ZN9pgrouting3tsp3TSPINS0_7DmatrixEE9annealingEdddlllbd+0x1a4) [0x7f4aceb05bd0]
[bt]/usr/lib/postgresql/10/lib/libpgrouting-3.0.so(do_pgr_tsp+0x521) [0x7f4aceb035d0]
[bt]/usr/lib/postgresql/10/lib/libpgrouting-3.0.so(+0x5f992b) [0x7f4aceb0292b]
```

@pgRouting/admins
