### PR TITLE
Adjust drivers: max_flow

### DIFF
--- a/include/drivers/max_flow/edge_disjoint_paths_driver.h
+++ b/include/drivers/max_flow/edge_disjoint_paths_driver.h
@@ -34,13 +34,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using General_path_element_t = struct General_path_element_t;
 #else
 #   include <stddef.h>
+typedef struct Edge_t Edge_t;
+typedef struct General_path_element_t General_path_element_t;
 #endif
 
-typedef struct Edge_t Edge_t;
+
 #include "c_types/pgr_combination_t.h"
-typedef struct General_path_element_t General_path_element_t;
+
 
 
 #ifdef __cplusplus

--- a/include/drivers/max_flow/max_flow_driver.h
+++ b/include/drivers/max_flow/max_flow_driver.h
@@ -34,14 +34,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using pgr_flow_t = struct pgr_flow_t;
 #else
 #   include <stddef.h>
+typedef struct Edge_t Edge_t;
+typedef struct pgr_flow_t pgr_flow_t;
 #endif
 
 #include "c_types/pgr_combination_t.h"
-typedef struct Edge_t Edge_t;
 
-typedef struct pgr_flow_t pgr_flow_t;
+
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/drivers/max_flow/minCostMaxFlow_driver.h
+++ b/include/drivers/max_flow/minCostMaxFlow_driver.h
@@ -34,14 +34,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using pgr_flow_t = struct pgr_flow_t;
 #else
 #   include <stddef.h>
+typedef struct pgr_flow_t pgr_flow_t;
 #endif
 
 #include "c_types/pgr_combination_t.h"
 #include "c_types/pgr_costFlow_t.h"
 
-typedef struct pgr_flow_t pgr_flow_t;
+
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes #2091 

Changes proposed in this pull request:

- keyword using instead of typedef in C++ to avoid the creation of a new type/type-id.
- Fixed the files edge_disjoint_paths_driver, max_flow_driver and minCostMaxFlow_driver.
@pgRouting/admins