### PR TITLE
Adjust drivers in bdAstar

### DIFF
--- a/include/drivers/bdAstar/bdAstar_driver.h
+++ b/include/drivers/bdAstar/bdAstar_driver.h
@@ -34,13 +34,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using General_path_element_t = struct General_path_element_t;
 #else
 #   include <stddef.h>
+typedef struct General_path_element_t General_path_element_t;
 #endif
 
 #include "c_types/pgr_edge_xy_t.h"
 #include "c_types/pgr_combination_t.h"
-#include "c_types/general_path_element_t.h"
 
 
 #ifdef __cplusplus

--- a/src/bdAstar/bdAstar.c
+++ b/src/bdAstar/bdAstar.c
@@ -31,6 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "c_common/postgres_connection.h"
 #include "utils/array.h"
 
+#include "c_types/general_path_element_t.h"
 #include "c_common/debug_macro.h"
 #include "c_common/e_report.h"
 #include "c_common/time_msg.h"


### PR DESCRIPTION
Fixes #2056

Changes proposed in this pull request:
- keyword `using` instead of `typedef` in C++ to avoid the creation of a new type/type-id.
- Changes made to headers in `include/drivers/bdAstar`.

@pgRouting/admins
