### PR TITLE
[travis] skiping code check 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -171,6 +171,7 @@ before_script:
   - psql -U postgres -c "CREATE EXTENSION postgis"  -d ___pgr___test___
   - mkdir build
   - cd build
+  - if [ "$TRAVIS_COMMIT_MESSAGE" != *"translation completed for the source file"* ]; then DOCUMENTATION=ON; fi
   - if [ "$DOCUMENTATION" == "OFF" ]; then cmake  -DPOSTGRESQL_VERSION=$POSTGRESQL_VERSION -DCMAKE_BUILD_TYPE=$BUILD_TYPE .. ; fi
   - if [ "$DOCUMENTATION" == "ON" ] && [ "$LINKCHECK" == "OFF" ] ; then cmake  -DPOSTGRESQL_VERSION=$POSTGRESQL_VERSION -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_DOC=ON -DES=ON .. ; fi
   - if [ "$DOCUMENTATION" == "ON" ] && [ "$LINKCHECK" == "ON" ] ; then cmake  -DPOSTGRESQL_VERSION=$POSTGRESQL_VERSION -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_DOC=ON -DES=ON -DLINKCHECK="ON" .. ; fi


### PR DESCRIPTION
When transifex does a PR it does not affect code so this prevents Travis code checking and only allows it to check documentation.
when part of the commit msg has: "translation completed for the source file"
it only checks documentations

This PR is testing the feature here: https://travis-ci.com/github/cvvergara/pgrouting/builds/174856317
Where the test done on all jobs is done only to documentation


@pgRouting/admins
