### PR TITLE
Licenses standard

### DIFF
--- a/include/allpairs/pgr_allpairs.hpp
+++ b/include/allpairs/pgr_allpairs.hpp
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 // http://www.cs.rpi.edu/~musser/archive/2005/gsd/restricted/FloydWarshall/FloydWarshall.pdf
 

--- a/include/alphaShape/pgr_alphaShape.h
+++ b/include/alphaShape/pgr_alphaShape.h
@@ -23,7 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_ALPHASHAPE_PGR_ALPHASHAPE_H_

--- a/include/astar/pgr_astar.hpp
+++ b/include/astar/pgr_astar.hpp
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_ASTAR_PGR_ASTAR_HPP_
 #define INCLUDE_ASTAR_PGR_ASTAR_HPP_

--- a/include/bdAstar/pgr_bdAstar.hpp
+++ b/include/bdAstar/pgr_bdAstar.hpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_BDASTAR_PGR_BDASTAR_HPP_
 #define INCLUDE_BDASTAR_PGR_BDASTAR_HPP_

--- a/include/bellman_ford/pgr_bellman_ford.hpp
+++ b/include/bellman_ford/pgr_bellman_ford.hpp
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_BELLMAN_FORD_PGR_BELLMAN_FORD_HPP_
 #define INCLUDE_BELLMAN_FORD_PGR_BELLMAN_FORD_HPP_

--- a/include/c_common/arrays_input.h
+++ b/include/c_common/arrays_input.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_C_COMMON_ARRAYS_INPUT_H_
 #define INCLUDE_C_COMMON_ARRAYS_INPUT_H_

--- a/include/c_common/check_parameters.h
+++ b/include/c_common/check_parameters.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_C_COMMON_CHECK_PARAMETERS_H_
 #define INCLUDE_C_COMMON_CHECK_PARAMETERS_H_

--- a/include/c_common/coordinates_input.h
+++ b/include/c_common/coordinates_input.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 #ifndef INCLUDE_C_COMMON_COORDINATES_INPUT_H_
 #define INCLUDE_C_COMMON_COORDINATES_INPUT_H_
 #pragma once

--- a/include/c_common/debug_macro.h
+++ b/include/c_common/debug_macro.h
@@ -21,7 +21,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_C_COMMON_DEBUG_MACRO_H_
 #define INCLUDE_C_COMMON_DEBUG_MACRO_H_

--- a/include/c_common/delauny_input.h
+++ b/include/c_common/delauny_input.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 #ifndef INCLUDE_C_COMMON_DELAUNY_INPUT_H_
 #define INCLUDE_C_COMMON_DELAUNY_INPUT_H_
 #pragma once

--- a/include/c_common/edges_input.h
+++ b/include/c_common/edges_input.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_C_COMMON_EDGES_INPUT_H_
 #define INCLUDE_C_COMMON_EDGES_INPUT_H_

--- a/include/c_common/get_check_data.h
+++ b/include/c_common/get_check_data.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_C_COMMON_GET_CHECK_DATA_H_
 #define INCLUDE_C_COMMON_GET_CHECK_DATA_H_

--- a/include/c_common/matrixRows_input.h
+++ b/include/c_common/matrixRows_input.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_C_COMMON_MATRIXROWS_INPUT_H_
 #define INCLUDE_C_COMMON_MATRIXROWS_INPUT_H_

--- a/include/c_common/pgr_point_input.h
+++ b/include/c_common/pgr_point_input.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_C_COMMON_PGR_POINT_INPUT_H_
 #define INCLUDE_C_COMMON_PGR_POINT_INPUT_H_

--- a/include/c_common/points_input.h
+++ b/include/c_common/points_input.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_C_COMMON_POINTS_INPUT_H_
 #define INCLUDE_C_COMMON_POINTS_INPUT_H_

--- a/include/c_common/postgres_connection.h
+++ b/include/c_common/postgres_connection.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 #ifndef INCLUDE_C_COMMON_POSTGRES_CONNECTION_H_
 #define INCLUDE_C_COMMON_POSTGRES_CONNECTION_H_
 #pragma once

--- a/include/c_common/restrictions_input.h
+++ b/include/c_common/restrictions_input.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_C_COMMON_RESTRICTIONS_INPUT_H_
 #define INCLUDE_C_COMMON_RESTRICTIONS_INPUT_H_

--- a/include/c_types/column_info_t.h
+++ b/include/c_types/column_info_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_COLUMN_INFO_T_H_

--- a/include/c_types/contracted_rt.h
+++ b/include/c_types/contracted_rt.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_CONTRACTED_RT_H_

--- a/include/c_types/coordinate_t.h
+++ b/include/c_types/coordinate_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_COORDINATE_T_H_

--- a/include/c_types/delauny_t.h
+++ b/include/c_types/delauny_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_DELAUNY_T_H_

--- a/include/c_types/general_path_element_t.h
+++ b/include/c_types/general_path_element_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_GENERAL_PATH_ELEMENT_T_H_

--- a/include/c_types/geom_text_rt.h
+++ b/include/c_types/geom_text_rt.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_GEOM_TEXT_RT_H_

--- a/include/c_types/graph_enum.h
+++ b/include/c_types/graph_enum.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_GRAPH_ENUM_H_

--- a/include/c_types/line_graph_full_rt.h
+++ b/include/c_types/line_graph_full_rt.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_LINE_GRAPH_FULL_RT_H_

--- a/include/c_types/line_graph_rt.h
+++ b/include/c_types/line_graph_rt.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_LINE_GRAPH_RT_H_

--- a/include/c_types/matrix_cell_t.h
+++ b/include/c_types/matrix_cell_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_MATRIX_CELL_T_H_

--- a/include/c_types/pgr_basic_edge_t.h
+++ b/include/c_types/pgr_basic_edge_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_PGR_BASIC_EDGE_T_H_

--- a/include/c_types/pgr_components_rt.h
+++ b/include/c_types/pgr_components_rt.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_PGR_COMPONENTS_RT_H_

--- a/include/c_types/pgr_costFlow_t.h
+++ b/include/c_types/pgr_costFlow_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_PGR_COSTFLOW_T_H_

--- a/include/c_types/pgr_edge_t.h
+++ b/include/c_types/pgr_edge_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_PGR_EDGE_T_H_

--- a/include/c_types/pgr_edge_xy_t.h
+++ b/include/c_types/pgr_edge_xy_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_PGR_EDGE_XY_T_H_

--- a/include/c_types/pgr_flow_t.h
+++ b/include/c_types/pgr_flow_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_PGR_FLOW_T_H_

--- a/include/c_types/pgr_mst_rt.h
+++ b/include/c_types/pgr_mst_rt.h
@@ -4,18 +4,22 @@ File: pgr_kruskal_t.h
 Copyright (c) 2015 Aditya Pratap Singh
 Mail: adityapratap.singh28@gmail.com
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_PGR_MST_RT_H_

--- a/include/c_types/pgr_point_t.h
+++ b/include/c_types/pgr_point_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_PGR_POINT_T_H_

--- a/include/c_types/pgr_prim_rt.h
+++ b/include/c_types/pgr_prim_rt.h
@@ -4,18 +4,22 @@ File: pgr_prim_t.h
 Copyright (c) 2015 Aditya Pratap Singh
 Mail: adityapratap.singh28@gmail.com
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_PGR_PRIM_RT_H_

--- a/include/c_types/pgr_randomSpanningTree_t.h
+++ b/include/c_types/pgr_randomSpanningTree_t.h
@@ -4,18 +4,22 @@ File: pgr_randomSpnningTree_t.h
 Copyright (c) 2015 Aditya Pratap Singh
 Mail: adityapratap.singh28@gmail.com
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_PGR_RANDOMSPANNINGTREE_T_H_

--- a/include/c_types/pgr_stoerWagner_t.h
+++ b/include/c_types/pgr_stoerWagner_t.h
@@ -4,18 +4,22 @@ File: pgr_stoerWagner_t.h
 Copyright (c) 2015 Aditya Pratap Singh
 Mail: adityapratap.singh28@gmail.com
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_PGR_STOERWAGNER_T_H_

--- a/include/c_types/pickDeliver/general_vehicle_orders_t.h
+++ b/include/c_types/pickDeliver/general_vehicle_orders_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_PICKDELIVER_GENERAL_VEHICLE_ORDERS_T_H_

--- a/include/c_types/pickDeliver/pickDeliveryOrders_t.h
+++ b/include/c_types/pickDeliver/pickDeliveryOrders_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_PICKDELIVER_PICKDELIVERYORDERS_T_H_

--- a/include/c_types/pickDeliver/vehicle_t.h
+++ b/include/c_types/pickDeliver/vehicle_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_PICKDELIVER_VEHICLE_T_H_

--- a/include/c_types/point_on_edge_t.h
+++ b/include/c_types/point_on_edge_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_POINT_ON_EDGE_T_H_

--- a/include/c_types/restriction_t.h
+++ b/include/c_types/restriction_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_RESTRICTION_T_H_

--- a/include/c_types/routes_t.h
+++ b/include/c_types/routes_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_C_TYPES_ROUTES_T_H_

