### PR TITLE
Removing codeforce link

### DIFF
--- a/doc/breadthFirstSearch/pgr_binaryBreadthFirstSearch.rst
+++ b/doc/breadthFirstSearch/pgr_binaryBreadthFirstSearch.rst
@@ -224,7 +224,6 @@ See Also
 -------------------------------------------------------------------------------
 
 * https://cp-algorithms.com/graph/01_bfs.html
-* https://codeforces.com/blog/entry/22276
 * https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm#Specialized_variants
 
 .. rubric:: Indices and tables

--- a/locale/en/LC_MESSAGES/pgr_binaryBreadthFirstSearch.po
+++ b/locale/en/LC_MESSAGES/pgr_binaryBreadthFirstSearch.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-22 08:19-0500\n"
+"POT-Creation-Date: 2020-10-07 21:01-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 #: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:11
 msgid "pgr_binaryBreadthFirstSearch - Experimental"
@@ -593,23 +593,22 @@ msgid "https://cp-algorithms.com/graph/01_bfs.html"
 msgstr ""
 
 #: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:227
-msgid "https://codeforces.com/blog/entry/22276"
-msgstr ""
-
-#: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:228
 #, python-format
 msgid "https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm#Specialized_variants"
 msgstr ""
 
-#: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:231
+#: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:230
 msgid "Indices and tables"
 msgstr ""
 
-#: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:232
+#: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:231
 msgid ":ref:`genindex`"
 msgstr ""
 
-#: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:233
+#: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:232
 msgid ":ref:`search`"
 msgstr ""
+
+#~ msgid "https://codeforces.com/blog/entry/22276"
+#~ msgstr ""
 

--- a/locale/pot/pgr_binaryBreadthFirstSearch.pot
+++ b/locale/pot/pgr_binaryBreadthFirstSearch.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.1.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-07 12:15-0500\n"
+"POT-Creation-Date: 2020-10-07 21:01-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -528,22 +528,18 @@ msgid "https://cp-algorithms.com/graph/01_bfs.html"
 msgstr ""
 
 #: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:227
-msgid "https://codeforces.com/blog/entry/22276"
-msgstr ""
-
-#: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:228
 msgid "https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm#Specialized_variants"
 msgstr ""
 
-#: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:231
+#: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:230
 msgid "Indices and tables"
 msgstr ""
 
-#: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:232
+#: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:231
 msgid ":ref:`genindex`"
 msgstr ""
 
-#: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:233
+#: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:232
 msgid ":ref:`search`"
 msgstr ""
 


### PR DESCRIPTION
On experimental pgr_binaryBreadthFirstSearch there is a link to
https://codeforces.com/blog/entry/22276
Which is a site of:
"Codeforces is a website that hosts competitive programming contests."
- Reference to a contest for an algorithm is not a reliable source
- Its so unreliable that it is out of service and its blocking #1621 PR

@pgRouting/admins
