### PR TITLE
Links to old pages update

### DIFF
--- a/doc/allpairs/allpairs-family.rst
+++ b/doc/allpairs/allpairs-family.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/allpairs-family.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/allpairs-family.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/allpairs-family.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/allpairs-family.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/allpairs-family.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/allpairs-family.html>`__
 * **Unsupported versions:**

--- a/doc/allpairs/pgr_floydWarshall.rst
+++ b/doc/allpairs/pgr_floydWarshall.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_floydWarshall.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_floydWarshall.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_floydWarshall.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_floydWarshall.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_floydWarshall.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_floydWarshall.html>`__
 * **Unsupported versions:**

--- a/doc/allpairs/pgr_johnson.rst
+++ b/doc/allpairs/pgr_johnson.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_johnson.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_johnson.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_johnson.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_johnson.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_johnson.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_johnson.html>`__
   `2.6 <https://docs.pgrouting.org/2.6/en/pgr_johnson.html>`__

--- a/doc/alpha_shape/pgr_alphaShape.rst
+++ b/doc/alpha_shape/pgr_alphaShape.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_alphaShape.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_alphaShape.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_alphaShape.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_alphaShape.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_alphaShape.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_alphaShape.html>`__
 * **Unsupported versions:**

--- a/doc/astar/aStar-family.rst
+++ b/doc/astar/aStar-family.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/aStar-family.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/aStar-family.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/aStar-family.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/aStar-family.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/aStar-family.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/aStar-family.html>`__
 * **Unsupported versions:**

--- a/doc/astar/pgr_aStar.rst
+++ b/doc/astar/pgr_aStar.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_aStar.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_aStar.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_aStar.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_aStar.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_aStar.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_aStar.html>`__
 * **Unsupported versions:**

--- a/doc/astar/pgr_aStarCost.rst
+++ b/doc/astar/pgr_aStarCost.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_aStarCost.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_aStarCost.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_aStarCost.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_aStarCost.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_aStarCost.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_aStarCost.html>`__
 * **Unsupported versions:**

--- a/doc/astar/pgr_aStarCostMatrix.rst
+++ b/doc/astar/pgr_aStarCostMatrix.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_aStarCostMatrix.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_aStarCostMatrix.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_aStarCostMatrix.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_aStarCostMatrix.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_aStarCostMatrix.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_aStarCostMatrix.html>`__
 * **Unsupported versions:**

--- a/doc/bdAstar/bdAstar-family.rst
+++ b/doc/bdAstar/bdAstar-family.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/bdAstar-family.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/bdAstar-family.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/bdAstar-family.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/bdAstar-family.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/bdAstar-family.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/bdAstar-family.html>`__
 * **Unsupported versions:**

--- a/doc/bdAstar/pgr_bdAstar.rst
+++ b/doc/bdAstar/pgr_bdAstar.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_bdAstar.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_bdAstar.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_bdAstar.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_bdAstar.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_bdAstar.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_bdAstar.html>`__
 * **Unsupported versions:**

--- a/doc/bdAstar/pgr_bdAstarCost.rst
+++ b/doc/bdAstar/pgr_bdAstarCost.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_bdAstarCost.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_bdAstarCost.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_bdAstarCost.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_bdAstarCost.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_bdAstarCost.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_bdAstarCost.html>`__
 * **Unsupported versions:**

--- a/doc/bdAstar/pgr_bdAstarCostMatrix.rst
+++ b/doc/bdAstar/pgr_bdAstarCostMatrix.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_bdAstarCostMatrix.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_bdAstarCostMatrix.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_bdAstarCostMatrix.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_bdAstarCostMatrix.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_bdAstarCostMatrix.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_bdAstarCostMatrix.html>`__
 * **Unsupported versions:**

--- a/doc/bdDijkstra/bdDijkstra-family.rst
+++ b/doc/bdDijkstra/bdDijkstra-family.rst
@@ -13,7 +13,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/bdDijkstra-family.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/bdDijkstra-family.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/bdDijkstra-family.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/bdDijkstra-family.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/bdDijkstra-family.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/bdDijkstra-family.html>`__
 * **Unsupported versions:**

--- a/doc/bdDijkstra/pgr_bdDijkstra.rst
+++ b/doc/bdDijkstra/pgr_bdDijkstra.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_bdDijkstra.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_bdDijkstra.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_bdDijkstra.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_bdDijkstra.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_bdDijkstra.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_bdDijkstra.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_bdDijkstra.html>`__

--- a/doc/bdDijkstra/pgr_bdDijkstraCost.rst
+++ b/doc/bdDijkstra/pgr_bdDijkstraCost.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_bdDijkstraCost.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_bdDijkstraCost.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_bdDijkstraCost.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_bdDijkstraCost.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_bdDijkstraCost.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_bdDijkstraCost.html>`__
 * **Unsupported versions:**

--- a/doc/bdDijkstra/pgr_bdDijkstraCostMatrix.rst
+++ b/doc/bdDijkstra/pgr_bdDijkstraCostMatrix.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_bdDijkstraCostMatrix.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_bdDijkstraCostMatrix.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_bdDijkstraCostMatrix.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_bdDijkstraCostMatrix.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_bdDijkstraCostMatrix.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_bdDijkstraCostMatrix.html>`__
 * **Unsupported versions:**

--- a/doc/bellman_ford/pgr_bellmanFord.rst
+++ b/doc/bellman_ford/pgr_bellmanFord.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_bellmanFord.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_bellmanFord.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_bellmanFord.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_bellmanFord.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_bellmanFord.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_bellmanFord.html>`__
 