--- a/include/c_types/trsp/trsp.h
+++ b/include/c_types/trsp/trsp.h
@@ -1,23 +1,27 @@
-/*
- * Shortest path with turn restrictions algorithm for PostgreSQL
- *
- * Copyright (c) 2011 Stephen Woodbridge
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * aint64 with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- */
+/*PGR-GNU*****************************************************************
+
+FILE: trsp.h
+
+Copyright (c) 2015 pgRouting developers
+Mail: project@pgrouting.org
+
+------
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_C_TYPES_TRSP_TRSP_H_
 #define INCLUDE_C_TYPES_TRSP_TRSP_H_

--- a/include/c_types/trsp_types.h
+++ b/include/c_types/trsp_types.h
@@ -1,24 +1,27 @@
-/*
- * Shortest path with turn restrictions algorithm for PostgreSQL
- *
- * Copyright (c) 2017 pgRouting developers
- * Mail: project@pgrouting.org
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- */
+/*PGR-GNU*****************************************************************
+
+FILE: trsp_types.h
+
+Copyright (c) 2015 pgRouting developers
+Mail: project@pgrouting.org
+
+------
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_C_TYPES_TRSP_TYPES_H_
 #define INCLUDE_C_TYPES_TRSP_TYPES_H_

--- a/include/chinese/pgr_chinesePostman.hpp
+++ b/include/chinese/pgr_chinesePostman.hpp
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_CHPP_PGR_DIRECTEDCHPP_HPP_
 #define INCLUDE_CHPP_PGR_DIRECTEDCHPP_HPP_

--- a/include/components/componentsResult.h
+++ b/include/components/componentsResult.h
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_COMPONENTS_COMPONENTSRESULT_H_
 #define INCLUDE_COMPONENTS_COMPONENTSRESULT_H_

--- a/include/components/pgr_components.hpp
+++ b/include/components/pgr_components.hpp
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_COMPONENTS_PGR_COMPONENTS_HPP_
 #define INCLUDE_COMPONENTS_PGR_COMPONENTS_HPP_

--- a/include/contraction/pgr_contract.hpp
+++ b/include/contraction/pgr_contract.hpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_CONTRACTION_PGR_CONTRACT_HPP_
 #define INCLUDE_CONTRACTION_PGR_CONTRACT_HPP_

--- a/include/cpp_common/basePath_SSEC.hpp
+++ b/include/cpp_common/basePath_SSEC.hpp
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /*! @file */
 

--- a/include/cpp_common/basic_edge.h
+++ b/include/cpp_common/basic_edge.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /*! @file */
 

--- a/include/cpp_common/basic_vertex.h
+++ b/include/cpp_common/basic_vertex.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /*! @file */
 

--- a/include/cpp_common/bline.hpp
+++ b/include/cpp_common/bline.hpp
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /*! @file */
 

--- a/include/cpp_common/bpoint.hpp
+++ b/include/cpp_common/bpoint.hpp
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /*! @file */
 

--- a/include/cpp_common/compPaths.h
+++ b/include/cpp_common/compPaths.h
@@ -6,18 +6,22 @@ Copyright (c) 2018 Celia Virginia Vergara Castillo
 Mail: vicky@georepublic.de
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_CPP_COMMON_COMPPATHS_H_
 #define INCLUDE_CPP_COMMON_COMPPATHS_H_

--- a/include/cpp_common/identifier.h
+++ b/include/cpp_common/identifier.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /*! @file */
 

--- a/include/cpp_common/identifiers.hpp
+++ b/include/cpp_common/identifiers.hpp
@@ -1,6 +1,6 @@
 /*PGR-GNU*****************************************************************
 
-File: identifiers.hpp
+FILE: identifiers.hpp
 
 Generated with Template by:
 Copyright (c) 2015 pgRouting developers
@@ -10,6 +10,7 @@ Function's developer:
 Copyright (c) 2016 Rohith Reddy
 Mail:
 
+------
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/include/cpp_common/line_vertex.h
+++ b/include/cpp_common/line_vertex.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /*! @file */
 

--- a/include/cpp_common/linear_directed_graph.h
+++ b/include/cpp_common/linear_directed_graph.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_CPP_COMMON_LINEAR_DIRECTED_GRAPH_H_

--- a/include/cpp_common/path_t.h
+++ b/include/cpp_common/path_t.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /*! @file */
 

--- a/include/cpp_common/pgr_alloc.hpp
+++ b/include/cpp_common/pgr_alloc.hpp
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /*! @file */
 

--- a/include/cpp_common/pgr_assert.h
+++ b/include/cpp_common/pgr_assert.h
@@ -1,14 +1,27 @@
-/*PGR-MIT******************************************************************
- *
- * file pgr_assert.h
- *
- * Copyright 2014 Stephen Woodbridge <woodbri@imaptools.com>
- * Copyright 2014 Vicky Vergara <vicky_vergara@hotmail.com>
- *
- * This is free software; you can redistribute and/or modify it under
- * the terms of the MIT License. Please file MIT-LICENSE for details.
- *
- *****************************************************************PGR-MIT*/
+/*PGR-GNU*****************************************************************
+
+FILE: pgr_assert
+
+Copyright 2015~ Vicky Vergara <vicky_vergara@hotmail.com>
+Copyright 2014 Stephen Woodbridge <woodbri@imaptools.com>
+
+------
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
 
 #ifndef  INCLUDE_CPP_COMMON_PGR_ASSERT_H_
 #define  INCLUDE_CPP_COMMON_PGR_ASSERT_H_

--- a/include/cpp_common/pgr_base_graph.hpp
+++ b/include/cpp_common/pgr_base_graph.hpp
@@ -3,18 +3,22 @@
 Copyright (c) 2015 Celia Virginia Vergara Castillo
 vicky_vergara@hotmail.com
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 /*! @file */
 

--- a/include/cpp_common/pgr_bidirectional.hpp
+++ b/include/cpp_common/pgr_bidirectional.hpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /*! @file */
 

--- a/include/cpp_common/rule.h
+++ b/include/cpp_common/rule.h
@@ -18,7 +18,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-aint64_t with this program; if not, write to the Free Software
+along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/

--- a/include/cpp_common/signalhandler.h
+++ b/include/cpp_common/signalhandler.h
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*PGR-MIT******************************************************************
  *
  * file signalhandler.h

--- a/include/cpp_common/xy_vertex.h
+++ b/include/cpp_common/xy_vertex.h
@@ -6,19 +6,19 @@
 
  ------
 
- This program is free software; you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation; either version 2 of the License, or
- (at your option) any later version.
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- GNU General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
 
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 

--- a/include/dagShortestPath/pgr_dagShortestPath.hpp
+++ b/include/dagShortestPath/pgr_dagShortestPath.hpp
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DAGSHORTESTPATH_PGR_DAGSHORTESTPATH_HPP_
 #define INCLUDE_DAGSHORTESTPATH_PGR_DAGSHORTESTPATH_HPP_

--- a/include/dijkstra/pgr_dijkstra.hpp
+++ b/include/dijkstra/pgr_dijkstra.hpp
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DIJKSTRA_PGR_DIJKSTRA_HPP_
 #define INCLUDE_DIJKSTRA_PGR_DIJKSTRA_HPP_

--- a/include/dijkstra/pgr_dijkstraVia.hpp
+++ b/include/dijkstra/pgr_dijkstraVia.hpp
@@ -23,7 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DIJKSTRA_PGR_DIJKSTRAVIA_HPP_
 #define INCLUDE_DIJKSTRA_PGR_DIJKSTRAVIA_HPP_

--- a/include/drivers/allpairs/floydWarshall_driver.h
+++ b/include/drivers/allpairs/floydWarshall_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_ALLPAIRS_FLOYDWARSHALL_DRIVER_H_
 #define INCLUDE_DRIVERS_ALLPAIRS_FLOYDWARSHALL_DRIVER_H_

--- a/include/drivers/allpairs/johnson_driver.h
+++ b/include/drivers/allpairs/johnson_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 #ifndef INCLUDE_DRIVERS_ALLPAIRS_JOHNSON_DRIVER_H_
 #define INCLUDE_DRIVERS_ALLPAIRS_JOHNSON_DRIVER_H_
 #pragma once

--- a/include/drivers/alpha_shape/alphaShape_driver.h
+++ b/include/drivers/alpha_shape/alphaShape_driver.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_ALPHA_SHAPE_ALPHASHAPE_DRIVER_H_
 #define INCLUDE_DRIVERS_ALPHA_SHAPE_ALPHASHAPE_DRIVER_H_

--- a/include/drivers/astar/astar_driver.h
+++ b/include/drivers/astar/astar_driver.h
@@ -24,7 +24,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_ASTAR_ASTAR_DRIVER_H_
 #define INCLUDE_DRIVERS_ASTAR_ASTAR_DRIVER_H_

--- a/include/drivers/bdAstar/bdAstar_driver.h
+++ b/include/drivers/bdAstar/bdAstar_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_BDASTAR_BDASTAR_DRIVER_H_
 #define INCLUDE_DRIVERS_BDASTAR_BDASTAR_DRIVER_H_

--- a/include/drivers/bdDijkstra/bdDijkstra_driver.h
+++ b/include/drivers/bdDijkstra/bdDijkstra_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_BDDIJKSTRA_BDDIJKSTRA_DRIVER_H_
 #define INCLUDE_DRIVERS_BDDIJKSTRA_BDDIJKSTRA_DRIVER_H_

--- a/include/drivers/bellman_ford/bellman_ford_driver.h
+++ b/include/drivers/bellman_ford/bellman_ford_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_BELLMAN_FORD_BELLMAN_FORD_DRIVER_H_
 #define INCLUDE_DRIVERS_BELLMAN_FORD_BELLMAN_FORD_DRIVER_H_

--- a/include/drivers/bellman_ford/bellman_ford_neg_driver.h
+++ b/include/drivers/bellman_ford/bellman_ford_neg_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_BELLMAN_FORD_BELLMAN_FORD_NEG_DRIVER_H_
 #define INCLUDE_DRIVERS_BELLMAN_FORD_BELLMAN_FORD_NEG_DRIVER_H_

--- a/include/drivers/chinese/chinesePostman_driver.h
+++ b/include/drivers/chinese/chinesePostman_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_CHPP_DIRECTEDCHPP_DRIVER_H_
 #define INCLUDE_DRIVERS_CHPP_DIRECTEDCHPP_DRIVER_H_

--- a/include/drivers/components/articulationPoints_driver.h
+++ b/include/drivers/components/articulationPoints_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_COMPONENTS_ARTICULATIONPOINTS_DRIVER_H_
 #define INCLUDE_DRIVERS_COMPONENTS_ARTICULATIONPOINTS_DRIVER_H_

--- a/include/drivers/components/biconnectedComponents_driver.h
+++ b/include/drivers/components/biconnectedComponents_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_COMPONENTS_BICONNECTEDCOMPONENTS_DRIVER_H_
 #define INCLUDE_DRIVERS_COMPONENTS_BICONNECTEDCOMPONENTS_DRIVER_H_

--- a/include/drivers/components/bridges_driver.h
+++ b/include/drivers/components/bridges_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_COMPONENTS_BRIDGES_DRIVER_H_
 #define INCLUDE_DRIVERS_COMPONENTS_BRIDGES_DRIVER_H_

--- a/include/drivers/components/connectedComponents_driver.h
+++ b/include/drivers/components/connectedComponents_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_COMPONENTS_CONNECTEDCOMPONENTS_DRIVER_H_
 #define INCLUDE_DRIVERS_COMPONENTS_CONNECTEDCOMPONENTS_DRIVER_H_

