### PR TITLE
Using parse-literal on allpairs, alphashape & pgr_dijkstra

### DIFF
--- a/doc/allpairs/allpairs-family.rst
+++ b/doc/allpairs/allpairs-family.rst
@@ -41,6 +41,81 @@ The following functions work on all vertices pair combinations
     pgr_floydWarshall
     pgr_johnson
 
+Introduction:
+...............................................................................
+
+.. characteristics_start
+
+The main characteristics are:
+
+- It does not return a path.
+- Returns the sum of the costs of the shortest path for each pair of nodes in
+  the graph.
+- Process is done only on edges with positive costs.
+- Boost returns a :math:`V \times V` matrix, where the infinity values.
+  Represent the distance between vertices for which there is no path.
+
+  - We return only the non infinity values in form of a set of `(start_vid,
+    end_vid, agg_cost)`.
+
+- Let be the case the values returned are stored in a table, so the unique index
+  would be the pair: `(start_vid, end_vid)`.
+
+- For the undirected graph, the results are symmetric.
+
+  - The  `agg_cost` of `(u, v)` is the same as for `(v, u)`.
+
+- When  `start_vid` = `end_vid`, the `agg_cost` = 0.
+
+- **Recommended, use a bounding box of no more than 3500 edges.**
+
+.. characteristics_end
+
+Parameters
+-------------------------------------------------------------------------------
+
+.. edges_directed_start
+
+.. list-table::
+   :width: 81
+   :widths: auto
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Default
+     - Description
+   * - `Edges SQL`_
+     - ``TEXT``
+     -
+     - SQL query as described below.
+   * - ``directed``
+     - ``BOOLEAN``
+     - ``true``
+     - * When ``true`` the graph is considered **directed**
+       * When ``false`` the graph is considered **undirected**
+
+.. edges_directed_end
+
+Inner query
+-------------------------------------------------------------------------------
+
+Edges SQL
+...............................................................................
+
+.. include:: pgRouting-concepts.rst
+    :start-after: no_id_edges_sql_start
+    :end-before: no_id_edges_sql_end
+
+Result Columns
+-------------------------------------------------------------------------------
+
+Returns set of ``(start_vid, end_vid, agg_cost)``
+
+.. include:: pgRouting-concepts.rst
+    :start-after: return_cost_start
+    :end-before: return_cost_end
+
 
 Performance
 ------------------------------------------------------------------------------

--- a/doc/allpairs/allpairs-family.rst
+++ b/doc/allpairs/allpairs-family.rst
@@ -41,8 +41,8 @@ The following functions work on all vertices pair combinations
     pgr_floydWarshall
     pgr_johnson
 
-Introduction:
-...............................................................................
+Introduction
+-------------------------------------------------------------------------------
 
 .. characteristics_start
 
@@ -74,7 +74,7 @@ The main characteristics are:
 Parameters
 -------------------------------------------------------------------------------
 
-.. edges_directed_start
+.. edges_start
 
 .. list-table::
    :width: 81
@@ -89,13 +89,15 @@ Parameters
      - ``TEXT``
      -
      - SQL query as described below.
-   * - ``directed``
-     - ``BOOLEAN``
-     - ``true``
-     - * When ``true`` the graph is considered **directed**
-       * When ``false`` the graph is considered **undirected**
 
-.. edges_directed_end
+.. edges_end
+
+Optional parameters
+...............................................................................
+
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_optionals_start
+    :end-before: dijkstra_optionals_end
 
 Inner query
 -------------------------------------------------------------------------------
@@ -109,8 +111,6 @@ Edges SQL
 
 Result Columns
 -------------------------------------------------------------------------------
-
-Returns set of ``(start_vid, end_vid, agg_cost)``
 
 .. include:: pgRouting-concepts.rst
     :start-after: return_cost_start

--- a/doc/allpairs/allpairs-family.rst
+++ b/doc/allpairs/allpairs-family.rst
@@ -88,7 +88,7 @@ Parameters
    * - `Edges SQL`_
      - ``TEXT``
      -
-     - SQL query as described below.
+     - `Edges SQL`_ as described below.
 
 .. edges_end
 

--- a/doc/allpairs/pgr_floydWarshall.rst
+++ b/doc/allpairs/pgr_floydWarshall.rst
@@ -46,6 +46,7 @@ pair of nodes in the graph using Floyd-Warshall algorithm.
 
   * **Official** function
 
+|
 
 Description
 -------------------------------------------------------------------------------
@@ -55,95 +56,64 @@ is a good choice to calculate the sum of the costs of the shortest path for each
 pair of nodes in the graph, for *dense graphs*. We use Boost's
 implementation which runs in :math:`\Theta(V^3)` time,
 
-The main characteristics are:
-  - It does not return a path.
-  - Returns the sum of the costs of the shortest path for each pair of nodes in the graph.
-  - Process is done only on edges with positive costs.
-  - Boost returns a :math:`V \times V` matrix, where the infinity values.
-    Represent the distance between vertices for which there is no path.
+.. include:: allpairs-family.rst
+   :start-after: characteristics_start
+   :end-before: characteristics_end
 
-    - We return only the non infinity values in form of a set of `(start_vid, end_vid, agg_cost)`.
-
-  - Let be the case the values returned are stored in a table, so the unique index would be the pair:
-    `(start_vid, end_vid)`.
-
-  - For the undirected graph, the results are symmetric.
-
-    - The  `agg_cost` of `(u, v)` is the same as for `(v, u)`.
-
-  - When  `start_vid` = `end_vid`, the `agg_cost` = 0.
-
-  - **Recommended, use a bounding box of no more than 3500 edges.**
+|
 
 Signatures
 -------------------------------------------------------------------------------
 
 .. rubric:: Summary
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr floydWarshall(edges_sql [, directed])
-    RETURNS SET OF (start_vid, end_vid,  agg_cost)
+    pgr floydWarshall(`Edges SQL`_ [, directed])
+    RETURNS SET OF (start_vid, end_vid, agg_cost)
     OR EMPTY SET
 
-.. rubric:: Using defaults
-
-.. code-block:: none
-
-    pgr_floydWarshall(edges_sql)
-    RETURNS SET OF (start_vid, end_vid,  agg_cost)
-    OR EMPTY SET
-
-:Example 1: For vertices :math:`\{1, 2, 3, 4\}` on a **directed** graph
-
-.. literalinclude:: doc-floydWarshall.queries
-   :start-after: -- q1
-   :end-before: -- q2
-
-Complete Signature
-...............................................................................
-
-.. code-block:: none
-
-    pgr_floydWarshall(edges_sql [, directed])
-    RETURNS SET OF (start_vid, end_vid,  agg_cost)
-    OR EMPTY SET
-
-:Example 2: For vertices :math:`\{1, 2, 3, 4\}` on an **undirected** graph
+:Example: For vertices :math:`\{1, 2, 3, 4\}` on an **undirected** graph
 
 .. literalinclude:: doc-floydWarshall.queries
    :start-after: -- q2
    :end-before: -- q3
 
+|
+
 Parameters
 -------------------------------------------------------------------------------
 
-============= ============= =================================================
-Parameter     Type          Description
-============= ============= =================================================
-**edges_sql** ``TEXT``      SQL query as described above.
-**directed**  ``BOOLEAN``   (optional) Default is true (is directed). When set to false the graph is considered as Undirected
-============= ============= =================================================
+.. include:: allpairs-family.rst
+    :start-after: edges_directed_start
+    :end-before: edges_directed_end
+
+|
 
 Inner query
 -------------------------------------------------------------------------------
 
+|
+
+Edges SQL
+...............................................................................
+
 .. include:: pgRouting-concepts.rst
     :start-after: no_id_edges_sql_start
     :end-before: no_id_edges_sql_end
+
+|
 
 Result Columns
 -------------------------------------------------------------------------------
 
 Returns set of ``(start_vid, end_vid, agg_cost)``
 
-============= ============= =================================================
-Column        Type          Description
-============= ============= =================================================
-**start_vid** ``BIGINT``    Identifier of the starting vertex.
-**end_vid**   ``BIGINT``    Identifier of the ending vertex.
-**agg_cost**  ``FLOAT``     Total cost from ``start_vid`` to ``end_vid``.
-============= ============= =================================================
+.. include:: pgRouting-concepts.rst
+    :start-after: return_cost_start
+    :end-before: return_cost_end
+
+|
 
 See Also
 -------------------------------------------------------------------------------
@@ -156,4 +126,3 @@ See Also
 
 * :ref:`genindex`
 * :ref:`search`
-

--- a/doc/allpairs/pgr_floydWarshall.rst
+++ b/doc/allpairs/pgr_floydWarshall.rst
@@ -24,7 +24,7 @@
   `2.1 <https://docs.pgrouting.org/2.1/en/src/apsp_warshall/doc/index.html>`__
   `2.0 <https://docs.pgrouting.org/2.0/en/src/apsp_warshall/doc/index.html>`__
 
-pgr_floydWarshall
+``pgr_floydWarshall``
 ===============================================================================
 
 ``pgr_floydWarshall`` - Returns the sum of the costs of the shortest path for each
@@ -46,8 +46,6 @@ pair of nodes in the graph using Floyd-Warshall algorithm.
 
   * **Official** function
 
-|
-
 Description
 -------------------------------------------------------------------------------
 
@@ -59,8 +57,6 @@ implementation which runs in :math:`\Theta(V^3)` time,
 .. include:: allpairs-family.rst
    :start-after: characteristics_start
    :end-before: characteristics_end
-
-|
 
 Signatures
 -------------------------------------------------------------------------------
@@ -79,21 +75,22 @@ Signatures
    :start-after: -- q2
    :end-before: -- q3
 
-|
-
 Parameters
 -------------------------------------------------------------------------------
 
 .. include:: allpairs-family.rst
-    :start-after: edges_directed_start
-    :end-before: edges_directed_end
+    :start-after: edges_start
+    :end-before: edges_end
 
-|
+Optional parameters
+...............................................................................
+
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_optionals_start
+    :end-before: dijkstra_optionals_end
 
 Inner query
 -------------------------------------------------------------------------------
-
-|
 
 Edges SQL
 ...............................................................................
@@ -101,8 +98,6 @@ Edges SQL
 .. include:: pgRouting-concepts.rst
     :start-after: no_id_edges_sql_start
     :end-before: no_id_edges_sql_end
-
-|
 
 Result Columns
 -------------------------------------------------------------------------------
@@ -112,8 +107,6 @@ Returns set of ``(start_vid, end_vid, agg_cost)``
 .. include:: pgRouting-concepts.rst
     :start-after: return_cost_start
     :end-before: return_cost_end
-
-|
 
 See Also
 -------------------------------------------------------------------------------

--- a/doc/allpairs/pgr_johnson.rst
+++ b/doc/allpairs/pgr_johnson.rst
@@ -46,7 +46,7 @@ pair of nodes in the graph using Floyd-Warshall algorithm.
 
   * **Official** function
 
-
+|
 
 Description
 -------------------------------------------------------------------------------
@@ -55,94 +55,64 @@ The Johnson algorithm, is a good choice to calculate the sum of the costs
 of the shortest path for each pair of nodes in the graph, for *sparse graphs*.
 It usees the Boost's implementation which runs in :math:`O(V E \log V)` time,
 
-The main characteristics are:
-  - It does not return a path.
-  - Returns the sum of the costs of the shortest path for each pair of nodes in the graph.
-  - Process is done only on edges with positive costs.
-  - Boost returns a :math:`V \times V` matrix, where the infinity values.
-    Represent the distance between vertices for which there is no path.
+.. include:: allpairs-family.rst
+   :start-after: characteristics_start
+   :end-before: characteristics_end
 
