### PR TITLE
Adjust drivers in dominator

### DIFF
--- a/include/drivers/dominator/lengauerTarjanDominatorTree_driver.h
+++ b/include/drivers/dominator/lengauerTarjanDominatorTree_driver.h
@@ -34,15 +34,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
-
-
+using Edge_t = struct Edge_t;
+using pgr_ltdtree_rt = struct pgr_ltdtree_rt;
 #else
 #   include <stddef.h>
+typedef struct Edge_t Edge_t;
+typedef struct pgr_ltdtree_rt pgr_ltdtree_rt;
 #endif
 
-typedef struct Edge_t Edge_t;
 
-typedef struct pgr_ltdtree_rt pgr_ltdtree_rt;
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes #2081 

Changes proposed in this pull request:
- keyword `using` instead of `typedef` in C++ to avoid the creation of a new type/type-id.
- Changes made to headers in `include/drivers/dominator`.

@pgRouting/admins