--- a/include/drivers/components/strongComponents_driver.h
+++ b/include/drivers/components/strongComponents_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_COMPONENTS_STRONGCOMPONENTS_DRIVER_H_
 #define INCLUDE_DRIVERS_COMPONENTS_STRONGCOMPONENTS_DRIVER_H_

--- a/include/drivers/contraction/contractGraph_driver.h
+++ b/include/drivers/contraction/contractGraph_driver.h
@@ -24,7 +24,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_CONTRACTION_CONTRACTGRAPH_DRIVER_H_
 #define INCLUDE_DRIVERS_CONTRACTION_CONTRACTGRAPH_DRIVER_H_

--- a/include/drivers/dagShortestPath/dagShortestPath_driver.h
+++ b/include/drivers/dagShortestPath/dagShortestPath_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_DAGSHORTESTPATH_DAGSHORTESTPATH_DRIVER_H_
 #define INCLUDE_DRIVERS_DAGSHORTESTPATH_DAGSHORTESTPATH_DRIVER_H_

--- a/include/drivers/dijkstra/dijkstraVia_driver.h
+++ b/include/drivers/dijkstra/dijkstraVia_driver.h
@@ -23,7 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_DIJKSTRA_DIJKSTRAVIA_DRIVER_H_
 #define INCLUDE_DRIVERS_DIJKSTRA_DIJKSTRAVIA_DRIVER_H_

--- a/include/drivers/dijkstra/dijkstra_driver.h
+++ b/include/drivers/dijkstra/dijkstra_driver.h
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_DIJKSTRA_DIJKSTRA_DRIVER_H_
 #define INCLUDE_DRIVERS_DIJKSTRA_DIJKSTRA_DRIVER_H_

--- a/include/drivers/driving_distance/drivedist_driver.h
+++ b/include/drivers/driving_distance/drivedist_driver.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_DRIVING_DISTANCE_DRIVEDIST_DRIVER_H_
 #define INCLUDE_DRIVERS_DRIVING_DISTANCE_DRIVEDIST_DRIVER_H_

--- a/include/drivers/driving_distance/withPoints_dd_driver.h
+++ b/include/drivers/driving_distance/withPoints_dd_driver.h
@@ -24,7 +24,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_DRIVING_DISTANCE_WITHPOINTS_DD_DRIVER_H_
 #define INCLUDE_DRIVERS_DRIVING_DISTANCE_WITHPOINTS_DD_DRIVER_H_

--- a/include/drivers/lineGraph/lineGraphFull_driver.h
+++ b/include/drivers/lineGraph/lineGraphFull_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_LINEGRAPH_LINEGRAPHFULL_DRIVER_H_
 #define INCLUDE_DRIVERS_LINEGRAPH_LINEGRAPHFULL_DRIVER_H_

--- a/include/drivers/lineGraph/lineGraph_driver.h
+++ b/include/drivers/lineGraph/lineGraph_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_LINEGRAPH_LINEGRAPH_DRIVER_H_
 #define INCLUDE_DRIVERS_LINEGRAPH_LINEGRAPH_DRIVER_H_

--- a/include/drivers/max_flow/edge_disjoint_paths_driver.h
+++ b/include/drivers/max_flow/edge_disjoint_paths_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_MAX_FLOW_EDGE_DISJOINT_PATHS_DRIVER_H_
 #define INCLUDE_DRIVERS_MAX_FLOW_EDGE_DISJOINT_PATHS_DRIVER_H_

--- a/include/drivers/max_flow/max_flow_driver.h
+++ b/include/drivers/max_flow/max_flow_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_MAX_FLOW_MAX_FLOW_DRIVER_H_
 #define INCLUDE_DRIVERS_MAX_FLOW_MAX_FLOW_DRIVER_H_

--- a/include/drivers/max_flow/maximum_cardinality_matching_driver.h
+++ b/include/drivers/max_flow/maximum_cardinality_matching_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_MAX_FLOW_MAXIMUM_CARDINALITY_MATCHING_DRIVER_H_
 #define INCLUDE_DRIVERS_MAX_FLOW_MAXIMUM_CARDINALITY_MATCHING_DRIVER_H_

--- a/include/drivers/max_flow/minCostMaxFlow_driver.h
+++ b/include/drivers/max_flow/minCostMaxFlow_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_COSTFLOW_MINCOSTMAXFLOW_DRIVER_H_
 #define INCLUDE_DRIVERS_COSTFLOW_MINCOSTMAXFLOW_DRIVER_H_

--- a/include/drivers/mincut/stoerWagner_driver.h
+++ b/include/drivers/mincut/stoerWagner_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_MINCUT_STOERWAGNER_DRIVER_H_
 #define INCLUDE_DRIVERS_MINCUT_STOERWAGNER_DRIVER_H_

--- a/include/drivers/spanningTree/kruskal_driver.h
+++ b/include/drivers/spanningTree/kruskal_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_SPANNINGTREE_KRUSKAL_DRIVER_H_
 #define INCLUDE_DRIVERS_SPANNINGTREE_KRUSKAL_DRIVER_H_

--- a/include/drivers/spanningTree/mst_common.h
+++ b/include/drivers/spanningTree/mst_common.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_SPANNINGTREE_MST_COMMON_H_
 #define INCLUDE_DRIVERS_SPANNINGTREE_MST_COMMON_H_

--- a/include/drivers/spanningTree/prim_driver.h
+++ b/include/drivers/spanningTree/prim_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_SPANNINGTREE_PRIM_DRIVER_H_
 #define INCLUDE_DRIVERS_SPANNINGTREE_PRIM_DRIVER_H_

--- a/include/drivers/spanningTree/randomSpanningTree_driver.h
+++ b/include/drivers/spanningTree/randomSpanningTree_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_SPANNINGTREE_RANDOMSPANNINGTREE_DRIVER_H_
 #define INCLUDE_DRIVERS_SPANNINGTREE_RANDOMSPANNINGTREE_DRIVER_H_

--- a/include/drivers/trsp/trsp_driver.h
+++ b/include/drivers/trsp/trsp_driver.h
@@ -15,14 +15,14 @@ the Free Software Foundation; either version 2 of the License, or
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_TRSP_TRSP_DRIVER_H_
 #define INCLUDE_DRIVERS_TRSP_TRSP_DRIVER_H_

--- a/include/drivers/tsp/TSP_driver.h
+++ b/include/drivers/tsp/TSP_driver.h
@@ -10,22 +10,22 @@
  * Mail: vicky_vergara@hotmail.com
  *
  * ------
- *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- *  ********************************************************************PGR-GNU*/
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_TSP_TSP_DRIVER_H_
 #define INCLUDE_DRIVERS_TSP_TSP_DRIVER_H_

--- a/include/drivers/tsp/euclideanTSP_driver.h
+++ b/include/drivers/tsp/euclideanTSP_driver.h
@@ -10,22 +10,22 @@
  * Mail: vicky_vergara@hotmail.com
  *
  * ------
- *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- *  ********************************************************************PGR-GNU*/
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_TSP_EUCLIDEANTSP_DRIVER_H_
 #define INCLUDE_DRIVERS_TSP_EUCLIDEANTSP_DRIVER_H_

--- a/include/drivers/withPoints/get_new_queries.h
+++ b/include/drivers/withPoints/get_new_queries.h
@@ -24,7 +24,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 #ifndef INCLUDE_DRIVERS_WITHPOINTS_GET_NEW_QUERIES_H_
 #define INCLUDE_DRIVERS_WITHPOINTS_GET_NEW_QUERIES_H_
 

--- a/include/drivers/withPoints/withPoints_driver.h
+++ b/include/drivers/withPoints/withPoints_driver.h
@@ -24,7 +24,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_WITHPOINTS_WITHPOINTS_DRIVER_H_
 #define INCLUDE_DRIVERS_WITHPOINTS_WITHPOINTS_DRIVER_H_

--- a/include/drivers/yen/ksp_driver.h
+++ b/include/drivers/yen/ksp_driver.h
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_YEN_KSP_DRIVER_H_
 #define INCLUDE_DRIVERS_YEN_KSP_DRIVER_H_

--- a/include/drivers/yen/turnRestrictedPath_driver.h
+++ b/include/drivers/yen/turnRestrictedPath_driver.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_YEN_TURNRESTRICTEDPATH_DRIVER_H_
 #define INCLUDE_DRIVERS_YEN_TURNRESTRICTEDPATH_DRIVER_H_

--- a/include/drivers/yen/withPoints_ksp_driver.h
+++ b/include/drivers/yen/withPoints_ksp_driver.h
@@ -24,7 +24,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_DRIVERS_YEN_WITHPOINTS_KSP_DRIVER_H_
 #define INCLUDE_DRIVERS_YEN_WITHPOINTS_KSP_DRIVER_H_

--- a/include/lineGraph/pgr_lineGraph.hpp
+++ b/include/lineGraph/pgr_lineGraph.hpp
@@ -10,17 +10,21 @@ Copyright (c) 2017 Vidhan Jain
 Mail: vidhanj1307@gmail.com
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
  ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_LINEGRAPH_PGR_LINEGRAPH_HPP_

--- a/include/lineGraph/pgr_lineGraphFull.hpp
+++ b/include/lineGraph/pgr_lineGraphFull.hpp
@@ -10,17 +10,21 @@ Copyright (c) 2017 Anthony Nicola Tasca
 Mail: atasca10@gmail.com
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
  ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_LINEGRAPH_PGR_LINEGRAPHFULL_HPP_

--- a/include/max_flow/pgr_costFlowGraph.hpp
+++ b/include/max_flow/pgr_costFlowGraph.hpp
@@ -23,7 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_COSTFLOW_PGR_COSTFLOWGRAPH_HPP_
 #define INCLUDE_COSTFLOW_PGR_COSTFLOWGRAPH_HPP_

--- a/include/max_flow/pgr_flowgraph.hpp
+++ b/include/max_flow/pgr_flowgraph.hpp
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_MAX_FLOW_PGR_FLOWGRAPH_HPP_
 #define INCLUDE_MAX_FLOW_PGR_FLOWGRAPH_HPP_