-    - We return only the non infinity values in form of a set of `(start_vid, end_vid, agg_cost)`.
-
-  - Let be the case the values returned are stored in a table, so the unique index would be the pair:
-    `(start_vid, end_vid)`.
-
-  - For the undirected graph, the results are symmetric.
-
-    - The  `agg_cost` of `(u, v)` is the same as for `(v, u)`.
-
-  - When  `start_vid` = `end_vid`, the `agg_cost` = 0.
+|
 
 Signatures
 -------------------------------------------------------------------------------
 
 .. rubric:: Summary
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_johnson(edges_sql)
-    pgr johnson(edges_sql [, directed])
+    pgr johnson(`Edges SQL`_ [, directed])
     RETURNS SET OF (start_vid, end_vid, agg_cost)
     OR EMPTY SET
 
-.. rubric:: Using default
-
-.. code-block:: none
-
-    pgr_johnson(edges_sql)
-    RETURNS SET OF (start_vid, end_vid, agg_cost)
-    OR EMPTY SET
-
-:Example 1: For vertices :math:`\{1, 2, 3, 4\}` on a **directed** graph
-
-.. literalinclude:: doc-johnson.queries
-   :start-after: -- q1
-   :end-before: -- q2
-
-Complete Signature
-...............................................................................
-
-.. code-block:: none
-
-    pgr_johnson(edges_sql[, directed])
-    RETURNS SET OF (start_vid, end_vid, agg_cost)
-    OR EMPTY SET
-
-:Example 2: For vertices :math:`\{1, 2, 3, 4\}` on an **undirected** graph
+:Example: For vertices :math:`\{1, 2, 3, 4\}` on an **undirected** graph
 
 .. literalinclude:: doc-johnson.queries
    :start-after: -- q2
    :end-before: -- q3
 
+|
+
 Parameters
 -------------------------------------------------------------------------------
 
-============= ============= =================================================
-Parameter     Type          Description
-============= ============= =================================================
-**edges_sql** ``TEXT``      SQL query as described above.
-**directed**  ``BOOLEAN``   (optional) Default is true (is directed). When set to false the graph is considered as Undirected
-============= ============= =================================================
+.. include:: allpairs-family.rst
+    :start-after: edges_directed_start
+    :end-before: edges_directed_end
+
+|
 
 Inner query
 -------------------------------------------------------------------------------
 
+|
+
+Edges SQL
+...............................................................................
+
 .. include:: pgRouting-concepts.rst
     :start-after: no_id_edges_sql_start
     :end-before: no_id_edges_sql_end
+
+|
 
 Result Columns
 -------------------------------------------------------------------------------
 
 Returns set of ``(start_vid, end_vid, agg_cost)``
 
-============= ============= =================================================
-Column        Type          Description
-============= ============= =================================================
-**start_vid** ``BIGINT``    Identifier of the starting vertex.
-**end_vid**   ``BIGINT``    Identifier of the ending vertex.
-**agg_cost**  ``FLOAT``     Total cost from ``start_vid`` to ``end_vid``.
-============= ============= =================================================
+.. include:: pgRouting-concepts.rst
+    :start-after: return_cost_start
+    :end-before: return_cost_end
+
+|
 
 See Also
 -------------------------------------------------------------------------------
@@ -155,4 +125,3 @@ See Also
 
 * :ref:`genindex`
 * :ref:`search`
-

--- a/doc/allpairs/pgr_johnson.rst
+++ b/doc/allpairs/pgr_johnson.rst
@@ -24,7 +24,7 @@
   `2.1 <https://docs.pgrouting.org/2.1/en/src/apsp_johnson/doc/index.html>`__
   `2.0 <https://docs.pgrouting.org/2.0/en/src/apsp_johnson/doc/index.html>`__
 
-pgr_johnson
+``pgr_johnson``
 ===============================================================================
 
 ``pgr_johnson`` - Returns the sum of the costs of the shortest path for each
@@ -46,8 +46,6 @@ pair of nodes in the graph using Floyd-Warshall algorithm.
 
   * **Official** function
 
-|
-
 Description
 -------------------------------------------------------------------------------
 
@@ -58,8 +56,6 @@ It usees the Boost's implementation which runs in :math:`O(V E \log V)` time,
 .. include:: allpairs-family.rst
    :start-after: characteristics_start
    :end-before: characteristics_end
-
-|
 
 Signatures
 -------------------------------------------------------------------------------
@@ -78,21 +74,22 @@ Signatures
    :start-after: -- q2
    :end-before: -- q3
 
-|
-
 Parameters
 -------------------------------------------------------------------------------
 
 .. include:: allpairs-family.rst
-    :start-after: edges_directed_start
-    :end-before: edges_directed_end
+    :start-after: edges_start
+    :end-before: edges_end
 
-|
+Optional parameters
+...............................................................................
+
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_optionals_start
+    :end-before: dijkstra_optionals_end
 
 Inner query
 -------------------------------------------------------------------------------
-
-|
 
 Edges SQL
 ...............................................................................
@@ -100,8 +97,6 @@ Edges SQL
 .. include:: pgRouting-concepts.rst
     :start-after: no_id_edges_sql_start
     :end-before: no_id_edges_sql_end
-
-|
 
 Result Columns
 -------------------------------------------------------------------------------
@@ -111,8 +106,6 @@ Returns set of ``(start_vid, end_vid, agg_cost)``
 .. include:: pgRouting-concepts.rst
     :start-after: return_cost_start
     :end-before: return_cost_end
-
-|
 
 See Also
 -------------------------------------------------------------------------------

--- a/doc/alpha_shape/pgr_alphaShape.rst
+++ b/doc/alpha_shape/pgr_alphaShape.rst
@@ -79,6 +79,7 @@ Characteristics
   * :math:`spoon\_radius = \sqrt alpha`
 
 * A Triangle area is considered part of the alpha shape when :math:`circumcenter\ radius < spoon\_radius`
+* The ``alpha`` parameter is the **spoon radius**
 * When the total number of points is less than 3, returns an EMPTY geometry
 
 
@@ -91,7 +92,7 @@ Signatures
 
 .. code-block:: none
 
-   pgr_alphaShape(geometry,   [spoon_radius])
+   pgr_alphaShape(geometry,   [alpha])
    RETURNS geometry
 
 
@@ -109,7 +110,7 @@ Parameters
 Parameter         Type               Default     Description
 ================= ================== ======== =================================================
 **geometry**      ``geometry``                Geometry with at least :math:`3` points
-**spoon_radius**  ``FLOAT``                   The radius of the spoon
+``alpha``         ``FLOAT``                   The radius of the spoon.
 ================= ================== ======== =================================================
 
 Return Value

--- a/doc/alpha_shape/pgr_alphaShape.rst
+++ b/doc/alpha_shape/pgr_alphaShape.rst
@@ -24,7 +24,7 @@
   `2.1 <https://docs.pgrouting.org/2.1/en/src/driving_distance/doc/dd_alphashape.html>`__
   `2.0 <https://docs.pgrouting.org/2.0/en/src/driving_distance/doc/dd_alphashape.html>`__
 
-pgr_alphaShape
+``pgr_alphaShape``
 ===============================================================================
 
 ``pgr_alphaShape`` — Polygon part of an alpha shape.
@@ -90,9 +90,9 @@ Signatures
 .. index::
     single: alphaShape
 
-.. code-block:: none
+.. parsed-literal::
 
-   pgr_alphaShape(geometry,   [alpha])
+   pgr_alphaShape(**geometry**,   [alpha])
    RETURNS geometry
 
 
@@ -110,7 +110,7 @@ Parameters
 Parameter         Type               Default     Description
 ================= ================== ======== =================================================
 **geometry**      ``geometry``                Geometry with at least :math:`3` points
-``alpha``         ``FLOAT``                   The radius of the spoon.
+``alpha``         ``FLOAT``          0        The radius of the spoon.
 ================= ================== ======== =================================================
 
 Return Value

--- a/doc/dijkstra/dijkstra-family.rst
+++ b/doc/dijkstra/dijkstra-family.rst
@@ -62,13 +62,125 @@ Dijkstra - Family of functions
     pgr_dijkstraNear
     pgr_dijkstraNearCost
 
+Introduction
+-------------------------------------------------------------------------------
+
+.. dijkstra_description_start
+
+Dijkstra's algorithm, conceived by Dutch computer scientist Edsger Dijkstra in
+1956.
+It is a graph search algorithm that solves the shortest path problem for a graph
+with non-negative edge path costs, producing a shortest path from a starting
+vertex to an ending vertex.
+This implementation can be used with a directed graph and an undirected graph.
+
+.. dijkstra_description_end
+
+.. dijkstra_details_start
+
+The main characteristics are:
+
+- Process is done only on edges with positive costs.
+- Values are returned when there is a path.
+- When there is no path:
+
+  - When the starting vertex and ending vertex :are the same.
+
+    - The **aggregate cost** the non included values :math:`(v, v)` is :math:`0`
+
+  - When the starting vertex and ending vertex are the different and there is
+    no path:
+
+    - The **aggregate cost** the non included values :math:`(u, v)` is
+      :math:`\infty`
+
+- For optimization purposes, any duplicated value in the starting vertices or on
+  the ending vertices are ignored.
+
+.. dijkstra_details_end
+
+The Dijkstra family functions are based on the Dijkstra algorithm.
+
+Parameters
+-------------------------------------------------------------------------------
+
+.. dijkstra_parameters_start
+
+.. list-table::
+   :width: 81
+   :widths: 14 14 44
+   :header-rows: 1
+
+   * - Column
+     - Type
+     - Description
+   * - `Edges SQL`_
+     - ``TEXT``
+     - `Edges SQL`_ as described below
+   * - `Combinations SQL`_
+     - ``TEXT``
+     - `Combinations SQL`_ as described below
+   * - **start vid**
+     - ``BIGINT``
+     - Identifier of the starting vertex of the path.
+   * - **start vids**
+     - ``ARRAY[BIGINT]``
+     -  Array of identifiers of starting vertices.
+   * - **end vid**
+     - ``BIGINT``
+     - Identifier of the ending vertex of the path.
+   * - **end vids**
+     - ``ARRAY[BIGINT]``
+     -  Array of identifiers of ending vertices.
+
+.. dijkstra_parameters_end
+
+Optional parameters
+...............................................................................
+
+.. dijkstra_optionals_start
+
+.. list-table::
+   :width: 81
+   :widths: auto
+   :header-rows: 1
+
+   * - Column
+     - Type
+     - default
+     - Description
+   * - ``directed``
+     - ``BOOLEAN``
+     - ``true``
+     - * When ``true`` Graph is considered `Directed`
+       * When ``false`` the graph is considered as `Undirected`.
+
+.. dijkstra_optionals_end
+
+Inner queries
+-------------------------------------------------------------------------------
+
+Edges SQL
+...............................................................................
+
+.. include:: pgRouting-concepts.rst
+    :start-after: basic_edges_sql_start
+    :end-before: basic_edges_sql_end
+
+Combinations SQL
+...............................................................................
+
+.. include:: pgRouting-concepts.rst
+    :start-after: basic_combinations_sql_start
+    :end-before: basic_combinations_sql_end
+
+Advanced documentation
+-------------------------------------------------------------------------------
 
 The problem definition (Advanced documentation)
------------------------------------------------
-
+...............................................................................
 
 Given the following query:
-
 
 pgr_dijkstra(:math:`sql, start_{vid}, end_{vid}, directed`)
 
@@ -158,10 +270,13 @@ where:
 
 
 
