### PR TITLE
Pumpup to 3.0.5

### DIFF
--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -22,7 +22,8 @@ jobs:
       - name: News file up to date
         run: |
           tools/release-scripts/notes2news.pl
-          ! git status | grep 'NEWS'
+          if git status | grep 'NEWS'; then echo "NEWS is not up to date"; exit 1; fi
+          if ! grep -q $(grep -Po '(?<=project\(PGROUTING VERSION )[^;]+' CMakeLists.txt) NEWS; then echo "Missing section in NEWS"; exit 1; fi
 
   license_check:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ include(pgr/BuildType)
 #---------------------------------------------
 #---------------------------------------------
 
-project(PGROUTING VERSION 3.0.4
+project(PGROUTING VERSION 3.0.5
     LANGUAGES C CXX )
 set(PGROUTING_VERSION_DEV "")
 
@@ -47,7 +47,7 @@ string(TIMESTAMP COMPILATION_DATE "%Y/%m/%d")
 
 set(MINORS 3.0 2.6)
 set(OLD_SIGNATURES
-    3.0.3 3.0.2 3.0.1 3.0.0
+    3.0.4 3.0.3 3.0.2 3.0.1 3.0.0
     2.6.3 2.6.2 2.6.1 2.6.0
     )
 

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,11 @@
 
+pgRouting 3.0.5 Release Notes
+-------------------------------------------------------------------------------
+
+To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.5
+<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.5%22>`_ on Github.
+
+
 pgRouting 3.0.4 Release Notes
 -------------------------------------------------------------------------------
 

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -18,6 +18,7 @@ To see the full list of changes check the list of `Git commits <https://github.c
 
 .. changelog start
 
+* :ref:`changelog_3_0_5`
 * :ref:`changelog_3_0_4`
 * :ref:`changelog_3_0_3`
 * :ref:`changelog_3_0_2`
@@ -51,7 +52,14 @@ To see the full list of changes check the list of `Git commits <https://github.c
 
 .. changelog end
 
-.. _changelog_3_0_4:
+.. _changelog_3_0_5:
+
+pgRouting 3.0.5 Release Notes
+-------------------------------------------------------------------------------
+
+To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.5
+<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.5%22>`_ on Github.
+
 
 pgRouting 3.0.4 Release Notes
 -------------------------------------------------------------------------------

--- a/docqueries/version/doc-full_version.result
+++ b/docqueries/version/doc-full_version.result
@@ -4,9 +4,9 @@ SET client_min_messages TO NOTICE;
 SET
 -- q1
 SELECT * FROM pgr_full_version();
- version | build_type | compile_date |     library     |         system         |                   postgresql                   | compiler  | boost  |   hash
----------+------------+--------------+-----------------+------------------------+------------------------------------------------+-----------+--------+-----------
- 3.0.4   | Debug      | 2020/12/14   | pgrouting-3.0.4 | Linux-5.4.0-56-generic | PostgreSQL 12.5 (Ubuntu 12.5-0ubuntu0.20.04.1) | GNU-8.4.0 | 1.71.0 | fddbbb2ee
+ version | build_type | compile_date |     library     |         system         |                   postgresql                   | compiler  | boost  |    hash
+---------+------------+--------------+-----------------+------------------------+------------------------------------------------+-----------+--------+------------
+ 3.0.5   | Debug      | 2020/12/21   | pgrouting-3.0.5 | Linux-5.4.0-58-generic | PostgreSQL 12.5 (Ubuntu 12.5-0ubuntu0.20.04.1) | GNU-8.4.0 | 1.71.0 | a6c19ed37f
 (1 row)
 
 -- q2

--- a/docqueries/version/doc-version.result
+++ b/docqueries/version/doc-version.result
@@ -6,7 +6,7 @@ SET
 SELECT pgr_version();
  pgr_version
 -------------
- 3.0.4
+ 3.0.5
 (1 row)
 
 -- q2


### PR DESCRIPTION
- Modifying action to verify that NEWS section has the corresponding version
- Pumping up from 3.0.4 to 3.0.5


@pgRouting/admins
