### PR TITLE
Adjust drivers: yen

### DIFF
--- a/include/drivers/yen/ksp_driver.h
+++ b/include/drivers/yen/ksp_driver.h
@@ -30,13 +30,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifdef __cplusplus
 #   include <cstdint>
 #   include <cstddef>
+using Edge_t = struct Edge_t;
+using Path_rt = struct Path_rt;
 #else
 #   include <stddef.h>
 #   include <stdint.h>
-#endif
-
 typedef struct Edge_t Edge_t;
 typedef struct Path_rt Path_rt;
+#endif
 
 
 #ifdef __cplusplus

--- a/include/drivers/yen/turnRestrictedPath_driver.h
+++ b/include/drivers/yen/turnRestrictedPath_driver.h
@@ -33,16 +33,19 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 /* for size_t and int64_t */
 #ifdef __cplusplus
-#  include <cstddef>
-#  include <cstdint>
+#   include <cstdint>
+#   include <cstddef>
+using Edge_t = struct Edge_t;
+using Restriction_t = struct Restriction_t;
+using Path_rt = struct Path_rt;
 #else
-#  include <stddef.h>
-#  include <stdint.h>
-#endif
-
+#   include <stddef.h>
+#   include <stdint.h>
 typedef struct Edge_t Edge_t;
 typedef struct Restriction_t Restriction_t;
 typedef struct Path_rt Path_rt;
+#endif
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/drivers/yen/withPoints_ksp_driver.h
+++ b/include/drivers/yen/withPoints_ksp_driver.h
@@ -32,16 +32,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 /* for size-t */
 #ifdef __cplusplus
-#   include <cstddef>
 #   include <cstdint>
+#   include <cstddef>
+using Point_on_edge_t = struct Point_on_edge_t;
+using Edge_t = struct Edge_t;
+using Path_rt = struct Path_rt;
 #else
 #   include <stddef.h>
 #   include <stdint.h>
-#endif
-
 typedef struct Point_on_edge_t Point_on_edge_t;
 typedef struct Edge_t Edge_t;
 typedef struct Path_rt Path_rt;
+#endif
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes #2106  .

Changes proposed in this pull request:

- keyword `using` instead of `typedef` in C++ to avoid the creation of a new type/type-id.
- Changes made to headers in `include/drivers/yen`.

@pgRouting/admins