--- a/include/max_flow/pgr_maxflow.hpp
+++ b/include/max_flow/pgr_maxflow.hpp
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_MAX_FLOW_PGR_MAXFLOW_HPP_
 #define INCLUDE_MAX_FLOW_PGR_MAXFLOW_HPP_

--- a/include/max_flow/pgr_maximumcardinalitymatching.hpp
+++ b/include/max_flow/pgr_maximumcardinalitymatching.hpp
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_MAX_FLOW_PGR_MAXIMUMCARDINALITYMATCHING_HPP_
 #define INCLUDE_MAX_FLOW_PGR_MAXIMUMCARDINALITYMATCHING_HPP_

--- a/include/max_flow/pgr_minCostMaxFlow.hpp
+++ b/include/max_flow/pgr_minCostMaxFlow.hpp
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_COSTFLOW_PGR_MINCOSTMAXFLOW_HPP_
 #define INCLUDE_COSTFLOW_PGR_MINCOSTMAXFLOW_HPP_

--- a/include/mincut/pgr_stoerWagner.hpp
+++ b/include/mincut/pgr_stoerWagner.hpp
@@ -8,18 +8,22 @@ Copyright (c) 2018 Aditya Pratap Singh
 adityapratap.singh28@gmail.com
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_MINCUT_PGR_STOERWAGNER_HPP_
 #define INCLUDE_MINCUT_PGR_STOERWAGNER_HPP_

--- a/include/spanningTree/details.hpp
+++ b/include/spanningTree/details.hpp
@@ -5,18 +5,22 @@ Copyright (c) 2018 Vicky Vergara
 
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_SPANNINGTREE_DETAILS_HPP_
 #define INCLUDE_SPANNINGTREE_DETAILS_HPP_

--- a/include/spanningTree/pgr_kruskal.hpp
+++ b/include/spanningTree/pgr_kruskal.hpp
@@ -8,18 +8,22 @@ Copyright (c) 2018 Aditya Pratap Singh
 adityapratap.singh28@gmail.com
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_SPANNINGTREE_PGR_KRUSKAL_HPP_
 #define INCLUDE_SPANNINGTREE_PGR_KRUSKAL_HPP_

--- a/include/spanningTree/pgr_mst.hpp
+++ b/include/spanningTree/pgr_mst.hpp
@@ -5,18 +5,22 @@ Copyright (c) 2018 Vicky Vergara
 mail: vicky at georepublic dot de
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_SPANNINGTREE_PGR_MST_HPP_
 #define INCLUDE_SPANNINGTREE_PGR_MST_HPP_

--- a/include/spanningTree/pgr_prim.hpp
+++ b/include/spanningTree/pgr_prim.hpp
@@ -8,18 +8,22 @@ Copyright (c) 2018 Aditya Pratap Singh
 adityapratap.singh28@gmail.com
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_SPANNINGTREE_PGR_PRIM_HPP_
 #define INCLUDE_SPANNINGTREE_PGR_PRIM_HPP_

--- a/include/spanningTree/pgr_randomSpanningTree.hpp
+++ b/include/spanningTree/pgr_randomSpanningTree.hpp
@@ -8,18 +8,22 @@ Copyright (c) 2018 Aditya Pratap Singh
 adityapratap.singh28@gmail.com
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_SPANNINGTREE_PGR_RANDOMSPANNINGTREE_HPP_
 #define INCLUDE_SPANNINGTREE_PGR_RANDOMSPANNINGTREE_HPP_

--- a/include/trsp/GraphDefinition.h
+++ b/include/trsp/GraphDefinition.h
@@ -1,4 +1,29 @@
-// Copyright 2012 steve
+/*PGR-GNU*****************************************************************
+
+FILE: GraphDefinition.h
+
+
+Copyright (c) 2012 pgRouting developers
+Mail: project@pgrouting.org
+
+Copyright 2012 steve
+------
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_TRSP_GRAPHDEFINITION_H_
 #define INCLUDE_TRSP_GRAPHDEFINITION_H_

--- a/include/trsp/edgeInfo.h
+++ b/include/trsp/edgeInfo.h
@@ -18,7 +18,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-aint64_t with this program; if not, write to the Free Software
+along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/

--- a/include/trsp/pgr_trspHandler.h
+++ b/include/trsp/pgr_trspHandler.h
@@ -18,7 +18,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-aint64_t with this program; if not, write to the Free Software
+along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/

--- a/include/tsp/pgr_tsp.cpp
+++ b/include/tsp/pgr_tsp.cpp
@@ -10,22 +10,22 @@
  * Mail: vicky_vergara@hotmail.com
  *
  * ------
- *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- *  ********************************************************************PGR-GNU*/
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
 
 
 #include "tsp/pgr_tsp.hpp"

--- a/include/tsp/pgr_tsp.hpp
+++ b/include/tsp/pgr_tsp.hpp
@@ -10,22 +10,22 @@
  * Mail: vicky_vergara@hotmail.com
  *
  * ------
- *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- *  ********************************************************************PGR-GNU*/
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_TSP_PGR_TSP_HPP_
 #define INCLUDE_TSP_PGR_TSP_HPP_

--- a/include/visitors/dfs_visitor_with_root.hpp
+++ b/include/visitors/dfs_visitor_with_root.hpp
@@ -8,18 +8,22 @@ Copyright (c) 2018 Aditya Pratap Singh
 adityapratap.singh28@gmail.com
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_VISITORS_DFS_VISITOR_WITH_ROOT_HPP_
 #define INCLUDE_VISITORS_DFS_VISITOR_WITH_ROOT_HPP_

--- a/include/visitors/dijkstra_one_goal_visitor.hpp
+++ b/include/visitors/dijkstra_one_goal_visitor.hpp
@@ -23,7 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_VISITORS_DIJKSTRA_ONE_GOAL_VISITOR_HPP_
 #define INCLUDE_VISITORS_DIJKSTRA_ONE_GOAL_VISITOR_HPP_

--- a/include/visitors/edges_order_bfs_visitor.hpp
+++ b/include/visitors/edges_order_bfs_visitor.hpp
@@ -8,18 +8,22 @@ Copyright (c) 2018 Aditya Pratap Singh
 adityapratap.singh28@gmail.com
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_VISITORS_EDGES_ORDER_BFS_VISITOR_HPP_

--- a/include/visitors/edges_order_dfs_visitor.hpp
+++ b/include/visitors/edges_order_dfs_visitor.hpp
@@ -8,18 +8,22 @@ Copyright (c) 2018 Aditya Pratap Singh
 adityapratap.singh28@gmail.com
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_VISITORS_EDGES_ORDER_DFS_VISITOR_HPP_

--- a/include/visitors/found_goals.hpp
+++ b/include/visitors/found_goals.hpp
@@ -23,7 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_VISITORS_FOUND_GOALS_HPP_
 #define INCLUDE_VISITORS_FOUND_GOALS_HPP_

--- a/include/visitors/prim_dijkstra_visitor.hpp
+++ b/include/visitors/prim_dijkstra_visitor.hpp
@@ -8,18 +8,22 @@ Copyright (c) 2018 Aditya Pratap Singh
 adityapratap.singh28@gmail.com
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 /*! @file */
 
 #ifndef INCLUDE_VISITORS_PRIM_DIJKSTRA_VISITOR_HPP_

--- a/include/vrp/book_keeping.h
+++ b/include/vrp/book_keeping.h
@@ -6,22 +6,22 @@
  * Mail: project@pgrouting.org
  *
  * ------
- *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- *********************************************************************PGR-GNU*/
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
 
 /*! @file */
 

--- a/include/withPoints/pgr_withPoints.hpp
+++ b/include/withPoints/pgr_withPoints.hpp
@@ -24,7 +24,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_WITHPOINTS_PGR_WITHPOINTS_HPP_
 #define INCLUDE_WITHPOINTS_PGR_WITHPOINTS_HPP_

--- a/include/yen/pgr_ksp.hpp
+++ b/include/yen/pgr_ksp.hpp
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifndef INCLUDE_YEN_PGR_KSP_HPP_
 #define INCLUDE_YEN_PGR_KSP_HPP_

--- a/include/yen/pgr_turnRestrictedPath.hpp
+++ b/include/yen/pgr_turnRestrictedPath.hpp
@@ -10,18 +10,22 @@ Copyright (c) 2017 Vidhan Jain
 Mail: vidhanj1307@gmail.com
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 #ifndef INCLUDE_YEN_PGR_TURNRESTRICTEDPATH_HPP_
 #define INCLUDE_YEN_PGR_TURNRESTRICTEDPATH_HPP_
 #pragma once

--- a/sql/allpairs/floydWarshall.sql
+++ b/sql/allpairs/floydWarshall.sql
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ---------------------
 -- pgr_floydWarshall

--- a/sql/allpairs/johnson.sql
+++ b/sql/allpairs/johnson.sql
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -----------------
 -----------------

--- a/sql/alpha_shape/_alphaShape.sql
+++ b/sql/alpha_shape/_alphaShape.sql
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 --------------
 --------------
 -- alpha_shape

--- a/sql/alpha_shape/alphaShape.sql
+++ b/sql/alpha_shape/alphaShape.sql
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 --------------
 --------------
 -- alpha_shape

--- a/sql/astar/_astar.sql
+++ b/sql/astar/_astar.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -----------------
 -----------------

--- a/sql/astar/astar.sql
+++ b/sql/astar/astar.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -----------------
 -- pgr_aStar

--- a/sql/astar/astarCost.sql
+++ b/sql/astar/astarCost.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 -----------------

--- a/sql/bdAstar/_bdAstar.sql
+++ b/sql/bdAstar/_bdAstar.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ----------------
 ----------------

--- a/sql/bdAstar/bdAstar.sql
+++ b/sql/bdAstar/bdAstar.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 --------------------
 -- pgr_bdAstar
 --------------------

--- a/sql/bdAstar/bdAstarCost.sql
+++ b/sql/bdAstar/bdAstarCost.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 --------------------
 -- pgr_bdAstarCost

--- a/sql/bdDijkstra/_bdDijkstra.sql
+++ b/sql/bdDijkstra/_bdDijkstra.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -------------
 -------------

--- a/sql/bdDijkstra/bdDijkstra.sql
+++ b/sql/bdDijkstra/bdDijkstra.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 -------------------

