### PR TITLE
Removed the generated links from linkcheck_ignore

### DIFF
--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -297,10 +297,6 @@ pdf_style_path = ['.', '_styles']
 # cases to ignore during link checking
 linkcheck_ignore = [
     # might not exist yet (we are generating it!)
-    "https://docs.pgrouting.org/3.2/en/pgr_depthFirstSearch.html",
-    "https://docs.pgrouting.org/3.2/en/pgr_sequentialVertexColoring.html",
-    "https://docs.pgrouting.org/3.2/en/coloring-family.html",
-    "https://docs.pgrouting.org/3.2/en/traversal-family.html",
 
     # FIXME: tmp disable due to Retry-After header for rate-limiting by Github not respected
     #        (see: https://github.com/sphinx-doc/sphinx/issues/7388)


### PR DESCRIPTION
Changes proposed in this pull request:
- Removed the generated links from `linkcheck_ignore`

@pgRouting/admins
