### PR TITLE
GSoC 2020 Removed links from linkcheck_ignore

### DIFF
--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -301,8 +301,6 @@ linkcheck_ignore = [
     # FIXME: tmp disable due to Retry-After header for rate-limiting by Github not respected
     #        (see: https://github.com/sphinx-doc/sphinx/issues/7388)
     "https://github.com/pgRouting/pgrouting/issues/*",    # limit only pgrouting
-    "https://docs.pgrouting.org/3.2/en/pgr_isPlanar.html",
-    "https://docs.pgrouting.org/3.2/en/pgr_makeConnected.html",
 ]
 
 linkcheck_timeout = 20


### PR DESCRIPTION
Changes proposed in this pull request:
- Removed the links from linkcheck_ignore

@pgRouting/admins