--- a/doc/bellman_ford/pgr_edwardMoore.rst
+++ b/doc/bellman_ford/pgr_edwardMoore.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_edwardMoore.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_edwardMoore.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_edwardMoore.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_edwardMoore.html>`__
 
 pgr_edwardMoore - Experimental
 ===============================================================================

--- a/doc/breadthFirstSearch/pgr_binaryBreadthFirstSearch.rst
+++ b/doc/breadthFirstSearch/pgr_binaryBreadthFirstSearch.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_binaryBreadthFirstSearch.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_binaryBreadthFirstSearch.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_binaryBreadthFirstSearch.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_binaryBreadthFirstSearch.html>`__
   
 pgr_binaryBreadthFirstSearch - Experimental
 ===============================================================================

--- a/doc/breadthFirstSearch/pgr_breadthFirstSearch.rst
+++ b/doc/breadthFirstSearch/pgr_breadthFirstSearch.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_breadthFirstSearch.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_breadthFirstSearch.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_breadthFirstSearch.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_breadthFirstSearch.html>`__
   
 pgr_breadthFirstSearch - Experimental
 ===============================================================================

--- a/doc/chinese/chinesePostmanProblem-family.rst
+++ b/doc/chinese/chinesePostmanProblem-family.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/chinesePostmanProblem-family.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/chinesePostmanProblem-family.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/chinesePostmanProblem-family.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/chinesePostmanProblem-family.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/chinesePostmanProblem-family.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/chinesePostmanProblem-family.html>`__
 

--- a/doc/chinese/pgr_chinesePostman.rst
+++ b/doc/chinese/pgr_chinesePostman.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_chinesePostman.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_chinesePostman.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_chinesePostman.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_chinesePostman.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_chinesePostman.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_chinesePostman.html>`__
 

--- a/doc/chinese/pgr_chinesePostmanCost.rst
+++ b/doc/chinese/pgr_chinesePostmanCost.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_chinesePostmanCost.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_chinesePostmanCost.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_chinesePostmanCost.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_chinesePostmanCost.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_chinesePostmanCost.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_chinesePostmanCost.html>`__
 

--- a/doc/coloring/coloring-family.rst
+++ b/doc/coloring/coloring-family.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/coloring-family.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/coloring-family.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/coloring-family.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/coloring-family.html>`__
 
 
 Coloring - Family of functions (Experimental)

--- a/doc/coloring/pgr_bipartite.rst
+++ b/doc/coloring/pgr_bipartite.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_bipartite.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_bipartite.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_bipartite.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_bipartite.html>`__
 
 pgr_bipartite -Experimental
 ===============================================================================

--- a/doc/coloring/pgr_sequentialVertexColoring.rst
+++ b/doc/coloring/pgr_sequentialVertexColoring.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_sequentialVertexColoring.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_sequentialVertexColoring.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_sequentialVertexColoring.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_sequentialVertexColoring.html>`__
 
 pgr_sequentialVertexColoring - Experimental
 ===============================================================================

--- a/doc/components/components-family.rst
+++ b/doc/components/components-family.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/components-family.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/components-family.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/components-family.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/components-family.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/components-family.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/components-family.html>`__
 * **Unsupported versions:**

--- a/doc/components/pgr_articulationPoints.rst
+++ b/doc/components/pgr_articulationPoints.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_articulationPoints.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_articulationPoints.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_articulationPoints.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_articulationPoints.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_articulationPoints.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_articulationPoints.html>`__
 * **Unsupported versions:**

--- a/doc/components/pgr_biconnectedComponents.rst
+++ b/doc/components/pgr_biconnectedComponents.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_biconnectedComponents.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_biconnectedComponents.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_biconnectedComponents.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_biconnectedComponents.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_biconnectedComponents.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_biconnectedComponents.html>`__
 * **Unsupported versions:**

--- a/doc/components/pgr_bridges.rst
+++ b/doc/components/pgr_bridges.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_bridges.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_bridges.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_bridges.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_bridges.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_bridges.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_bridges.html>`__
 * **Unsupported versions:**

--- a/doc/components/pgr_connectedComponents.rst
+++ b/doc/components/pgr_connectedComponents.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_connectedComponents.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_connectedComponents.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_connectedComponents.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_connectedComponents.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_connectedComponents.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_connectedComponents.html>`__
 * **Unsupported versions:**

