### PR TITLE
Adjust drivers in allpairs

### DIFF
--- a/include/drivers/allpairs/floydWarshall_driver.h
+++ b/include/drivers/allpairs/floydWarshall_driver.h
@@ -34,8 +34,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
-using Edge_t = struct Edge_t ;
-using Matrix_cell_t = struct Matrix_cell_t ;
+using Edge_t = struct Edge_t;
+using Matrix_cell_t = struct Matrix_cell_t;
 #else
 #   include <stddef.h>
 typedef struct Edge_t Edge_t;

--- a/include/drivers/allpairs/floydWarshall_driver.h
+++ b/include/drivers/allpairs/floydWarshall_driver.h
@@ -34,12 +34,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t ;
+using Matrix_cell_t = struct Matrix_cell_t ;
 #else
 #   include <stddef.h>
-#endif
-
 typedef struct Edge_t Edge_t;
 typedef struct Matrix_cell_t Matrix_cell_t;
+#endif
+
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/drivers/allpairs/johnson_driver.h
+++ b/include/drivers/allpairs/johnson_driver.h
@@ -33,12 +33,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using Matrix_cell_t = struct Matrix_cell_t;
 #else
 #   include <stddef.h>
-#endif
-
 typedef struct Edge_t Edge_t;
 typedef struct Matrix_cell_t Matrix_cell_t;
+#endif
+
+
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes #2051.

Changes proposed in this pull request:
- keyword `using` instead of `typedef` in C++ to avoid the creation of a new type/type-id.
- Changes made to headers in `include/drivers/allpairs`.

@pgRouting/admins
