### PR TITLE
Adjust drivers in astar

### DIFF
--- a/include/drivers/astar/astar_driver.h
+++ b/include/drivers/astar/astar_driver.h
@@ -33,13 +33,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using General_path_element_t = struct General_path_element_t;
 #else
 #   include <stddef.h>
+typedef struct General_path_element_t General_path_element_t;
 #endif
 
 #include "c_types/pgr_edge_xy_t.h"
 #include "c_types/pgr_combination_t.h"
-typedef struct General_path_element_t General_path_element_t;
+
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes #2054.

Changes proposed in this pull request:
- keyword `using` instead of `typedef` in C++ to avoid the creation of a new type/type-id.
- Changes made to headers in `include/drivers/astar`.

@pgRouting/admins
