### PR TITLE
Adjust drivers in bdDijkstra

### DIFF
--- a/include/drivers/bdDijkstra/bdDijkstra_driver.h
+++ b/include/drivers/bdDijkstra/bdDijkstra_driver.h
@@ -34,13 +34,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using General_path_element_t = struct General_path_element_t;
 #else
 #   include <stddef.h>
+typedef struct Edge_t Edge_t;
+typedef struct General_path_element_t General_path_element_t;
 #endif
 
-typedef struct Edge_t Edge_t;
 #include "c_types/pgr_combination_t.h"
-typedef struct General_path_element_t General_path_element_t;
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes # 2063

Changes proposed in this pull request:
- keyword `using` instead of `typedef` in C++ to avoid the creation of a new type/type-id.
- Changes made to headers in `include/drivers/bdDijkstra`.

@pgRouting/admins