--- a/doc/components/pgr_makeConnected.rst
+++ b/doc/components/pgr_makeConnected.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_makeConnected.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_makeConnected.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_makeConnected.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_makeConnected.html>`__
 
 pgr_makeConnected - Experimental
 ===============================================================================

--- a/doc/components/pgr_strongComponents.rst
+++ b/doc/components/pgr_strongComponents.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_strongComponents.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_strongComponents.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_strongComponents.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_strongComponents.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_strongComponents.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_strongComponents.html>`__
 * **Unsupported versions:**

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -318,28 +318,6 @@ pdf_style_path = ['.', '_styles']
 
 # cases to ignore during link checking
 linkcheck_ignore = [
-    # Link is going to be fixed by sponsor
-    'https://www.leopark.mx/',
-
-    # might not exist yet (we are generating it!)
-    'https://docs.pgrouting.org/3.2/en/pgr_dijkstraNear.html',
-    'https://docs.pgrouting.org/3.2/en/pgr_dijkstraNearCost.html',
-    'https://docs.pgrouting.org/3.2/en/pgr_randomSpanTree.html',
-    'https://docs.pgrouting.org/3.2/en/pgr_withPointsVia.html',
-    'https://docs.pgrouting.org/3.2/en/withPoints.html',
-    'https://docs.pgrouting.org/latest/en/pgr_makeConnected.html',
-    'https://docs.pgrouting.org/latest/en/coloring-family.html',
-    'https://docs.pgrouting.org/latest/en/pgr_bipartite.html',
-    'https://docs.pgrouting.org/latest/en/pgr_sequentialVertexColoring.html',
-    'https://docs.pgrouting.org/latest/en/pgr_dijkstraNear.html',
-    'https://docs.pgrouting.org/latest/en/pgr_dijkstraNearCost.html',
-    'https://docs.pgrouting.org/latest/en/pgr_lengauerTarjanDominatorTree.html',
-    'https://docs.pgrouting.org/latest/en/pgr_isPlanar.html',
-    'https://docs.pgrouting.org/latest/en/pgr_randomSpanTree.html',
-    'https://docs.pgrouting.org/latest/en/pgr_depthFirstSearch.html',
-    'https://docs.pgrouting.org/latest/en/traversal-family.html',
-    'https://docs.pgrouting.org/latest/en/pgr_withPointsVia.html',
-    'https://docs.pgrouting.org/latest/en/withPoints.html',
     'https://docs.pgrouting.org/latest/en/pgr_edgeColoring.html',
 
 

--- a/doc/contraction/contraction-family.rst
+++ b/doc/contraction/contraction-family.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/contraction-family.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/contraction-family.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/contraction-family.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/contraction-family.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/contraction-family.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/contraction-family.html>`__
 * **Unsupported versions:**

--- a/doc/contraction/pgr_contraction.rst
+++ b/doc/contraction/pgr_contraction.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_contraction.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_contraction.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_contraction.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_contraction.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_contraction.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_contraction.html>`__
 * **Unsupported versions:**

--- a/doc/dagShortestPath/pgr_dagShortestPath.rst
+++ b/doc/dagShortestPath/pgr_dagShortestPath.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_dagShortestPath.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_dagShortestPath.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_dagShortestPath.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_dagShortestPath.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_dagShortestPath.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_dagShortestPath.html>`__
 

--- a/doc/dijkstra/dijkstra-family.rst
+++ b/doc/dijkstra/dijkstra-family.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/dijkstra-family.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/dijkstra-family.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/dijkstra-family.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/dijkstra-family.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/dijkstra-family.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/dijkstra-family.html>`__
 * **Unsupported versions:**

--- a/doc/dijkstra/pgr_dijkstra.rst
+++ b/doc/dijkstra/pgr_dijkstra.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_dijkstra.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_dijkstra.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_dijkstra.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_dijkstra.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_dijkstra.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_dijkstra.html>`__
 * **Unsupported versions:**

--- a/doc/dijkstra/pgr_dijkstraCostMatrix.rst
+++ b/doc/dijkstra/pgr_dijkstraCostMatrix.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_dijkstraCostMatrix.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_dijkstraCostMatrix.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_dijkstraCostMatrix.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_dijkstraCostMatrix.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_dijkstraCostMatrix.html>`__)
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_dijkstraCostMatrix.html>`__
 * **Unsupported versions:**

--- a/doc/dijkstra/pgr_dijkstraNear.rst
+++ b/doc/dijkstra/pgr_dijkstraNear.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_dijkstraNear.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_dijkstraNear.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_dijkstraNear.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_dijkstraNear.html>`__
 
 pgr_dijkstraNear - Experimental
 ===============================================================================

--- a/doc/dijkstra/pgr_dijkstraNearCost.rst
+++ b/doc/dijkstra/pgr_dijkstraNearCost.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_dijkstraNearCost.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_dijkstraNearCost.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_dijkstraNearCost.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_dijkstraNearCost.html>`__
 
 pgr_dijkstraNearCost - Experimental
 ===============================================================================

--- a/doc/dijkstra/pgr_dijkstraVia.rst
+++ b/doc/dijkstra/pgr_dijkstraVia.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_dijkstraVia.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_dijkstraVia.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_dijkstraVia.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_dijkstraVia.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_dijkstraVia.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_dijkstraVia.html>`__
 * **Unsupported versions:**

--- a/doc/dominator/pgr_lengauerTarjanDominatorTree.rst
+++ b/doc/dominator/pgr_lengauerTarjanDominatorTree.rst
@@ -12,7 +12,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_lengauerTarjanDominatorTree.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_lengauerTarjanDominatorTree.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_lengauerTarjanDominatorTree.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_lengauerTarjanDominatorTree.html>`__
 
 pgr_lengauerTarjanDominatorTree -Experimental
 ===============================================================================

--- a/doc/driving_distance/drivingDistance-category.rst
+++ b/doc/driving_distance/drivingDistance-category.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/drivingDistance-category.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/drivingDistance-category.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/drivingDistance-category.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/drivingDistance-category.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/drivingDistance-category.html>`__)
   `3.0 <https://docs.pgrouting.org/3.0/en/drivingDistance-category.html>`__
 * **Unsupported versions:**

--- a/doc/driving_distance/pgr_drivingDistance.rst
+++ b/doc/driving_distance/pgr_drivingDistance.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_drivingDistance.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_drivingDistance.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_drivingDistance.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_drivingDistance.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_drivingDistance.html>`__)
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_drivingDistance.html>`__
 * **Unsupported versions:**

