### PR TITLE
Added broken link to linkcheck_ignore on 3.0

### DIFF
--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -318,6 +318,9 @@ pdf_style_path = ['.', '_styles']
 
 # cases to ignore during link checking
 linkcheck_ignore = [
+    # Link is going to be fixed by sponsor
+    'https://www.leopark.mx/',
+
     # might not exist yet (we are generating it!)
 
     # FIXME: tmp disable due to Retry-After header for rate-limiting by Github not respected


### PR DESCRIPTION
Changes proposed in this pull request:
- Added broken link to `linkcheck_ignore`

@pgRouting/admins
