### PR TITLE
Support macOS on CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Test
         run: |
+          export PATH=/usr/local/Cellar/perl/5.32.0/bin:$PATH
           pg_ctl -D /usr/local/var/postgres start
           createuser -s postgres
           createdb ___pgr___test___

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,6 +40,7 @@ jobs:
           cd pgTapExtension
           make -j
           sudo make install
+          cpan TAP::Parser::SourceHandler::pgTAP
 
       - name: Test
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Install pgTAP
         run: |
-          git clone https://github.com/theory/pgtap.git
-          cd pgtap
+          git clone https://github.com/theory/pgtap.git pgTapExtension
+          cd pgTapExtension
           make -j
           sudo make install
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,5 +41,5 @@ jobs:
 
       - name: Test
         run: |
-          pg_ctl -D ${{ matrix.brewpsqls }} start &
+          pg_ctl -D /usr/local/var/${{ matrix.brewpsqls }} start
           bash ./tools/testers/pg_prove_tests.sh postgres 5432 Release

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,9 +1,13 @@
-name: Build for MacOS
+name: Build for macOS
 
 on:
   push:
     branches-ignore:
-        - '**'
+      - 'translations_*'
+    tags: []
+  pull_request:
+    paths-ignore:
+      - '**.po'
 
 jobs:
   build:
@@ -11,54 +15,32 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-        matrix:
-          psql: [10]
-          os: [macos-latest]
+      matrix:
+        brewpsqls: [posgres@9.5, posgres@9.6, posgres@10, posgres@11, posgres@12, posgres]
+        postgis: [postgis]
+        boost: [boost@1.57, boost@1.60, boost]
+        os: [macos-latest]
 
     steps:
-      # - name: Add PostgreSQL APT repository
-      #   run: |
-      #     sudo apt-get install curl ca-certificates gnupg
-      #     curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-      #     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ \
-      #       $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-
-      # - name: Install dependencies
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install -y \
-      #       libboost-graph-dev \
-      #       libtap-parser-sourcehandler-pgtap-perl \
-      #       postgresql-${{ matrix.psql }} \
-      #       postgresql-${{ matrix.psql }}-pgtap \
-      #       postgresql-${{ matrix.psql }}-postgis-${{ matrix.postgis }} \
-      #       postgresql-${{ matrix.psql }}-postgis-${{ matrix.postgis }}-scripts \
-      #       postgresql-server-dev-${{ matrix.psql }} \
-      #       python-sphinx
-
       - name: Checkout repository
         uses: actions/checkout@v2
+      
+      - name: install deps
+        run: |
+          brew install ${{ matrix.brewpsqls }} ${{ matrix.boost }}
 
-      # - name: Prepare
-      #   run: |
-      #     sphinx-build --version
-      #     sudo -u postgres psql -p 5432 -c "CREATE EXTENSION postgis"
-      #     export PATH=/usr/lib/postgresql/${{ matrix.psql }}/bin:$PATH
-      #     sudo -u postgres createdb ___pgr___test___
-      #     sudo -u postgres createdb pgr_test__db__test
+      - name: Configure
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Release -DWITH_DOC=OFF ..
 
-      # - name: Configure
-      #   run: |
-      #     mkdir build
-      #     cd build
-      #     cmake -DPOSTGRESQL_VERSION=${{ matrix.psql }} -DCMAKE_BUILD_TYPE=Release -DWITH_DOC=OFF ..
+      - name: Build
+        run: |
+          cd build
+          make
+          sudo make install
 
-      # - name: Build
-      #   run: |
-      #     cd build
-      #     make
-      #     sudo make install
-
-      # - name: Test
-      #   run: |
-      #     sudo -u postgres bash ./tools/testers/pg_prove_tests.sh postgres 5432 Release
+      - name: Test
+        run: |
+          bash ./tools/testers/pg_prove_tests.sh postgres 5432 Release

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build
         run: |
           cd build
-          make
+          make -j
           sudo make install
 
       - name: Test

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,4 +37,5 @@ jobs:
       - name: Test
         run: |
           pg_ctl -D /usr/local/var/postgres start
+          createuser -s postgres
           bash ./tools/testers/pg_prove_tests.sh postgres 5432 Release

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,18 +14,13 @@ jobs:
     name: Build
     runs-on: ${{ matrix.os }}
 
-    strategy:
-      matrix:
-        brewpsqls: [postgresql@9.5, postgresql@9.6, postgresql@10, postgresql@11, postgresql@12, postgres]
-        os: [macos-latest]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       
       - name: install deps
         run: |
-          brew install ${{ matrix.brewpsqls }} postgis boost
+          brew install postgresql postgis boost
 
       - name: Configure
         run: |
@@ -41,5 +36,5 @@ jobs:
 
       - name: Test
         run: |
