### PR TITLE
Using requirements.txt in GitHub actions on 3.1

### DIFF
--- a/.github/workflows/locale-and-website.yml
+++ b/.github/workflows/locale-and-website.yml
@@ -63,8 +63,7 @@ jobs:
             graphviz \
             doxygen
           python -m pip install --upgrade pip
-          pip install Sphinx
-          pip install sphinx-bootstrap-theme
+          pip install -r requirements.txt
           pip install sphinx-intl[transifex]
           pip list
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,7 @@ jobs:
             graphviz \
             doxygen
           python -m pip install --upgrade pip
-          pip install Sphinx
-          pip install sphinx-bootstrap-theme
+          pip install -r requirements.txt
           pip list
 
       - name: Configure


### PR DESCRIPTION
Changes proposed in this pull request:
- Using requirements.txt in GitHub actions on 3.1 for installing Sphinx and sphinx-bootstrap-theme.

@pgRouting/admins