-In other words: The algorithm returns a the shortest path between :math:`start_{vid}` and :math:`end_{vid}` , if it exists, in terms of a sequence of nodes  and of edges,
-  - :math:`path\_seq` indicates the relative position in the path of the :math:`node` or :math:`edge`.
-  - :math:`cost` is the cost of the edge to be used to go to the next node.
-  - :math:`agg\_cost` is the cost from the :math:`start_{vid}` up to the node.
+In other words: The algorithm returns a the shortest path between
+:math:`start_{vid}` and :math:`end_{vid}`, if it exists, in terms of a sequence
+of nodes  and of edges,
+
+- :math:`path\_seq` indicates the relative position in the path of the :math:`node` or :math:`edge`.
+- :math:`cost` is the cost of the edge to be used to go to the next node.
+- :math:`agg\_cost` is the cost from the :math:`start_{vid}` up to the node.
 
 
 If there is no path, the resulting set is empty.

--- a/doc/dijkstra/pgr_dijkstra.rst
+++ b/doc/dijkstra/pgr_dijkstra.rst
@@ -41,7 +41,7 @@ In particular, the Dijkstra algorithm implemented by Boost.Graph.
 
   * New **Proposed** functions:
 
-    * pgr_dijkstra(combinations)
+    * ``pgr_dijkstra`` (`Combinations`_)
 
 * Version 3.0.0
 
@@ -51,26 +51,35 @@ In particular, the Dijkstra algorithm implemented by Boost.Graph.
 
   * New **proposed** functions:
 
-    * pgr_dijkstra(One to Many)
-    * pgr_dijkstra(Many to One)
-    * pgr_dijkstra(Many to Many)
+    * ``pgr_dijkstra`` (`One to Many`_)
+    * ``pgr_dijkstra`` (`Many to One`_)
+    * ``pgr_dijkstra`` (`Many to Many`_)
 
 * Version 2.1.0
 
-  * Signature change on pgr_dijkstra(One to One)
+  * Signature change on ``pgr_dijkstra`` (`One to One`_)
 
 * Version 2.0.0
 
-  * **Official** pgr_dijkstra(One to One)
+  * **Official** ``pgr_dijkstra`` (`One to One`_)
 
 
 Description
 -------------------------------------------------------------------------------
 
-Dijkstra's algorithm, conceived by Dutch computer scientist Edsger Dijkstra in 1956.
-It is a graph search algorithm that solves the shortest path problem for
-a graph with non-negative edge path costs, producing a shortest path from
-a starting vertex (``start_vid``) to an ending vertex (``end_vid``).
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_description_start
+    :end-before: dijkstra_description_end
+
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_details_start
+    :end-before: dijkstra_details_end
+
+Dijkstra's algorithm, conceived by Dutch computer scientist Edsger Dijkstra in
+1956.
+It is a graph search algorithm that solves the shortest path problem for a graph
+with non-negative edge path costs, producing a shortest path from a starting
+vertex (**start vid**) to an ending vertex (**end vid**).
 This implementation can be used with a directed graph and an undirected graph.
 
 The main characteristics are:
@@ -85,12 +94,12 @@ The main characteristics are:
 
       - The `agg_cost` the non included values `(u, v)` is :math:`\infty`
 
-  - For optimization purposes, any duplicated value in the `start_vids` or `end_vids` are ignored.
+  - For optimization purposes, any duplicated value in the `start vids` or `end vids` are ignored.
 
   - The returned values are ordered:
 
-    - `start_vid` ascending
-    - `end_vid` ascending
+    - ``start_vid`` ascending
+    - ``end vid`` ascending
 
   - Running time: :math:`O(| start\_vids | * (V \log V + E))`
 
@@ -99,28 +108,15 @@ Signatures
 
 .. rubric:: Summary
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_dijkstra(Edges SQL, start_vid,  end_vid  [, directed])
-    pgr_dijkstra(Edges SQL, start_vid,  end_vids [, directed])
-    pgr_dijkstra(Edges SQL, start_vids, end_vid  [, directed])
-    pgr_dijkstra(Edges SQL, start_vids, end_vids [, directed])
-    pgr_dijkstra(Edges SQL, Combinations SQL [, directed])
-    RETURNS SET OF (seq, path_seq [, start_vid] [, end_vid], node, edge, cost, agg_cost)
+    pgr_dijkstra(`Edges SQL`_, **start vid**, **end vid**  [, directed])
+    pgr_dijkstra(`Edges SQL`_, **start vid**, **end vids** [, directed])
+    pgr_dijkstra(`Edges SQL`_, **start vids**, **end vid**  [, directed])
+    pgr_dijkstra(`Edges SQL`_, **start vids**, **end vids** [, directed])
+    pgr_dijkstra(`Edges SQL`_, `Combinations SQL`_ [, directed])
+    RETURNS SET OF (seq, path_seq [, start vid] [, end vid], node, edge, cost, agg_cost)
     OR EMPTY SET
-
-.. rubric:: Using defaults
-
-.. code-block:: none
-
-    pgr_dijkstra(Edges SQL, start_vid, end_vid)
-    RETURNS SET OF (seq, path_seq, node, edge, cost, agg_cost) or EMPTY SET
-
-:Example: From vertex :math:`2` to vertex  :math:`3` on a **directed** graph
-
-.. literalinclude:: doc-pgr_dijkstra.queries
-   :start-after: -- q1
-   :end-before: -- q2
 
 .. index::
     single: dijkstra(One to One)
@@ -128,9 +124,10 @@ Signatures
 One to One
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_dijkstra(Edges SQL, start_vid,  end_vid  [, directed])
+    pgr_dijkstra(Edges SQL, start vid,  end vid  [, directed])
+    pgr_dijkstra(`Edges SQL`_, **start vid**, **end vid**  [, directed])
     RETURNS SET OF (seq, path_seq, node, edge, cost, agg_cost)
     OR EMPTY SET
 
@@ -146,10 +143,11 @@ One to One
 One to many
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_dijkstra(Edges SQL, start_vid, end_vids, [, directed])
-    RETURNS SET OF (seq, path_seq, end_vid, node, edge, cost, agg_cost)
+    pgr_dijkstra(`Edges SQL`_, **start vid**, **end vids** [, directed])
+    pgr_dijkstra(`Edges SQL`_, `Combinations SQL`_ [, directed])
+    RETURNS SET OF (seq, path_seq, end vid, node, edge, cost, agg_cost)
     OR EMPTY SET
 
 :Example: From vertex :math:`2` to vertices :math:`\{3, 5\}` on an **undirected** graph
@@ -164,10 +162,10 @@ One to many
 Many to One
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_dijkstra(Edges SQL, start_vids, end_vid, [, directed])
-    RETURNS SET OF (seq, path_seq, start_vid, node, edge, cost, agg_cost)
+    pgr_dijkstra(`Edges SQL`_, **start vids**, **end vids** [, directed])
+    RETURNS SET OF (seq, path_seq, start vid, node, edge, cost, agg_cost)
     OR EMPTY SET
 
 :Example: From vertices :math:`\{2, 11\}` to vertex :math:`5` on a **directed** graph
@@ -182,10 +180,10 @@ Many to One
 Many to Many
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_dijkstra(Edges SQL, start_vids, end_vids, [, directed])
-    RETURNS SET OF (seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)
+    pgr_dijkstra(`Edges SQL`_, **start vids**, **end vids** [, directed])
+    RETURNS SET OF (seq, path_seq, start vid, end vid, node, edge, cost, agg_cost)
     OR EMPTY SET
 
 :Example: From vertices :math:`\{2, 11\}` to vertices :math:`\{3, 5\}` on an **undirected** graph
@@ -200,50 +198,44 @@ Many to Many
 Combinations
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_dijkstra(Edges SQL, Combinations SQL, end_vids, [, directed])
-    RETURNS SET OF (seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)
+    pgr_dijkstra(`Edges SQL`_, `Combinations SQL`_ [, directed])
+    RETURNS SET OF (seq, path_seq, start vid, end vid, node, edge, cost, agg_cost)
     OR EMPTY SET
 
 :Example: Using a combinations table on an **undirected** graph
 
 .. literalinclude:: doc-pgr_dijkstra.queries
-   :start-after: -- q19
-   :end-before: -- q20
+   :start-after: -- q6
+   :end-before: -- q61
 
 
 Parameters
 -------------------------------------------------------------------------------
 
-.. pgr_dijkstra_parameters_start
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_parameters_start
+    :end-before: dijkstra_parameters_end
 
-====================== ================== ======== =================================================
-Parameter              Type               Default     Description
-====================== ================== ======== =================================================
-**Edges SQL**          ``TEXT``                    `Edges query`_ as described below
-**Combinations SQL**   ``TEXT``                    `Combinations query`_ as described below
-**start_vid**          ``BIGINT``                  Identifier of the starting vertex of the path.
-**start_vids**         ``ARRAY[BIGINT]``           Array of identifiers of starting vertices.
-**end_vid**            ``BIGINT``                  Identifier of the ending vertex of the path.
-**end_vids**           ``ARRAY[BIGINT]``           Array of identifiers of ending vertices.
-**directed**           ``BOOLEAN``        ``true`` - When ``true`` Graph is considered `Directed`
-                                                   - When ``false`` the graph is considered as `Undirected`.
-====================== ================== ======== =================================================
+Optional parameters
+...............................................................................
 
-.. pgr_dijkstra_parameters_end
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_optionals_start
+    :end-before: dijkstra_optionals_end
 
 Inner queries
 -------------------------------------------------------------------------------
 
-Edges query
+Edges SQL
 ...............................................................................
 
 .. include:: pgRouting-concepts.rst
     :start-after: basic_edges_sql_start
     :end-before: basic_edges_sql_end
 
-Combinations query
+Combinations SQL
 ...............................................................................
 
 .. include:: pgRouting-concepts.rst
@@ -263,63 +255,300 @@ Additional Examples
 
 The examples of this section are based on the :doc:`sampledata` network.
 
-The examples include combinations from starting vertices 2 and 11 to ending vertices 3 and 5 in a directed and
-undirected graph with and with out reverse_cost.
+.. contents::
+   :local:
 
-:Examples: For queries marked as ``directed`` with ``cost`` and ``reverse_cost`` columns
+For **directed** graphs with ``cost`` and ``reverse_cost`` columns
+...............................................................................
 
-The examples in this section use the following :ref:`fig1`
+.. figure:: /images/Fig1-originalData.png
+   :scale: 50%
+
+   Directed graph with cost and reverse cost columns
+
+:Example 1: Path from :math:`2` to :math:`3`
 
 .. literalinclude:: doc-pgr_dijkstra.queries
    :start-after: -- q7
+   :end-before: -- q71
+
+:Example 2: Path from :math:`2` to :math:`5`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q71
+   :end-before: -- q72
+
+:Example 3: Path from :math:`11` to :math:`3`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q72
+   :end-before: -- q73
+
+:Example 4: Path from :math:`11` to :math:`5`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q73
+   :end-before: -- q74
+
+:Example 5: Using `One to Many`_ to get the solution of examples 1 and 2
+
+Paths :math:`\{2\}\rightarrow\{3, 5\}`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q74
+   :end-before: -- q75
+
+:Example 6: Using `Many to One`_ to get the solution of examples 2 and 4
+
+Paths :math:`\{2, 11\}\rightarrow\{5\}`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q75
+   :end-before: -- q76
+
+:Example 7: Using `Many to Many`_ to get the solution of examples 1 to 4
+
+Paths :math:`\{2, 11\}\rightarrow\{3, 5\}`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q76
+   :end-before: -- q77
+
+:Example 8: Using `Combinations`_ to get the solution of examples 1 to 3
+
+Paths :math:`\{2\}\rightarrow\{3, 5\}\cup\{11\}\rightarrow\{3\}`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q77
    :end-before: -- q8
 
