### PR TITLE
fixed typing error under STATUS section of README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### Branches
 
 * The *master* branch has the development of the next micro release
-* The *develop* branch has the development of the next minor/mayor release
+* The *develop* branch has the development of the next minor/major release
 
 For the complete list of releases go to:
 https://github.com/pgRouting/pgrouting/releases


### PR DESCRIPTION
Changes proposed in this pull request:
-  Under Branches section, there is a typing error :
-  "The *develop* branch has the development of the next **minor/mayor** release"


@pgRouting/admins
