### PR TITLE
Adjust drivers in bellman_ford

### DIFF
--- a/include/drivers/bellman_ford/bellman_ford_driver.h
+++ b/include/drivers/bellman_ford/bellman_ford_driver.h
@@ -34,13 +34,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using General_path_element_t = struct General_path_element_t;
 #else
 #   include <stddef.h>
+typedef struct Edge_t Edge_t;
+typedef struct General_path_element_t General_path_element_t;
 #endif
 
-typedef struct Edge_t Edge_t;
+
 #include "c_types/pgr_combination_t.h"
-typedef struct General_path_element_t General_path_element_t;
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/drivers/bellman_ford/bellman_ford_neg_driver.h
+++ b/include/drivers/bellman_ford/bellman_ford_neg_driver.h
@@ -34,13 +34,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using General_path_element_t = struct General_path_element_t;
 #else
 #   include <stddef.h>
+typedef struct Edge_t Edge_t;
+typedef struct General_path_element_t General_path_element_t;
 #endif
 
-typedef struct Edge_t Edge_t;
 #include "c_types/pgr_combination_t.h"
-#include "c_types/general_path_element_t.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/drivers/bellman_ford/edwardMoore_driver.h
+++ b/include/drivers/bellman_ford/edwardMoore_driver.h
@@ -34,13 +34,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using General_path_element_t = struct General_path_element_t;
 #else
 #   include <stddef.h>
+typedef struct Edge_t Edge_t;
+typedef struct General_path_element_t General_path_element_t;
 #endif
 
-typedef struct Edge_t Edge_t;
+
 #include "c_types/pgr_combination_t.h"
-typedef struct General_path_element_t General_path_element_t;
+
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes #2065

Changes proposed in this pull request:
- keyword `using` instead of `typedef` in C++ to avoid the creation of a new type/type-id.
- Changes made to headers in `include/drivers/bellman_ford`.

@pgRouting/admins