-:Examples: For queries marked as ``undirected`` with ``cost`` and ``reverse_cost`` columns
+For **undirected** graphs with ``cost`` and ``reverse_cost`` columns
+...............................................................................
 
-The examples in this section use the following :ref:`fig2`
+.. figure:: /images/Fig6-undirected.png
+   :scale: 50%
+
+   Undirected graph with cost and reverse cost columns
+
+:Example 9: Path from :math:`2` to :math:`3`
 
 .. literalinclude:: doc-pgr_dijkstra.queries
    :start-after: -- q9
+   :end-before: -- q91
+
+:Example 10: Path from :math:`2` to :math:`5`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q91
+   :end-before: -- q92
+
+:Example 11: Path from :math:`11` to :math:`3`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q92
+   :end-before: -- q93
+
+:Example 12: Path from :math:`11` to :math:`5`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q93
+   :end-before: -- q94
+
+:Example 13: Using `One to Many`_ to get the solution of examples 9 and 10
+
+Paths :math:`\{2\}\rightarrow\{3, 5\}`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q94
+   :end-before: -- q95
+
+:Example 14: Using `Many to One`_ to get the solution of examples 10 and 12
+
+Paths :math:`\{2, 11\}\rightarrow\{5\}`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q95
+   :end-before: -- q96
+
+:Example 15: Using `Many to Many`_ to get the solution of examples 9 to 12
+
+Paths :math:`\{2, 11\}\rightarrow\{3, 5\}`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q96
+   :end-before: -- q97
+
+:Example 16: Using `Combinations`_ to get the solution of examples 9 to 11
+
+Paths :math:`\{2\}\rightarrow\{3, 5\}\cup\{11\}\rightarrow\{3\}`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q97
    :end-before: -- q10
 
-:Examples: For queries marked as ``directed`` with ``cost`` column
+For **directed** graphs only with ``cost`` column
+...............................................................................
 
-The examples in this section use the following :ref:`fig3`
+.. figure:: /images/Fig2-cost.png
+   :scale: 50%
+
+   Directed graph only with cost column
+
+:Example 17: Path from :math:`2` to :math:`3`
 
 .. literalinclude:: doc-pgr_dijkstra.queries
    :start-after: -- q11
+   :end-before: -- q111
+
+:Example 18: Path from :math:`2` to :math:`5`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q111
+   :end-before: -- q112
+
+:Example 19: Path from :math:`11` to :math:`3`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q112
+   :end-before: -- q113
+
+:Example 20: Path from :math:`11` to :math:`5`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q113
+   :end-before: -- q114
+
+:Example 21: Using `One to Many`_ to get the solution of examples 17 and 18
+
+Paths :math:`\{2\}\rightarrow\{3, 5\}`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q114
+   :end-before: -- q115
+
+:Example 22: Using `Many to One`_ to get the solution of examples 18 and 20
+
+Paths :math:`\{2, 11\}\rightarrow\{5\}`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q115
+   :end-before: -- q116
+
+:Example 23: Using `Many to Many`_ to get the solution of examples 17 to 20
+
+Paths :math:`\{2, 11\}\rightarrow\{3, 5\}`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q116
+   :end-before: -- q117
+
+:Example 24: Using `Combinations`_ to get the solution of examples 17 to 19
+
+Paths :math:`\{2\}\rightarrow\{3, 5\}\cup\{11\}\rightarrow\{3\}`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q117
    :end-before: -- q12
 
-:Examples: For queries marked as ``undirected`` with ``cost`` column
+For **undirected** graphs only with ``cost`` column
+...............................................................................
 
-The examples in this section use the following :ref:`fig4`
+.. figure:: /images/Fig4-costUndirected.png
+   :scale: 50%
+
+   Undirected graph only with cost column
+
+:Example 25: Path from :math:`2` to :math:`3`
 
 .. literalinclude:: doc-pgr_dijkstra.queries
    :start-after: -- q13
+   :end-before: -- q131
+
+:Example 26: Path from :math:`2` to :math:`5`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q131
+   :end-before: -- q132
+
+:Example 27: Path from :math:`11` to :math:`3`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q132
+   :end-before: -- q133
+
+:Example 28: Path from :math:`11` to :math:`5`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q133
+   :end-before: -- q134
+
+:Example 29: Using `One to Many`_ to get the solution of examples 17 and 18
+
+Paths :math:`\{2\}\rightarrow\{3, 5\}`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q134
+   :end-before: -- q135
+
+:Example 30: Using `Many to One`_ to get the solution of examples 18 and 20
+
+Paths :math:`\{2, 11\}\rightarrow\{5\}`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q135
+   :end-before: -- q136
+
+:Example 31: Using `Many to Many`_ to get the solution of examples 17 to 20
+
+Paths :math:`\{2, 11\}\rightarrow\{3, 5\}`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q136
+   :end-before: -- q137
+
+:Example 32: Using `Combinations`_ to get the solution of examples 17 to 19
+
+Paths :math:`\{2\}\rightarrow\{3, 5\}\cup\{11\}\rightarrow\{3\}`
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q137
    :end-before: -- q14
+
 
 Equvalences between signatures
 ...............................................................................
 
-:Examples: For queries marked as ``directed`` with ``cost`` and ``reverse_cost`` columns
+The following examples find the path for :math:`\{2\}\rightarrow\{3\}`
 
-The examples in this section use the following:
-
-* :ref:`fig1`
+:Example 33: Using `One to One`_
 
 .. literalinclude:: doc-pgr_dijkstra.queries
    :start-after: -- q15
-   :end-before: -- q16
+   :end-before: -- q151
 
-:Examples: For queries marked as ``undirected`` with ``cost`` and ``reverse_cost`` columns
-
-The examples in this section use the following:
-
-* :ref:`fig2`
+:Example 34: Using `One to Many`_
 
 .. literalinclude:: doc-pgr_dijkstra.queries
-   :start-after: -- q17
-   :end-before: -- q18
+   :start-after: -- q151
+   :end-before: -- q152
+
+:Example 35: Using `Many to One`_
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q152
+   :end-before: -- q153
+
+:Example 36: Using `Many to Many`_
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q153
+   :end-before: -- q154
+
+:Example 37: Using `Combinations`_
+
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q154
+   :end-before: -- q16
 
 See Also
 -------------------------------------------------------------------------------

--- a/doc/dijkstra/pgr_dijkstra.rst
+++ b/doc/dijkstra/pgr_dijkstra.rst
@@ -24,7 +24,7 @@
   `2.1 <https://docs.pgrouting.org/2.1/en/src/dijkstra/doc/index.html>`__
   `2.0 <https://docs.pgrouting.org/2.0/en/src/dijkstra/doc/index.html>`__
 
-pgr_dijkstra
+``pgr_dijkstra``
 ===============================================================================
 
 ``pgr_dijkstra`` — Returns the shortest path(s) using Dijkstra algorithm.

--- a/doc/dijkstra/pgr_dijkstraCost.rst
+++ b/doc/dijkstra/pgr_dijkstraCost.rst
@@ -210,21 +210,28 @@ Combinations
 Parameters
 -------------------------------------------------------------------------------
 
-.. include:: pgr_dijkstra.rst
-    :start-after: pgr_dijkstra_parameters_start
-    :end-before: pgr_dijkstra_parameters_end
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_parameters_start
+    :end-before: dijkstra_parameters_end
+
+Optional parameters
+...............................................................................
+
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_optionals_start
+    :end-before: dijkstra_optionals_end
 
 Inner query
 -------------------------------------------------------------------------------
 
-Edges query
+Edges SQL
 ...............................................................................
 
 .. include:: pgRouting-concepts.rst
     :start-after: basic_edges_sql_start
     :end-before: basic_edges_sql_end
 
-Combinations query
+Combinations SQL
 ...............................................................................
 
 .. include:: pgRouting-concepts.rst

--- a/doc/src/pgRouting-concepts.rst
+++ b/doc/src/pgRouting-concepts.rst
@@ -688,6 +688,7 @@ Return columns for cost functions
 
 * Cost functions
 * :doc:`costMatrix-category`
+* :doc:`allpairs-family`
 
 .. return_cost_start
 

--- a/docqueries/dijkstra/doc-pgr_dijkstra.result
+++ b/docqueries/dijkstra/doc-pgr_dijkstra.result
@@ -4,8 +4,8 @@ SET client_min_messages TO NOTICE;
 SET
 /* -- q1 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, 3
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, 3
 );
  seq | path_seq | node | edge | cost | agg_cost
 -----+----------+------+------+------+----------
@@ -19,9 +19,9 @@ SELECT * FROM pgr_dijkstra(
 
 /* -- q2 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, 3,
-    FALSE
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, 3,
+  false
 );
  seq | path_seq | node | edge | cost | agg_cost
 -----+----------+------+------+------+----------
@@ -31,9 +31,9 @@ SELECT * FROM pgr_dijkstra(
 
 /* -- q3 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    2, ARRAY[3,5],
-    FALSE
+  'SELECT id, source, target, cost FROM edge_table',
+  2, ARRAY[3,5],
+  false
 );
  seq | path_seq | end_vid | node | edge | cost | agg_cost
 -----+----------+---------+------+------+------+----------
@@ -47,8 +47,8 @@ SELECT * FROM pgr_dijkstra(
 
 /* -- q4 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2,11], 5
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  ARRAY[2,11], 5
 );
  seq | path_seq | start_vid | node | edge | cost | agg_cost
 -----+----------+-----------+------+------+------+----------
@@ -63,9 +63,9 @@ SELECT * FROM pgr_dijkstra(
 
 /* -- q5 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2,11], ARRAY[3,5],
-    FALSE
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  ARRAY[2,11], ARRAY[3,5],
+  false
 );
  seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
 -----+----------+-----------+---------+------+------+------+----------
@@ -82,630 +82,10 @@ SELECT * FROM pgr_dijkstra(
 (10 rows)
 
 /* -- q6 */