--- a/doc/ksp/KSP-category.rst
+++ b/doc/ksp/KSP-category.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/KSP-category.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/KSP-category.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/KSP-category.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/KSP-category.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/KSP-category.html>`__)
   `3.0 <https://docs.pgrouting.org/3.0/en/KSP-category.html>`__
 * **Unsupported versions:**

--- a/doc/ksp/pgr_KSP.rst
+++ b/doc/ksp/pgr_KSP.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_KSP.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_KSP.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_KSP.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_KSP.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_KSP.html>`__)
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_KSP.html>`__
 * **Unsupported versions:**

--- a/doc/lineGraph/pgr_lineGraph.rst
+++ b/doc/lineGraph/pgr_lineGraph.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_lineGraph.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_lineGraph.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_lineGraph.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_lineGraph.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_lineGraph.html>`__)
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_lineGraph.html>`__
 * **Unsupported versions:**

--- a/doc/lineGraph/pgr_lineGraphFull.rst
+++ b/doc/lineGraph/pgr_lineGraphFull.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_lineGraphFull.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_lineGraphFull.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_lineGraphFull.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_lineGraphFull.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_lineGraphFull.html>`__)
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_lineGraphFull.html>`__
 * **Unsupported versions:**

--- a/doc/lineGraph/transformation-family.rst
+++ b/doc/lineGraph/transformation-family.rst
@@ -10,7 +10,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/transformation-family.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/transformation-family.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/transformation-family.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/transformation-family.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/transformation-family.html>`__)
   `3.0 <https://docs.pgrouting.org/3.0/en/transformation-family.html>`__
 * **Unsupported versions:**

--- a/doc/max_flow/flow-family.rst
+++ b/doc/max_flow/flow-family.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/flow-family.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/flow-family.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/flow-family.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/flow-family.html>`__
   current(`3.2 <https://docs.pgrouting.org/3.2/en/flow-family.html>`__)
   `3.1 <https://docs.pgrouting.org/3.1/en/flow-family.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/flow-family.html>`__

--- a/doc/max_flow/pgr_boykovKolmogorov.rst
+++ b/doc/max_flow/pgr_boykovKolmogorov.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_boykovKolmogorov.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_boykovKolmogorov.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_boykovKolmogorov.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_boykovKolmogorov.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_boykovKolmogorov.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_boykovKolmogorov.html>`__
 * **Unsupported versions:**

--- a/doc/max_flow/pgr_edgeDisjointPaths.rst
+++ b/doc/max_flow/pgr_edgeDisjointPaths.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_edgeDisjointPaths.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_edgeDisjointPaths.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_edgeDisjointPaths.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_edgeDisjointPaths.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_edgeDisjointPaths.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_edgeDisjointPaths.html>`__
 * **Unsupported versions:**

--- a/doc/max_flow/pgr_edmondsKarp.rst
+++ b/doc/max_flow/pgr_edmondsKarp.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_edmondsKarp.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_edmondsKarp.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_edmondsKarp.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_edmondsKarp.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_edmondsKarp.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_edmondsKarp.html>`__
 * **Unsupported versions:**

--- a/doc/max_flow/pgr_maxFlow.rst
+++ b/doc/max_flow/pgr_maxFlow.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_maxFlow.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_maxFlow.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_maxFlow.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_maxFlow.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_maxFlow.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_maxFlow.html>`__
 * **Unsupported versions:**

--- a/doc/max_flow/pgr_maxFlowMinCost.rst
+++ b/doc/max_flow/pgr_maxFlowMinCost.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_maxFlowMinCost.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_maxFlowMinCost.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_maxFlowMinCost.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_maxFlowMinCost.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_maxFlowMinCost.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_maxFlowMinCost.html>`__
 

--- a/doc/max_flow/pgr_maxFlowMinCost_Cost.rst
+++ b/doc/max_flow/pgr_maxFlowMinCost_Cost.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_maxFlowMinCost_Cost.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_maxFlowMinCost_Cost.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_maxFlowMinCost_Cost.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_maxFlowMinCost_Cost.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_maxFlowMinCost_Cost.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_maxFlowMinCost_Cost.html>`__
 

--- a/doc/max_flow/pgr_pushRelabel.rst
+++ b/doc/max_flow/pgr_pushRelabel.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_pushRelabel.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_pushRelabel.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_pushRelabel.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_pushRelabel.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_pushRelabel.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_pushRelabel.html>`__
 * **Unsupported versions:**

--- a/doc/mincut/pgr_stoerWagner.rst
+++ b/doc/mincut/pgr_stoerWagner.rst
@@ -10,7 +10,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_stoerWagner.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_stoerWagner.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_stoerWagner.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_stoerWagner.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_stoerWagner.html>`__)
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_stoerWagner.html>`__
 

--- a/doc/pickDeliver/pgr_pickDeliver.rst
+++ b/doc/pickDeliver/pgr_pickDeliver.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_pickDeliver.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_pickDeliver.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_pickDeliver.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_pickDeliver.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_pickDeliver.html>`__)
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_pickDeliver.html>`__
 

--- a/doc/pickDeliver/pgr_pickDeliverEuclidean.rst
+++ b/doc/pickDeliver/pgr_pickDeliverEuclidean.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_pickDeliverEuclidean.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_pickDeliverEuclidean.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_pickDeliverEuclidean.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_pickDeliverEuclidean.html>`__
   current(`3.1 <https://docs.pgrouting.org/3.1/en/pgr_pickDeliverEuclidean.html>`__)
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_pickDeliverEuclidean.html>`__
 * **Unsupported versions:**

--- a/doc/planar/pgr_isPlanar.rst
+++ b/doc/planar/pgr_isPlanar.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_isPlanar.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_isPlanar.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_isPlanar.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_isPlanar.html>`__
 
 pgr_isPlanar - Experimental
 ===============================================================================

