### PR TITLE
Add GitHub actions script for publishing documentation to 3.1

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,12 +5,7 @@ name: Build documentation
 # - postgres 12
 # - postgis 3
 
-on:
-  push:
-    branches:
-      - main
-    tags:
-      - '*'
+on: [push, pull_request]
 
 jobs:
   build:
@@ -19,11 +14,30 @@ jobs:
 
     strategy:
         fail-fast: false
+        matrix:
+          language: [de, en, es, ja]
+
+    env:
+        LANG_MSG: "in${{ matrix.language }}"
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Get commit message
+        run: |
+           PROCESS=${{ false }}
+           if [[ $(git log --format=%B -n 2 | tr -d "'" | tr -d " " | grep -Po '(?<=\.po)[^;]+') == *"${LANG_MSG}"* ]]; then
+             PROCESS=${{ true }}
+           fi
+           if [[ "${{ matrix.language }}" == "en" ]]; then
+             PROCESS=${{ true }}
+           fi
+           echo "PROCESS=${PROCESS}" >> $GITHUB_ENV
 
       - name: Get postgres version
+        if: env.PROCESS == 'true'
         run: |
           sudo service postgresql start
           pgver=$(psql --version | grep -Po '(?<=psql \(PostgreSQL\) )[^;]+(?=\.\d \()')
@@ -31,6 +45,7 @@ jobs:
           echo "PGIS=3" >> $GITHUB_ENV
 
       - name: Add PostgreSQL APT repository
+        if: env.PROCESS == 'true'
         run: |
           sudo apt-get install curl ca-certificates gnupg
           curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
@@ -38,11 +53,13 @@ jobs:
             $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 
       - name: Install python
+        if: env.PROCESS == 'true'
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
 
       - name: Install dependencies
+        if: env.PROCESS == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -57,6 +74,7 @@ jobs:
           pip list
 
       - name: Configure link checks
+        if: env.PROCESS == 'true'
         run: |
           export PATH=/usr/lib/postgresql/${PGVER}/bin:$PATH
           mkdir build
@@ -65,6 +83,7 @@ jobs:
                 -DWITH_DOC=ON -DES=ON ..
 
       - name: Build Documentation
+        if: env.PROCESS == 'true'
         run: |
           cd build
           make html

--- a/.github/workflows/publish-users-doc.yml
+++ b/.github/workflows/publish-users-doc.yml
@@ -1,0 +1,100 @@
+name: Publish Users Documentation
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - develop
+    paths:
+      - 'doc/**'
+      - 'docqueries/**'
+      - 'locale/**'
+
+jobs:
+  release:
+    name: Publish Users Documentation
+    runs-on: ubuntu-latest
+
+    strategy:
+        fail-fast: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get postgres version
+        run: |
+          sudo service postgresql start
+          PGVER=$(psql --version | grep -Po '(?<=psql \(PostgreSQL\) )[^;]+(?=\.\d \()')
+          PROJECT_VERSION=$(grep -Po '(?<=project\(PGROUTING VERSION )[^;]+' CMakeLists.txt)
+          echo "PGVER=${PGVER}" >> $GITHUB_ENV
+          echo "PGPORT=5432" >> $GITHUB_ENV
+          echo "PGIS=3" >> $GITHUB_ENV
+          echo "PROJECT_VERSION=${PROJECT_VERSION}" >> $GITHUB_ENV
+
+      - name: Add PostgreSQL APT repository
+        run: |
+          sudo apt-get install curl ca-certificates gnupg
+          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ \
+            $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libboost-graph-dev \
+            postgresql-${PGVER} \
+            postgresql-${PGVER}-postgis-${PGIS} \
+            postgresql-${PGVER}-postgis-${PGIS}-scripts \
+            postgresql-server-dev-${PGVER} \
+            graphviz \
+            doxygen
+          python -m pip install --upgrade pip
+          pip install Sphinx
+          pip install sphinx-bootstrap-theme
+          pip list
+
+      - name: Configure
+        run: |
+          export PATH=/usr/lib/postgresql/${PGVER}/bin:$PATH
+          mkdir build
+          cd build
+          cmake -DPOSTGRESQL_VERSION=${PGVER} -DDOC_USE_BOOTSTRAP=ON -DWITH_DOC=ON -DBUILD_DOXY=ON -DCMAKE_BUILD_TYPE=Release -DES=ON ..
+
+      - name: Build
+        run: |
+          cd build
+          make doc
+          make -j 4
+          sudo make install
+
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Update Users Documentation
+        run: |
+          git checkout origin/gh-pages
+          git checkout -b gh-pages
+          PROJECT_MAJOR_MINOR="${PROJECT_VERSION%.*}"
+          rm -rf ${PROJECT_MAJOR_MINOR}
+          cp -r build/doc/html ${PROJECT_MAJOR_MINOR}
+          rm -rf ${PROJECT_MAJOR_MINOR}/es
+          git add ${PROJECT_MAJOR_MINOR}
+          git diff-index --quiet HEAD || git commit -m "Update users documentation for ${PROJECT_VERSION}"
+          git fetch origin
+          git rebase origin/gh-pages
+          git push origin gh-pages
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-users-doc.yml
+++ b/.github/workflows/publish-users-doc.yml
@@ -35,6 +35,11 @@ jobs:
           echo "PGIS=3" >> $GITHUB_ENV
           echo "PROJECT_VERSION=${PROJECT_VERSION}" >> $GITHUB_ENV
 
