### PR TITLE
[doc] fixing pgr_pickDeliver & pgr_pickDeliverEuclidean queries

### DIFF
--- a/docqueries/pickDeliver/doc-pickDeliver.result
+++ b/docqueries/pickDeliver/doc-pickDeliver.result
@@ -3,7 +3,7 @@ BEGIN
 SET client_min_messages TO NOTICE;
 SET
 --q1
-SELECT * FROM _pgr_pickDeliver(
+SELECT * FROM pgr_pickDeliver(
     'SELECT * FROM orders ORDER BY id',
     'SELECT * from vehicles',
 
@@ -34,7 +34,7 @@ SELECT * FROM _pgr_pickDeliver(
 (11 rows)
 
 --q2
-SELECT * FROM _pgr_pickDeliver(
+SELECT * FROM pgr_pickDeliver(
     $$ SELECT * FROM orders ORDER BY id $$,
     $$ SELECT * FROM vehicles $$,
     $$ SELECT * from pgr_dijkstraCostMatrix(

--- a/docqueries/pickDeliver/doc-pickDeliver.test.sql
+++ b/docqueries/pickDeliver/doc-pickDeliver.test.sql
@@ -1,5 +1,5 @@
 \echo --q1
-SELECT * FROM _pgr_pickDeliver(
+SELECT * FROM pgr_pickDeliver(
     'SELECT * FROM orders ORDER BY id',
     'SELECT * from vehicles',
     -- matrix query
@@ -17,7 +17,7 @@ SELECT * FROM _pgr_pickDeliver(
 
 \echo --q2
 
-SELECT * FROM _pgr_pickDeliver(
+SELECT * FROM pgr_pickDeliver(
     $$ SELECT * FROM orders ORDER BY id $$,
     $$ SELECT * FROM vehicles $$,
     $$ SELECT * from pgr_dijkstraCostMatrix(

--- a/docqueries/pickDeliver/doc-pickDeliverEuclidean.result
+++ b/docqueries/pickDeliver/doc-pickDeliverEuclidean.result
@@ -3,7 +3,7 @@ BEGIN
 SET client_min_messages TO NOTICE;
 SET
 --q1
-SELECT * FROM _pgr_pickDeliverEuclidean(
+SELECT * FROM pgr_pickDeliverEuclidean(
     'SELECT * FROM orders ORDER BY id',
     'SELECT * from vehicles'
 );

--- a/docqueries/pickDeliver/doc-pickDeliverEuclidean.test.sql
+++ b/docqueries/pickDeliver/doc-pickDeliverEuclidean.test.sql
@@ -1,5 +1,5 @@
 \echo --q1
-SELECT * FROM _pgr_pickDeliverEuclidean(
+SELECT * FROM pgr_pickDeliverEuclidean(
     'SELECT * FROM orders ORDER BY id',
     'SELECT * from vehicles'
 );


### PR DESCRIPTION
Removing underscore from documentation examples on 
 `pgr_pickDeliver` & `pgr_pickDeliverEuclidean`

@pgRouting/admins
