### PR TITLE
Run locale & doc actions only on the main repository

### DIFF
--- a/.github/workflows/locale-and-website.yml
+++ b/.github/workflows/locale-and-website.yml
@@ -2,11 +2,16 @@ name: Update Locale and Website
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+      - develop
 
 jobs:
   release:
     name: Update Locale and Website
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'pgRouting' }}
 
     strategy:
         fail-fast: false


### PR DESCRIPTION
Changes proposed in this pull request:
- Add code to automatically run locale and documentation actions only on the pgRouting's repository (not on forks)
- Should run when a PR is merged to either main/develop branch on the pgRouting's repository.
- Tested on forks: https://github.com/krashish8/pgrouting/actions/runs/1285246433 (The workflow run was skipped)

@pgRouting/admins