--- a/sql/bdDijkstra/bdDijkstraCost.sql
+++ b/sql/bdDijkstra/bdDijkstraCost.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 ----------------------

--- a/sql/bellman_ford/_bellman_ford.sql
+++ b/sql/bellman_ford/_bellman_ford.sql
@@ -23,7 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 -------------------------
 -------------------------
 -- bellman_ford

--- a/sql/bellman_ford/_bellman_ford_neg.sql
+++ b/sql/bellman_ford/_bellman_ford_neg.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -------------------------
 -- pgr_bellmanFordNeg

--- a/sql/bellman_ford/bellman_ford.sql
+++ b/sql/bellman_ford/bellman_ford.sql
@@ -24,7 +24,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ------------------
 -- pgr_bellmanFord

--- a/sql/bellman_ford/bellman_ford_neg.sql
+++ b/sql/bellman_ford/bellman_ford_neg.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ------------------
 -- pgr_bellmanFord

--- a/sql/chinese/_pgr_chinesePostman.sql
+++ b/sql/chinese/_pgr_chinesePostman.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 ----------
 ----------
 -- ChPP

--- a/sql/chinese/pgr_chinesePostman.sql
+++ b/sql/chinese/pgr_chinesePostman.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 --------------------

--- a/sql/chinese/pgr_chinesePostmanCost.sql
+++ b/sql/chinese/pgr_chinesePostmanCost.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 --------------------

--- a/sql/common/_point_toId.sql
+++ b/sql/common/_point_toId.sql
@@ -21,7 +21,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*
 .. function:: _pgr_pointToId(point geometry, tolerance double precision,vname text,srid integer)
 Using tolerance to determine if its an existing point:

--- a/sql/common/createIndex.sql
+++ b/sql/common/createIndex.sql
@@ -21,7 +21,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 

