### PR TITLE
[docqueries][tsp] removing randomize parameter from calls (#2234)

### DIFF
--- a/docqueries/bdAstar/doc-pgr_bdAstarCostMatrix.result
+++ b/docqueries/bdAstar/doc-pgr_bdAstarCostMatrix.result
@@ -55,8 +55,7 @@ SELECT * FROM pgr_TSP(
         (SELECT array_agg(id) FROM edge_table_vertices_pgr WHERE id < 5),
         false
     )
-    $$,
-    randomize := false
+    $$
 );
  seq | node | cost | agg_cost
 -----+------+------+----------

--- a/docqueries/bdAstar/doc-pgr_bdAstarCostMatrix.test.sql
+++ b/docqueries/bdAstar/doc-pgr_bdAstarCostMatrix.test.sql
@@ -21,7 +21,6 @@ SELECT * FROM pgr_TSP(
         (SELECT array_agg(id) FROM edge_table_vertices_pgr WHERE id < 5),
         false
     )
-    $$,
-    randomize := false
+    $$
 );
 /* -- bdAstar q4 */

--- a/docqueries/bdDijkstra/doc-pgr_bdDijkstraCostMatrix.result
+++ b/docqueries/bdDijkstra/doc-pgr_bdDijkstraCostMatrix.result
@@ -55,8 +55,7 @@ SELECT * FROM pgr_TSP(
         (SELECT array_agg(id) FROM edge_table_vertices_pgr WHERE id < 5),
         false
     )
-    $$,
-    randomize := false
+    $$
 );
  seq | node | cost | agg_cost
 -----+------+------+----------

--- a/docqueries/bdDijkstra/doc-pgr_bdDijkstraCostMatrix.test.sql
+++ b/docqueries/bdDijkstra/doc-pgr_bdDijkstraCostMatrix.test.sql
@@ -21,7 +21,6 @@ SELECT * FROM pgr_TSP(
         (SELECT array_agg(id) FROM edge_table_vertices_pgr WHERE id < 5),
         false
     )
-    $$,
-    randomize := false
+    $$
 );
 /* -- bdDijkstra q4 */

--- a/docqueries/dijkstra/doc-pgr_dijkstraCostMatrix.result
+++ b/docqueries/dijkstra/doc-pgr_dijkstraCostMatrix.result
@@ -55,8 +55,7 @@ SELECT * FROM pgr_TSP(
         (SELECT array_agg(id) FROM edge_table_vertices_pgr WHERE id < 5),
         false
     )
-    $$,
-    randomize := false
+    $$
 );
  seq | node | cost | agg_cost
 -----+------+------+----------

--- a/docqueries/dijkstra/doc-pgr_dijkstraCostMatrix.test.sql
+++ b/docqueries/dijkstra/doc-pgr_dijkstraCostMatrix.test.sql
@@ -21,7 +21,6 @@ SELECT * FROM pgr_TSP(
         (SELECT array_agg(id) FROM edge_table_vertices_pgr WHERE id < 5),
         false
     )
-    $$,
-    randomize := false
+    $$
 );
 /* -- dijkstra q4 */

--- a/docqueries/tsp/doc-pgr_TSP.result
+++ b/docqueries/tsp/doc-pgr_TSP.result
@@ -85,7 +85,7 @@ SELECT * FROM pgr_TSP(
 
 /* -- q4 */
 SELECT source AS start_vid, target AS end_vid, 1 AS agg_cost
-FROM edge_table WHERE id IN (2,4,5,8, 9, 15);
+FROM edge_table WHERE id IN (2, 4, 5, 8, 9, 15);
  start_vid | end_vid | agg_cost
 -----------+---------+----------
          2 |       3 |        1
@@ -100,8 +100,7 @@ FROM edge_table WHERE id IN (2,4,5,8, 9, 15);
 SELECT * FROM pgr_TSP(
   $$
   SELECT source AS start_vid, target AS end_vid, 1 AS agg_cost
-  FROM edge_table
-  WHERE id IN (2,4,5,8,9,15)
+  FROM edge_table WHERE id IN (2, 4, 5, 8, 9, 15)
   $$);
  seq | node | cost | agg_cost
 -----+------+------+----------

--- a/docqueries/tsp/doc-pgr_TSP.test.sql
+++ b/docqueries/tsp/doc-pgr_TSP.test.sql
@@ -34,12 +34,11 @@ SELECT * FROM pgr_TSP(
 );
 /* -- q4 */
 SELECT source AS start_vid, target AS end_vid, 1 AS agg_cost
-FROM edge_table WHERE id IN (2,4,5,8, 9, 15);
+FROM edge_table WHERE id IN (2, 4, 5, 8, 9, 15);
 /* -- q5 */
 SELECT * FROM pgr_TSP(
   $$
   SELECT source AS start_vid, target AS end_vid, 1 AS agg_cost
-  FROM edge_table
-  WHERE id IN (2,4,5,8,9,15)
+  FROM edge_table WHERE id IN (2, 4, 5, 8, 9, 15)
   $$);
 /* -- q6 */

--- a/docqueries/withPoints/doc-pgr_withPointsCostMatrix.result
+++ b/docqueries/withPoints/doc-pgr_withPointsCostMatrix.result
@@ -55,8 +55,7 @@ SELECT * FROM pgr_TSP(
         'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
         'SELECT pid, edge_id, fraction from pointsOfInterest',
         array[-1, 3, 6, -6], directed := false);
-    $$,
-    randomize := false
+    $$
 );
  seq | node | cost | agg_cost
 -----+------+------+----------

--- a/docqueries/withPoints/doc-pgr_withPointsCostMatrix.test.sql
+++ b/docqueries/withPoints/doc-pgr_withPointsCostMatrix.test.sql
@@ -21,7 +21,6 @@ SELECT * FROM pgr_TSP(
         'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
         'SELECT pid, edge_id, fraction from pointsOfInterest',
         array[-1, 3, 6, -6], directed := false);
-    $$,
-    randomize := false
+    $$
 );
 /* -- withPoints q4 */


### PR DESCRIPTION
* removing `randomize` parameter from calls

@pgRouting/admins