-
-
-/* -- q7 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, 3
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |    2 |    4 |    1 |        0
-   2 |        2 |    5 |    8 |    1 |        1
-   3 |        3 |    6 |    9 |    1 |        2
-   4 |        4 |    9 |   16 |    1 |        3
-   5 |        5 |    4 |    3 |    1 |        4
-   6 |        6 |    3 |   -1 |    0 |        5
-(6 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, 5
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |    2 |    4 |    1 |        0
-   2 |        2 |    5 |   -1 |    0 |        1
-(2 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, ARRAY[3,5]
-);
- seq | path_seq | end_vid | node | edge | cost | agg_cost
------+----------+---------+------+------+------+----------
-   1 |        1 |       3 |    2 |    4 |    1 |        0
-   2 |        2 |       3 |    5 |    8 |    1 |        1
-   3 |        3 |       3 |    6 |    9 |    1 |        2
-   4 |        4 |       3 |    9 |   16 |    1 |        3
-   5 |        5 |       3 |    4 |    3 |    1 |        4
-   6 |        6 |       3 |    3 |   -1 |    0 |        5
-   7 |        1 |       5 |    2 |    4 |    1 |        0
-   8 |        2 |       5 |    5 |   -1 |    0 |        1
-(8 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    11, 3
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |   11 |   13 |    1 |        0
-   2 |        2 |   12 |   15 |    1 |        1
-   3 |        3 |    9 |   16 |    1 |        2
-   4 |        4 |    4 |    3 |    1 |        3
-   5 |        5 |    3 |   -1 |    0 |        4
-(5 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    11, 5
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |   11 |   13 |    1 |        0
-   2 |        2 |   12 |   15 |    1 |        1
-   3 |        3 |    9 |    9 |    1 |        2
-   4 |        4 |    6 |    8 |    1 |        3
-   5 |        5 |    5 |   -1 |    0 |        4
-(5 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2,11], 5
-);
- seq | path_seq | start_vid | node | edge | cost | agg_cost
------+----------+-----------+------+------+------+----------
-   1 |        1 |         2 |    2 |    4 |    1 |        0
-   2 |        2 |         2 |    5 |   -1 |    0 |        1
-   3 |        1 |        11 |   11 |   13 |    1 |        0
-   4 |        2 |        11 |   12 |   15 |    1 |        1
-   5 |        3 |        11 |    9 |    9 |    1 |        2
-   6 |        4 |        11 |    6 |    8 |    1 |        3
-   7 |        5 |        11 |    5 |   -1 |    0 |        4
-(7 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2, 11], ARRAY[3,5]
-);
- seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
------+----------+-----------+---------+------+------+------+----------
-   1 |        1 |         2 |       3 |    2 |    4 |    1 |        0
-   2 |        2 |         2 |       3 |    5 |    8 |    1 |        1
-   3 |        3 |         2 |       3 |    6 |    9 |    1 |        2
-   4 |        4 |         2 |       3 |    9 |   16 |    1 |        3
-   5 |        5 |         2 |       3 |    4 |    3 |    1 |        4
-   6 |        6 |         2 |       3 |    3 |   -1 |    0 |        5
-   7 |        1 |         2 |       5 |    2 |    4 |    1 |        0
-   8 |        2 |         2 |       5 |    5 |   -1 |    0 |        1
-   9 |        1 |        11 |       3 |   11 |   13 |    1 |        0
-  10 |        2 |        11 |       3 |   12 |   15 |    1 |        1
-  11 |        3 |        11 |       3 |    9 |   16 |    1 |        2
-  12 |        4 |        11 |       3 |    4 |    3 |    1 |        3
-  13 |        5 |        11 |       3 |    3 |   -1 |    0 |        4
-  14 |        1 |        11 |       5 |   11 |   13 |    1 |        0
-  15 |        2 |        11 |       5 |   12 |   15 |    1 |        1
-  16 |        3 |        11 |       5 |    9 |    9 |    1 |        2
-  17 |        4 |        11 |       5 |    6 |    8 |    1 |        3
-  18 |        5 |        11 |       5 |    5 |   -1 |    0 |        4
-(18 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    'SELECT * FROM (VALUES (2, 3), (2, 5), (11, 3), (11, 5)) AS combinations (source, target)'
-);
- seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
------+----------+-----------+---------+------+------+------+----------
-   1 |        1 |         2 |       3 |    2 |    4 |    1 |        0
-   2 |        2 |         2 |       3 |    5 |    8 |    1 |        1
-   3 |        3 |         2 |       3 |    6 |    9 |    1 |        2
-   4 |        4 |         2 |       3 |    9 |   16 |    1 |        3
-   5 |        5 |         2 |       3 |    4 |    3 |    1 |        4
-   6 |        6 |         2 |       3 |    3 |   -1 |    0 |        5
-   7 |        1 |         2 |       5 |    2 |    4 |    1 |        0
-   8 |        2 |         2 |       5 |    5 |   -1 |    0 |        1
-   9 |        1 |        11 |       3 |   11 |   13 |    1 |        0
-  10 |        2 |        11 |       3 |   12 |   15 |    1 |        1
-  11 |        3 |        11 |       3 |    9 |   16 |    1 |        2
-  12 |        4 |        11 |       3 |    4 |    3 |    1 |        3
-  13 |        5 |        11 |       3 |    3 |   -1 |    0 |        4
-  14 |        1 |        11 |       5 |   11 |   13 |    1 |        0
-  15 |        2 |        11 |       5 |   12 |   15 |    1 |        1
-  16 |        3 |        11 |       5 |    9 |    9 |    1 |        2
-  17 |        4 |        11 |       5 |    6 |    8 |    1 |        3
-  18 |        5 |        11 |       5 |    5 |   -1 |    0 |        4
-(18 rows)
-
-/* -- q8 */
-
-
-/* -- q9 */
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, 3,
-    FALSE
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |    2 |    2 |    1 |        0
-   2 |        2 |    3 |   -1 |    0 |        1
-(2 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, 5,
-    FALSE
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |    2 |    4 |    1 |        0
-   2 |        2 |    5 |   -1 |    0 |        1
-(2 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    11, 3,
-    FALSE
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |   11 |   11 |    1 |        0
-   2 |        2 |    6 |    5 |    1 |        1
-   3 |        3 |    3 |   -1 |    0 |        2
-(3 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    11, 5,
-    FALSE
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |   11 |   11 |    1 |        0
-   2 |        2 |    6 |    8 |    1 |        1
-   3 |        3 |    5 |   -1 |    0 |        2
-(3 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2,11], 5,
-    FALSE
-);
- seq | path_seq | start_vid | node | edge | cost | agg_cost
------+----------+-----------+------+------+------+----------
-   1 |        1 |         2 |    2 |    4 |    1 |        0
-   2 |        2 |         2 |    5 |   -1 |    0 |        1
-   3 |        1 |        11 |   11 |   12 |    1 |        0
-   4 |        2 |        11 |   10 |   10 |    1 |        1
-   5 |        3 |        11 |    5 |   -1 |    0 |        2
-(5 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, ARRAY[3,5],
-    FALSE
-);
- seq | path_seq | end_vid | node | edge | cost | agg_cost
------+----------+---------+------+------+------+----------
-   1 |        1 |       3 |    2 |    2 |    1 |        0
-   2 |        2 |       3 |    3 |   -1 |    0 |        1
-   3 |        1 |       5 |    2 |    4 |    1 |        0
-   4 |        2 |       5 |    5 |   -1 |    0 |        1
-(4 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2, 11], ARRAY[3,5],
-    FALSE
-);
- seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
------+----------+-----------+---------+------+------+------+----------
-   1 |        1 |         2 |       3 |    2 |    2 |    1 |        0
-   2 |        2 |         2 |       3 |    3 |   -1 |    0 |        1
-   3 |        1 |         2 |       5 |    2 |    4 |    1 |        0
-   4 |        2 |         2 |       5 |    5 |   -1 |    0 |        1
-   5 |        1 |        11 |       3 |   11 |   11 |    1 |        0
-   6 |        2 |        11 |       3 |    6 |    5 |    1 |        1
-   7 |        3 |        11 |       3 |    3 |   -1 |    0 |        2
-   8 |        1 |        11 |       5 |   11 |   11 |    1 |        0
-   9 |        2 |        11 |       5 |    6 |    8 |    1 |        1
-  10 |        3 |        11 |       5 |    5 |   -1 |    0 |        2
-(10 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    'SELECT * FROM (VALUES (2, 3), (2, 5), (11, 3), (11, 5)) AS combinations (source, target)',
-    FALSE
-);
- seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
------+----------+-----------+---------+------+------+------+----------
-   1 |        1 |         2 |       3 |    2 |    2 |    1 |        0
-   2 |        2 |         2 |       3 |    3 |   -1 |    0 |        1
-   3 |        1 |         2 |       5 |    2 |    4 |    1 |        0
-   4 |        2 |         2 |       5 |    5 |   -1 |    0 |        1
-   5 |        1 |        11 |       3 |   11 |   11 |    1 |        0
-   6 |        2 |        11 |       3 |    6 |    5 |    1 |        1
-   7 |        3 |        11 |       3 |    3 |   -1 |    0 |        2
-   8 |        1 |        11 |       5 |   11 |   11 |    1 |        0
-   9 |        2 |        11 |       5 |    6 |    8 |    1 |        1
-  10 |        3 |        11 |       5 |    5 |   -1 |    0 |        2
-(10 rows)
-
-/* -- q10 */
-
-
-/* -- q11 */
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    2, 3
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-(0 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    2, 5
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |    2 |    4 |    1 |        0
-   2 |        2 |    5 |   -1 |    0 |        1
-(2 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    11, 3
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-(0 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    11, 5
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-(0 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    ARRAY[2,11], 5
-);
- seq | path_seq | start_vid | node | edge | cost | agg_cost
------+----------+-----------+------+------+------+----------
-   1 |        1 |         2 |    2 |    4 |    1 |        0
-   2 |        2 |         2 |    5 |   -1 |    0 |        1
-(2 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    2, ARRAY[3,5]
-);
- seq | path_seq | end_vid | node | edge | cost | agg_cost
------+----------+---------+------+------+------+----------
-   1 |        1 |       5 |    2 |    4 |    1 |        0
-   2 |        2 |       5 |    5 |   -1 |    0 |        1
-(2 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    ARRAY[2, 11], ARRAY[3,5]
-);
- seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
------+----------+-----------+---------+------+------+------+----------
-   1 |        1 |         2 |       5 |    2 |    4 |    1 |        0
-   2 |        2 |         2 |       5 |    5 |   -1 |    0 |        1
-(2 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    'SELECT * FROM (VALUES (2, 3), (2, 5), (11, 3), (11, 5)) AS combinations (source, target)'
-);
- seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
------+----------+-----------+---------+------+------+------+----------
-   1 |        1 |         2 |       5 |    2 |    4 |    1 |        0
-   2 |        2 |         2 |       5 |    5 |   -1 |    0 |        1
-(2 rows)
-
-/* -- q12 */
-
-
-/* -- q13 */
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    2, 3,
-    FALSE
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |    2 |    4 |    1 |        0
-   2 |        2 |    5 |    8 |    1 |        1
-   3 |        3 |    6 |    5 |    1 |        2
-   4 |        4 |    3 |   -1 |    0 |        3
-(4 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    2, 5,
-    FALSE
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |    2 |    4 |    1 |        0
-   2 |        2 |    5 |   -1 |    0 |        1
-(2 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    11, 3,
-    FALSE
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |   11 |   11 |    1 |        0
-   2 |        2 |    6 |    5 |    1 |        1
-   3 |        3 |    3 |   -1 |    0 |        2
-(3 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    11, 5,
-    FALSE
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |   11 |   11 |    1 |        0
-   2 |        2 |    6 |    8 |    1 |        1
-   3 |        3 |    5 |   -1 |    0 |        2
-(3 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    ARRAY[2,11], 5,
-    FALSE
-);
- seq | path_seq | start_vid | node | edge | cost | agg_cost
------+----------+-----------+------+------+------+----------
-   1 |        1 |         2 |    2 |    4 |    1 |        0
-   2 |        2 |         2 |    5 |   -1 |    0 |        1
-   3 |        1 |        11 |   11 |   12 |    1 |        0
-   4 |        2 |        11 |   10 |   10 |    1 |        1
-   5 |        3 |        11 |    5 |   -1 |    0 |        2
-(5 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    2, ARRAY[3,5],
-    FALSE
-);
- seq | path_seq | end_vid | node | edge | cost | agg_cost
------+----------+---------+------+------+------+----------
-   1 |        1 |       3 |    2 |    4 |    1 |        0
-   2 |        2 |       3 |    5 |    8 |    1 |        1
-   3 |        3 |       3 |    6 |    5 |    1 |        2
-   4 |        4 |       3 |    3 |   -1 |    0 |        3
-   5 |        1 |       5 |    2 |    4 |    1 |        0
-   6 |        2 |       5 |    5 |   -1 |    0 |        1
-(6 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    ARRAY[2, 11], ARRAY[3,5],
-    FALSE
-);
- seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
------+----------+-----------+---------+------+------+------+----------
-   1 |        1 |         2 |       3 |    2 |    4 |    1 |        0
-   2 |        2 |         2 |       3 |    5 |    8 |    1 |        1
-   3 |        3 |         2 |       3 |    6 |    5 |    1 |        2
-   4 |        4 |         2 |       3 |    3 |   -1 |    0 |        3
-   5 |        1 |         2 |       5 |    2 |    4 |    1 |        0
-   6 |        2 |         2 |       5 |    5 |   -1 |    0 |        1
-   7 |        1 |        11 |       3 |   11 |   11 |    1 |        0
-   8 |        2 |        11 |       3 |    6 |    5 |    1 |        1
-   9 |        3 |        11 |       3 |    3 |   -1 |    0 |        2
-  10 |        1 |        11 |       5 |   11 |   11 |    1 |        0
-  11 |        2 |        11 |       5 |    6 |    8 |    1 |        1
-  12 |        3 |        11 |       5 |    5 |   -1 |    0 |        2
-(12 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    'SELECT * FROM (VALUES (2, 3), (2, 5), (11, 3), (11, 5)) AS combinations (source, target)',
-    FALSE
-);
- seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
------+----------+-----------+---------+------+------+------+----------
-   1 |        1 |         2 |       3 |    2 |    4 |    1 |        0
-   2 |        2 |         2 |       3 |    5 |    8 |    1 |        1
-   3 |        3 |         2 |       3 |    6 |    5 |    1 |        2
-   4 |        4 |         2 |       3 |    3 |   -1 |    0 |        3
-   5 |        1 |         2 |       5 |    2 |    4 |    1 |        0
-   6 |        2 |         2 |       5 |    5 |   -1 |    0 |        1
-   7 |        1 |        11 |       3 |   11 |   11 |    1 |        0
-   8 |        2 |        11 |       3 |    6 |    5 |    1 |        1
-   9 |        3 |        11 |       3 |    3 |   -1 |    0 |        2
-  10 |        1 |        11 |       5 |   11 |   11 |    1 |        0
-  11 |        2 |        11 |       5 |    6 |    8 |    1 |        1
-  12 |        3 |        11 |       5 |    5 |   -1 |    0 |        2
-(12 rows)
-
-/* -- q14 */
-
-
-/* -- q15 */
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, 3,
-    TRUE
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |    2 |    4 |    1 |        0
-   2 |        2 |    5 |    8 |    1 |        1
-   3 |        3 |    6 |    9 |    1 |        2
-   4 |        4 |    9 |   16 |    1 |        3
-   5 |        5 |    4 |    3 |    1 |        4
-   6 |        6 |    3 |   -1 |    0 |        5
-(6 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2,3
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |    2 |    4 |    1 |        0
-   2 |        2 |    5 |    8 |    1 |        1
-   3 |        3 |    6 |    9 |    1 |        2
-   4 |        4 |    9 |   16 |    1 |        3
-   5 |        5 |    4 |    3 |    1 |        4
-   6 |        6 |    3 |   -1 |    0 |        5
-(6 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, ARRAY[3],
-    TRUE
-);
- seq | path_seq | end_vid | node | edge | cost | agg_cost
------+----------+---------+------+------+------+----------
-   1 |        1 |       3 |    2 |    4 |    1 |        0
-   2 |        2 |       3 |    5 |    8 |    1 |        1
-   3 |        3 |       3 |    6 |    9 |    1 |        2
-   4 |        4 |       3 |    9 |   16 |    1 |        3
-   5 |        5 |       3 |    4 |    3 |    1 |        4
-   6 |        6 |       3 |    3 |   -1 |    0 |        5
-(6 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, ARRAY[3]
-);
- seq | path_seq | end_vid | node | edge | cost | agg_cost
------+----------+---------+------+------+------+----------
-   1 |        1 |       3 |    2 |    4 |    1 |        0
-   2 |        2 |       3 |    5 |    8 |    1 |        1
-   3 |        3 |       3 |    6 |    9 |    1 |        2
-   4 |        4 |       3 |    9 |   16 |    1 |        3
-   5 |        5 |       3 |    4 |    3 |    1 |        4
-   6 |        6 |       3 |    3 |   -1 |    0 |        5
-(6 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2], ARRAY[3],
-    TRUE
-);
- seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
------+----------+-----------+---------+------+------+------+----------
-   1 |        1 |         2 |       3 |    2 |    4 |    1 |        0
-   2 |        2 |         2 |       3 |    5 |    8 |    1 |        1
-   3 |        3 |         2 |       3 |    6 |    9 |    1 |        2
-   4 |        4 |         2 |       3 |    9 |   16 |    1 |        3
-   5 |        5 |         2 |       3 |    4 |    3 |    1 |        4
-   6 |        6 |         2 |       3 |    3 |   -1 |    0 |        5
-(6 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2], ARRAY[3]
-);
- seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
------+----------+-----------+---------+------+------+------+----------
-   1 |        1 |         2 |       3 |    2 |    4 |    1 |        0
-   2 |        2 |         2 |       3 |    5 |    8 |    1 |        1
-   3 |        3 |         2 |       3 |    6 |    9 |    1 |        2
-   4 |        4 |         2 |       3 |    9 |   16 |    1 |        3
-   5 |        5 |         2 |       3 |    4 |    3 |    1 |        4
-   6 |        6 |         2 |       3 |    3 |   -1 |    0 |        5
-(6 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    'SELECT * FROM (VALUES(2, 3)) AS combinations (source, target)'
-);
- seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
------+----------+-----------+---------+------+------+------+----------
-   1 |        1 |         2 |       3 |    2 |    4 |    1 |        0
-   2 |        2 |         2 |       3 |    5 |    8 |    1 |        1
-   3 |        3 |         2 |       3 |    6 |    9 |    1 |        2
-   4 |        4 |         2 |       3 |    9 |   16 |    1 |        3
-   5 |        5 |         2 |       3 |    4 |    3 |    1 |        4
-   6 |        6 |         2 |       3 |    3 |   -1 |    0 |        5
-(6 rows)
-
-/* -- q16 */
-
-
-/* -- q17 */
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, 3,
-    FALSE
-);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |    2 |    2 |    1 |        0
-   2 |        2 |    3 |   -1 |    0 |        1
-(2 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, ARRAY[3],
-    FALSE
-);
- seq | path_seq | end_vid | node | edge | cost | agg_cost
------+----------+---------+------+------+------+----------
-   1 |        1 |       3 |    2 |    2 |    1 |        0
-   2 |        2 |       3 |    3 |   -1 |    0 |        1
-(2 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2], 3,
-    FALSE
-);
- seq | path_seq | start_vid | node | edge | cost | agg_cost
------+----------+-----------+------+------+------+----------
-   1 |        1 |         2 |    2 |    2 |    1 |        0
-   2 |        2 |         2 |    3 |   -1 |    0 |        1
-(2 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2], ARRAY[3],
-    FALSE
-);
- seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
------+----------+-----------+---------+------+------+------+----------
-   1 |        1 |         2 |       3 |    2 |    2 |    1 |        0
-   2 |        2 |         2 |       3 |    3 |   -1 |    0 |        1
-(2 rows)
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    'SELECT * FROM (VALUES(2, 3)) AS combinations (source, target)',
-    FALSE
-);
- seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
------+----------+-----------+---------+------+------+------+----------
-   1 |        1 |         2 |       3 |    2 |    2 |    1 |        0
-   2 |        2 |         2 |       3 |    3 |   -1 |    0 |        1
-(2 rows)
-
-/* -- q18 */
-
-
-/* -- q19 */
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    'SELECT * FROM combinations_table',
-    FALSE
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  'SELECT * FROM combinations_table',
+  false
 );
  seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
 -----+----------+-----------+---------+------+------+------+----------
@@ -721,6 +101,554 @@ SELECT * FROM pgr_dijkstra(
   10 |        3 |         2 |       4 |    4 |   -1 |    0 |        2
 (10 rows)
 
-/* -- q20 */
+/* -- q61 */
+
+
+/* -- q7 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, 3
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+   1 |        1 |    2 |    4 |    1 |        0
+   2 |        2 |    5 |    8 |    1 |        1
+   3 |        3 |    6 |    9 |    1 |        2
+   4 |        4 |    9 |   16 |    1 |        3
+   5 |        5 |    4 |    3 |    1 |        4
+   6 |        6 |    3 |   -1 |    0 |        5
+(6 rows)
+
+/* -- q71 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, 5
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+   1 |        1 |    2 |    4 |    1 |        0
+   2 |        2 |    5 |   -1 |    0 |        1
+(2 rows)
+
+/* -- q72 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  11, 3
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+   1 |        1 |   11 |   13 |    1 |        0
+   2 |        2 |   12 |   15 |    1 |        1
+   3 |        3 |    9 |   16 |    1 |        2
+   4 |        4 |    4 |    3 |    1 |        3
+   5 |        5 |    3 |   -1 |    0 |        4
+(5 rows)
+
+/* -- q73 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  11, 5
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+   1 |        1 |   11 |   13 |    1 |        0
+   2 |        2 |   12 |   15 |    1 |        1
+   3 |        3 |    9 |    9 |    1 |        2
+   4 |        4 |    6 |    8 |    1 |        3
+   5 |        5 |    5 |   -1 |    0 |        4
+(5 rows)
+
+/* -- q74 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, ARRAY[3, 5]
+);
+ seq | path_seq | end_vid | node | edge | cost | agg_cost
+-----+----------+---------+------+------+------+----------
+   1 |        1 |       3 |    2 |    4 |    1 |        0
+   2 |        2 |       3 |    5 |    8 |    1 |        1
+   3 |        3 |       3 |    6 |    9 |    1 |        2
+   4 |        4 |       3 |    9 |   16 |    1 |        3
+   5 |        5 |       3 |    4 |    3 |    1 |        4
+   6 |        6 |       3 |    3 |   -1 |    0 |        5
+   7 |        1 |       5 |    2 |    4 |    1 |        0
+   8 |        2 |       5 |    5 |   -1 |    0 |        1
+(8 rows)
+
+/* -- q75 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  ARRAY[2, 11], 5
+);
+ seq | path_seq | start_vid | node | edge | cost | agg_cost
+-----+----------+-----------+------+------+------+----------
+   1 |        1 |         2 |    2 |    4 |    1 |        0
+   2 |        2 |         2 |    5 |   -1 |    0 |        1
+   3 |        1 |        11 |   11 |   13 |    1 |        0
+   4 |        2 |        11 |   12 |   15 |    1 |        1
+   5 |        3 |        11 |    9 |    9 |    1 |        2
+   6 |        4 |        11 |    6 |    8 |    1 |        3
+   7 |        5 |        11 |    5 |   -1 |    0 |        4
+(7 rows)
+
+/* -- q76 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  ARRAY[2, 11], ARRAY[3,5]
+);
+ seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
+-----+----------+-----------+---------+------+------+------+----------
+   1 |        1 |         2 |       3 |    2 |    4 |    1 |        0
+   2 |        2 |         2 |       3 |    5 |    8 |    1 |        1
+   3 |        3 |         2 |       3 |    6 |    9 |    1 |        2
+   4 |        4 |         2 |       3 |    9 |   16 |    1 |        3
+   5 |        5 |         2 |       3 |    4 |    3 |    1 |        4
+   6 |        6 |         2 |       3 |    3 |   -1 |    0 |        5
+   7 |        1 |         2 |       5 |    2 |    4 |    1 |        0
+   8 |        2 |         2 |       5 |    5 |   -1 |    0 |        1
+   9 |        1 |        11 |       3 |   11 |   13 |    1 |        0
+  10 |        2 |        11 |       3 |   12 |   15 |    1 |        1
+  11 |        3 |        11 |       3 |    9 |   16 |    1 |        2
+  12 |        4 |        11 |       3 |    4 |    3 |    1 |        3
+  13 |        5 |        11 |       3 |    3 |   -1 |    0 |        4
+  14 |        1 |        11 |       5 |   11 |   13 |    1 |        0
+  15 |        2 |        11 |       5 |   12 |   15 |    1 |        1
+  16 |        3 |        11 |       5 |    9 |    9 |    1 |        2
+  17 |        4 |        11 |       5 |    6 |    8 |    1 |        3
+  18 |        5 |        11 |       5 |    5 |   -1 |    0 |        4
+(18 rows)
+
+/* -- q77 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  'SELECT * FROM (VALUES (2, 3), (2, 5), (11, 3)) AS combinations (source, target)'
+);
+ seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
+-----+----------+-----------+---------+------+------+------+----------
+   1 |        1 |         2 |       3 |    2 |    4 |    1 |        0
+   2 |        2 |         2 |       3 |    5 |    8 |    1 |        1
+   3 |        3 |         2 |       3 |    6 |    9 |    1 |        2
+   4 |        4 |         2 |       3 |    9 |   16 |    1 |        3
+   5 |        5 |         2 |       3 |    4 |    3 |    1 |        4
+   6 |        6 |         2 |       3 |    3 |   -1 |    0 |        5
+   7 |        1 |         2 |       5 |    2 |    4 |    1 |        0
+   8 |        2 |         2 |       5 |    5 |   -1 |    0 |        1
+   9 |        1 |        11 |       3 |   11 |   13 |    1 |        0
+  10 |        2 |        11 |       3 |   12 |   15 |    1 |        1
+  11 |        3 |        11 |       3 |    9 |   16 |    1 |        2
+  12 |        4 |        11 |       3 |    4 |    3 |    1 |        3
+  13 |        5 |        11 |       3 |    3 |   -1 |    0 |        4
+(13 rows)
+
+/* -- q8 */
+
+
+/* -- q9 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, 3,
+  false
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+   1 |        1 |    2 |    2 |    1 |        0
+   2 |        2 |    3 |   -1 |    0 |        1
+(2 rows)
+
+/* -- q91 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, 5,
+  false
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+   1 |        1 |    2 |    4 |    1 |        0
+   2 |        2 |    5 |   -1 |    0 |        1
+(2 rows)
+
+/* -- q92 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  11, 3,
+  false
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+   1 |        1 |   11 |   11 |    1 |        0
+   2 |        2 |    6 |    5 |    1 |        1
+   3 |        3 |    3 |   -1 |    0 |        2
+(3 rows)
+
+/* -- q93 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  11, 5,
+  false
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+   1 |        1 |   11 |   11 |    1 |        0
+   2 |        2 |    6 |    8 |    1 |        1
+   3 |        3 |    5 |   -1 |    0 |        2
+(3 rows)
+
+/* -- q94 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, ARRAY[3,5],
+  false
+);
+ seq | path_seq | end_vid | node | edge | cost | agg_cost
+-----+----------+---------+------+------+------+----------
+   1 |        1 |       3 |    2 |    2 |    1 |        0
+   2 |        2 |       3 |    3 |   -1 |    0 |        1
+   3 |        1 |       5 |    2 |    4 |    1 |        0
+   4 |        2 |       5 |    5 |   -1 |    0 |        1
+(4 rows)
+
+/* -- q95 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  ARRAY[2,11], 5,
+  false
+);
+ seq | path_seq | start_vid | node | edge | cost | agg_cost
+-----+----------+-----------+------+------+------+----------
+   1 |        1 |         2 |    2 |    4 |    1 |        0
+   2 |        2 |         2 |    5 |   -1 |    0 |        1
+   3 |        1 |        11 |   11 |   12 |    1 |        0
+   4 |        2 |        11 |   10 |   10 |    1 |        1
+   5 |        3 |        11 |    5 |   -1 |    0 |        2
+(5 rows)
+
+/* -- q96 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  ARRAY[2, 11], ARRAY[3,5],
+  false
+);
+ seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
+-----+----------+-----------+---------+------+------+------+----------
+   1 |        1 |         2 |       3 |    2 |    2 |    1 |        0
+   2 |        2 |         2 |       3 |    3 |   -1 |    0 |        1
+   3 |        1 |         2 |       5 |    2 |    4 |    1 |        0
+   4 |        2 |         2 |       5 |    5 |   -1 |    0 |        1
+   5 |        1 |        11 |       3 |   11 |   11 |    1 |        0
+   6 |        2 |        11 |       3 |    6 |    5 |    1 |        1
+   7 |        3 |        11 |       3 |    3 |   -1 |    0 |        2
+   8 |        1 |        11 |       5 |   11 |   11 |    1 |        0
+   9 |        2 |        11 |       5 |    6 |    8 |    1 |        1
+  10 |        3 |        11 |       5 |    5 |   -1 |    0 |        2
+(10 rows)
+
+/* -- q97 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  'SELECT * FROM (VALUES (2, 3), (2, 5), (11, 3)) AS combinations (source, target)',
+  false
+);
+ seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
+-----+----------+-----------+---------+------+------+------+----------
+   1 |        1 |         2 |       3 |    2 |    2 |    1 |        0
+   2 |        2 |         2 |       3 |    3 |   -1 |    0 |        1
+   3 |        1 |         2 |       5 |    2 |    4 |    1 |        0
+   4 |        2 |         2 |       5 |    5 |   -1 |    0 |        1
+   5 |        1 |        11 |       3 |   11 |   11 |    1 |        0
+   6 |        2 |        11 |       3 |    6 |    5 |    1 |        1
+   7 |        3 |        11 |       3 |    3 |   -1 |    0 |        2
+(7 rows)
+
+/* -- q10 */
+
+
+/* -- q11 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost FROM edge_table',
+  2, 3
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+(0 rows)
+
+/* -- q111 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost FROM edge_table',
+  2, 5
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+   1 |        1 |    2 |    4 |    1 |        0
+   2 |        2 |    5 |   -1 |    0 |        1
+(2 rows)
+
+/* -- q112 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost FROM edge_table',
+  11, 3
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+(0 rows)
+
+/* -- q113 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost FROM edge_table',
+  11, 5
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+(0 rows)
+
+/* -- q114 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost FROM edge_table',
+  2, ARRAY[3,5]
+);
+ seq | path_seq | end_vid | node | edge | cost | agg_cost
+-----+----------+---------+------+------+------+----------
+   1 |        1 |       5 |    2 |    4 |    1 |        0
+   2 |        2 |       5 |    5 |   -1 |    0 |        1
+(2 rows)
+
+/* -- q115 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost FROM edge_table',
+  ARRAY[2,11], 5
+);
+ seq | path_seq | start_vid | node | edge | cost | agg_cost
+-----+----------+-----------+------+------+------+----------
+   1 |        1 |         2 |    2 |    4 |    1 |        0
+   2 |        2 |         2 |    5 |   -1 |    0 |        1
+(2 rows)
+
+/* -- q116 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost FROM edge_table',
+  ARRAY[2, 11], ARRAY[3,5]
+);
+ seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
+-----+----------+-----------+---------+------+------+------+----------
+   1 |        1 |         2 |       5 |    2 |    4 |    1 |        0
+   2 |        2 |         2 |       5 |    5 |   -1 |    0 |        1
+(2 rows)
+
+/* -- q117 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost FROM edge_table',
+  'SELECT * FROM (VALUES (2, 3), (2, 5), (11, 3)) AS combinations (source, target)'
+);
+ seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
+-----+----------+-----------+---------+------+------+------+----------
+   1 |        1 |         2 |       5 |    2 |    4 |    1 |        0
+   2 |        2 |         2 |       5 |    5 |   -1 |    0 |        1
+(2 rows)
+
+/* -- q12 */
+
+
+/* -- q13 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost FROM edge_table',
+  2, 3,
+  false
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+   1 |        1 |    2 |    4 |    1 |        0
+   2 |        2 |    5 |    8 |    1 |        1
+   3 |        3 |    6 |    5 |    1 |        2
+   4 |        4 |    3 |   -1 |    0 |        3
+(4 rows)
+
+/* -- q131 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost FROM edge_table',
+  2, 5,
+  false
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+   1 |        1 |    2 |    4 |    1 |        0
+   2 |        2 |    5 |   -1 |    0 |        1
+(2 rows)
+
+/* -- q132 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost FROM edge_table',
+  11, 3,
+  false
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+   1 |        1 |   11 |   11 |    1 |        0
+   2 |        2 |    6 |    5 |    1 |        1
+   3 |        3 |    3 |   -1 |    0 |        2
+(3 rows)
+
+/* -- q133 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost FROM edge_table',
+  11, 5,
+  false
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+   1 |        1 |   11 |   11 |    1 |        0
+   2 |        2 |    6 |    8 |    1 |        1
+   3 |        3 |    5 |   -1 |    0 |        2
+(3 rows)
+
+/* -- q134 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost FROM edge_table',
+  2, ARRAY[3,5],
+  false
+);
+ seq | path_seq | end_vid | node | edge | cost | agg_cost
+-----+----------+---------+------+------+------+----------
+   1 |        1 |       3 |    2 |    4 |    1 |        0
+   2 |        2 |       3 |    5 |    8 |    1 |        1
+   3 |        3 |       3 |    6 |    5 |    1 |        2
+   4 |        4 |       3 |    3 |   -1 |    0 |        3
+   5 |        1 |       5 |    2 |    4 |    1 |        0
+   6 |        2 |       5 |    5 |   -1 |    0 |        1
+(6 rows)
+
+/* -- q135 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost FROM edge_table',
+  ARRAY[2,11], 5,
+  false
+);
+ seq | path_seq | start_vid | node | edge | cost | agg_cost
+-----+----------+-----------+------+------+------+----------
+   1 |        1 |         2 |    2 |    4 |    1 |        0
+   2 |        2 |         2 |    5 |   -1 |    0 |        1
+   3 |        1 |        11 |   11 |   12 |    1 |        0
+   4 |        2 |        11 |   10 |   10 |    1 |        1
+   5 |        3 |        11 |    5 |   -1 |    0 |        2
+(5 rows)
+
+/* -- q136 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost FROM edge_table',
+  ARRAY[2, 11], ARRAY[3,5],
+  false
+);
+ seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
+-----+----------+-----------+---------+------+------+------+----------
+   1 |        1 |         2 |       3 |    2 |    4 |    1 |        0
+   2 |        2 |         2 |       3 |    5 |    8 |    1 |        1
+   3 |        3 |         2 |       3 |    6 |    5 |    1 |        2
+   4 |        4 |         2 |       3 |    3 |   -1 |    0 |        3
+   5 |        1 |         2 |       5 |    2 |    4 |    1 |        0
+   6 |        2 |         2 |       5 |    5 |   -1 |    0 |        1
+   7 |        1 |        11 |       3 |   11 |   11 |    1 |        0
+   8 |        2 |        11 |       3 |    6 |    5 |    1 |        1
+   9 |        3 |        11 |       3 |    3 |   -1 |    0 |        2
+  10 |        1 |        11 |       5 |   11 |   11 |    1 |        0
+  11 |        2 |        11 |       5 |    6 |    8 |    1 |        1
+  12 |        3 |        11 |       5 |    5 |   -1 |    0 |        2
+(12 rows)
+
+/* -- q137 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost FROM edge_table',
+  'SELECT * FROM (VALUES (2, 3), (2, 5), (11, 3)) AS combinations (source, target)',
+  false
+);
+ seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
+-----+----------+-----------+---------+------+------+------+----------
+   1 |        1 |         2 |       3 |    2 |    4 |    1 |        0
+   2 |        2 |         2 |       3 |    5 |    8 |    1 |        1
+   3 |        3 |         2 |       3 |    6 |    5 |    1 |        2
+   4 |        4 |         2 |       3 |    3 |   -1 |    0 |        3
+   5 |        1 |         2 |       5 |    2 |    4 |    1 |        0
+   6 |        2 |         2 |       5 |    5 |   -1 |    0 |        1
+   7 |        1 |        11 |       3 |   11 |   11 |    1 |        0
+   8 |        2 |        11 |       3 |    6 |    5 |    1 |        1
+   9 |        3 |        11 |       3 |    3 |   -1 |    0 |        2
+(9 rows)
+
+/* -- q14 */
+
+
+/* -- q15 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, 3
+);
+ seq | path_seq | node | edge | cost | agg_cost
+-----+----------+------+------+------+----------
+   1 |        1 |    2 |    4 |    1 |        0
+   2 |        2 |    5 |    8 |    1 |        1
+   3 |        3 |    6 |    9 |    1 |        2
+   4 |        4 |    9 |   16 |    1 |        3
+   5 |        5 |    4 |    3 |    1 |        4
+   6 |        6 |    3 |   -1 |    0 |        5
+(6 rows)
+
+/* -- q151*/
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, ARRAY[3]
+);
+ seq | path_seq | end_vid | node | edge | cost | agg_cost
+-----+----------+---------+------+------+------+----------
+   1 |        1 |       3 |    2 |    4 |    1 |        0
+   2 |        2 |       3 |    5 |    8 |    1 |        1
+   3 |        3 |       3 |    6 |    9 |    1 |        2
+   4 |        4 |       3 |    9 |   16 |    1 |        3
+   5 |        5 |       3 |    4 |    3 |    1 |        4
+   6 |        6 |       3 |    3 |   -1 |    0 |        5
+(6 rows)
+
+/* -- q152*/
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  ARRAY[2], 3
+);
+ seq | path_seq | start_vid | node | edge | cost | agg_cost
+-----+----------+-----------+------+------+------+----------
+   1 |        1 |         2 |    2 |    4 |    1 |        0
+   2 |        2 |         2 |    5 |    8 |    1 |        1
+   3 |        3 |         2 |    6 |    9 |    1 |        2
+   4 |        4 |         2 |    9 |   16 |    1 |        3
+   5 |        5 |         2 |    4 |    3 |    1 |        4
+   6 |        6 |         2 |    3 |   -1 |    0 |        5
+(6 rows)
+
+/* -- q153*/
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  ARRAY[2], ARRAY[3]
+);
+ seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
+-----+----------+-----------+---------+------+------+------+----------
+   1 |        1 |         2 |       3 |    2 |    4 |    1 |        0
+   2 |        2 |         2 |       3 |    5 |    8 |    1 |        1
+   3 |        3 |         2 |       3 |    6 |    9 |    1 |        2
+   4 |        4 |         2 |       3 |    9 |   16 |    1 |        3
+   5 |        5 |         2 |       3 |    4 |    3 |    1 |        4
+   6 |        6 |         2 |       3 |    3 |   -1 |    0 |        5
+(6 rows)
+
+/* -- q154*/
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  'SELECT * FROM (VALUES(2, 3)) AS combinations (source, target)'
+);
+ seq | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
+-----+----------+-----------+---------+------+------+------+----------
+   1 |        1 |         2 |       3 |    2 |    4 |    1 |        0
+   2 |        2 |         2 |       3 |    5 |    8 |    1 |        1
+   3 |        3 |         2 |       3 |    6 |    9 |    1 |        2
+   4 |        4 |         2 |       3 |    9 |   16 |    1 |        3
+   5 |        5 |         2 |       3 |    4 |    3 |    1 |        4
+   6 |        6 |         2 |       3 |    3 |   -1 |    0 |        5
+(6 rows)
+
+/* -- q16 */
 ROLLBACK;
 ROLLBACK

