### PR TITLE
Port typo fixes to 3.2, add commit hash while publishing doc

### DIFF
--- a/.github/workflows/publish-users-doc.yml
+++ b/.github/workflows/publish-users-doc.yml
@@ -35,6 +35,11 @@ jobs:
           echo "PGIS=3" >> $GITHUB_ENV
           echo "PROJECT_VERSION=${PROJECT_VERSION}" >> $GITHUB_ENV
 
+      - name: Extract commit hash
+        run: |
+          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          echo "GIT_HASH=$git_hash" >> $GITHUB_ENV
+
       - name: Add PostgreSQL APT repository
         run: |
           sudo apt-get install curl ca-certificates gnupg
@@ -91,7 +96,7 @@ jobs:
           cp -r build/doc/html ${PROJECT_MAJOR_MINOR}
           rm -rf ${PROJECT_MAJOR_MINOR}/es
           git add ${PROJECT_MAJOR_MINOR}
-          git diff-index --quiet HEAD || git commit -m "Update users documentation for ${PROJECT_VERSION}"
+          git diff-index --quiet HEAD || git commit -m "Update users documentation for ${PROJECT_VERSION}: commit ${{ env.GIT_HASH }}"
           git fetch origin
           git rebase origin/gh-pages
           git push origin gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,13 @@ jobs:
             exit 1
           fi
 
-      - name: Extract branch name
+      - name: Extract branch name and commit hash
         run: |
           raw=$(git branch -r --contains ${{ github.ref }})
           branch=${raw##*/}
           echo "BRANCH=$branch" >> $GITHUB_ENV
+          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          echo "GIT_HASH=$git_hash" >> $GITHUB_ENV
 
       - name: Add PostgreSQL APT repository
         run: |
@@ -103,7 +105,7 @@ jobs:
           rm -rf ${PGROUTING_MAJOR_MINOR}
           cp -r build/doc/html ${PGROUTING_MAJOR_MINOR}
           git add ${PGROUTING_MAJOR_MINOR}
-          git commit -m "Update users documentation for ${PGROUTING_VERSION}"
+          git diff-index --quiet HEAD || git commit -m "Update users documentation for ${PGROUTING_VERSION}: commit ${{ env.GIT_HASH }}"
           git fetch origin
           git rebase origin/gh-pages
           git push origin gh-pages
@@ -116,7 +118,7 @@ jobs:
           rm -rf doxygen
           cp -r build/doxygen/html doxygen
           git add doxygen
-          git commit -m "Update developers documentation for ${PGROUTING_VERSION}"
+          git diff-index --quiet HEAD || git commit -m "Update developers documentation for ${PGROUTING_VERSION}: commit ${{ env.GIT_HASH }}"
           git fetch origin
           git rebase origin/gh-pages
           git push origin gh-pages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Here are some important resources:
 Any kind of contribution will automatically fall to the following Licences:
 
 - Code contribution: GNU General Public License v2.0 or later,
-  - Directly by making a pul explicit pull request.
+  - Directly by making an explicit pull request.
   - Indirectly by posting code on issues/wiki/gitter/mailng lists
 - Documentation contribution:
   - Creative Commons Attribution-Share Alike 3.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### Branches
 
 * The *master* branch has the development of the next micro release
-* The *develop* branch has the development of the next minor/mayor release
+* The *develop* branch has the development of the next minor/major release
 
 For the complete list of releases go to:
 https://github.com/pgRouting/pgrouting/releases

--- a/tools/NOTES.txt
+++ b/tools/NOTES.txt
@@ -83,7 +83,7 @@ b2.bat
 exit
 ./bjam toolset=gcc address-model=64 define=BOOST_USE_WINDOWS_H link=static threading=multi --with-thread --prefix=/usr/local install
 
-# ------------------------- miscelaneous ----------------------------
+# ------------------------- miscellaneous ----------------------------
 
 # you can regenerate trsp-test-image.png with the command
 shp2img -m trsp-test-image.map -o trsp-test-image.png -i agg_qn


### PR DESCRIPTION
Changes proposed in this pull request:
- Ports typo fixes (#1870, #1839, #1837) to 3.2
- Added commit hash in the message during publishing documentation. (Refer https://github.com/pgRouting/pgrouting/pull/1878#issuecomment-798831665)

@pgRouting/admins
