### PR TITLE
Adjust drivers in chinese

### DIFF
--- a/include/drivers/chinese/chinesePostman_driver.h
+++ b/include/drivers/chinese/chinesePostman_driver.h
@@ -34,12 +34,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using General_path_element_t = struct General_path_element_t;
 #else
 #   include <stddef.h>
-#endif
-
 typedef struct Edge_t Edge_t;
 typedef struct General_path_element_t General_path_element_t;
+#endif
+
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes #2069  

Changes proposed in this pull request:
- keyword `using` instead of `typedef` in C++ to avoid the creation of a new type/type-id.
- Changes made to headers in `include/drivers/chinese`.

@pgRouting/admins