--- a/doc/spanningTree/kruskal-family.rst
+++ b/doc/spanningTree/kruskal-family.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/kruskal-family.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/kruskal-family.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/kruskal-family.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/kruskal-family.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/kruskal-family.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/kruskal-family.html>`__
 

--- a/doc/spanningTree/pgr_kruskal.rst
+++ b/doc/spanningTree/pgr_kruskal.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_kruskal.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_kruskal.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_kruskal.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_kruskal.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_kruskal.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_kruskal.html>`__
 

--- a/doc/spanningTree/pgr_kruskalBFS.rst
+++ b/doc/spanningTree/pgr_kruskalBFS.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_kruskalBFS.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_kruskalBFS.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_kruskalBFS.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_kruskalBFS.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_kruskalBFS.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_kruskalBFS.html>`__
 

--- a/doc/spanningTree/pgr_kruskalDD.rst
+++ b/doc/spanningTree/pgr_kruskalDD.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_kruskalDD.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_kruskalDD.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_kruskalDD.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_kruskalDD.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_kruskalDD.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_kruskalDD.html>`__
 

--- a/doc/spanningTree/pgr_kruskalDFS.rst
+++ b/doc/spanningTree/pgr_kruskalDFS.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_kruskalDFS.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_kruskalDFS.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_kruskalDFS.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_kruskalDFS.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_kruskalDFS.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_kruskalDFS.html>`__
 

--- a/doc/spanningTree/pgr_prim.rst
+++ b/doc/spanningTree/pgr_prim.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_prim.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_prim.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_prim.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_prim.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_prim.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_prim.html>`__
 

--- a/doc/spanningTree/pgr_primBFS.rst
+++ b/doc/spanningTree/pgr_primBFS.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_primBFS.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_primBFS.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_primBFS.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_primBFS.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_primBFS.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_primBFS.html>`__
 

--- a/doc/spanningTree/pgr_primDD.rst
+++ b/doc/spanningTree/pgr_primDD.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_primDD.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_primDD.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_primDD.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_primDD.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_primDD.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_primDD.html>`__
 

--- a/doc/spanningTree/pgr_primDFS.rst
+++ b/doc/spanningTree/pgr_primDFS.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_primDFS.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_primDFS.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_primDFS.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_primDFS.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_primDFS.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_primDFS.html>`__
 

--- a/doc/spanningTree/pgr_randomSpanTree.rst
+++ b/doc/spanningTree/pgr_randomSpanTree.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_randomSpanTree.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_randomSpanTree.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_randomSpanTree.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_randomSpanTree.html>`__
 
 pgr_randomSpanTree - Experimental
 ===============================================================================

--- a/doc/spanningTree/prim-family.rst
+++ b/doc/spanningTree/prim-family.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/prim-family.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/prim-family.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/prim-family.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/prim-family.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/prim-family.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/prim-family.html>`__
 

--- a/doc/spanningTree/spanningTree-family.rst
+++ b/doc/spanningTree/spanningTree-family.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/spanningTree-family.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/spanningTree-family.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/spanningTree-family.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/spanningTree-family.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/spanningTree-family.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/spanningTree-family.html>`__
 

--- a/doc/src/cost-category.rst
+++ b/doc/src/cost-category.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/cost-category.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/cost-category.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/cost-category.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/cost-category.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/cost-category.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/cost-category.html>`__
 * **Unsupported versions:**

--- a/doc/src/costMatrix-category.rst
+++ b/doc/src/costMatrix-category.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/costMatrix-category.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/costMatrix-category.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/costMatrix-category.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/costMatrix-category.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/costMatrix-category.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/costMatrix-category.html>`__
 * **Unsupported versions:**

--- a/doc/src/experimental.rst
+++ b/doc/src/experimental.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/experimental.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/experimental.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/experimental.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/experimental.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/experimental.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/experimental.html>`__
 * **Unsupported versions:**

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/index.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/index.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/index.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/index.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/index.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/index.html>`__
 * **Unsupported versions:**

--- a/doc/src/pgRouting-concepts.rst
+++ b/doc/src/pgRouting-concepts.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgRouting-concepts.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgRouting-concepts.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgRouting-concepts.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgRouting-concepts.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgRouting-concepts.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgRouting-concepts.html>`__
 * **Unsupported versions:**

--- a/doc/src/pgRouting-installation.rst
+++ b/doc/src/pgRouting-installation.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgRouting-installation.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgRouting-installation.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgRouting-installation.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgRouting-installation.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgRouting-installation.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgRouting-installation.html>`__
 * **Unsupported versions:**

