### PR TITLE
Add GitHub Actions script for releases on 3.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,170 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    strategy:
+        fail-fast: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get postgres version
+        run: |
+          sudo service postgresql start
+          PGVER=$(psql --version | grep -Po '(?<=psql \(PostgreSQL\) )[^;]+(?=\.\d \()')
+          PGROUTING_VERSION=$(grep -Po '(?<=project\(PGROUTING VERSION )[^;]+' CMakeLists.txt)
+          echo "PGVER=${PGVER}" >> $GITHUB_ENV
+          echo "PGPORT=5432" >> $GITHUB_ENV
+          echo "PGIS=3" >> $GITHUB_ENV
+          echo "PGROUTING_VERSION=${PGROUTING_VERSION}" >> $GITHUB_ENV
+
+      - name: Verify Tag Name
+        run: |
+          TAG_NAME=${GITHUB_REF#refs/*/}
+          echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_ENV
+          echo ${TAG_NAME}
+          echo ${PGROUTING_VERSION}
+          if [ "${TAG_NAME}" != "v${PGROUTING_VERSION}" ]; then
+            echo "Tag name should be v${PGROUTING_VERSION}"
+            exit 1
+          fi
+
+      - name: Extract branch name
+        run: |
+          raw=$(git branch -r --contains ${{ github.ref }})
+          branch=${raw##*/}
+          echo "BRANCH=$branch" >> $GITHUB_ENV
+
+      - name: Add PostgreSQL APT repository
+        run: |
+          sudo apt-get install curl ca-certificates gnupg
+          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ \
+            $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libboost-graph-dev \
+            postgresql-${PGVER} \
+            postgresql-${PGVER}-postgis-${PGIS} \
+            postgresql-${PGVER}-postgis-${PGIS}-scripts \
+            postgresql-server-dev-${PGVER} \
+            graphviz \
+            doxygen
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip list
+
+      - name: Configure
+        run: |
+          export PATH=/usr/lib/postgresql/${PGVER}/bin:$PATH
+          mkdir build
+          cd build
+          cmake -DPOSTGRESQL_VERSION=${PGVER} -DDOC_USE_BOOTSTRAP=ON -DWITH_DOC=ON -DBUILD_DOXY=ON -DCMAKE_BUILD_TYPE=Release -DES=ON ..
+
+      - name: Build
+        run: |
+          cd build
+          make doc
+          make -j 4
+          sudo make install
+          make doxy
+
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Update Users Documentation
+        run: |
+          git checkout origin/gh-pages
+          git checkout -b gh-pages
+          PGROUTING_MAJOR_MINOR="${PGROUTING_VERSION%.*}"
+          rm -rf ${PGROUTING_MAJOR_MINOR}
+          cp -r build/doc/html ${PGROUTING_MAJOR_MINOR}
+          git add ${PGROUTING_MAJOR_MINOR}
+          git commit -m "Update users documentation for ${PGROUTING_VERSION}"
+          git push origin gh-pages
+          git checkout @{-2}
+
+      - name: Update Developers Documentation
+        if: ${{ env.BRANCH == 'master' }}
+        run: |
+          git checkout gh-pages
+          rm -rf doxygen
+          cp -r build/doxygen/html doxygen
+          git add doxygen
+          git commit -m "Update developers documentation for ${PGROUTING_VERSION}"
+          git push origin gh-pages
+          git checkout @{-1}
+
+      - name: Download Assets
+        run: |
+          wget -c https://github.com/${{ github.repository }}/archive/${TAG_NAME}.zip
+          wget -c https://github.com/${{ github.repository }}/archive/${TAG_NAME}.tar.gz
+          mv ${TAG_NAME}.zip ${{ github.event.repository.name }}-${PGROUTING_VERSION}.zip
+          mv ${TAG_NAME}.tar.gz ${{ github.event.repository.name }}-${PGROUTING_VERSION}.tar.gz
+
+      - name: Make Attachments
+        run: |
+          cd build/doc
+
+          cp -r html doc-v${PGROUTING_VERSION}-en-es
+          tar -zcvf doc-v${PGROUTING_VERSION}-en-es.tar.gz doc-v${PGROUTING_VERSION}-en-es
+
+          cp -r html doc-v${PGROUTING_VERSION}-en
+          rm -rf doc-v${PGROUTING_VERSION}-en/es
+          tar -zcvf doc-v${PGROUTING_VERSION}-en.tar.gz doc-v${PGROUTING_VERSION}-en
+
+          cp -r html doc-v${PGROUTING_VERSION}-es
+          rm -rf doc-v${PGROUTING_VERSION}-es/en
+          perl -pi -e 's/en\/index.html/es\/index.html/g' doc-v${PGROUTING_VERSION}-es/index.html
+          tar -zcvf doc-v${PGROUTING_VERSION}-es.tar.gz doc-v${PGROUTING_VERSION}-es
+
+          cd ../..
+          grep -Pzo "(?s)pgRouting ${PGROUTING_VERSION//./\\.} Release Notes.*?(?=pgRouting .\..\.. Release Notes)" NEWS | tr '\0' '\n' > release_body.txt
+          echo "**Attachments**" >> release_body.txt
+          echo "File | Contents" >> release_body.txt
+          echo "| --- | --- |" >> release_body.txt
+          echo "| \`doc-v${PGROUTING_VERSION}-en-es.tar.gz\` | English and Spanish documentation. Redirection to English" >> release_body.txt
+          echo "| \`doc-v${PGROUTING_VERSION}-en.tar.gz\`|English documentation. Redirection to English" >> release_body.txt
+          echo "| \`doc-v${PGROUTING_VERSION}-es.tar.gz\`|Spanish documentation. Redirection to Spanish" >> release_body.txt
+          echo "| \`pgrouting-${PGROUTING_VERSION}.tar.gz\` | tar.gz of the release" >> release_body.txt
+          echo "| \`pgrouting-${PGROUTING_VERSION}.zip\`| zip of the release" >> release_body.txt
+          cat release_body.txt
+
+      - name: Create Draft Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: release_body.txt
+          name: ${{ env.TAG_NAME }}
+          draft: true
+          prerelease: false
+          files: |
+            build/doc/doc-v${{ env.PGROUTING_VERSION }}-en-es.tar.gz
+            build/doc/doc-v${{ env.PGROUTING_VERSION }}-en.tar.gz
+            build/doc/doc-v${{ env.PGROUTING_VERSION }}-es.tar.gz
+            ${{ github.event.repository.name }}-${{ env.PGROUTING_VERSION }}.zip
+            ${{ github.event.repository.name }}-${{ env.PGROUTING_VERSION }}.tar.gz
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,8 @@ jobs:
           cp -r build/doc/html ${PGROUTING_MAJOR_MINOR}
           git add ${PGROUTING_MAJOR_MINOR}
           git commit -m "Update users documentation for ${PGROUTING_VERSION}"
+          git fetch origin
+          git rebase origin/gh-pages
           git push origin gh-pages
           git checkout @{-2}
 
@@ -114,6 +116,8 @@ jobs:
           cp -r build/doxygen/html doxygen
           git add doxygen
           git commit -m "Update developers documentation for ${PGROUTING_VERSION}"
+          git fetch origin
+          git rebase origin/gh-pages
           git push origin gh-pages
           git checkout @{-1}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,8 @@ jobs:
             graphviz \
             doxygen
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install Sphinx
+          pip install sphinx-bootstrap-theme
           pip list
 
       - name: Configure

--- a/NEWS
+++ b/NEWS
@@ -1,16 +1,15 @@
 pgRouting 3.2.0 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.2.0
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.2.0%22>`_ on Github.
+To see all issues & pull requests closed by this release see the [Git closed milestone for 3.2.0](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.2.0%22) on Github.
 
-*Build*
+**Build**
 
-* [#1825 ](https://github.com/pgRouting/pgrouting/issues/1850)_: Change Boost min version to 1.56
+* [#1825](https://github.com/pgRouting/pgrouting/issues/1850): Change Boost min version to 1.56
 
   * Removing support for Boost v1.53, v1.54 & v1.55
 
-*New experimental functions*
+**New experimental functions**
 
 * pgr_bellmanFord(Combinations)
 * pgr_binaryBreadthFirstSearch(Combinations)
@@ -44,7 +43,7 @@ To see all issues & pull requests closed by this release see the `Git closed mil
 
 * pgr_sequentialVertexColoring
 
-*New proposed functions*
+**New proposed functions**
 
 * Astar
 
@@ -76,59 +75,55 @@ To see all issues & pull requests closed by this release see the `Git closed mil
 pgRouting 3.1.3 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.1.3
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.3%22>`_ on Github.
+To see all issues & pull requests closed by this release see the [Git closed milestone for 3.1.3](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.3%22) on Github.
 
-*Issues fixes*
+**Issues fixes**
 
-* [#1825 ](https://github.com/pgRouting/pgrouting/issues/1825)_: Boost versions are not honored
-* [#1849 ](https://github.com/pgRouting/pgrouting/issues/1849)_: Boost 1.75.0 geometry "point_xy.hpp" build error on macOS environment
-* [#1861 ](https://github.com/pgRouting/pgrouting/issues/1861)_: vrp functions crash server
+* [#1825](https://github.com/pgRouting/pgrouting/issues/1825): Boost versions are not honored
+* [#1849](https://github.com/pgRouting/pgrouting/issues/1849): Boost 1.75.0 geometry "point_xy.hpp" build error on macOS environment
+* [#1861](https://github.com/pgRouting/pgrouting/issues/1861): vrp functions crash server
 
 
 pgRouting 3.1.2 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.1.2
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.2%22>`_ on Github.
+To see all issues & pull requests closed by this release see the [Git closed milestone for 3.1.2](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.2%22) on Github.
 
-*Issues fixes*
+**Issues fixes**
 
-* [#1304 ](https://github.com/pgRouting/pgrouting/issues/1304)_: FreeBSD 12 64-bit crashes on pgr_vrOneDepot tests Experimental Function
-* [#1356 ](https://github.com/pgRouting/pgrouting/issues/1356)_: tools/testers/pg_prove_tests.sh fails when PostgreSQL port is not passed
-* [#1725 ](https://github.com/pgRouting/pgrouting/issues/1725)_: Server crash on pgr_pickDeliver and pgr_vrpOneDepot on openbsd
-* [#1760 ](https://github.com/pgRouting/pgrouting/issues/1760)_: TSP server crash on ubuntu 20.04 #1760
-* [#1770 ](https://github.com/pgRouting/pgrouting/issues/1770)_: Remove warnings when using clang compiler
+* [#1304](https://github.com/pgRouting/pgrouting/issues/1304): FreeBSD 12 64-bit crashes on pgr_vrOneDepot tests Experimental Function
+* [#1356](https://github.com/pgRouting/pgrouting/issues/1356): tools/testers/pg_prove_tests.sh fails when PostgreSQL port is not passed
+* [#1725](https://github.com/pgRouting/pgrouting/issues/1725): Server crash on pgr_pickDeliver and pgr_vrpOneDepot on openbsd
+* [#1760](https://github.com/pgRouting/pgrouting/issues/1760): TSP server crash on ubuntu 20.04 #1760
+* [#1770](https://github.com/pgRouting/pgrouting/issues/1770): Remove warnings when using clang compiler
 
 
 pgRouting 3.1.1 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.1.1
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.1%22>`_ on Github.
+To see all issues & pull requests closed by this release see the [Git closed milestone for 3.1.1](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.1%22) on Github.
 
-*Issues fixes*
+**Issues fixes**
 
-* [#1733 ](https://github.com/pgRouting/pgrouting/issues/1733)_: pgr_bdAstar fails when source or target vertex does not exist in the graph
-* [#1647 ](https://github.com/pgRouting/pgrouting/issues/1647)_: Linear Contraction contracts self loops
-* [#1640 ](https://github.com/pgRouting/pgrouting/issues/1640)_: pgr_withPoints fails when points_sql is empty
-* [#1616 ](https://github.com/pgRouting/pgrouting/issues/1616)_: Path evaluation on C++ not updated before the results go back to C
-* [#1300 ](https://github.com/pgRouting/pgrouting/issues/1300)_: pgr_chinesePostman crash on test data
+* [#1733](https://github.com/pgRouting/pgrouting/issues/1733): pgr_bdAstar fails when source or target vertex does not exist in the graph
+* [#1647](https://github.com/pgRouting/pgrouting/issues/1647): Linear Contraction contracts self loops
+* [#1640](https://github.com/pgRouting/pgrouting/issues/1640): pgr_withPoints fails when points_sql is empty
+* [#1616](https://github.com/pgRouting/pgrouting/issues/1616): Path evaluation on C++ not updated before the results go back to C
+* [#1300](https://github.com/pgRouting/pgrouting/issues/1300): pgr_chinesePostman crash on test data
 
 
 
 pgRouting 3.1.0 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.1.0
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.0%22>`_ on Github.
+To see all issues & pull requests closed by this release see the [Git closed milestone for 3.1.0](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.0%22) on Github.
 
-*New proposed functions*
+**New proposed functions**
 
 * pgr_dijkstra(combinations)
 * pgr_dijkstraCost(combinations)
 
-*Build changes*
+**Build changes**
 
 * Minimal requirement for Sphinx: version 1.8
 
@@ -136,84 +131,79 @@ To see all issues & pull requests closed by this release see the `Git closed mil
 pgRouting 3.0.5 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.5
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.5%22>`_ on Github.
+To see all issues & pull requests closed by this release see the [Git closed milestone for 3.0.5](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.5%22) on Github.
 
-*Backport issues fixes*
+**Backport issues fixes**
 
-* [#1825 ](https://github.com/pgRouting/pgrouting/issues/1825)_: Boost versions are not honored
-* [#1849 ](https://github.com/pgRouting/pgrouting/issues/1849)_: Boost 1.75.0 geometry "point_xy.hpp" build error on macOS environment
-* [#1861 ](https://github.com/pgRouting/pgrouting/issues/1861)_: vrp functions crash server
+* [#1825](https://github.com/pgRouting/pgrouting/issues/1825): Boost versions are not honored
+* [#1849](https://github.com/pgRouting/pgrouting/issues/1849): Boost 1.75.0 geometry "point_xy.hpp" build error on macOS environment
+* [#1861](https://github.com/pgRouting/pgrouting/issues/1861): vrp functions crash server
 
 
 pgRouting 3.0.4 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.4
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.4%22>`_ on Github.
+To see all issues & pull requests closed by this release see the [Git closed milestone for 3.0.4](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.4%22) on Github.
 
-*Backport issues fixes*
+**Backport issues fixes**
 
-* [#1304 ](https://github.com/pgRouting/pgrouting/issues/1304)_: FreeBSD 12 64-bit crashes on pgr_vrOneDepot tests Experimental Function
-* [#1356 ](https://github.com/pgRouting/pgrouting/issues/1356)_: tools/testers/pg_prove_tests.sh fails when PostgreSQL port is not passed
-* [#1725 ](https://github.com/pgRouting/pgrouting/issues/1725)_: Server crash on pgr_pickDeliver and pgr_vrpOneDepot on openbsd
-* [#1760 ](https://github.com/pgRouting/pgrouting/issues/1760)_: TSP server crash on ubuntu 20.04 #1760
-* [#1770 ](https://github.com/pgRouting/pgrouting/issues/1770)_: Remove warnings when using clang compiler
+* [#1304](https://github.com/pgRouting/pgrouting/issues/1304): FreeBSD 12 64-bit crashes on pgr_vrOneDepot tests Experimental Function
+* [#1356](https://github.com/pgRouting/pgrouting/issues/1356): tools/testers/pg_prove_tests.sh fails when PostgreSQL port is not passed
+* [#1725](https://github.com/pgRouting/pgrouting/issues/1725): Server crash on pgr_pickDeliver and pgr_vrpOneDepot on openbsd
+* [#1760](https://github.com/pgRouting/pgrouting/issues/1760): TSP server crash on ubuntu 20.04 #1760
+* [#1770](https://github.com/pgRouting/pgrouting/issues/1770): Remove warnings when using clang compiler
 
 
 
 pgRouting 3.0.3 Release Notes
 -------------------------------------------------------------------------------
 
-*Backport issues fixes*
+**Backport issues fixes**
 
-* [#1733 ](https://github.com/pgRouting/pgrouting/issues/1733)_: pgr_bdAstar fails when source or target vertex does not exist in the graph
-* [#1647 ](https://github.com/pgRouting/pgrouting/issues/1647)_: Linear Contraction contracts self loops
-* [#1640 ](https://github.com/pgRouting/pgrouting/issues/1640)_: pgr_withPoints fails when points_sql is empty
-* [#1616 ](https://github.com/pgRouting/pgrouting/issues/1616)_: Path evaluation on C++ not updated before the results go back to C
-* [#1300 ](https://github.com/pgRouting/pgrouting/issues/1300)_: pgr_chinesePostman crash on test data
+* [#1733](https://github.com/pgRouting/pgrouting/issues/1733): pgr_bdAstar fails when source or target vertex does not exist in the graph
+* [#1647](https://github.com/pgRouting/pgrouting/issues/1647): Linear Contraction contracts self loops
+* [#1640](https://github.com/pgRouting/pgrouting/issues/1640): pgr_withPoints fails when points_sql is empty
+* [#1616](https://github.com/pgRouting/pgrouting/issues/1616): Path evaluation on C++ not updated before the results go back to C
+* [#1300](https://github.com/pgRouting/pgrouting/issues/1300): pgr_chinesePostman crash on test data
 
 
 
 pgRouting 3.0.2 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.2
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.2%22>`_ on Github.
+To see all issues & pull requests closed by this release see the [Git closed milestone for 3.0.2](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.2%22) on Github.
 
-*Issues fixes*
+**Issues fixes**
 
-* [#1378 ](https://github.com/pgRouting/pgrouting/issues/1378)_: Visual Studio build failing
+* [#1378](https://github.com/pgRouting/pgrouting/issues/1378): Visual Studio build failing
 
 
 pgRouting 3.0.1 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.1
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.1%22>`_ on Github.
+To see all issues & pull requests closed by this release see the [Git closed milestone for 3.0.1](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.1%22) on Github.
 
-*Issues fixes*
+**Issues fixes**
 
-* [#232 ](https://github.com/pgRouting/pgrouting/issues/232)_:  Honor client cancel requests in C /C++ code
+* [#232](https://github.com/pgRouting/pgrouting/issues/232):  Honor client cancel requests in C /C++ code
 
 
 pgRouting 3.0.0 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.0
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.0%22>`_ on Github.
+To see all issues & pull requests closed by this release see the [Git closed milestone for 3.0.0](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.0%22) on Github.
 
-*Fixed Issues*
+**Fixed Issues**
 
-* [#1153 ](https://github.com/pgRouting/pgrouting/issues/1153)_: Renamed pgr_eucledianTSP to pgr_TSPeuclidean
-* [#1188 ](https://github.com/pgRouting/pgrouting/issues/1188)_: Removed CGAL dependency
-* [#1002 ](https://github.com/pgRouting/pgrouting/issues/1002)_: Fixed contraction issues:
+* [#1153](https://github.com/pgRouting/pgrouting/issues/1153): Renamed pgr_eucledianTSP to pgr_TSPeuclidean
+* [#1188](https://github.com/pgRouting/pgrouting/issues/1188): Removed CGAL dependency
+* [#1002](https://github.com/pgRouting/pgrouting/issues/1002): Fixed contraction issues:
 
-  * [#1004 ](https://github.com/pgRouting/pgrouting/issues/1004)_: Contracts when forbidden vertices do not belong to graph
-  * [#1005 ](https://github.com/pgRouting/pgrouting/issues/1005)_: Intermideate results eliminated
-  * [#1006 ](https://github.com/pgRouting/pgrouting/issues/1006)_: No loss of information
+  * [#1004](https://github.com/pgRouting/pgrouting/issues/1004): Contracts when forbidden vertices do not belong to graph
+  * [#1005](https://github.com/pgRouting/pgrouting/issues/1005): Intermideate results eliminated
+  * [#1006](https://github.com/pgRouting/pgrouting/issues/1006): No loss of information
 
-*New functions*
+**New functions**
 
 * Kruskal family
 
@@ -230,7 +220,7 @@ To see all issues & pull requests closed by this release see the `Git closed mil
   * pgr_primBFS
 
 
-*Proposed moved to official on pgRouting*
+**Proposed moved to official on pgRouting**
 
 * aStar Family
 
@@ -309,7 +299,7 @@ To see all issues & pull requests closed by this release see the `Git closed mil
   * Bug Fixes
 
 
-*New Experimental functions*
+**New Experimental functions**
 
 * pgr_maxFlowMinCost
 * pgr_maxFlowMinCost_Cost
@@ -339,7 +329,7 @@ To see all issues & pull requests closed by this release see the `Git closed mil
   * pgr_bellmanFord
   * pgr_edwardMoore
 
-*Moved to legacy*
+**Moved to legacy**
 
 * Experimental functions
 
@@ -364,32 +354,32 @@ To see all issues & pull requests closed by this release see the `Git closed mil
 pgRouting 2.6.3 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed milestone for 2.6.3 ](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.6.3%22%20) on Github.
+To see the issues closed by this release see the [Git closed milestone for 2.6.3](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.6.3%22%20) on Github.
 
-*Bug fixes*
+**Bug fixes**
 
-* [#1219 ](https://github.com/pgRouting/pgrouting/pull/1219)_ Implicit cast for via_path integer to text
-* [#1193 ](https://github.com/pgRouting/pgrouting/pull/1193)_ Fixed pgr_pointsAsPolygon breaking when comparing strings in WHERE clause
-* [#1185 ](https://github.com/pgRouting/pgrouting/pull/1185)_ Improve FindPostgreSQL.cmake
+* [#1219](https://github.com/pgRouting/pgrouting/pull/1219) Implicit cast for via_path integer to text
+* [#1193](https://github.com/pgRouting/pgrouting/pull/1193) Fixed pgr_pointsAsPolygon breaking when comparing strings in WHERE clause
+* [#1185](https://github.com/pgRouting/pgrouting/pull/1185) Improve FindPostgreSQL.cmake
 
 
 
 pgRouting 2.6.2 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed milestone for 2.6.2 ](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.6.2%22%20) on Github.
+To see the issues closed by this release see the [Git closed milestone for 2.6.2](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.6.2%22%20) on Github.
 
-*Bug fixes*
+**Bug fixes**
 
-* [#1152 ](https://github.com/pgRouting/pgrouting/issues/1152)_ Fixes driving distance when vertex is not part of the graph
-* [#1098 ](https://github.com/pgRouting/pgrouting/issues/1098)_ Fixes windows test
-* [#1165 ](https://github.com/pgRouting/pgrouting/issues/1165)_ Fixes build for python3 and perl5
+* [#1152](https://github.com/pgRouting/pgrouting/issues/1152) Fixes driving distance when vertex is not part of the graph
+* [#1098](https://github.com/pgRouting/pgrouting/issues/1098) Fixes windows test
+* [#1165](https://github.com/pgRouting/pgrouting/issues/1165) Fixes build for python3 and perl5
 
 
 pgRouting 2.6.1 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed milestone for 2.6.1 ](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.6.1%22%20) on Github.
+To see the issues closed by this release see the [Git closed milestone for 2.6.1](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.6.1%22%20) on Github.
 
 * Fixes server crash on several functions.
 
@@ -428,14 +418,14 @@ To see the issues closed by this release see the [Git closed milestone for 2.6.1
 pgRouting 2.6.0 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed milestone for 2.6.0 ](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.6.0%22%20) on Github.
+To see the issues closed by this release see the [Git closed milestone for 2.6.0](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.6.0%22%20) on Github.
 
 
-*New fexperimental functions*
+**New fexperimental functions**
 
 *  pgr_lineGraphFull
 
-*Bug fixes*
+**Bug fixes**
 
 * Fix pgr_trsp(text,integer,double precision,integer,double precision,boolean,boolean[,text])
 
@@ -448,7 +438,7 @@ To see the issues closed by this release see the [Git closed milestone for 2.6.0
 
     * calls original trsp code
 
-*Internal code*
+**Internal code**
 
 * Cleaned the internal code of trsp(text,integer,integer,boolean,boolean [, text])
 
@@ -461,9 +451,9 @@ To see the issues closed by this release see the [Git closed milestone for 2.6.0
 pgRouting 2.5.5 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed milestone for 2.5.5 ](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.5.5%22%20) on Github.
+To see the issues closed by this release see the [Git closed milestone for 2.5.5](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.5.5%22%20) on Github.
 
-*Bug fixes*
+**Bug fixes**
 
 * Fixes driving distance when vertex is not part of the graph
 * Fixes windows test
@@ -473,7 +463,7 @@ To see the issues closed by this release see the [Git closed milestone for 2.5.5
 pgRouting 2.5.4 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed milestone for 2.5.4 ](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.5.4%22%20) on Github.
+To see the issues closed by this release see the [Git closed milestone for 2.5.4](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.5.4%22%20) on Github.
 
 * Fixes server crash on several functions.
 
@@ -512,9 +502,9 @@ To see the issues closed by this release see the [Git closed milestone for 2.5.4
 pgRouting 2.5.3 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed milestone for 2.5.3 ](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.5.3%22%20) on Github.
+To see the issues closed by this release see the [Git closed milestone for 2.5.3](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.5.3%22%20) on Github.
 
-*Bug fixes*
+**Bug fixes**
 
 * Fix for postgresql 11: Removed a compilation error when compiling with postgreSQL
 
@@ -522,9 +512,9 @@ To see the issues closed by this release see the [Git closed milestone for 2.5.3
 pgRouting 2.5.2 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed milestone for 2.5.2 ](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.5.2%22%20) on Github.
+To see the issues closed by this release see the [Git closed milestone for 2.5.2](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.5.2%22%20) on Github.
 
-*Bug fixes*
+**Bug fixes**
 
 * Fix for postgresql 10.1: Removed a compiler condition
 
@@ -533,9 +523,9 @@ To see the issues closed by this release see the [Git closed milestone for 2.5.2
 pgRouting 2.5.1 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed milestone for 2.5.1 ](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.5.1%22%20) on Github.
+To see the issues closed by this release see the [Git closed milestone for 2.5.1](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.5.1%22%20) on Github.
 
-*Bug fixes*
+**Bug fixes**
 
 * Fixed prerequisite minimum version of: cmake
 
@@ -544,14 +534,14 @@ To see the issues closed by this release see the [Git closed milestone for 2.5.1
 pgRouting 2.5.0 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed issues for 2.5.0 ](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.5.0%22+is%3Aclosed) on Github.
+To see the issues closed by this release see the [Git closed issues for 2.5.0](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.5.0%22+is%3Aclosed) on Github.
 
 
-*enhancement:*
+**enhancement:**
 
 * pgr_version is now on SQL language
 
-*Breaking change on:*
+**Breaking change on:**
 
 * pgr_edgeDisjointPaths:
 
@@ -559,11 +549,11 @@ To see the issues closed by this release see the [Git closed issues for 2.5.0 ](
   * Parameter names changed
   * The many version results are the union of the one to one version
 
-*New Signatures:*
+**New Signatures:**
 
 * pgr_bdAstar(one to one)
 
-*New Proposed functions*
+**New Proposed functions**
 
 * pgr_bdAstar(one to many)
 * pgr_bdAstar(many to one)
@@ -589,18 +579,18 @@ To see the issues closed by this release see the [Git closed issues for 2.5.0 ](
 * pgr_articulationPoints
 * pgr_bridges
 
-*Deprecated Signatures*
+**Deprecated Signatures**
 
 * pgr_bdastar - use pgr_bdAstar instead
 
-*Renamed Functions*
+**Renamed Functions**
 
 * pgr_maxFlowPushRelabel - use pgr_pushRelabel instead
 * pgr_maxFlowEdmondsKarp -use pgr_edmondsKarp instead
 * pgr_maxFlowBoykovKolmogorov - use pgr_boykovKolmogorov instead
 * pgr_maximumCardinalityMatching - use pgr_maxCardinalityMatch instead
 
-*Deprecated function*
+**Deprecated function**
 
 * pgr_pointToEdgeNode
 
@@ -609,13 +599,13 @@ To see the issues closed by this release see the [Git closed issues for 2.5.0 ](
 pgRouting 2.4.2 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed milestone for 2.4.2 ](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.4.2%22%20) on Github.
+To see the issues closed by this release see the [Git closed milestone for 2.4.2](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.4.2%22%20) on Github.
 
-*Improvement*
+**Improvement**
 
 * Works for postgreSQL 10
 
-*Bug fixes*
+**Bug fixes**
 
 * Fixed: Unexpected error column "cname"
 * Replace __linux__ with __GLIBC__ for glibc-specific headers and functions
@@ -626,9 +616,9 @@ To see the issues closed by this release see the [Git closed milestone for 2.4.2
 pgRouting 2.4.1 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed milestone for 2.4.1 ](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.4.1%22%20) on Github.
+To see the issues closed by this release see the [Git closed milestone for 2.4.1](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%202.4.1%22%20) on Github.
 
-*Bug fixes*
+**Bug fixes**
 
 * Fixed compiling error on macOS
 * Condition error on pgr_withPoints
@@ -637,14 +627,14 @@ To see the issues closed by this release see the [Git closed milestone for 2.4.1
 pgRouting 2.4.0 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed issues for 2.4.0 ](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.4.0%22+is%3Aclosed) on Github.
+To see the issues closed by this release see the [Git closed issues for 2.4.0](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.4.0%22+is%3Aclosed) on Github.
 
-*New Signatures*
+**New Signatures**
 
 * pgr_bdDijkstra
 
 
-*New Proposed Signatures*
+**New Proposed Signatures**
 
 * pgr_maxFlow
 * pgr_astar(one to many)
@@ -656,15 +646,15 @@ To see the issues closed by this release see the [Git closed issues for 2.4.0 ](
 * pgr_astarCost(many to many)
 * pgr_astarCostMatrix
 
-*Deprecated Signatures*
+**Deprecated Signatures**
 
 * pgr_bddijkstra - use pgr_bdDijkstra instead
 
-*Deprecated Functions*
+**Deprecated Functions**
 
 * pgr_pointsToVids
 
-*Bug fixes*
+**Bug fixes**
 
 * Bug fixes on proposed functions
 
@@ -676,9 +666,9 @@ To see the issues closed by this release see the [Git closed issues for 2.4.0 ](
 pgRouting 2.3.2 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed issues for 2.3.2 ](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.3.2%22+is%3Aclosed) on Github.
+To see the issues closed by this release see the [Git closed issues for 2.3.2](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.3.2%22+is%3Aclosed) on Github.
 
-*Bug Fixes*
+**Bug Fixes**
 
 * Fixed pgr_gsoc_vrppdtw crash when all orders fit on one truck.
 * Fixed pgr_trsp:
@@ -691,9 +681,9 @@ To see the issues closed by this release see the [Git closed issues for 2.3.2 ](
 pgRouting 2.3.1 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed issues for 2.3.1 ](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.3.1%22+is%3Aclosed) on Github.
+To see the issues closed by this release see the [Git closed issues for 2.3.1](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.3.1%22+is%3Aclosed) on Github.
 
-*Bug Fixes*
+**Bug Fixes**
 
 * Leaks on proposed max_flow functions
 * Regression error on pgr_trsp
@@ -704,19 +694,19 @@ To see the issues closed by this release see the [Git closed issues for 2.3.1 ](
 pgRouting 2.3.0 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed issues for 2.3.0 ](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.3.0%22+is%3Aclosed) on Github.
+To see the issues closed by this release see the [Git closed issues for 2.3.0](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.3.0%22+is%3Aclosed) on Github.
 
-*New Signatures*
+**New Signatures**
 
 * pgr_TSP
 * pgr_aStar
 
-*New Functions*
+**New Functions**
 
 * pgr_eucledianTSP
 
 
-*New Proposed functions*
+**New Proposed functions**
 
 * pgr_dijkstraCostMatrix
 * pgr_withPointsCostMatrix
@@ -740,13 +730,13 @@ To see the issues closed by this release see the [Git closed issues for 2.3.0 ](
 * pgr_contractGraph
 
 
-*Deprecated Signatures*
+**Deprecated Signatures**
 
 * pgr_tsp - use pgr_TSP or pgr_eucledianTSP instead
 * pgr_astar - use pgr_aStar instead
 
 
-*Deprecated Functions*
+**Deprecated Functions**
 
 * pgr_flip_edges
 * pgr_vidsToDmatrix
@@ -759,9 +749,9 @@ To see the issues closed by this release see the [Git closed issues for 2.3.0 ](
 pgRouting 2.2.4 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed issues for 2.2.4 ](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.2.4%22+is%3Aclosed) on Github.
+To see the issues closed by this release see the [Git closed issues for 2.2.4](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.2.4%22+is%3Aclosed) on Github.
 
-*Bug Fixes*
+**Bug Fixes**
 
 * Bogus uses of extern "C"
 * Build error on Fedora 24 + GCC 6.0
@@ -771,9 +761,9 @@ To see the issues closed by this release see the [Git closed issues for 2.2.4 ](
 pgRouting 2.2.3 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed issues for 2.2.3 ](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.2.3%22+is%3Aclosed) on Github.
+To see the issues closed by this release see the [Git closed issues for 2.2.3](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.2.3%22+is%3Aclosed) on Github.
 
-*Bug Fixes*
+**Bug Fixes**
 
 * Fixed compatibility issues with PostgreSQL 9.6.
 
@@ -781,9 +771,9 @@ To see the issues closed by this release see the [Git closed issues for 2.2.3 ](
 pgRouting 2.2.2 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed issues for 2.2.2 ](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.2.2%22+is%3Aclosed) on Github.
+To see the issues closed by this release see the [Git closed issues for 2.2.2](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.2.2%22+is%3Aclosed) on Github.
 
-*Bug Fixes*
+**Bug Fixes**
 
 * Fixed regression error on pgr_drivingDistance
 
@@ -792,9 +782,9 @@ To see the issues closed by this release see the [Git closed issues for 2.2.2 ](
 pgRouting 2.2.1 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed issues for 2.2.1 ](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A2.2.1+is%3Aclosed) on Github.
+To see the issues closed by this release see the [Git closed issues for 2.2.1](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A2.2.1+is%3Aclosed) on Github.
 
-*Bug Fixes*
+**Bug Fixes**
 
 * Server crash fix on pgr_alphaShape
 * Bug fix on With Points family of functions
@@ -804,10 +794,10 @@ To see the issues closed by this release see the [Git closed issues for 2.2.1 ](
 pgRouting 2.2.0 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed issues for 2.2.0 ](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.2.0%22+is%3Aclosed) on Github.
+To see the issues closed by this release see the [Git closed issues for 2.2.0](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.2.0%22+is%3Aclosed) on Github.
 
 
-*Improvements*
+**Improvements**
 
 - pgr_nodeNetwork
 
@@ -818,7 +808,7 @@ To see the issues closed by this release see the [Git closed issues for 2.2.0 ](
   - pgr_dijkstra  -- to match what is documented
 
 
-*New Functions*
+**New Functions**
 
 - pgr_floydWarshall
 - pgr_Johnson
@@ -827,7 +817,7 @@ To see the issues closed by this release see the [Git closed issues for 2.2.0 ](
 - pgr_dijkstraCost(many to one)
 - pgr_dijkstraCost(many to many)
 
-*Proposed functionality*
+**Proposed functionality**
 
 - pgr_withPoints(one to one)
 - pgr_withPoints(one to many)
@@ -843,14 +833,14 @@ To see the issues closed by this release see the [Git closed issues for 2.2.0 ](
 - pgr_dijkstraVia
 
 
-*Deprecated functions:*
+**Deprecated functions:**
 
 - pgr_apspWarshall  use pgr_floydWarshall instead
 - pgr_apspJohnson   use pgr_Johnson instead
 - pgr_kDijkstraCost use pgr_dijkstraCost instead
 - pgr_kDijkstraPath use pgr_dijkstra instead
 
-*Renamed and deprecated function*
+**Renamed and deprecated function**
 
 - pgr_makeDistanceMatrix renamed to _pgr_makeDistanceMatrix
 
@@ -859,26 +849,26 @@ To see the issues closed by this release see the [Git closed issues for 2.2.0 ](
 pgRouting 2.1.0 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed issues for 2.1.0 ](https://github.com/pgRouting/pgrouting/issues?q=is%3Aissue+milestone%3A%22Release+2.1.0%22+is%3Aclosed) on Github.
+To see the issues closed by this release see the [Git closed issues for 2.1.0](https://github.com/pgRouting/pgrouting/issues?q=is%3Aissue+milestone%3A%22Release+2.1.0%22+is%3Aclosed) on Github.
 
-*New Signatures*
+**New Signatures**
 
 - pgr_dijkstra(one to many)
 - pgr_dijkstra(many to one)
 - pgr_dijkstra(many to many)
 - pgr_drivingDistance(multiple vertices)
 
-*Refactored*
+**Refactored**
 
 - pgr_dijkstra(one to one)
 - pgr_ksp
 - pgr_drivingDistance(single vertex)
 
-*Improvements*
+**Improvements**
 
 - pgr_alphaShape function now can generate better (multi)polygon with holes and alpha parameter.
 
-*Proposed functionality*
+**Proposed functionality**
 
 - Proposed functions from Steve Woodbridge, (Classified as Convenience by the author.)
 
@@ -895,7 +885,7 @@ To see the issues closed by this release see the [Git closed issues for 2.1.0 ](
   - pgr_vrppdtw
   - pgr_vrponedepot
 
-*Deprecated functions*
+**Deprecated functions**
 
 - pgr_getColumnName
 - pgr_getTableName
@@ -907,16 +897,16 @@ To see the issues closed by this release see the [Git closed issues for 2.1.0 ](
 - pgr_endPoint
 - pgr_pointToId
 
-*No longer supported*
+**No longer supported**
 
 - Removed the 1.x legacy functions
 
-*Bug Fixes*
+**Bug Fixes**
 
 - Some bug fixes in other functions
 
 
-*Refactoring Internal Code*
+**Refactoring Internal Code**
 
 - A C and C++ library for developer was created
 
@@ -940,7 +930,7 @@ pgRouting 2.0.1 Release Notes
 
 Minor bug fixes.
 
-*Bug Fixes*
+**Bug Fixes**
 
 * No track of the bug fixes were kept.
 
@@ -949,7 +939,7 @@ Minor bug fixes.
 pgRouting 2.0.0 Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed issues for 2.0.0 ](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.0.0%22+is%3Aclosed) on Github.
+To see the issues closed by this release see the [Git closed issues for 2.0.0](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+2.0.0%22+is%3Aclosed) on Github.
 
 With the release of pgRouting 2.0.0 the library has abandoned backwards compatibility to `pgRouting 1.x Release Notes`_ releases.
 The main Goals for this release are:
@@ -967,7 +957,7 @@ As a result of this effort:
 * And made it easier for multiple developers to make contributions.
 
 
-*Important Changes*
+**Important Changes**
 
 * Graph Analytics - tools for detecting and fixing connection some problems in a graph
 * A collection of useful utility functions
@@ -999,7 +989,7 @@ As a result of this effort:
 pgRouting 1.x Release Notes
 -------------------------------------------------------------------------------
 
-To see the issues closed by this release see the [Git closed issues for 1.x ](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+1.x%22+is%3Aclosed) on Github.
+To see the issues closed by this release see the [Git closed issues for 1.x](https://github.com/pgRouting/pgrouting/issues?q=milestone%3A%22Release+1.x%22+is%3Aclosed) on Github.
 The following release notes have been copied from the previous ``RELEASE_NOTES`` file and are kept as a reference.
 
 

--- a/NEWS
+++ b/NEWS
@@ -5,7 +5,7 @@ To see all issues & pull requests closed by this release see the [Git closed mil
 
 **Build**
 
-* [#1825](https://github.com/pgRouting/pgrouting/issues/1850): Change Boost min version to 1.56
+* [#1850](https://github.com/pgRouting/pgrouting/issues/1850): Change Boost min version to 1.56
 
   * Removing support for Boost v1.53, v1.54 & v1.55
 

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -20,8 +20,7 @@ To see the full list of changes check the list of `Git commits <https://github.c
 pgRouting 3.2.0 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.2.0
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.2.0%22>`_ on Github.
+To see all issues & pull requests closed by this release see the `Git closed milestone for 3.2.0 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.2.0%22>`_ on Github.
 
 .. rubric:: Build
 
@@ -95,8 +94,7 @@ To see all issues & pull requests closed by this release see the `Git closed mil
 pgRouting 3.1.3 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.1.3
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.3%22>`_ on Github.
+To see all issues & pull requests closed by this release see the `Git closed milestone for 3.1.3 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.3%22>`_ on Github.
 
 .. rubric:: Issues fixes
 
@@ -108,8 +106,7 @@ To see all issues & pull requests closed by this release see the `Git closed mil
 pgRouting 3.1.2 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.1.2
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.2%22>`_ on Github.
+To see all issues & pull requests closed by this release see the `Git closed milestone for 3.1.2 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.2%22>`_ on Github.
 
 .. rubric:: Issues fixes
 
@@ -123,8 +120,7 @@ To see all issues & pull requests closed by this release see the `Git closed mil
 pgRouting 3.1.1 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.1.1
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.1%22>`_ on Github.
+To see all issues & pull requests closed by this release see the `Git closed milestone for 3.1.1 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.1%22>`_ on Github.
 
 .. rubric:: Issues fixes
 
@@ -139,8 +135,7 @@ To see all issues & pull requests closed by this release see the `Git closed mil
 pgRouting 3.1.0 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.1.0
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.0%22>`_ on Github.
+To see all issues & pull requests closed by this release see the `Git closed milestone for 3.1.0 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.0%22>`_ on Github.
 
 .. rubric:: New proposed functions
 
@@ -155,8 +150,7 @@ To see all issues & pull requests closed by this release see the `Git closed mil
 pgRouting 3.0.5 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.5
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.5%22>`_ on Github.
+To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.5 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.5%22>`_ on Github.
 
 .. rubric:: Backport issues fixes
 
@@ -168,8 +162,7 @@ To see all issues & pull requests closed by this release see the `Git closed mil
 pgRouting 3.0.4 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.4
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.4%22>`_ on Github.
+To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.4 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.4%22>`_ on Github.
 
 .. rubric:: Backport issues fixes
 
@@ -197,8 +190,7 @@ pgRouting 3.0.3 Release Notes
 pgRouting 3.0.2 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.2
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.2%22>`_ on Github.
+To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.2 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.2%22>`_ on Github.
 
 .. rubric:: Issues fixes
 
@@ -208,8 +200,7 @@ To see all issues & pull requests closed by this release see the `Git closed mil
 pgRouting 3.0.1 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.1
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.1%22>`_ on Github.
+To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.1 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.1%22>`_ on Github.
 
 .. rubric:: Issues fixes
 
@@ -219,8 +210,7 @@ To see all issues & pull requests closed by this release see the `Git closed mil
 pgRouting 3.0.0 Release Notes
 -------------------------------------------------------------------------------
 
-To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.0
-<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.0%22>`_ on Github.
+To see all issues & pull requests closed by this release see the `Git closed milestone for 3.0.0 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.0.0%22>`_ on Github.
 
 .. rubric:: Fixed Issues
 

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -24,7 +24,7 @@ To see all issues & pull requests closed by this release see the `Git closed mil
 
 .. rubric:: Build
 
-* `#1825 <https://github.com/pgRouting/pgrouting/issues/1850>`__: Change Boost min version to 1.56
+* `#1850 <https://github.com/pgRouting/pgrouting/issues/1850>`__: Change Boost min version to 1.56
 
   * Removing support for Boost v1.53, v1.54 & v1.55
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx==1.8.2
-sphinx-bootstrap-theme==0.6.5
+Sphinx==3.4.3
+sphinx-bootstrap-theme==0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx==3.4.3
-sphinx-bootstrap-theme==0.7.1
+Sphinx==1.8.2
+sphinx-bootstrap-theme==0.6.5

--- a/tools/release-scripts/notes2news.pl
+++ b/tools/release-scripts/notes2news.pl
@@ -22,10 +22,11 @@ while (my $line = <$ifh>) {
   $skipping = 0;
 
   # convert urls to markdown
-  $line =~ s/`([^<]+)<([^>]+)>`_/\[$1\]($2)/g;
+  $line =~ s/`([^<]+?)\s*<([^>]+)>`__/\[$1\]($2)/g;
+  $line =~ s/`([^<]+?)\s*<([^>]+)>`_/\[$1\]($2)/g;
 
   # convert rubric to bold
-  $line =~ s/^\.\. rubric::\s*(.+)$/*$1*/;
+  $line =~ s/^\.\. rubric::\s*(.+)$/**$1**/;
 
   next if $line =~ /^\.\. _changelog/;
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Ports #1857 to 3.2
- Fixed NEWS and release_notes (changed `#1825` to `#1850`)

@pgRouting/admins