--- a/sql/common/findClosestEdge.sql
+++ b/sql/common/findClosestEdge.sql
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /*
  *  pgr_findClosestEdge(edges_sql text, pnt geometry, tol float8)

--- a/sql/common/pgRouting-header.sql
+++ b/sql/common/pgRouting-header.sql
@@ -1,3 +1,27 @@
+/*PGR-GNU*****************************************************************
+
+FILE: __FILENAME__
+
+Copyright (c) 2015 pgRouting developers
+Mail: project@pgrouting.org
+
+------
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
 \echo Use "CREATE EXTENSION pgrouting" to load this file. \quit
 
 

--- a/sql/common/pgr_parameter_check.sql
+++ b/sql/common/pgr_parameter_check.sql
@@ -21,7 +21,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 /*

--- a/sql/common/pgrouting_utilities.sql
+++ b/sql/common/pgrouting_utilities.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 

--- a/sql/common/pgrouting_version.sql
+++ b/sql/common/pgrouting_version.sql
@@ -1,20 +1,35 @@
-/*
--- -------------------------------------------------------------------
--- pgrouting_version.sql
--- AuthorL Stephen Woodbridge <woodbri@imaptools.com>
--- Copyright 2013 Stephen Woodbridge
--- This file is release unde an MIT-X license.
--- -------------------------------------------------------------------
-*/
+/*PGR-MIT*****************************************************************
 
-/*
-.. function:: pgr_version()
+FILE: pgrouting_version.sql
 
-   Author: Stephen Woodbridge <woodbri@imaptools.com>
+Copyright (c) 2013 pgRouting developers
+Mail: project@pgrouting.org
+Author: Stephen Woodbridge <woodbri@imaptools.com>
 
-   Returns the version of pgrouting,Git build,Git hash, Git branch and boost
-*/
+------
+MIT/X license
 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+********************************************************************PGR-MIT*/
 
 CREATE OR REPLACE FUNCTION pgr_version()
 RETURNS TABLE(

--- a/sql/common/utilities_pgr.sql
+++ b/sql/common/utilities_pgr.sql
@@ -21,7 +21,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 /************************************************************************

--- a/sql/components/_articulationPoints.sql
+++ b/sql/components/_articulationPoints.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -------------------------
 -- pgr_articulationPoints

--- a/sql/components/_biconnectedComponents.sql
+++ b/sql/components/_biconnectedComponents.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ----------------------------
 -- pgr_biconnectedComponents

--- a/sql/components/_bridges.sql
+++ b/sql/components/_bridges.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 --------------
 -- pgr_bridges

--- a/sql/components/_connectedComponents.sql
+++ b/sql/components/_connectedComponents.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ---------------
 ---------------

--- a/sql/components/_strongComponents.sql
+++ b/sql/components/_strongComponents.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -----------------------
 -- pgr_strongComponents

--- a/sql/components/articulationPoints.sql
+++ b/sql/components/articulationPoints.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 CREATE OR REPLACE FUNCTION pgr_articulationPoints(
     TEXT,   -- edges_sql (required)

--- a/sql/components/biconnectedComponents.sql
+++ b/sql/components/biconnectedComponents.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 CREATE OR REPLACE FUNCTION pgr_biconnectedComponents(
     TEXT, -- edges_sql (required)

--- a/sql/components/bridges.sql
+++ b/sql/components/bridges.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 CREATE OR REPLACE FUNCTION pgr_bridges(
     TEXT,  -- edges_sql (required)

--- a/sql/components/connectedComponents.sql
+++ b/sql/components/connectedComponents.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ---------------
 ---------------

--- a/sql/components/strongComponents.sql
+++ b/sql/components/strongComponents.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 CREATE OR REPLACE FUNCTION pgr_strongComponents(
     TEXT, -- edges_sql (required)

--- a/sql/contraction/_contraction.sql
+++ b/sql/contraction/_contraction.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 --------------------
 --------------------

--- a/sql/contraction/contraction.sql
+++ b/sql/contraction/contraction.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 --------------------
 --------------------

--- a/sql/costMatrix/astarCostMatrix.sql
+++ b/sql/costMatrix/astarCostMatrix.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -----------------------------
 -- pgr_aStarCostMatrix

--- a/sql/costMatrix/bdAstarCostMatrix.sql
+++ b/sql/costMatrix/bdAstarCostMatrix.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 -----------------------------

--- a/sql/costMatrix/bdDijkstraCostMatrix.sql
+++ b/sql/costMatrix/bdDijkstraCostMatrix.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -----------------------------
 -- pgr_bdDijkstraCostMatrix

--- a/sql/costMatrix/dijkstraCostMatrix.sql
+++ b/sql/costMatrix/dijkstraCostMatrix.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -----------------------------
 -- dijkstraCostMatrix

--- a/sql/costMatrix/withPointsCostMatrix.sql
+++ b/sql/costMatrix/withPointsCostMatrix.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ---------------------
 ---------------------

--- a/sql/dagShortestPath/_dagShortestPath.sql
+++ b/sql/dagShortestPath/_dagShortestPath.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ---------------------
 ---------------------

--- a/sql/dagShortestPath/dagShortestPath.sql
+++ b/sql/dagShortestPath/dagShortestPath.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ----------------------
 -- pgr_dagShortestPath

--- a/sql/dijkstra/_dijkstra.sql
+++ b/sql/dijkstra/_dijkstra.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ---------------
 ---------------

--- a/sql/dijkstra/_dijkstraNear.sql
+++ b/sql/dijkstra/_dijkstraNear.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 --------------------
 -- _pgr_dijkstraNear

--- a/sql/dijkstra/dijkstra.sql
+++ b/sql/dijkstra/dijkstra.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ---------------
 -- pgr_dijkstra

--- a/sql/dijkstra/dijkstraCost.sql
+++ b/sql/dijkstra/dijkstraCost.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -------------------
 -- pgr_dijkstraCost

--- a/sql/dijkstra/dijkstraVia.sql
+++ b/sql/dijkstra/dijkstraVia.sql
@@ -23,7 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ------------------
 -- pgr_dijkstraVia

--- a/sql/driving_distance/drivingDistance.sql
+++ b/sql/driving_distance/drivingDistance.sql
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ----------------------
 -- pgr_drivingDistance

--- a/sql/driving_distance/withPointsDD.sql
+++ b/sql/driving_distance/withPointsDD.sql
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -------------------
 -------------------

--- a/sql/ksp/ksp.sql
+++ b/sql/ksp/ksp.sql
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 ---------------
 ---------------
 -- pgr_ksp

--- a/sql/ksp/turnRestrictedPath.sql
+++ b/sql/ksp/turnRestrictedPath.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -------------------------
 -- pgr_turnRestrictedPath

--- a/sql/ksp/withPointsKSP.sql
+++ b/sql/ksp/withPointsKSP.sql
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 --------------------
 -- pgr_withPointsKSP

--- a/sql/legacy/alpha_shape.sql
+++ b/sql/legacy/alpha_shape.sql
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -----------------------------------------------------------------------
 -- legacy

--- a/sql/legacy/legacy-developers.sql
+++ b/sql/legacy/legacy-developers.sql
@@ -1,3 +1,27 @@
+/*PGR-GNU*****************************************************************
+
+FILE: legacy-developers.sql
+
+Copyright (c) 2015 pgRouting developers
+Mail: project@pgrouting.org
+
+------
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
 -------------------------------------------------------------------------------
 -- Legacy FUNCTIONs that were meant to be used by
 -- pgRouting developers

--- a/sql/legacy/legacy_experimental.sql
+++ b/sql/legacy/legacy_experimental.sql
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ----------------------------------------------------------------------------
 -- Experimental function: pgr_labelGraph

--- a/sql/legacy/pointsAsPolygon.sql
+++ b/sql/legacy/pointsAsPolygon.sql
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ----------------------
 -- pgr_pointsAsPolygon

--- a/sql/legacy/routing_legacy.sql
+++ b/sql/legacy/routing_legacy.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 CREATE TYPE pgr_costResult AS
 (

--- a/sql/legacy/tsp/TSPeucledian.sql
+++ b/sql/legacy/tsp/TSPeucledian.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 --------------------

--- a/sql/legacy/tsp/tsp_v2.0_coordinates.sql
+++ b/sql/legacy/tsp/tsp_v2.0_coordinates.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*
     Old signature has:
     sql: id INTEGER, x FLOAT, y FLOAT

--- a/sql/legacy/tsp/tsp_v2.0_matrix.sql
+++ b/sql/legacy/tsp/tsp_v2.0_matrix.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 ----------------

--- a/sql/legacy/vrppdtw/_gsoc_vrppdtw.sql
+++ b/sql/legacy/vrppdtw/_gsoc_vrppdtw.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 ----------------------------

--- a/sql/legacy/vrppdtw/gsoc_vrppdtw.sql
+++ b/sql/legacy/vrppdtw/gsoc_vrppdtw.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 ----------------------------

--- a/sql/lineGraph/lineGraph.sql
+++ b/sql/lineGraph/lineGraph.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ----------------------
 -- pgr_lineGraph

--- a/sql/lineGraph/lineGraphFull.sql
+++ b/sql/lineGraph/lineGraphFull.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ----------------------
 ----------------------

--- a/sql/max_flow/_maxFlowMinCost.sql
+++ b/sql/max_flow/_maxFlowMinCost.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ------------------------
 ------------------------

--- a/sql/max_flow/_maxflow.sql
+++ b/sql/max_flow/_maxflow.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 --------------
 --------------

--- a/sql/max_flow/boykovKolmogorov.sql
+++ b/sql/max_flow/boykovKolmogorov.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ------------------------------------
 -- pgr_boykovKolmogorov

--- a/sql/max_flow/edgeDisjointPaths.sql
+++ b/sql/max_flow/edgeDisjointPaths.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ------------------------
 -- pgr_edgeDisjointPaths

--- a/sql/max_flow/edmondsKarp.sql
+++ b/sql/max_flow/edmondsKarp.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -------------------
 -- pgr_edmondsKarp

--- a/sql/max_flow/maxCardinalityMatch.sql
+++ b/sql/max_flow/maxCardinalityMatch.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 --------------------------
 -- pgr_maxCardinalityMatch

--- a/sql/max_flow/maxFlow.sql
+++ b/sql/max_flow/maxFlow.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ---------------
 -- pgr_maxFlow

--- a/sql/max_flow/maxFlowMinCost.sql
+++ b/sql/max_flow/maxFlowMinCost.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ------------------------
 -- pgr_maxFlowMinCost

--- a/sql/max_flow/maxFlowMinCost_Cost.sql
+++ b/sql/max_flow/maxFlowMinCost_Cost.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ----------------------------
 -- pgr_maxFlowMinCost_Cost

--- a/sql/max_flow/pushRelabel.sql
+++ b/sql/max_flow/pushRelabel.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ------------------------------------
 -- pgr_pushRelabel

--- a/sql/mincut/stoerWagner.sql
+++ b/sql/mincut/stoerWagner.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ---------------
 ---------------

--- a/sql/pickDeliver/pickDeliver.sql
+++ b/sql/pickDeliver/pickDeliver.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 CREATE OR REPLACE FUNCTION _pgr_pickDeliver(
     TEXT, -- orders_sql

--- a/sql/pickDeliver/pickDeliverEuclidean.sql
+++ b/sql/pickDeliver/pickDeliverEuclidean.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 CREATE OR REPLACE FUNCTION _pgr_pickDeliverEuclidean (
     TEXT, -- orders_sql

--- a/sql/spanningTree/_kruskal.sql
+++ b/sql/spanningTree/_kruskal.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ----------------
 -- _pgr_kruskal

--- a/sql/spanningTree/_prim.sql
+++ b/sql/spanningTree/_prim.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 ----------
 ----------

--- a/sql/spanningTree/_randomSpanTree.sql
+++ b/sql/spanningTree/_randomSpanTree.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -----------------------
 -- _pgr_randomSpanTree

--- a/sql/spanningTree/kruskal.sql
+++ b/sql/spanningTree/kruskal.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 ---------------

--- a/sql/spanningTree/kruskalBFS.sql
+++ b/sql/spanningTree/kruskalBFS.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 -----------------

--- a/sql/spanningTree/kruskalDD.sql
+++ b/sql/spanningTree/kruskalDD.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 -----------------

--- a/sql/spanningTree/kruskalDFS.sql
+++ b/sql/spanningTree/kruskalDFS.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 -----------------

--- a/sql/spanningTree/prim.sql
+++ b/sql/spanningTree/prim.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 ------------

--- a/sql/spanningTree/primBFS.sql
+++ b/sql/spanningTree/primBFS.sql
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 -----------------

--- a/sql/spanningTree/primDD.sql
+++ b/sql/spanningTree/primDD.sql
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 --------------
 -- pgr_primDD

--- a/sql/spanningTree/primDFS.sql
+++ b/sql/spanningTree/primDFS.sql
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -----------------
 -- pgr_primDFS

--- a/sql/spanningTree/randomSpanTree.sql
+++ b/sql/spanningTree/randomSpanTree.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -----------------------
 -- pgr_randomSpanTree

--- a/sql/topology/createtopology.sql
+++ b/sql/topology/createtopology.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /*
 .. function:: _pgr_createtopology(edge_table, tolerance,the_geom,id,source,target,rows_where)

--- a/sql/topology/createverticestable.sql
+++ b/sql/topology/createverticestable.sql
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*
 
 This function should not be used directly. Use assign_vertex_id instead

--- a/sql/topology/extractVertices.sql
+++ b/sql/topology/extractVertices.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 CREATE OR REPLACE FUNCTION pgr_extractVertices(

--- a/sql/topology/nodeNetwork.sql
+++ b/sql/topology/nodeNetwork.sql
@@ -21,7 +21,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 ---------------------------

--- a/sql/trsp/_trsp.sql
+++ b/sql/trsp/_trsp.sql
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 --------------
 --------------

--- a/sql/trsp/trsp.sql
+++ b/sql/trsp/trsp.sql
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 --------------

--- a/sql/trsp/trsp_V2.2.sql
+++ b/sql/trsp/trsp_V2.2.sql
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*
 -----------------------------------------------------------------------
 -- Core function for time_dependent_shortest_path computation

--- a/sql/trsp/vias_trsp_V2.2.sql
+++ b/sql/trsp/vias_trsp_V2.2.sql
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 -----------------------

--- a/sql/tsp/TSP.sql
+++ b/sql/tsp/TSP.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 -------------
 -- pgr_TSP

--- a/sql/tsp/TSPeuclidean.sql
+++ b/sql/tsp/TSPeuclidean.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 --------------------

--- a/sql/tsp/_TSP.sql
+++ b/sql/tsp/_TSP.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 -------------

--- a/sql/tsp/_TSPeuclidean.sql
+++ b/sql/tsp/_TSPeuclidean.sql
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 CREATE OR REPLACE FUNCTION _pgr_TSPeuclidean(

--- a/sql/vrp_basic/_pgr_vrpOneDepot.sql
+++ b/sql/vrp_basic/_pgr_vrpOneDepot.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 --------------------
 -- _pgr_vrpOneDepot

--- a/sql/vrp_basic/pgr_vrpOneDepot.sql
+++ b/sql/vrp_basic/pgr_vrpOneDepot.sql
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 -----------------------------------------------------------------------
 -- Core function for vrp with sigle depot computation
 -- See README for description

--- a/sql/vrp_basic/routing_vrp.sql
+++ b/sql/vrp_basic/routing_vrp.sql
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 -----------------------------------------------------------------------
 -- Core function for vrp with sigle depot computation
 -- See README for description

--- a/sql/withPoints/_withPoints.sql
+++ b/sql/withPoints/_withPoints.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 ------------------

--- a/sql/withPoints/withPoints.sql
+++ b/sql/withPoints/withPoints.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 --------------------

--- a/sql/withPoints/withPointsCost.sql
+++ b/sql/withPoints/withPointsCost.sql
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 ----------------------

--- a/sql/withPoints/withPointsVia.sql
+++ b/sql/withPoints/withPointsVia.sql
@@ -1,11 +1,15 @@
 /*PGR-GNU*****************************************************************
+File: withPointsVia.sql
 
-Template:
+Generated with Template by:
 Copyright (c) 2015 pgRouting developers
+Mail: project@pgrouting.org
 
-Function developer:
-Copyright (c) 2015 Vicky Vergara
-vicky_vergara@hotmail.com
+Function's developer:
+Copyright (c) 2015 Celia Virginia Vergara Castillo
+Mail:
+
+------
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -21,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 ----------------------

--- a/src/allpairs/floydWarshall.c
+++ b/src/allpairs/floydWarshall.c
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/allpairs/floydWarshall_driver.cpp
+++ b/src/allpairs/floydWarshall_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/allpairs/floydWarshall_driver.h"
 

--- a/src/allpairs/johnson.c
+++ b/src/allpairs/johnson.c
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/allpairs/johnson_driver.cpp
+++ b/src/allpairs/johnson_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/allpairs/johnson_driver.h"
 

--- a/src/alpha_shape/alphaShape.c
+++ b/src/alpha_shape/alphaShape.c
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include <float.h>

--- a/src/alpha_shape/alphaShape_driver.cpp
+++ b/src/alpha_shape/alphaShape_driver.cpp
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/alpha_shape/alphaShape_driver.h"
 

--- a/src/alpha_shape/pgr_alphaShape.cpp
+++ b/src/alpha_shape/pgr_alphaShape.cpp
@@ -23,7 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "alphaShape/pgr_alphaShape.h"
 

--- a/src/astar/astar.c
+++ b/src/astar/astar.c
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/astar/astar_driver.cpp
+++ b/src/astar/astar_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/astar/astar_driver.h"
 

--- a/src/bdAstar/bdAstar.c
+++ b/src/bdAstar/bdAstar.c
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/bdAstar/bdAstar_driver.cpp
+++ b/src/bdAstar/bdAstar_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/bdAstar/bdAstar_driver.h"
 

--- a/src/bdDijkstra/bdDijkstra.c
+++ b/src/bdDijkstra/bdDijkstra.c
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/bdDijkstra/bdDijkstra_driver.cpp
+++ b/src/bdDijkstra/bdDijkstra_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/bdDijkstra/bdDijkstra_driver.h"
 

--- a/src/bellman_ford/bellman_ford.c
+++ b/src/bellman_ford/bellman_ford.c
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/bellman_ford/bellman_ford_driver.cpp
+++ b/src/bellman_ford/bellman_ford_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/bellman_ford/bellman_ford_driver.h"
 

--- a/src/bellman_ford/bellman_ford_neg.c
+++ b/src/bellman_ford/bellman_ford_neg.c
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/bellman_ford/bellman_ford_neg_driver.cpp
+++ b/src/bellman_ford/bellman_ford_neg_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/bellman_ford/bellman_ford_neg_driver.h"
 

--- a/src/chinese/chinesePostman.c
+++ b/src/chinese/chinesePostman.c
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /** @file chinesePostman.c */
 

--- a/src/chinese/chinesePostman_driver.cpp
+++ b/src/chinese/chinesePostman_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/chinese/chinesePostman_driver.h"
 

--- a/src/common/arrays_input.c
+++ b/src/common/arrays_input.c
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "c_common/arrays_input.h"
 

--- a/src/common/basePath_SSEC.cpp
+++ b/src/common/basePath_SSEC.cpp
@@ -18,8 +18,9 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "cpp_common/basePath_SSEC.hpp"
 

--- a/src/common/basic_edge.cpp
+++ b/src/common/basic_edge.cpp
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "cpp_common/basic_edge.h"
 

--- a/src/common/basic_vertex.cpp
+++ b/src/common/basic_vertex.cpp
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "cpp_common/basic_vertex.h"
 

--- a/src/common/check_parameters.c
+++ b/src/common/check_parameters.c
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "c_common/check_parameters.h"
 

--- a/src/common/coordinates_input.c
+++ b/src/common/coordinates_input.c
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "c_common/coordinates_input.h"
 

--- a/src/common/delauny_input.c
+++ b/src/common/delauny_input.c
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "c_common/delauny_input.h"
 

--- a/src/common/edges_input.c
+++ b/src/common/edges_input.c
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "c_common/edges_input.h"
 

--- a/src/common/get_check_data.c
+++ b/src/common/get_check_data.c
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/common/identifier.cpp
+++ b/src/common/identifier.cpp
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "cpp_common/identifier.h"
 

--- a/src/common/matrixRows_input.c
+++ b/src/common/matrixRows_input.c
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "c_common/matrixRows_input.h"
 

--- a/src/common/pgr_alloc.cpp
+++ b/src/common/pgr_alloc.cpp
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "cpp_common/pgr_alloc.hpp"
 #include <cstring>

--- a/src/common/pgr_assert.cpp
+++ b/src/common/pgr_assert.cpp
@@ -1,14 +1,28 @@
-/*PGR-MIT******************************************************************
- *
- * file pgr_assert.cpp
- *
- * Copyright 2014 Stephen Woodbridge <woodbri@imaptools.com>
- * Copyright 2014 Vicky Vergara <vicky_vergara@hotmail.com>
- *
- * This is free software; you can redistribute and/or modify it under
- * the terms of the MIT License. Please file MIT-LICENSE for details.
- *
- *****************************************************************PGR-MIT*/
+/*PGR-GNU*****************************************************************
+
+FILE: pgr_assert.cpp
+
+Copyright 2015~  Vicky Vergara <vicky_vergara@hotmail.com>
+Copyright 2014 Stephen Woodbridge <woodbri@imaptools.com>
+Mail: project@pgrouting.org
+
+------
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
 #include "cpp_common/pgr_assert.h"
 
 #include <stdio.h>

--- a/src/common/pgr_point_input.c
+++ b/src/common/pgr_point_input.c
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "c_common/pgr_point_input.h"
 

--- a/src/common/points_input.c
+++ b/src/common/points_input.c
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "c_common/points_input.h"
 

--- a/src/common/postgres_connection.c
+++ b/src/common/postgres_connection.c
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "c_common/postgres_connection.h"
 

--- a/src/common/restrictions_input.c
+++ b/src/common/restrictions_input.c
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "c_common/restrictions_input.h"
 

--- a/src/common/signalhandler.cpp
+++ b/src/common/signalhandler.cpp
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 /*PGR-MIT******************************************************************
  *
  * file signalhandler.cpp

--- a/src/common/xy_vertex.cpp
+++ b/src/common/xy_vertex.cpp
@@ -6,19 +6,19 @@
 
  ------
 
- This program is free software; you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation; either version 2 of the License, or
- (at your option) any later version.
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- GNU General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
 
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 

--- a/src/components/articulationPoints.c
+++ b/src/components/articulationPoints.c
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /** @file articulationPoints.c */
 

--- a/src/components/articulationPoints_driver.cpp
+++ b/src/components/articulationPoints_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/components/articulationPoints_driver.h"
 

--- a/src/components/biconnectedComponents.c
+++ b/src/components/biconnectedComponents.c
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /** @file biconnectedComponents.c */
 

--- a/src/components/biconnectedComponents_driver.cpp
+++ b/src/components/biconnectedComponents_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/components/biconnectedComponents_driver.h"
 

--- a/src/components/bridges.c
+++ b/src/components/bridges.c
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /** @file bridges.c */
 

--- a/src/components/bridges_driver.cpp
+++ b/src/components/bridges_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/components/bridges_driver.h"
 

--- a/src/components/componentsResult.cpp
+++ b/src/components/componentsResult.cpp
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "components/componentsResult.h"
 

--- a/src/components/connectedComponents.c
+++ b/src/components/connectedComponents.c
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /** @file connectedComponents.c */
 

--- a/src/components/connectedComponents_driver.cpp
+++ b/src/components/connectedComponents_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/components/connectedComponents_driver.h"
 

--- a/src/components/pgr_components.cpp
+++ b/src/components/pgr_components.cpp
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "components/pgr_components.hpp"
 

--- a/src/components/strongComponents.c
+++ b/src/components/strongComponents.c
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /** @file strongComponents.c */
 

--- a/src/components/strongComponents_driver.cpp
+++ b/src/components/strongComponents_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/components/strongComponents_driver.h"
 

--- a/src/contraction/contractGraph.c
+++ b/src/contraction/contractGraph.c
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 

--- a/src/contraction/pgr_contract.cpp
+++ b/src/contraction/pgr_contract.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "contraction/pgr_contract.hpp"
 

--- a/src/cpp_common/bpoint.cpp
+++ b/src/cpp_common/bpoint.cpp
@@ -23,7 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "cpp_common/bpoint.hpp"
 

--- a/src/cpp_common/compPaths.cpp
+++ b/src/cpp_common/compPaths.cpp
@@ -10,18 +10,22 @@ Copyright (c) 2017 Vidhan Jain
 Mail: vidhanj1307@gmail.com
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #include <cmath>
 #include <limits>

--- a/src/cpp_common/rule.cpp
+++ b/src/cpp_common/rule.cpp
@@ -18,7 +18,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-aint64_t with this program; if not, write to the Free Software
+along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/

--- a/src/dagShortestPath/dagShortestPath.c
+++ b/src/dagShortestPath/dagShortestPath.c
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/dagShortestPath/dagShortestPath_driver.cpp
+++ b/src/dagShortestPath/dagShortestPath_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/dagShortestPath/dagShortestPath_driver.h"
 

--- a/src/dijkstra/dijkstra.c
+++ b/src/dijkstra/dijkstra.c
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 

--- a/src/dijkstra/dijkstraVia.c
+++ b/src/dijkstra/dijkstraVia.c
@@ -23,7 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/dijkstra/dijkstraVia_driver.cpp
+++ b/src/dijkstra/dijkstraVia_driver.cpp
@@ -23,7 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/dijkstra/dijkstraVia_driver.h"
 

--- a/src/dijkstra/dijkstra_driver.cpp
+++ b/src/dijkstra/dijkstra_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/dijkstra/dijkstra_driver.h"
 

--- a/src/driving_distance/many_to_dist_withPointsDD.c
+++ b/src/driving_distance/many_to_dist_withPointsDD.c
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/driving_distance/withPoints_dd_driver.cpp
+++ b/src/driving_distance/withPoints_dd_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 #include "drivers/driving_distance/withPoints_dd_driver.h"

--- a/src/ksp/ksp.c
+++ b/src/ksp/ksp.c
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/ksp/ksp_driver.cpp
+++ b/src/ksp/ksp_driver.cpp
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 #include "drivers/yen/ksp_driver.h"

--- a/src/ksp/turnRestrictedPath.c
+++ b/src/ksp/turnRestrictedPath.c
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /** @file turnRestrictedPath.c */
 

--- a/src/ksp/turnRestrictedPath_driver.cpp
+++ b/src/ksp/turnRestrictedPath_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/yen/turnRestrictedPath_driver.h"
 

--- a/src/ksp/withPoints_ksp.c
+++ b/src/ksp/withPoints_ksp.c
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/ksp/withPoints_ksp_driver.cpp
+++ b/src/ksp/withPoints_ksp_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/yen/withPoints_ksp_driver.h"
 

--- a/src/lineGraph/lineGraph.c
+++ b/src/lineGraph/lineGraph.c
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /** @file lineGraph.c
  * @brief Connecting code with postgres.

--- a/src/lineGraph/lineGraphFull.c
+++ b/src/lineGraph/lineGraphFull.c
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/lineGraph/lineGraphFull_driver.cpp
+++ b/src/lineGraph/lineGraphFull_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/lineGraph/lineGraphFull_driver.h"
 

--- a/src/lineGraph/lineGraph_driver.cpp
+++ b/src/lineGraph/lineGraph_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/lineGraph/lineGraph_driver.h"
 

--- a/src/max_flow/edge_disjoint_paths.c
+++ b/src/max_flow/edge_disjoint_paths.c
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 

--- a/src/max_flow/edge_disjoint_paths_driver.cpp
+++ b/src/max_flow/edge_disjoint_paths_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/max_flow/edge_disjoint_paths_driver.h"
 

--- a/src/max_flow/max_flow.c
+++ b/src/max_flow/max_flow.c
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 

--- a/src/max_flow/max_flow_driver.cpp
+++ b/src/max_flow/max_flow_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/max_flow/max_flow_driver.h"
 

--- a/src/max_flow/maximum_cardinality_matching.c
+++ b/src/max_flow/maximum_cardinality_matching.c
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 

--- a/src/max_flow/maximum_cardinality_matching_driver.cpp
+++ b/src/max_flow/maximum_cardinality_matching_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/max_flow/maximum_cardinality_matching_driver.h"
 

--- a/src/max_flow/minCostMaxFlow.c
+++ b/src/max_flow/minCostMaxFlow.c
@@ -26,7 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 /** @file minCostMaxFlow.c
  * @brief Connecting code with postgres.

--- a/src/max_flow/minCostMaxFlow_driver.cpp
+++ b/src/max_flow/minCostMaxFlow_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/max_flow/minCostMaxFlow_driver.h"
 

--- a/src/max_flow/pgr_flowgraph.cpp
+++ b/src/max_flow/pgr_flowgraph.cpp
@@ -22,6 +22,6 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "max_flow/pgr_flowgraph.hpp"

--- a/src/max_flow/pgr_maxflow.cpp
+++ b/src/max_flow/pgr_maxflow.cpp
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "max_flow/pgr_maxflow.hpp"
 

--- a/src/max_flow/pgr_minCostMaxFlow.cpp
+++ b/src/max_flow/pgr_minCostMaxFlow.cpp
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "max_flow/pgr_minCostMaxFlow.hpp"
 

--- a/src/mincut/stoerWagner.c
+++ b/src/mincut/stoerWagner.c
@@ -9,18 +9,22 @@ Function's developer:
 Copyright (c) 2018 Aditya Pratap Singh
 Mail: adityapratap.singh28@gmail.com
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/mincut/stoerWagner_driver.cpp
+++ b/src/mincut/stoerWagner_driver.cpp
@@ -9,18 +9,22 @@ Function's developer:
 Copyright (c) 2018 Aditya Pratap Singh
 Mail: adityapratap.singh28@gmail.com
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/mincut/stoerWagner_driver.h"
 

--- a/src/spanningTree/details.cpp
+++ b/src/spanningTree/details.cpp
@@ -5,18 +5,22 @@ Copyright (c) 2018 Vicky Vergara
 
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #include "spanningTree/details.hpp"
 #include <vector>

--- a/src/spanningTree/kruskal.c
+++ b/src/spanningTree/kruskal.c
@@ -9,18 +9,22 @@ Function's developer:
 Copyright (c) 2018 Aditya Pratap Singh
 Mail: adityapratap.singh28@gmail.com
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 

--- a/src/spanningTree/kruskal_driver.cpp
+++ b/src/spanningTree/kruskal_driver.cpp
@@ -9,18 +9,22 @@ Function's developer:
 Copyright (c) 2018 Aditya Pratap Singh
 Mail: adityapratap.singh28@gmail.com
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/spanningTree/kruskal_driver.h"
 

--- a/src/spanningTree/mst_common.cpp
+++ b/src/spanningTree/mst_common.cpp
@@ -5,18 +5,22 @@ Copyright (c) 2018 Vicky Vergara
 Mail: vicky at georepublic dot de
 
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/spanningTree/mst_common.h"
 

--- a/src/spanningTree/prim.c
+++ b/src/spanningTree/prim.c
@@ -9,18 +9,22 @@ Function's developer:
 Copyright (c) 2018 Aditya Pratap Singh
 Mail: adityapratap.singh28@gmail.com
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/spanningTree/prim_driver.cpp
+++ b/src/spanningTree/prim_driver.cpp
@@ -9,18 +9,22 @@ Function's developer:
 Copyright (c) 2018 Aditya Pratap Singh
 Mail: adityapratap.singh28@gmail.com
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/spanningTree/prim_driver.h"
 

--- a/src/spanningTree/randomSpanningTree.c
+++ b/src/spanningTree/randomSpanningTree.c
@@ -9,18 +9,22 @@ Function's developer:
 Copyright (c) 2018 Aditya Pratap Singh
 Mail: adityapratap.singh28@gmail.com
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/spanningTree/randomSpanningTree_driver.cpp
+++ b/src/spanningTree/randomSpanningTree_driver.cpp
@@ -9,18 +9,22 @@ Function's developer:
 Copyright (c) 2018 Aditya Pratap Singh
 Mail: adityapratap.singh28@gmail.com
 ------
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-********************************************************************PGR-GNU*/
+
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/spanningTree/randomSpanningTree_driver.h"
 

--- a/src/trsp/GraphDefinition.cpp
+++ b/src/trsp/GraphDefinition.cpp
@@ -18,10 +18,10 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-aint64 with this program; if not, write to the Free Software
+along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifdef __MINGW32__
 #include <winsock2.h>

--- a/src/trsp/edgeInfo.cpp
+++ b/src/trsp/edgeInfo.cpp
@@ -18,7 +18,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-aint64_t with this program; if not, write to the Free Software
+along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/

--- a/src/trsp/new_trsp.c
+++ b/src/trsp/new_trsp.c
@@ -21,7 +21,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/trsp/pgr_trspHandler.cpp
+++ b/src/trsp/pgr_trspHandler.cpp
@@ -18,10 +18,10 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-aint64_t with this program; if not, write to the Free Software
+along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "trsp/pgr_trspHandler.h"
 

--- a/src/trsp/trsp.c
+++ b/src/trsp/trsp.c
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 #include "c_common/postgres_connection.h"

--- a/src/trsp/trsp_core.cpp
+++ b/src/trsp/trsp_core.cpp
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #ifdef __MINGW32__
 #include <winsock2.h>

--- a/src/trsp/trsp_driver.cpp
+++ b/src/trsp/trsp_driver.cpp
@@ -21,7 +21,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 #include "drivers/trsp/trsp_driver.h"

--- a/src/tsp/TSP_driver.cpp
+++ b/src/tsp/TSP_driver.cpp
@@ -1,31 +1,32 @@
-/* PGR-GNU*****************************************************************
- * File: newTSP_driver.cpp
- *
- * Generated with Template by:
- * Copyright (c) 2015 pgRouting developers
- * Mail: project@pgrouting.org
- *
- * Function's developer:
- * Copyright (c) 2015 Celia Virginia Vergara Castillo
- * Mail: vicky_vergara@hotmail.com
- *
- * ------
- *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- *  ******************************************************************** PGR-GNU*/
+/*PGR-GNU*****************************************************************
+
+FILE: TSP_driver.cpp
+
+Generated with Template by:
+Copyright (c) 2015 pgRouting developers
+Mail: project@pgrouting.org
+
+Function's developer:
+Copyright (c) 2015 Celia Virginia Vergara Castillo
+Mail: vicky_vergara@hotmail.com
+
+------
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/tsp/TSP_driver.h"
 

--- a/src/tsp/euclideanTSP_driver.cpp
+++ b/src/tsp/euclideanTSP_driver.cpp
@@ -1,32 +1,32 @@
-/* PGR-GNU*****************************************************************
- * File: euclideanTSP_driver.cpp
- *
- * Generated with Template by:
- * Copyright (c) 2015 pgRouting developers
- * Mail: project@pgrouting.org
- *
- * Function's developer:
- * Copyright (c) 2015 Celia Virginia Vergara Castillo
- * Mail: vicky_vergara@hotmail.com
- *
- * ------
- *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- *  ******************************************************************** PGR-GNU*/
+/*PGR-GNU*****************************************************************
 
+FILE: euclideanTSP_driver.cpp
+
+Generated with Template by:
+Copyright (c) 2015 pgRouting developers
+Mail: project@pgrouting.org
+
+Function's developer:
+Copyright (c) 2015 Celia Virginia Vergara Castillo
+Mail: vicky_vergara@hotmail.com
+
+------
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/tsp/euclideanTSP_driver.h"
 

--- a/src/withPoints/get_new_queries.cpp
+++ b/src/withPoints/get_new_queries.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/withPoints/get_new_queries.h"
 #include <string.h>

--- a/src/withPoints/pgr_withPoints.cpp
+++ b/src/withPoints/pgr_withPoints.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 
 #include "withPoints/pgr_withPoints.hpp"

--- a/src/withPoints/withPoints.c
+++ b/src/withPoints/withPoints.c
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include <stdbool.h>
 #include "c_common/postgres_connection.h"

--- a/src/withPoints/withPoints_driver.cpp
+++ b/src/withPoints/withPoints_driver.cpp
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-********************************************************************PGR-GNU*/
+ ********************************************************************PGR-GNU*/
 
 #include "drivers/withPoints/withPoints_driver.h"
 

--- a/tools/licences/add-licenses
+++ b/tools/licences/add-licenses
@@ -65,7 +65,7 @@ for my $file (sort @files) {
     my $f = basename($file);
     next if $exclude{$f};
     my $task = get_task($file);
-    print "\n\n PROCESSING '$file' --- task '$task' \n" if $task != 0;
+    print "\n PROCESSING '$file' --- task '$task' \n" if $task == 1;
     next if $task == 0;
     update_license($task, $file) if $DOUPDATES;
 }
@@ -188,7 +188,7 @@ sub update_license {
 
     } else {
         #task = 2
-        print "  Changing Body of license\n";
+        #print "  Changing Body of license\n";
 
 
         # Find the dividing line

--- a/tools/licences/add-licenses
+++ b/tools/licences/add-licenses
@@ -65,7 +65,7 @@ for my $file (sort @files) {
     my $f = basename($file);
     next if $exclude{$f};
     my $task = get_task($file);
-    print "\n\n PROCESSING '$file' --- task '$task' \n";
+    print "\n\n PROCESSING '$file' --- task '$task' \n" if $task != 0;
     next if $task == 0;
     update_license($task, $file) if $DOUPDATES;
 }

--- a/tools/licences/add-licenses
+++ b/tools/licences/add-licenses
@@ -27,17 +27,17 @@ my @files = ();
 my %exclude = (
 );
 
-my $gnu_license = "GNU_license.txt";
+my $gnu_license = "tools/licences/GNU_license.txt";
 my @GNU_LICENSE = loadLicense($gnu_license);
 my @GNU_BODY = @GNU_LICENSE;
 splice @GNU_BODY, 0, 8;
 
-my $mit_license = "MIT_license.txt";
+my $mit_license = "tools/licences/MIT_license.txt";
 my @MIT_LICENSE = loadLicense($mit_license);
 my @MIT_BODY = @MIT_LICENSE;
 splice @MIT_BODY, 0, 6;
 
-my $ccm_license = "CCM_license.txt";
+my $ccm_license = "tools/licences/CCM_license.txt";
 my @CCM_LICENSE = loadLicense($ccm_license);
 my @CCM_BODY = @CCM_LICENSE;
 splice @CCM_BODY, 0, 1;


### PR DESCRIPTION
Standarizes the licenses
code used for standarizing is in the PR:
https://github.com/pgRouting/pgrouting/blob/3857ad6bae35a441bcc239c9e0176ac07a299d0b/tools/licences/add-licenses

Most of the changes is a space

@pgRouting/admins
