### PR TITLE
Adjust drivers in breadthFirstSearch

### DIFF
--- a/include/drivers/breadthFirstSearch/binaryBreadthFirstSearch_driver.h
+++ b/include/drivers/breadthFirstSearch/binaryBreadthFirstSearch_driver.h
@@ -34,13 +34,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using General_path_element_t = struct General_path_element_t;
 #else
 #   include <stddef.h>
+typedef struct Edge_t Edge_t;
+typedef struct General_path_element_t General_path_element_t;
 #endif
 
-typedef struct Edge_t Edge_t;
+
 #include "c_types/pgr_combination_t.h"
-typedef struct General_path_element_t General_path_element_t;
+
 
 
 #ifdef __cplusplus

--- a/include/drivers/breadthFirstSearch/breadthFirstSearch_driver.h
+++ b/include/drivers/breadthFirstSearch/breadthFirstSearch_driver.h
@@ -35,13 +35,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifdef __cplusplus
 #   include <cstddef>
 #   include <cstdint>
+using Edge_t = struct Edge_t;
+using MST_rt = struct MST_rt;
 #else
 #   include <stddef.h>
 #   include <stdint.h>
-#endif
-
 typedef struct Edge_t Edge_t;
 typedef struct MST_rt MST_rt;
+#endif
+
+
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes #2067 

Changes proposed in this pull request:
- keyword `using` instead of `typedef` in C++ to avoid the creation of a new type/type-id.
- Changes made to headers in `include/drivers/breadthFirstSearch`.

@pgRouting/admins