-          pg_ctl -D /usr/local/var/${{ matrix.brewpsqls }} start
+          pg_ctl -D /usr/local/var/postgres start
           bash ./tools/testers/pg_prove_tests.sh postgres 5432 Release

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,7 @@ jobs:
       
       - name: install deps
         run: |
-          brew install ${{ matrix.brewpsqls }} ${{ matrix.boost }}
+          brew install --force ${{ matrix.brewpsqls }} ${{ matrix.boost }}
 
       - name: Configure
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -34,6 +34,13 @@ jobs:
           make -j
           sudo make install
 
+      - name: Install pgTAP
+        run: |
+          git clone https://github.com/theory/pgtap.git
+          cd pgtap
+          make -j
+          sudo make install
+
       - name: Test
         run: |
           pg_ctl -D /usr/local/var/postgres start

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        brewpsqls: [postgres@9.5, postgres@9.6, postgres@10, postgres@11, postgres@12, postgres]
+        brewpsqls: [postgresql@9.5, postgresql@9.6, postgresql@10, postgresql@11, postgresql@12, postgresql]
         postgis: [postgis]
         boost: [boost@1.57, boost@1.60, boost]
         os: [macos-latest]

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         brewpsqls: [postgresql@9.5, postgresql@9.6, postgresql@10, postgresql@11, postgresql@12, postgresql]
         postgis: [postgis]
-        boost: [bitshares/boost160/boost@1.60, boost]
         os: [macos-latest]
 
     steps:
@@ -27,8 +26,7 @@ jobs:
       
       - name: install deps
         run: |
-          brew tap bitshares/boost160
-          brew install --force ${{ matrix.brewpsqls }} ${{ matrix.boost }}
+          brew install ${{ matrix.brewpsqls }} boost
 
       - name: Configure
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         brewpsqls: [postgresql@9.5, postgresql@9.6, postgresql@10, postgresql@11, postgresql@12, postgresql]
         postgis: [postgis]
-        boost: [boost@1.57, boost@1.60, boost]
+        boost: [bitshares/boost160/boost@1.60, boost]
         os: [macos-latest]
 
     steps:
@@ -27,6 +27,7 @@ jobs:
       
       - name: install deps
         run: |
+          brew tap bitshares/boost160
           brew install --force ${{ matrix.brewpsqls }} ${{ matrix.boost }}
 
       - name: Configure

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        brewpsqls: [postgresql@9.5, postgresql@9.6, postgresql@10, postgresql@11, postgresql@12, postgresql]
+        brewpsqls: [postgresql@9.5, postgresql@9.6, postgresql@10, postgresql@11, postgresql@12, postgres]
         os: [macos-latest]
 
     steps:
@@ -41,5 +41,5 @@ jobs:
 
       - name: Test
         run: |
-          brew services start ${{ matrix.brewpsqls }}
+          pg_ctl -D ${{ matrix.brewpsqls }} start &
           bash ./tools/testers/pg_prove_tests.sh postgres 5432 Release

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        brewpsqls: [posgres@9.5, posgres@9.6, posgres@10, posgres@11, posgres@12, posgres]
+        brewpsqls: [postgres@9.5, postgres@9.6, postgres@10, postgres@11, postgres@12, postgres]
         postgis: [postgis]
         boost: [boost@1.57, boost@1.60, boost]
         os: [macos-latest]

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         brewpsqls: [postgresql@9.5, postgresql@9.6, postgresql@10, postgresql@11, postgresql@12, postgresql]
-        postgis: [postgis]
         os: [macos-latest]
 
     steps:
@@ -26,7 +25,7 @@ jobs:
       
       - name: install deps
         run: |
-          brew install ${{ matrix.brewpsqls }} boost
+          brew install ${{ matrix.brewpsqls }} postgis boost
 
       - name: Configure
         run: |
@@ -42,4 +41,5 @@ jobs:
 
       - name: Test
         run: |
+          brew services start ${{ matrix.brewpsqls }}
           bash ./tools/testers/pg_prove_tests.sh postgres 5432 Release

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Test
         run: |
-          export PATH=/usr/local/Cellar/perl/5.32.0/bin:$PATH
+          export PATH=/usr/local/Cellar/perl/$(perl -e 'print substr($^V, 1)')/bin:$PATH
           pg_ctl -D /usr/local/var/postgres start
           createuser -s postgres
           createdb ___pgr___test___

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,4 +38,5 @@ jobs:
         run: |
           pg_ctl -D /usr/local/var/postgres start
           createuser -s postgres
+          createdb ___pgr___test___
           bash ./tools/testers/pg_prove_tests.sh postgres 5432 Release


### PR DESCRIPTION
Changes proposed in this pull request:
- Add CI scripts for macOS Environment

I've written GH Actions for macOS environment. This pull request makes us build and test pgRouting on macOS.

NOTE: At first, I've tried to test multiple PostgreSQL versions with version matrix but I've given up it, since only latest version doesn't have version suffix on the homebrew package name like `postgresql@13`.

@pgRouting/admins