--- a/doc/src/pgRouting-introduction.rst
+++ b/doc/src/pgRouting-introduction.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgRouting-introduction.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgRouting-introduction.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgRouting-introduction.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgRouting-introduction.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgRouting-introduction.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgRouting-introduction.html>`__
 * **Unsupported versions:**

--- a/doc/src/proposed.rst
+++ b/doc/src/proposed.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/proposed.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/proposed.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/proposed.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/proposed.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/proposed.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/proposed.html>`__
 * **Unsupported versions:**

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/release_notes.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/release_notes.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/release_notes.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/release_notes.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/release_notes.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/release_notes.html>`__
 * **Unsupported versions:**

--- a/doc/src/routingFunctions.rst
+++ b/doc/src/routingFunctions.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/routingFunctions.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/routingFunctions.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/routingFunctions.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/routingFunctions.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/routingFunctions.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/routingFunctions.html>`__
 * **Unsupported versions:**

--- a/doc/src/sampledata.rst
+++ b/doc/src/sampledata.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/sampledata.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/sampledata.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/sampledata.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/sampledata.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/sampledata.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/sampledata.html>`__
 * **Unsupported versions:**

--- a/doc/src/support.rst
+++ b/doc/src/support.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/support.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/support.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/support.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/support.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/support.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/support.html>`__
 * **Unsupported versions:**

--- a/doc/src/support.rst
+++ b/doc/src/support.rst
@@ -26,7 +26,7 @@
 Support
 ===============================================================================
 
-pgRouting community support is available through the `pgRouting website <https://pgrouting.org/support.html>`_, `documentation <http://docs.pgrouting.org>`_, tutorials, mailing lists and others. If you’re looking for :ref:`commercial support <support_commercial>`, find below a list of companies providing pgRouting development and consulting services.
+pgRouting community support is available through the `pgRouting website <https://pgrouting.org/support.html>`_, `documentation <https://docs.pgrouting.org>`_, tutorials, mailing lists and others. If you’re looking for :ref:`commercial support <support_commercial>`, find below a list of companies providing pgRouting development and consulting services.
 
 
 Reporting Problems
@@ -84,9 +84,6 @@ For users who require professional support, development and consulting services,
    * - Paragon Corporation
      - United States
      - https://www.paragoncorporation.com
-   * - Camptocamp
-     - Switzerland, France
-     - https://www.camptocamp.com
    * - Netlab
      - Capranica, Italy
      - https://www.osgeo.org/service-providers/netlab/

--- a/doc/topologicalSort/pgr_topologicalSort.rst
+++ b/doc/topologicalSort/pgr_topologicalSort.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_topologicalSort.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_topologicalSort.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_topologicalSort.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_topologicalSort.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_topologicalSort.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_topologicalSort.html>`__
 

--- a/doc/topology/pgr_analyzeGraph.rst
+++ b/doc/topology/pgr_analyzeGraph.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_analyzeGraph.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_analyzeGraph.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_analyzeGraph.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_analyzeGraph.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_analyzeGraph.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_analyzeGraph.html>`__
 * **Unsupported versions:**

--- a/doc/topology/pgr_analyzeOneWay.rst
+++ b/doc/topology/pgr_analyzeOneWay.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_analyzeOneWay.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_analyzeOneWay.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_analyzeOneWay.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_analyzeOneWay.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_analyzeOneWay.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_analyzeOneWay.html>`__
 * **Unsupported versions:**

--- a/doc/topology/pgr_createTopology.rst
+++ b/doc/topology/pgr_createTopology.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_createTopology.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_createTopology.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_createTopology.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_createTopology.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_createTopology.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_createTopology.html>`__
 * **Unsupported versions:**

--- a/doc/topology/pgr_createVerticesTable.rst
+++ b/doc/topology/pgr_createVerticesTable.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_createVerticesTable.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_createVerticesTable.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_createVerticesTable.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_createVerticesTable.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_createVerticesTable.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_createVerticesTable.html>`__
 * **Unsupported versions:**

--- a/doc/topology/pgr_extractVertices.rst
+++ b/doc/topology/pgr_extractVertices.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_extractVertices.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_extractVertices.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_extractVertices.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_extractVertices.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_extractVertices.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_extractVertices.html>`__
 

--- a/doc/topology/pgr_nodeNetwork.rst
+++ b/doc/topology/pgr_nodeNetwork.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_nodeNetwork.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_nodeNetwork.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_nodeNetwork.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_nodeNetwork.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_nodeNetwork.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_nodeNetwork.html>`__
 * **Unsupported versions:**

--- a/doc/topology/topology-functions.rst
+++ b/doc/topology/topology-functions.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/topology-functions.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/topology-functions.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/topology-functions.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/topology-functions.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/topology-functions.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/topology-functions.html>`__
 * **Unsupported versions:**

--- a/doc/transitiveClosure/pgr_transitiveClosure.rst
+++ b/doc/transitiveClosure/pgr_transitiveClosure.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_transitiveClosure.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_transitiveClosure.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_transitiveClosure.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_transitiveClosure.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_transitiveClosure.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_transitiveClosure.html>`__
 

--- a/doc/traversal/pgr_depthFirstSearch.rst
+++ b/doc/traversal/pgr_depthFirstSearch.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_depthFirstSearch.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_depthFirstSearch.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_depthFirstSearch.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_depthFirstSearch.html>`__
 
 pgr_depthFirstSearch - Experimental
 ===============================================================================

--- a/doc/trsp/pgr_trsp.rst
+++ b/doc/trsp/pgr_trsp.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_trsp.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_trsp.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_trsp.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_trsp.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_trsp.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_trsp.html>`__
 * **Unsupported versions:**

--- a/doc/trsp/pgr_turnRestrictedPath.rst
+++ b/doc/trsp/pgr_turnRestrictedPath.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_turnRestrictedPath.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_turnRestrictedPath.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_turnRestrictedPath.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_turnRestrictedPath.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_turnRestrictedPath.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_turnRestrictedPath.html>`__
 