--- a/docqueries/dijkstra/doc-pgr_dijkstra.test.sql
+++ b/docqueries/dijkstra/doc-pgr_dijkstra.test.sql
@@ -1,33 +1,39 @@
 
 /* -- q1 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, 3
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, 3
 );
 /* -- q2 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, 3,
-    FALSE
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, 3,
+  false
 );
 /* -- q3 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    2, ARRAY[3,5],
-    FALSE
+  'SELECT id, source, target, cost FROM edge_table',
+  2, ARRAY[3,5],
+  false
 );
 /* -- q4 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2,11], 5
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  ARRAY[2,11], 5
 );
 /* -- q5 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2,11], ARRAY[3,5],
-    FALSE
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  ARRAY[2,11], ARRAY[3,5],
+  false
 );
 /* -- q6 */
+SELECT * FROM pgr_dijkstra(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  'SELECT * FROM combinations_table',
+  false
+);
+/* -- q61 */
 
 
 -- Examples for :ref:`fig1-direct-Cost-Reverse`
@@ -35,36 +41,43 @@ SELECT * FROM pgr_dijkstra(
 
 /* -- q7 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, 3
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, 3
 );
+/* -- q71 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, 5
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, 5
 );
+/* -- q72 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, ARRAY[3,5]
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  11, 3
 );
+/* -- q73 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    11, 3
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  11, 5
 );
+/* -- q74 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    11, 5
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, ARRAY[3, 5]
 );
+/* -- q75 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2,11], 5
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  ARRAY[2, 11], 5
 );
+/* -- q76 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2, 11], ARRAY[3,5]
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  ARRAY[2, 11], ARRAY[3,5]
 );
+/* -- q77 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    'SELECT * FROM (VALUES (2, 3), (2, 5), (11, 3), (11, 5)) AS combinations (source, target)'
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  'SELECT * FROM (VALUES (2, 3), (2, 5), (11, 3)) AS combinations (source, target)'
 );
 /* -- q8 */
 
@@ -75,44 +88,51 @@ SELECT * FROM pgr_dijkstra(
 
 /* -- q9 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, 3,
-    FALSE
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, 3,
+  false
 );
+/* -- q91 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, 5,
-    FALSE
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, 5,
+  false
 );
+/* -- q92 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    11, 3,
-    FALSE
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  11, 3,
+  false
 );
+/* -- q93 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    11, 5,
-    FALSE
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  11, 5,
+  false
 );
+/* -- q94 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2,11], 5,
-    FALSE
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, ARRAY[3,5],
+  false
 );
+/* -- q95 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, ARRAY[3,5],
-    FALSE
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  ARRAY[2,11], 5,
+  false
 );
+/* -- q96 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2, 11], ARRAY[3,5],
-    FALSE
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  ARRAY[2, 11], ARRAY[3,5],
+  false
 );
+/* -- q97 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    'SELECT * FROM (VALUES (2, 3), (2, 5), (11, 3), (11, 5)) AS combinations (source, target)',
-    FALSE
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  'SELECT * FROM (VALUES (2, 3), (2, 5), (11, 3)) AS combinations (source, target)',
+  false
 );
 /* -- q10 */
 
@@ -123,36 +143,43 @@ SELECT * FROM pgr_dijkstra(
 
 /* -- q11 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    2, 3
+  'SELECT id, source, target, cost FROM edge_table',
+  2, 3
 );
+/* -- q111 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    2, 5
+  'SELECT id, source, target, cost FROM edge_table',
+  2, 5
 );
+/* -- q112 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    11, 3
+  'SELECT id, source, target, cost FROM edge_table',
+  11, 3
 );
+/* -- q113 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    11, 5
+  'SELECT id, source, target, cost FROM edge_table',
+  11, 5
 );
+/* -- q114 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    ARRAY[2,11], 5
+  'SELECT id, source, target, cost FROM edge_table',
+  2, ARRAY[3,5]
 );
+/* -- q115 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    2, ARRAY[3,5]
+  'SELECT id, source, target, cost FROM edge_table',
+  ARRAY[2,11], 5
 );
+/* -- q116 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    ARRAY[2, 11], ARRAY[3,5]
+  'SELECT id, source, target, cost FROM edge_table',
+  ARRAY[2, 11], ARRAY[3,5]
 );
+/* -- q117 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    'SELECT * FROM (VALUES (2, 3), (2, 5), (11, 3), (11, 5)) AS combinations (source, target)'
+  'SELECT id, source, target, cost FROM edge_table',
+  'SELECT * FROM (VALUES (2, 3), (2, 5), (11, 3)) AS combinations (source, target)'
 );
 /* -- q12 */
 
@@ -162,44 +189,51 @@ SELECT * FROM pgr_dijkstra(
 
 /* -- q13 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    2, 3,
-    FALSE
+  'SELECT id, source, target, cost FROM edge_table',
+  2, 3,
+  false
 );
+/* -- q131 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    2, 5,
-    FALSE
+  'SELECT id, source, target, cost FROM edge_table',
+  2, 5,
+  false
 );
+/* -- q132 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    11, 3,
-    FALSE
+  'SELECT id, source, target, cost FROM edge_table',
+  11, 3,
+  false
 );
+/* -- q133 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    11, 5,
-    FALSE
+  'SELECT id, source, target, cost FROM edge_table',
+  11, 5,
+  false
 );
+/* -- q134 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    ARRAY[2,11], 5,
-    FALSE
+  'SELECT id, source, target, cost FROM edge_table',
+  2, ARRAY[3,5],
+  false
 );
+/* -- q135 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    2, ARRAY[3,5],
-    FALSE
+  'SELECT id, source, target, cost FROM edge_table',
+  ARRAY[2,11], 5,
+  false
 );
+/* -- q136 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    ARRAY[2, 11], ARRAY[3,5],
-    FALSE
+  'SELECT id, source, target, cost FROM edge_table',
+  ARRAY[2, 11], ARRAY[3,5],
+  false
 );
+/* -- q137 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost FROM edge_table',
-    'SELECT * FROM (VALUES (2, 3), (2, 5), (11, 3), (11, 5)) AS combinations (source, target)',
-    FALSE
+  'SELECT id, source, target, cost FROM edge_table',
+  'SELECT * FROM (VALUES (2, 3), (2, 5), (11, 3)) AS combinations (source, target)',
+  false
 );
 /* -- q14 */
 
@@ -211,81 +245,27 @@ SELECT * FROM pgr_dijkstra(
 
 /* -- q15 */
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, 3,
-    TRUE     -- directed flag
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, 3
 );
+/* -- q151*/
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2,3
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  2, ARRAY[3]
 );
+/* -- q152*/
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, ARRAY[3],
-    TRUE
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  ARRAY[2], 3
 );
+/* -- q153*/
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, ARRAY[3]
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  ARRAY[2], ARRAY[3]
 );
+/* -- q154*/
 SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2], ARRAY[3],
