### PR TITLE
Adjust drivers: topologicalSort

### DIFF
--- a/include/drivers/topologicalSort/topologicalSort_driver.h
+++ b/include/drivers/topologicalSort/topologicalSort_driver.h
@@ -34,12 +34,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /* for size-t */
 #ifdef __cplusplus
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using I_rt = struct I_rt;
 #else
 #   include <stddef.h>
-#endif
-
 typedef struct Edge_t Edge_t;
 typedef struct I_rt I_rt;
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes #2104 

Changes proposed in this pull request:

-keyword `using` instead of `typedef` in C++ to avoid the creation of a new type/type-id.
-Changes made to header in `include/drivers/topologicalSort`.

@pgRouting/admins
