### PR TITLE
Adjust drivers in components

### DIFF
--- a/include/drivers/components/articulationPoints_driver.h
+++ b/include/drivers/components/articulationPoints_driver.h
@@ -35,13 +35,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifdef __cplusplus
 #   include <cstddef>
 #   include <cstdint>
+using Edge_t = struct Edge_t;
 #else
 #   include <stddef.h>
 #   include <stdint.h>
+typedef struct Edge_t Edge_t;
 #endif
 
-typedef struct Edge_t Edge_t;
-typedef struct pgr_components_rt pgr_components_rt;
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/drivers/components/articulationPoints_driver.h
+++ b/include/drivers/components/articulationPoints_driver.h
@@ -34,12 +34,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+#   include <cstdint>
 #else
 #   include <stddef.h>
+#   include <stdint.h>
 #endif
 
 typedef struct Edge_t Edge_t;
-#include "c_types/pgr_components_rt.h"
+typedef struct pgr_components_rt pgr_components_rt;
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/drivers/components/biconnectedComponents_driver.h
+++ b/include/drivers/components/biconnectedComponents_driver.h
@@ -34,12 +34,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using pgr_components_rt = struct pgr_components_rt;
 #else
 #   include <stddef.h>
-#endif
-
 typedef struct Edge_t Edge_t;
 typedef struct pgr_components_rt pgr_components_rt;
+#endif
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/drivers/components/bridges_driver.h
+++ b/include/drivers/components/bridges_driver.h
@@ -35,13 +35,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifdef __cplusplus
 #   include <cstddef>
 #   include <cstdint>
+using Edge_t = struct Edge_t;
 #else
 #   include <stddef.h>
 #   include <stdint.h>
+typedef struct Edge_t Edge_t;
 #endif
 
-typedef struct Edge_t Edge_t;
-typedef struct pgr_components_rt pgr_components_rt;
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/drivers/components/bridges_driver.h
+++ b/include/drivers/components/bridges_driver.h
@@ -34,12 +34,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+#   include <cstdint>
 #else
 #   include <stddef.h>
+#   include <stdint.h>
 #endif
 
 typedef struct Edge_t Edge_t;
-#include "c_types/pgr_components_rt.h"
+typedef struct pgr_components_rt pgr_components_rt;
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/drivers/components/connectedComponents_driver.h
+++ b/include/drivers/components/connectedComponents_driver.h
@@ -34,12 +34,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using pgr_components_rt = struct pgr_components_rt;
 #else
 #   include <stddef.h>
-#endif
-
 typedef struct Edge_t Edge_t;
 typedef struct pgr_components_rt pgr_components_rt;
+#endif
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/drivers/components/makeConnected_driver.h
+++ b/include/drivers/components/makeConnected_driver.h
@@ -34,12 +34,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using pgr_makeConnected_t = struct pgr_makeConnected_t;
 #else
 #   include <stddef.h>
-#endif
-
 typedef struct Edge_t Edge_t;
 typedef struct pgr_makeConnected_t pgr_makeConnected_t;
+#endif
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/drivers/components/strongComponents_driver.h
+++ b/include/drivers/components/strongComponents_driver.h
@@ -34,12 +34,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using pgr_components_rt = struct pgr_components_rt;
 #else
 #   include <stddef.h>
-#endif
-
 typedef struct Edge_t Edge_t;
 typedef struct pgr_components_rt pgr_components_rt;
+#endif
+
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes #2073  

Changes proposed in this pull request:
- keyword `using` instead of `typedef` in C++ to avoid the creation of a new type/type-id.
- Changes made to headers in `include/drivers/components`.
- Remove unnecessary struct and includes, added includes for int64_t.

@pgRouting/admins