### PR TITLE
Change license to GPL-2.0-or-later on 3.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,12 +17,12 @@ Here are some important resources:
 
 Any kind of contribution will automatically fall to the following Licences:
 
-- Code contribution: GNU GENERAL PUBLIC LICENSE Version 2,
+- Code contribution: GNU General Public License v2.0 or later,
   - Directly by making a pul explicit pull request.
   - Indirectly by posting code on issues/wiki/gitter/mailng lists
 - Documentation contribution:
   - Creative Commons Attribution-Share Alike 3.0
-  
+
 ## Submitting changes
 
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ See online documentation: http://docs.pgrouting.org/latest/en/index.html
 
 ## LICENSE
 
-* Most features are available under GPLv2.0+
+* Most features are available under [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html)
 * Some Boost extensions are available under Boost license (see LICENSE_1_0.txt)
 * Some code contributed by iMaptools.com is available under MIT-X license.
 

--- a/doc/src/pgRouting-introduction.rst
+++ b/doc/src/pgRouting-introduction.rst
@@ -34,8 +34,8 @@ The following licenses can be found in pgRouting:
 
    * - **License**
      -
-   * - GNU General Public License, version 2
-     - Most features of pgRouting are available under `GNU General Public License, version 2.0+ <https://www.gnu.org/licenses/gpl-2.0.html>`_.
+   * - GNU General Public License v2.0 or later
+     - Most features of pgRouting are available under `GNU General Public License v2.0 or later <https://spdx.org/licenses/GPL-2.0-or-later.html>`_.
    * - Boost Software License - Version 1.0
      - Some Boost extensions are available under `Boost Software License - Version 1.0 <https://www.boost.org/LICENSE_1_0.txt>`_.
    * - MIT-X License


### PR DESCRIPTION
Fixes #1851.

Changes proposed in this pull request:
- Changed license to GNU General Public License v2.0 or later.
- See https://github.com/pgRouting/pgrouting/pull/1852#issuecomment-765063536

@pgRouting/admins
