### PR TITLE
Adjust drivers:  max_flow

### DIFF
--- a/include/drivers/max_flow/edge_disjoint_paths_driver.h
+++ b/include/drivers/max_flow/edge_disjoint_paths_driver.h
@@ -34,13 +34,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using General_path_element_t = struct General_path_element_t;
 #else
 #   include <stddef.h>
+typedef struct Edge_t Edge_t;
+typedef struct General_path_element_t General_path_element_t;
 #endif
 
-#include "c_types/pgr_edge_t.h"
+
 #include "c_types/pgr_combination_t.h"
-#include "c_types/general_path_element_t.h"
+
 
 
 #ifdef __cplusplus
@@ -49,7 +53,7 @@ extern "C" {
 
     void
         do_pgr_edge_disjoint_paths(
-            pgr_edge_t *data_edges,
+            Edge_t *data_edges,
             size_t total_tuples,
             pgr_combination_t  *combinations,
             size_t total_combinations,

--- a/include/drivers/max_flow/max_flow_driver.h
+++ b/include/drivers/max_flow/max_flow_driver.h
@@ -34,13 +34,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using pgr_flow_t = struct pgr_flow_t;
 #else
 #   include <stddef.h>
+typedef struct Edge_t Edge_t;
+typedef struct pgr_flow_t pgr_flow_t;
 #endif
 
-#include "c_types/pgr_flow_t.h"
 #include "c_types/pgr_combination_t.h"
-#include "c_types/pgr_edge_t.h"
+
+
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,7 +53,7 @@ extern "C" {
 
     void
         do_pgr_max_flow(
-            pgr_edge_t *data_edges,
+            Edge_t *data_edges,
             size_t total_tuples,
 
             pgr_combination_t  *combinations,

--- a/include/drivers/max_flow/minCostMaxFlow_driver.h
+++ b/include/drivers/max_flow/minCostMaxFlow_driver.h
@@ -34,13 +34,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using pgr_flow_t = struct pgr_flow_t;
 #else
 #   include <stddef.h>
+typedef struct pgr_flow_t pgr_flow_t;
 #endif
 
-#include "c_types/pgr_flow_t.h"
 #include "c_types/pgr_combination_t.h"
 #include "c_types/pgr_costFlow_t.h"
+
+
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes #2050

Changes proposed in this pull request:
- keyword using instead of typedef in C++ to avoid the creation of a new type/type-id.
- Fixed the files edge_disjoint_paths_driver, max_flow_driver and minCostMaxFlow_driver

@pgRouting/admins
