### PR TITLE
Making compilation faster general vehicle orders t

### DIFF
--- a/include/c_types/pickDeliver/schedule_rt.h
+++ b/include/c_types/pickDeliver/schedule_rt.h
@@ -23,8 +23,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  ********************************************************************PGR-GNU*/
 /*! @file */
 
-#ifndef INCLUDE_C_TYPES_PICKDELIVER_GENERAL_VEHICLE_ORDERS_T_H_
-#define INCLUDE_C_TYPES_PICKDELIVER_GENERAL_VEHICLE_ORDERS_T_H_
+#ifndef INCLUDE_C_TYPES_PICKDELIVER_SCHEDULE_RT_H_
+#define INCLUDE_C_TYPES_PICKDELIVER_SCHEDULE_RT_H_
 #pragma once
 
 /* for int64_t */
@@ -46,7 +46,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
    OUT departureTime FLOAT,
    */
 
-typedef struct  {
+struct  Schedule_rt {
     int vehicle_seq;
     int64_t vehicle_id;
     int stop_seq;
@@ -59,8 +59,8 @@ typedef struct  {
     double waitTime;
     double serviceTime;
     double departureTime;
-} General_vehicle_orders_t;
+};
 
 /*************************************************************************/
 
-#endif  // INCLUDE_C_TYPES_PICKDELIVER_GENERAL_VEHICLE_ORDERS_T_H_
+#endif  // INCLUDE_C_TYPES_PICKDELIVER_SCHEDULE_RT_H_

--- a/include/drivers/pickDeliver/pickDeliverEuclidean_driver.h
+++ b/include/drivers/pickDeliver/pickDeliverEuclidean_driver.h
@@ -39,7 +39,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #   include <stddef.h>
 #endif
 
-#include "c_types/pickDeliver/general_vehicle_orders_t.h"
+typedef struct Schedule_rt Schedule_rt;
 #include "c_types/pickDeliver/pickDeliveryOrders_t.h"
 #include "c_types/pickDeliver/vehicle_t.h"
 
@@ -61,7 +61,7 @@ extern "C" {
             int max_cycles,
             int initial_solution_id,
 
-            General_vehicle_orders_t **return_tuples,
+            Schedule_rt **return_tuples,
             size_t *return_count,
 
             char **log_msg,

--- a/include/drivers/pickDeliver/pickDeliver_driver.h
+++ b/include/drivers/pickDeliver/pickDeliver_driver.h
@@ -42,7 +42,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "c_types/pickDeliver/pickDeliveryOrders_t.h"
 #include "c_types/pickDeliver/vehicle_t.h"
 #include "c_types/matrix_cell_t.h"
-#include "c_types/pickDeliver/general_vehicle_orders_t.h"
+typedef struct Schedule_rt Schedule_rt;
 
 #ifdef __cplusplus
 extern "C" {
@@ -63,7 +63,7 @@ extern "C" {
             int max_cycles,
             int initial_solution_id,
 
-            General_vehicle_orders_t **return_tuples,
+            Schedule_rt **return_tuples,
             size_t *return_count,
 
             char **log_msg,

--- a/include/vrp/pgr_pickDeliver.h
+++ b/include/vrp/pgr_pickDeliver.h
@@ -35,7 +35,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <memory>
 #include <utility>
 
-#include "c_types/pickDeliver/general_vehicle_orders_t.h"
 #include "c_types/pickDeliver/vehicle_t.h"
 #include "c_types/pickDeliver/pickDeliveryOrders_t.h"
 #include "vrp/pd_problem.h"
@@ -43,6 +42,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "vrp/fleet.h"
 #include "vrp/pd_orders.h"
 #include "vrp/solution.h"
+
+using Schedule_rt = struct Schedule_rt;
 
 namespace pgrouting {
 namespace vrp {
@@ -72,7 +73,7 @@ class Pgr_pickDeliver : public PD_problem {
 
     void solve();
 
-    std::vector<General_vehicle_orders_t>
+    std::vector<Schedule_rt>
         get_postgres_result() const;
 
 

--- a/include/vrp/solution.h
+++ b/include/vrp/solution.h
@@ -37,6 +37,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "vrp/vehicle_pickDeliver.h"
 #include "vrp/fleet.h"
 
+using Schedule_rt = struct Schedule_rt;
+
 namespace pgrouting {
 namespace vrp {
 
@@ -52,7 +54,7 @@ class Solution {
      Fleet trucks;
 
  public:
-     std::vector<General_vehicle_orders_t>
+     std::vector<Schedule_rt>
          get_postgres_result() const;
 
 

--- a/include/vrp/vehicle.h
+++ b/include/vrp/vehicle.h
@@ -40,7 +40,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "cpp_common/identifier.h"
 #include "vrp/vehicle_node.h"
-#include "c_types/pickDeliver/general_vehicle_orders_t.h"
+using Schedule_rt = struct Schedule_rt;
 
 namespace pgrouting {
 namespace vrp {
@@ -88,7 +88,7 @@ class Vehicle : public Identifier {
       * (twv, cv, fleet_size, wait_time, duration)
       */
      typedef std::tuple< int, int, size_t, double, double > Cost;
-     std::vector<General_vehicle_orders_t>
+     std::vector<Schedule_rt>
            get_postgres_result(int vid) const;
 
      Vehicle(const Vehicle &) = default;

--- a/src/pickDeliver/pgr_pickDeliver.cpp
+++ b/src/pickDeliver/pgr_pickDeliver.cpp
@@ -30,6 +30,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <algorithm>
 #include <utility>
 
+#include "c_types/pickDeliver/schedule_rt.h"
+
 #include "cpp_common/pgr_assert.h"
 
 #include "vrp/initials_code.h"
@@ -90,11 +92,11 @@ Pgr_pickDeliver::solve() {
 
 
 
-std::vector< General_vehicle_orders_t >
+std::vector< Schedule_rt >
 Pgr_pickDeliver::get_postgres_result() const {
     auto result = solutions.back().get_postgres_result();
 
-    General_vehicle_orders_t aggregates = {
+    Schedule_rt aggregates = {
             /*
              * Vehicle id = -2 indicates its an aggregate row
              *

--- a/src/pickDeliver/pickDeliver.c
+++ b/src/pickDeliver/pickDeliver.c
@@ -34,6 +34,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "c_common/orders_input.h"
 #include "c_common/vehicles_input.h"
 #include "c_common/matrixRows_input.h"
+
+#include "c_types/pickDeliver/schedule_rt.h"
+
 #include "drivers/pickDeliver/pickDeliver_driver.h"
 
 PGDLLEXPORT Datum
@@ -51,7 +54,7 @@ process(
         int max_cycles,
         int initial_solution_id,
 
-        General_vehicle_orders_t **result_tuples,
+        Schedule_rt **result_tuples,
         size_t *result_count) {
     if (factor <= 0) {
         ereport(ERROR,
@@ -213,7 +216,7 @@ _pgr_pickdeliver(PG_FUNCTION_ARGS) {
     TupleDesc            tuple_desc;
 
     /**************************************************************************/
-    General_vehicle_orders_t *result_tuples = 0;
+    Schedule_rt *result_tuples = 0;
     size_t result_count = 0;
     /**************************************************************************/
 
@@ -261,7 +264,7 @@ _pgr_pickdeliver(PG_FUNCTION_ARGS) {
 
     funcctx = SRF_PERCALL_SETUP();
     tuple_desc = funcctx->tuple_desc;
-    result_tuples = (General_vehicle_orders_t*) funcctx->user_fctx;
+    result_tuples = (Schedule_rt*) funcctx->user_fctx;
 
     if (funcctx->call_cntr <  funcctx->max_calls) {
         HeapTuple   tuple;

--- a/src/pickDeliver/pickDeliverEuclidean.c
+++ b/src/pickDeliver/pickDeliverEuclidean.c
@@ -35,6 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "c_common/time_msg.h"
 #include "c_common/orders_input.h"
 #include "c_common/vehicles_input.h"
+#include "c_types/pickDeliver/schedule_rt.h"
 
 #include "drivers/pickDeliver/pickDeliverEuclidean_driver.h"
 
@@ -51,7 +52,7 @@ process(
         double factor,
         int max_cycles,
         int initial_solution_id,
-        General_vehicle_orders_t **result_tuples,
+        Schedule_rt **result_tuples,
         size_t *result_count) {
     if (factor <= 0) {
         ereport(ERROR,
@@ -198,7 +199,7 @@ _pgr_pickdelivereuclidean(PG_FUNCTION_ARGS) {
     /**************************************************************************/
     /*                          MODIFY AS NEEDED                              */
     /*                                                                        */
-    General_vehicle_orders_t *result_tuples = 0;
+    Schedule_rt *result_tuples = 0;
     size_t result_count = 0;
     /*                                                                        */
     /**************************************************************************/
@@ -248,7 +249,7 @@ _pgr_pickdelivereuclidean(PG_FUNCTION_ARGS) {
 
     funcctx = SRF_PERCALL_SETUP();
     tuple_desc = funcctx->tuple_desc;
-    result_tuples = (General_vehicle_orders_t*) funcctx->user_fctx;
+    result_tuples = (Schedule_rt*) funcctx->user_fctx;
 
     if (funcctx->call_cntr <  funcctx->max_calls) {
         HeapTuple   tuple;

--- a/src/pickDeliver/pickDeliverEuclidean_driver.cpp
+++ b/src/pickDeliver/pickDeliverEuclidean_driver.cpp
@@ -37,6 +37,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <map>
 #include <utility>
 
+#include "c_types/pickDeliver/schedule_rt.h"
+
 #include "vrp/pgr_pickDeliver.h"
 
 #include "cpp_common/pgr_assert.h"
@@ -61,7 +63,7 @@ do_pgr_pickDeliverEuclidean(
         int max_cycles,
         int initial_solution_id,
 
-        General_vehicle_orders_t **return_tuples,
+        Schedule_rt **return_tuples,
         size_t *return_count,
 
         char **log_msg,

--- a/src/pickDeliver/pickDeliver_driver.cpp
+++ b/src/pickDeliver/pickDeliver_driver.cpp
@@ -36,6 +36,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <vector>
 #include <utility>
 
+#include "c_types/pickDeliver/schedule_rt.h"
+
 #include "vrp/pgr_pickDeliver.h"
 #include "vrp/initials_code.h"
 #include "cpp_common/Dmatrix.h"
@@ -58,7 +60,7 @@ do_pgr_pickDeliver(
         int max_cycles,
         int initial_solution_id,
 
-        General_vehicle_orders_t **return_tuples,
+        Schedule_rt **return_tuples,
         size_t *return_count,
 
         char **log_msg,

--- a/src/pickDeliver/solution.cpp
+++ b/src/pickDeliver/solution.cpp
@@ -29,8 +29,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <string>
 #include <algorithm>
 
+#include "c_types/pickDeliver/schedule_rt.h"
+
 #include "vrp/pgr_pickDeliver.h"
-#include "c_types/pickDeliver/general_vehicle_orders_t.h"
+
 
 namespace pgrouting {
 namespace vrp {
@@ -38,13 +40,13 @@ namespace vrp {
 Pgr_pickDeliver* Solution::problem;
 
 
-std::vector<General_vehicle_orders_t>
+std::vector<Schedule_rt>
 Solution::get_postgres_result() const {
-    std::vector<General_vehicle_orders_t> result;
+    std::vector<Schedule_rt> result;
     /* postgres numbering starts with 1 */
     int i(1);
     for (const auto& truck : fleet) {
-        std::vector<General_vehicle_orders_t> data =
+        std::vector<Schedule_rt> data =
             truck.get_postgres_result(i);
         result.insert(result.end(), data.begin(), data.end());
 

--- a/src/pickDeliver/vehicle.cpp
+++ b/src/pickDeliver/vehicle.cpp
@@ -34,6 +34,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <utility>
 #include <vector>
 
+#include "c_types/pickDeliver/schedule_rt.h"
+
 #include "cpp_common/pgr_assert.h"
 
 #include "vrp/pgr_pickDeliver.h"
@@ -140,15 +142,15 @@ Vehicle::cost_compare(const Cost &lhs, const Cost &rhs) const {
 
 
 
-std::vector<General_vehicle_orders_t>
+std::vector<Schedule_rt>
 Vehicle::get_postgres_result(
         int vid) const {
-    std::vector<General_vehicle_orders_t> result;
+    std::vector<Schedule_rt> result;
     /* postgres numbering starts with 1 */
     int stop_seq(1);
     msg().log << "getting solution: " << tau() << "\n";
     for (const auto &p_stop : m_path) {
-        General_vehicle_orders_t data = {
+        Schedule_rt data = {
             vid,
             id(),
             stop_seq,


### PR DESCRIPTION
Fixes #1922  .

- more meaningful name to the struct: General_vehicle_orders_t -> Schedule_rt
- and the required simplification

@pgRouting/admins