-    TRUE
-);
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2], ARRAY[3]
-);
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    'SELECT * FROM (VALUES(2, 3)) AS combinations (source, target)'
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table',
+  'SELECT * FROM (VALUES(2, 3)) AS combinations (source, target)'
 );
 /* -- q16 */
-
-
--- Equivalences for :ref:`fig2-undirect-Cost-Reverse`
--------------------------------------------------------------------------------
-
-
-/* -- q17 */
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, 3,
-    FALSE     -- directed flag
-);
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    2, ARRAY[3],
-    FALSE
-);
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2], 3,
-    FALSE
-);
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    ARRAY[2], ARRAY[3],
-    FALSE
-);
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    'SELECT * FROM (VALUES(2, 3)) AS combinations (source, target)',
-    FALSE
-);
-/* -- q18 */
-
--- pgr_dijkstra combinations SQL
--------------------------------------------------------------------------------
-
-/* -- q19 */
-
-SELECT * FROM pgr_dijkstra(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table',
-    'SELECT * FROM combinations_table',
-    FALSE
-);
-
-/* -- q20 */
-


### PR DESCRIPTION
Fixes #2244  .

Commit names are directory based.
Marking as done on initial issue so no one else takes the directory files.
Besides of using `parse-literal` the following was made

- allpairs
  - Cleaned documentation
  - Added information to the family
  

@pgRouting/admins