+      - name: Extract commit hash
+        run: |
+          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          echo "GIT_HASH=$git_hash" >> $GITHUB_ENV
+
       - name: Add PostgreSQL APT repository
         run: |
           sudo apt-get install curl ca-certificates gnupg
@@ -91,7 +96,7 @@ jobs:
           cp -r build/doc/html ${PROJECT_MAJOR_MINOR}
           rm -rf ${PROJECT_MAJOR_MINOR}/es
           git add ${PROJECT_MAJOR_MINOR}
-          git diff-index --quiet HEAD || git commit -m "Update users documentation for ${PROJECT_VERSION}"
+          git diff-index --quiet HEAD || git commit -m "Update users documentation for ${PROJECT_VERSION}: commit ${{ env.GIT_HASH }}"
           git fetch origin
           git rebase origin/gh-pages
           git push origin gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,13 @@ jobs:
             exit 1
           fi
 
-      - name: Extract branch name
+      - name: Extract branch name and commit hash
         run: |
           raw=$(git branch -r --contains ${{ github.ref }})
           branch=${raw##*/}
           echo "BRANCH=$branch" >> $GITHUB_ENV
+          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          echo "GIT_HASH=$git_hash" >> $GITHUB_ENV
 
       - name: Add PostgreSQL APT repository
         run: |
@@ -103,7 +105,7 @@ jobs:
           rm -rf ${PGROUTING_MAJOR_MINOR}
           cp -r build/doc/html ${PGROUTING_MAJOR_MINOR}
           git add ${PGROUTING_MAJOR_MINOR}
-          git commit -m "Update users documentation for ${PGROUTING_VERSION}"
+          git diff-index --quiet HEAD || git commit -m "Update users documentation for ${PGROUTING_VERSION}: commit ${{ env.GIT_HASH }}"
           git fetch origin
           git rebase origin/gh-pages
           git push origin gh-pages
@@ -116,7 +118,7 @@ jobs:
           rm -rf doxygen
           cp -r build/doxygen/html doxygen
           git add doxygen
-          git commit -m "Update developers documentation for ${PGROUTING_VERSION}"
+          git diff-index --quiet HEAD || git commit -m "Update developers documentation for ${PGROUTING_VERSION}: commit ${{ env.GIT_HASH }}"
           git fetch origin
           git rebase origin/gh-pages
           git push origin gh-pages


### PR DESCRIPTION
Changes proposed in this pull request:
- Ports #1877 to 3.1
- Added commit hash in the message during publishing documentation.

@pgRouting/admins
