### PR TITLE
Add automatic locale update in GitHub actions

### DIFF
--- a/.github/workflows/locale-and-website.yml
+++ b/.github/workflows/locale-and-website.yml
@@ -1,11 +1,11 @@
-name: Publish Users Documentation
+name: Update Locale and Website
 
 on:
   workflow_dispatch:
 
 jobs:
   release:
-    name: Publish Users Documentation
+    name: Update Locale and Website
     runs-on: ubuntu-latest
 
     strategy:
@@ -27,8 +27,10 @@ jobs:
           echo "PGIS=3" >> $GITHUB_ENV
           echo "PROJECT_VERSION=${PROJECT_VERSION}" >> $GITHUB_ENV
 
-      - name: Extract commit hash
+      - name: Extract branch name and commit hash
         run: |
+          branch=${GITHUB_REF#refs/heads/}
+          echo "BRANCH=$branch" >> $GITHUB_ENV
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
           echo "GIT_HASH=$git_hash" >> $GITHUB_ENV
 
@@ -58,6 +60,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install Sphinx
           pip install sphinx-bootstrap-theme
+          pip install sphinx-intl[transifex]
           pip list
 
       - name: Configure
@@ -65,19 +68,38 @@ jobs:
           export PATH=/usr/lib/postgresql/${PGVER}/bin:$PATH
           mkdir build
           cd build
-          cmake -DPOSTGRESQL_VERSION=${PGVER} -DDOC_USE_BOOTSTRAP=ON -DWITH_DOC=ON -DBUILD_DOXY=ON -DCMAKE_BUILD_TYPE=Release -DES=ON ..
+          cmake -DPOSTGRESQL_VERSION=${PGVER} -DDOC_USE_BOOTSTRAP=ON -DWITH_DOC=ON -DBUILD_DOXY=ON -DCMAKE_BUILD_TYPE=Release -DLOCALE=ON -DES=ON ..
 
       - name: Build
         run: |
           cd build
+          if [[ "${{ env.BRANCH }}" == "develop" ]]; then
+            make locale
+          fi
           make doc
-          make -j 4
-          sudo make install
 
       - name: Initialize mandatory git config
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Update locale
+        if: github.ref == 'refs/heads/develop'
+        run: |
+          # List all the files that needs to be committed in build/doc/locale_changes.txt
+          awk '/^Update|^Create/{print $2}' build/doc/locale_changes.txt > tmp && mv tmp build/doc/locale_changes.txt        # .po files
+          cat build/doc/locale_changes.txt | perl -pe 's/(.*)en\/LC_MESSAGES(.*)/$1pot$2t/' >> build/doc/locale_changes.txt  # .pot files
+          cat build/doc/locale_changes.txt
+          # Remove obsolete entries #~ from .po files
+          tools/transifex/remove_obsolete_entries.sh
+          # Add the files, commit and push
+          for line in `cat build/doc/locale_changes.txt`; do git add "$line"; done
+          git diff --staged --quiet || git commit -m "Update locale: commit ${{ env.GIT_HASH }}"
+          git fetch origin
+          git reset --hard  # Remove the unstaged changes before rebasing
+          git rebase origin/develop
+          git push origin develop
+
 
       - name: Update Users Documentation
         run: |

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -236,7 +236,7 @@ if (LOCALE)
         "${PGR_DOCUMENTATION_SOURCE_DIR}"
         "${CMAKE_SOURCE_DIR}/locale/pot"
 
-        COMMAND sphinx-intl update -d ${CMAKE_SOURCE_DIR}/locale -l en
+        COMMAND sphinx-intl update -d ${CMAKE_SOURCE_DIR}/locale -l en > locale_changes.txt
     #COMMAND sphinx-intl update -p ${CMAKE_SOURCE_DIR}/locale/pot -d ${CMAKE_SOURCE_DIR}/locale --language=${SPHINXINTL_LANGUAGE}
     #COMMAND sphinx-intl update-txconfig-resources --locale-dir ${CMAKE_SOURCE_DIR}/locale --pot-dir ${CMAKE_SOURCE_DIR}/locale/pot --transifex-project-name pgrouting
 
@@ -244,7 +244,6 @@ if (LOCALE)
     COMMENT "Generating POT files ..."
     SOURCES ${PROJECT_DOC_FILES}
     )
-    return()
 endif()
 
 

--- a/tools/transifex/remove_obsolete_entries.sh
+++ b/tools/transifex/remove_obsolete_entries.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# pgRouting Scripts
+# Copyright(c) pgRouting Contributors
+#
+# Remove all the obsolete entries, i.e. lines starting with #~ from .po files
+# ------------------------------------------------------------------------------
+
+# For all the chapter files
+for file in locale/en/LC_MESSAGES/*.po; do
+    if grep -q '#~' $file; then
+        perl -pi -0777 -e 's/#~.*//s' $file
+        git add $file
+    fi
+done
+


### PR DESCRIPTION
Changes proposed in this pull request:
- Add code to automatically update locale on `develop`, when PR is merged to `develop`.
- Add script to remove the obsolete entries, i.e. lines starting with `#~` from .po files
- Tested on my fork: [develop branch](https://github.com/krashish8/pgrouting/commits/develop), [Actions Workflow](https://github.com/krashish8/pgrouting/actions/workflows/locale-and-website.yml)

@pgRouting/admins
