### PR TITLE
Fixed coloring family and sequentialVertexColoring documentation

### DIFF
--- a/doc/coloring/coloring-family.rst
+++ b/doc/coloring/coloring-family.rst
@@ -35,12 +35,15 @@ Coloring - Family of functions (Experimental)
 Parameters
 -------------------------------------------------------------------------------
 
+.. parameters start
+
 =================== ====================== =================================================
 Parameter           Type                   Description
 =================== ====================== =================================================
 **Edges SQL**       ``TEXT``               Inner query as described below.
 =================== ====================== =================================================
 
+.. parameters end
 
 Inner query
 -------------------------------------------------------------------------------
@@ -56,12 +59,21 @@ Inner query
 Result Columns
 -------------------------------------------------------------------------------
 
-pgr_sequentialVertexColoring
-...............................................................................
+.. result columns start
 
-.. include:: pgr_sequentialVertexColoring.rst
-    :start-after: result columns start
-    :end-before: result columns end
+Returns SET OF ``(vertex_id, color_id)``
+
+===============  =========== ====================================================
+Column           Type        Description
+===============  =========== ====================================================
+**vertex_id**    ``BIGINT``  Identifier of the vertex.
+**color_id**     ``BIGINT``  Identifier of the color of the vertex.
+
+                             - The minimum value of color is 1.
+
+===============  =========== ====================================================
+
+.. result columns end
 
 
 See Also

--- a/doc/coloring/pgr_sequentialVertexColoring.rst
+++ b/doc/coloring/pgr_sequentialVertexColoring.rst
@@ -81,11 +81,9 @@ Signatures
 Parameters
 -------------------------------------------------------------------------------
 
-=================== ====================== =================================================
-Parameter           Type                   Description
-=================== ====================== =================================================
-**Edges SQL**       ``TEXT``               Inner query as described below.
-=================== ====================== =================================================
+.. include:: coloring-family.rst
+    :start-after: parameters start
+    :end-before: parameters end
 
 Inner query
 -------------------------------------------------------------------------------
@@ -100,23 +98,9 @@ Inner query
 Result Columns
 -------------------------------------------------------------------------------
 
-.. result columns start
-
-Returns SET OF ``(vertex_id, color_id)``
-
-===============  =========== ====================================================
-Column           Type        Description
-===============  =========== ====================================================
-**vertex_id**    ``BIGINT``  Identifier of the vertex.
-**color_id**     ``BIGINT``  Identifier of the color of the vertex.
-
-                             - The minimum value of color is 1.
-                             - The maximum value will not be greater than the
-                               number of vertices in the graph.
-
-===============  =========== ====================================================
-
-.. result columns end
+.. include:: coloring-family.rst
+    :start-after: result columns start
+    :end-before: result columns end
 
 
 See Also


### PR DESCRIPTION
Changes proposed in this pull request:
- Defined the parameters and the result columns in the coloring family doc, instead of the sequentialVertexColoring doc.
- Referenced these parameters in the sequentialVertexColoring doc.

@pgRouting/admins