--- a/doc/tsp/TSP-family.rst
+++ b/doc/tsp/TSP-family.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/TSP-family.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/TSP-family.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/TSP-family.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/TSP-family.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/TSP-family.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/TSP-family.html>`__
 * **Unsupported versions:**

--- a/doc/tsp/pgr_TSP.rst
+++ b/doc/tsp/pgr_TSP.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_TSP.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_TSP.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_TSP.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_TSP.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_TSP.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_TSP.html>`__
 * **Unsupported versions:**

--- a/doc/tsp/pgr_TSPeuclidean.rst
+++ b/doc/tsp/pgr_TSPeuclidean.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_TSPeuclidean.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_TSPeuclidean.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_TSPeuclidean.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_TSPeuclidean.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_TSPeuclidean.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_TSPeuclidean.html>`__
 * **Unsupported versions:**

--- a/doc/version/pgr_full_version.rst
+++ b/doc/version/pgr_full_version.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_full_version.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_full_version.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_full_version.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_full_version.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_full_version.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_full_version.html>`__
 

--- a/doc/version/pgr_version.rst
+++ b/doc/version/pgr_version.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_version.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_version.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_version.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_version.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_version.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_version.html>`__
 * **Unsupported versions:**

--- a/doc/vrp_basic/pgr_vrpOneDepot.rst
+++ b/doc/vrp_basic/pgr_vrpOneDepot.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_vrpOneDepot.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_vrpOneDepot.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_vrpOneDepot.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_vrpOneDepot.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_vrpOneDepot.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_vrpOneDepot.html>`__
 * **Unsupported versions:**

--- a/doc/withPoints/pgr_withPoints.rst
+++ b/doc/withPoints/pgr_withPoints.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_withPoints.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_withPoints.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_withPoints.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_withPoints.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_withPoints.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_withPoints.html>`__
 * **Unsupported versions:**

--- a/doc/withPoints/pgr_withPointsCost.rst
+++ b/doc/withPoints/pgr_withPointsCost.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_withPointsCost.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_withPointsCost.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_withPointsCost.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_withPointsCost.html>`__
   `3.2 <https://docs.pgrouting.org/3.2/en/pgr_withPointsCost.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_withPointsCost.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_withPointsCost.html>`__

--- a/doc/withPoints/pgr_withPointsCostMatrix.rst
+++ b/doc/withPoints/pgr_withPointsCostMatrix.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_withPointsCostMatrix.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_withPointsCostMatrix.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_withPointsCostMatrix.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_withPointsCostMatrix.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_withPointsCostMatrix.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_withPointsCostMatrix.html>`__
 * **Unsupported versions:**

--- a/doc/withPoints/pgr_withPointsDD.rst
+++ b/doc/withPoints/pgr_withPointsDD.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_withPointsDD.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_withPointsDD.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_withPointsDD.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_withPointsDD.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_withPointsDD.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_withPointsDD.html>`__
 * **Unsupported versions:**

--- a/doc/withPoints/pgr_withPointsKSP.rst
+++ b/doc/withPoints/pgr_withPointsKSP.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_withPointsKSP.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_withPointsKSP.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_withPointsKSP.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_withPointsKSP.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_withPointsKSP.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_withPointsKSP.html>`__
 * **Unsupported versions:**

--- a/doc/withPoints/pgr_withPointsVia.rst
+++ b/doc/withPoints/pgr_withPointsVia.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/pgr_withPointsVia.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_withPointsVia.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_withPointsVia.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_withPointsVia.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_withPointsVia.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_withPointsVia.html>`__
 

--- a/doc/withPoints/withPoints-family.rst
+++ b/doc/withPoints/withPoints-family.rst
@@ -11,7 +11,8 @@
 
 * **Supported versions:**
   `Latest <https://docs.pgrouting.org/latest/en/withPoints-family.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/withPoints-family.html>`__)
