### PR TITLE
Porting pumpups

### DIFF
--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -22,7 +22,8 @@ jobs:
       - name: News file up to date
         run: |
           tools/release-scripts/notes2news.pl
-          ! git status | grep 'NEWS'
+          if git status | grep 'NEWS'; then echo "NEWS is not up to date"; exit 1; fi
+          if ! grep -q $(grep -Po '(?<=project\(PGROUTING VERSION )[^;]+' CMakeLists.txt) NEWS; then echo "Missing section in NEWS"; exit 1; fi
 
   license_check:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ string(TIMESTAMP COMPILATION_DATE "%Y/%m/%d")
 
 set(MINORS 3.2 3.1 3.0 2.6)
 set(OLD_SIGNATURES
-    3.1.2 3.1.1 3.1.0
+    3.1.3 3.1.2 3.1.1 3.1.0
     3.0.5 3.0.4 3.0.3 3.0.2 3.0.1 3.0.0
     2.6.3 2.6.2 2.6.1 2.6.0
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ string(TIMESTAMP COMPILATION_DATE "%Y/%m/%d")
 set(MINORS 3.2 3.1 3.0 2.6)
 set(OLD_SIGNATURES
     3.1.2 3.1.1 3.1.0
-    3.0.4 3.0.3 3.0.2 3.0.1 3.0.0
+    3.0.5 3.0.4 3.0.3 3.0.2 3.0.1 3.0.0
     2.6.3 2.6.2 2.6.1 2.6.0
     )
 

--- a/NEWS
+++ b/NEWS
@@ -88,6 +88,12 @@ To see all issues & pull requests closed by this release see the `Git closed mil
 
 * Minimal requirement for Sphinx: version 1.8
 
+pgRouting 3.0.5 Release Notes
+-------------------------------------------------------------------------------
+
+To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.5
+<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.5%22>`_ on Github.
+
 
 pgRouting 3.0.4 Release Notes
 -------------------------------------------------------------------------------

--- a/NEWS
+++ b/NEWS
@@ -42,6 +42,13 @@ pgRouting 3.2.0 Release Notes
 * pgr_withPointsCost(Combinations)
 
 
+pgRouting 3.1.3 Release Notes
+-------------------------------------------------------------------------------
+
+To see all issues & pull requests closed by this release see the `Git closed milestone for 3.1.3
+<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.3%22>`_ on Github.
+
+
 pgRouting 3.1.2 Release Notes
 -------------------------------------------------------------------------------
 
@@ -88,11 +95,13 @@ To see all issues & pull requests closed by this release see the `Git closed mil
 
 * Minimal requirement for Sphinx: version 1.8
 
+
 pgRouting 3.0.5 Release Notes
 -------------------------------------------------------------------------------
 
 To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.5
 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.5%22>`_ on Github.
+
 
 
 pgRouting 3.0.4 Release Notes

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -22,6 +22,7 @@ To see the full list of changes check the list of `Git commits <https://github.c
 * :ref:`changelog_3_1_2`
 * :ref:`changelog_3_1_1`
 * :ref:`changelog_3_1_0`
+* :ref:`changelog_3_0_5`
 * :ref:`changelog_3_0_4`
 * :ref:`changelog_3_0_3`
 * :ref:`changelog_3_0_2`
@@ -149,6 +150,15 @@ To see all issues & pull requests closed by this release see the `Git closed mil
 .. rubric:: Build changes
 
 * Minimal requirement for Sphinx: version 1.8
+
+.. _changelog_3_0_5:
+
+pgRouting 3.0.5 Release Notes
+-------------------------------------------------------------------------------
+
+To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.5
+<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.5%22>`_ on Github.
+
 
 .. _changelog_3_0_4:
 

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -19,6 +19,7 @@ To see the full list of changes check the list of `Git commits <https://github.c
 .. changelog start
 
 * :ref:`changelog_3_2_0`
+* :ref:`changelog_3_1_3`
 * :ref:`changelog_3_1_2`
 * :ref:`changelog_3_1_1`
 * :ref:`changelog_3_1_0`
@@ -100,6 +101,14 @@ pgRouting 3.2.0 Release Notes
 * pgr_pushRelabel(Combinations)
 * pgr_withPoints(Combinations)
 * pgr_withPointsCost(Combinations)
+
+.. _changelog_3_1_3:
+
+pgRouting 3.1.3 Release Notes
+-------------------------------------------------------------------------------
+
+To see all issues & pull requests closed by this release see the `Git closed milestone for 3.1.3
+<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.3%22>`_ on Github.
 
 .. _changelog_3_1_2:
 


### PR DESCRIPTION

* Action to verify section in news exists for new version
* Porting documentation section from 3.0.5
* Porting documentation section from 3.1.2


@pgRouting/admins
