### PR TITLE
Adjust drivers in coloring

### DIFF
--- a/include/drivers/coloring/bipartite_driver.h
+++ b/include/drivers/coloring/bipartite_driver.h
@@ -34,11 +34,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using pgr_bipartite_rt = struct pgr_bipartite_rt;
 #else
 #   include <stddef.h>
-#endif
 typedef struct Edge_t Edge_t;
 typedef struct pgr_bipartite_rt pgr_bipartite_rt;
+#endif
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/drivers/coloring/sequentialVertexColoring_driver.h
+++ b/include/drivers/coloring/sequentialVertexColoring_driver.h
@@ -34,12 +34,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using pgr_vertex_color_rt = struct pgr_vertex_color_rt;
 #else
 #   include <stddef.h>
-#endif
-
 typedef struct Edge_t Edge_t;
 typedef struct pgr_vertex_color_rt pgr_vertex_color_rt;
+#endif
+
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes #2071 

Changes proposed in this pull request:
- keyword `using` instead of `typedef` in C++ to avoid the creation of a new type/type-id.
- Changes made to headers in `include/drivers/coloring`.

@pgRouting/admins