+  (`3.3 <https://docs.pgrouting.org/3.3/en/withPoints-family.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/withPoints-family.html>`__
   `3.1 <https://docs.pgrouting.org/3.1/en/withPoints-family.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/withPoints-family.html>`__
 * **Unsupported versions:**

--- a/doc/withPoints/withPoints-family.rst
+++ b/doc/withPoints/withPoints-family.rst
@@ -10,8 +10,8 @@
 |
 
 * **Supported versions:**
-  `Latest <https://docs.pgrouting.org/latest/en/withPoints.html>`__
-  (`3.2 <https://docs.pgrouting.org/3.2/en/withPoints.html>`__)
+  `Latest <https://docs.pgrouting.org/latest/en/withPoints-family.html>`__
+  (`3.2 <https://docs.pgrouting.org/3.2/en/withPoints-family.html>`__)
   `3.1 <https://docs.pgrouting.org/3.1/en/withPoints-family.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/withPoints-family.html>`__
 * **Unsupported versions:**

--- a/tools/developer/README.md
+++ b/tools/developer/README.md
@@ -1,0 +1,55 @@
+How to use the scripts
+
+# addNewVersionLink.sh
+
+All the documentation files have a history of older versions.
+When a new mayor or minor is created the top lines need to change
+
+For example: the one in parenthesis is the latest version which is 3.2
+```
+  (`3.2 <https://docs.pgrouting.org/3.2/en/pgr_bipartite.html>`__)
+  `3.1 <https://docs.pgrouting.org/3.2/en/pgr_bipartite.html>`__
+  ...
+```
+And needs to be 3.3:
+```
+  (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_bipartite.html>`__)
+  `3.2 <https://docs.pgrouting.org/3.2/en/pgr_bipartite.html>`__
+  `3.1 <https://docs.pgrouting.org/3.2/en/pgr_bipartite.html>`__
+  ...
+```
+
+To achive the change: from the root of the repository:
+```
+./tools/developer/addNewVersionLink.sh "3\.2" "3\.3"'
+```
+
+# commitByDirectory.sh
+
+Some times legwork is done on a directory, for example when using the
+`addNewVersionLink.sh` script
+
+And for reviewing the pull request it is easier to do it by directory
+
+From the root of the repository:
+```
+./tools/developer/commitByDirectory.sh doc "Updating linls"
+```
+sub-directories without changes will be ignored
+
+It will create a series of commits on sub-direcotries that were changed
+for example the following commit messages will be created:
+```
+    [doc/allpairs] Updating links
+    [doc/alpha_shape] Updating links
+    [doc/astar] Updating links
+    [doc/bdAstar] Updating links
+    ...
+    [doc/transitiveClosure] Updating links
+    [doc/traversal] Updating links
+    [doc/trsp] Updating links
+    [doc/tsp] Updating links
+    [doc/version] Updating links
+    [doc/vrp_basic] Updating links
+    [doc/withPoints] Updating links
+```

--- a/tools/developer/README.md
+++ b/tools/developer/README.md
@@ -1,6 +1,6 @@
-How to use the scripts
+# How to use the scripts
 
-# addNewVersionLink.sh
+## addNewVersionLink.sh
 
 All the documentation files have a history of older versions.
 When a new mayor or minor is created the top lines need to change
@@ -24,7 +24,7 @@ To achive the change: from the root of the repository:
 ./tools/developer/addNewVersionLink.sh "3\.2" "3\.3"'
 ```
 
-# commitByDirectory.sh
+## commitByDirectory.sh
 
 Some times legwork is done on a directory, for example when using the
 `addNewVersionLink.sh` script

--- a/tools/developer/addNewVersionLink.sh
+++ b/tools/developer/addNewVersionLink.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+OLDVER=$1
+NEWVER=$2
+
+if [ -z "${OLDVER}" ] ; then echo 'USE: tools/developer/addNewVersionLink.sh "3\.2" "3\.3"'; exit 1; fi;
+if [ -z "${NEWVER}" ] ; then echo 'USE: tools/developer/addNewVersionLink.sh "3\.2" "3\.3"'; exit 1; fi;
+
+OLDSTR='^  \(`'"${OLDVER}"' (.*)\/'"${OLDVER}"'(.*)\)$'
+NEWSTR='  \(`'"${NEWVER}"' $1\/'"${NEWVER}"'$2\)\n  `'"${OLDVER}"' $1\/'"${OLDVER}"'$2'
+perl -pi -e 's/'"$OLDSTR"'/'"${NEWSTR}"'/' $(git ls-files | grep '\.rst')

--- a/tools/developer/commitByDirectory.sh
+++ b/tools/developer/commitByDirectory.sh
@@ -3,7 +3,6 @@
 DIR=$1
 TASK=$2
 
-To achive the change: ff [ -z "${DIR}" ] ; then echo "USE: tools/developer/commitByDirectory.sh directory message"; exit 1; fi;
 if [ -z "${DIR}" ] ; then echo "USE: tools/developer/commitByDirectory.sh directory message"; exit 1; fi;
 if [ -z "${TASK}" ] ; then echo "USE: tools/developer/commitByDirectory.sh directory message"; exit 1; fi;
 

--- a/tools/developer/commitByDirectory.sh
+++ b/tools/developer/commitByDirectory.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+DIR=$1
+TASK=$2
+
+To achive the change: ff [ -z "${DIR}" ] ; then echo "USE: tools/developer/commitByDirectory.sh directory message"; exit 1; fi;
+if [ -z "${DIR}" ] ; then echo "USE: tools/developer/commitByDirectory.sh directory message"; exit 1; fi;
+if [ -z "${TASK}" ] ; then echo "USE: tools/developer/commitByDirectory.sh directory message"; exit 1; fi;
+
+for d in "${DIR}"/* ; do
+    echo "--- PROCESSING $d ---"
+    COMMIT_MSG="[${d}] ${TASK}"
+    git add "${d}"
+    git diff --name-only --cached
+    sleep 3
+    git diff --cached --quiet || echo "${COMMIT_MSG}"
+    git diff --cached --quiet || git commit --no-status -m "${COMMIT_MSG}"
+done
+


### PR DESCRIPTION
Changes proposed in this pull request:
- Updates the menu of all .rst files
  - Commits are done by directory
- Cleaned up some links errors, and ignored links
- Created some scripts to do this task in a more automatic manner
  - Note that this task should be done when the major or minor version in develop changes

Basically the changes are of this kind:
```
(`3.2 <https://docs.pgrouting.org/3.2/en/allpairs-family.html>`__)
```  
to
```
  (`3.3 <https://docs.pgrouting.org/3.3/en/allpairs-family.html>`__)
  `3.2 <https://docs.pgrouting.org/3.2/en/allpairs-family.html>`__
```
@pgRouting/admins
