### PR TITLE
With points using parsed literal

### DIFF
--- a/doc/dijkstra/pgr_dijkstraVia.rst
+++ b/doc/dijkstra/pgr_dijkstraVia.rst
@@ -25,7 +25,7 @@
 ``pgr_dijkstraVia`` - Proposed
 ===============================================================================
 
-``pgr_dijkstraVia`` — Find the route that goes through a list of vertices.
+``pgr_dijkstraVia`` — Route that goes through a list of vertices.
 
 .. include:: proposed.rst
    :start-after: stable-begin-warning
@@ -42,9 +42,6 @@
 
   * New **proposed** function
 
-
-|
-
 Description
 -------------------------------------------------------------------------------
 
@@ -54,25 +51,11 @@ shortest path between :math:`vertex_i` and :math:`vertex_{i+1}` for all :math:`i
 
 The paths represents the sections of the route.
 
-|
-
 Signatures
 -------------------------------------------------------------------------------
 
-.. rubric:: Summary
-
 .. index::
     single: dijkstraVia - Proposed on 2.2
-
-.. parsed-literal::
-
-    pgr_dijkstraVia(`Edges SQL`_, **via vertices**
-               [, directed] [, strict] [, U_turn_on_edge])
-    RETURNS SET OF (seq, path_pid, path_seq, start_vid, end_vid,
-                    node, edge, cost, agg_cost, route_agg_cost)
-    OR EMPTY SET
-
-|
 
 One Via
 ...............................................................................
@@ -80,7 +63,7 @@ One Via
 .. parsed-literal::
 
     pgr_dijkstraVia(`Edges SQL`_, **via vertices**
-               [, directed] [, strict] [, U_turn_on_edge])
+               [, directed] [, strict] [, U_turn_on_edge]) - Proposed on v2.2
     RETURNS SET OF (seq, path_pid, path_seq, start_vid, end_vid,
                     node, edge, cost, agg_cost, route_agg_cost)
     OR EMPTY SET
@@ -92,8 +75,6 @@ One Via
     :start-after: -- q01
     :end-before: -- q1
 
-|
-
 Parameters
 -------------------------------------------------------------------------------
 
@@ -101,30 +82,22 @@ Parameters
     :start-after: via_parameters_start
     :end-before: via_parameters_end
 
-|
-
-Dijkstra optional parameters
+Optional parameters
 ...............................................................................
 
 .. include:: dijkstra-family.rst
     :start-after: dijkstra_optionals_start
     :end-before: dijkstra_optionals_end
 
-|
-
 Via optional parameters
 ...............................................................................
 
 .. include:: via-category.rst
-    :start-after: via_opt_parameters_start
-    :end-before: via_opt_parameters_end
-
-|
+    :start-after: via_optionals_start
+    :end-before: via_optionals_end
 
 Inner query
 -------------------------------------------------------------------------------
-
-|
 
 Edges SQL
 ...............................................................................
@@ -133,16 +106,12 @@ Edges SQL
     :start-after: basic_edges_sql_start
     :end-before: basic_edges_sql_end
 
-|
-
 Return Columns
 -------------------------------------------------------------------------------
 
 .. include:: via-category.rst
-    :start-after: result columns start
-    :end-before: result columns end
-
-|
+    :start-after: result via start
+    :end-before: result via end
 
 Additional Examples
 -------------------------------------------------------------------------------

--- a/doc/src/costMatrix-category.rst
+++ b/doc/src/costMatrix-category.rst
@@ -118,6 +118,14 @@ The main Characteristics are:
 
 .. costMatrix_details_end
 
+Parameters
+-------------------------------------------------------------------------------
+
+.. rubric:: Used in:
+
+* :doc:`pgr_aStarCostMatrix`
+* :doc:`pgr_dijkstraCostMatrix`
+
 .. costMatrix_parameters_start
 
 .. list-table::
@@ -137,6 +145,32 @@ The main Characteristics are:
 
 .. costMatrix_parameters_end
 
+.. rubric:: Used in:
+
+* :doc:`pgr_withPointsCostMatrix`
+
+.. costMatrix_withPoints_parameters_start
+
+.. list-table::
+   :width: 81
+   :widths: auto
+   :header-rows: 1
+
+   * - Column
+     - Type
+     - Description
+   * - `Edges SQL`_
+     - ``TEXT``
+     - `Edges SQL`_ as described below
+   * - `Points SQL`_
+     - ``TEXT``
+     - `Points SQL`_ as described below
+   * - **start vids**
+     - ``ARRAY[BIGINT]``
+     -  Array of identifiers of starting vertices.
+
+.. costMatrix_withPoints_parameters_end
+
 Optional parameters
 ...............................................................................
 
@@ -150,9 +184,21 @@ Inner query
 Edges SQL
 ...............................................................................
 
+.. rubric:: Used in:
+
+* :doc:`pgr_withPointsCostMatrix`
+* :doc:`pgr_dijkstraCostMatrix`
+
 .. include:: pgRouting-concepts.rst
     :start-after: basic_edges_sql_start
     :end-before: basic_edges_sql_end
+
+Points SQL
+...............................................................................
+
+.. include:: withPoints-category.rst
+    :start-after: points_sql_start
+    :end-before: points_sql_end
 
 Return Columns
 -------------------------------------------------------------------------------
@@ -162,7 +208,7 @@ Return Columns
     :end-before: return_cost_end
 
 See Also
-................
+-------------------------------------------------------------------------------
 
 * :doc:`TSP-family`
 

--- a/doc/src/pgRouting-concepts.rst
+++ b/doc/src/pgRouting-concepts.rst
@@ -617,6 +617,72 @@ agg_cost)``
 
 .. return_path_short_end
 
+.. rubric:: Used on functions the following:
+
+* :doc:`pgr_withPoints`
+
+
+.. return_withpoint_path_short_start
+
+Returns set of ``(seq, path_seq [, start_pid] [, end_pid], node, edge, cost,
+agg_cost)``
+
+.. list-table::
+   :width: 81
+   :widths: 12 14 60
+   :header-rows: 1
+
+   * - Column
+     - Type
+     - Description
+   * - ``seq``
+     - ``INTEGER``
+     - Sequential value starting from **1**.
+   * - ``path_seq``
+     - ``INTEGER``
+     - Relative position in the path.
+
+       * **1** For the first row of the path.
+   * - ``start_pid``
+     - ``BIGINT``
+     - Identifier of a starting vertex/point of the path.
+
+       * When positive is the identifier of the starting vertex.
+       * When negative is the identifier of the starting point.
+       * Returned on `Many to One`_  and `Many to Many`_
+   * - ``end_pid``
+     - ``BIGINT``
+     - Identifier of an ending vertex/point of the path.
+
+       * When positive is the identifier of the ending vertex.
+       * When negative is the identifier of the ending point.
+       * Returned on `One to Many`_ and `Many to Many`_
+   * - ``node``
+     - ``BIGINT``
+     - Identifier of the node in the path from ``start_pid`` to ``end_pid``.
+
+       * When positive is the identifier of the a vertex.
+       * When negative is the identifier of the a point.
+   * - ``edge``
+     - ``BIGINT``
+     - Identifier of the edge used to go from ``node`` to the next node in the
+       path sequence.
+
+       * **-1** for the last row of the path.
+   * - ``cost``
+     - ``FLOAT``
+     - Cost to traverse from ``node`` using ``edge`` to the next node in the
+       path sequence.
+
+       * **0** For the first row of the path.
+   * - ``agg_cost``
+     - ``FLOAT``
+     - Aggregate cost from ``start_vid`` to ``node``.
+
+       * **0** For the first row of the path.
+
+.. return_withpoint_path_short_end
+
 
 .. rubric:: Used on functions the following:
 

--- a/doc/src/pgRouting-concepts.rst
+++ b/doc/src/pgRouting-concepts.rst
@@ -814,18 +814,51 @@ Set of ``(start_vid, end_vid, agg_cost)``
    * - Column
      - Type
      - Description
-   * - **start_vid**
+   * - ``start_vid``
      - ``BIGINT``
      - Identifier of the starting vertex.
-   * - **end_vid**
+   * - ``end_vid``
      - ``BIGINT``
      - Identifier of the ending vertex.
-   * - **agg_cost**
+   * - ``agg_cost``
      - ``FLOAT``
      - Aggregate cost from ``start_vid`` to ``end_vid``.
 
 .. return_cost_end
 
+.. rubric:: Used in the following
+
+* :doc:`pgr_withPointsCost`
+
+.. return_cost_withPoints_start
+
+Set of ``(start_vid, end_vid, agg_cost)``
+
+.. list-table::
+   :width: 81
+   :widths: 12 14 60
+   :header-rows: 1
+
+   * - Column
+     - Type
+     - Description
+   * - ``start_vid``
+     - ``BIGINT``
+     - Identifier of the starting vertex or point.
+
+       * When positive: is a vertex’s identifier.
+       * When negative: is a point’s identifier.
+   * - ``end_vid``
+     - ``BIGINT``
+     - Identifier of the ending vertex or point.
+
+       * When positive: is a vertex’s identifier.
+       * When negative: is a point’s identifier.
+   * - ``agg_cost``
+     - ``FLOAT``
+     - Aggregate cost from ``start_vid`` to ``end_vid``.
+
+.. return_cost_withPoints_end
 
 |
 

--- a/doc/src/via-category.rst
+++ b/doc/src/via-category.rst
@@ -42,15 +42,18 @@ This category intends to solve the general problem:
 In other words, find a continuos route that visits all the vertices in the order
 given.
 
-**path**
-   represents a section of a **route**.
-**route**
-   is a sequence of **paths**
+:path: represents a section of a **route**.
+:route: is a sequence of **paths**
 
 |
 
 Parameters
 -------------------------------------------------------------------------------
+
+**Used on:**
+
+* :doc:`pgr_dijkstraVia`
+* :doc:`pgr_trspVia`
 
 .. via_parameters_start
 
@@ -74,6 +77,42 @@ Parameters
 
 .. via_parameters_end
 
+**Used on:**
+
+* :doc:`pgr_withPointsVia`
+* :doc:`pgr_trspVia_withPoints`
+
+.. via_withPoints_parameters_start
+
+.. list-table::
+   :width: 81
+   :widths: 14 20 7 40
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Default
+     - Description
+   * - `Edges SQL`_
+     - ``TEXT``
+     -
+     - SQL query as described.
+   * - `Points SQL`_
+     - ``TEXT``
+     -
+     - SQL query as described.
+   * - **via vertices**
+     - ``ARRAY[`` **ANY-INTEGER** ``]``
+     -
+     - Array of ordered vertices identifiers that are going to be visited.
+
+       * When positive it is considered a vertex identifier
+       * When negative it is considered a point identifier
+
+.. via_withPoints_parameters_end
+
+
+
 Besides the compulsory parameters each function has, there are optional
 parameters that exist due to the kind of function.
 
@@ -82,7 +121,7 @@ Via optional parameters
 
 .. rubric:: Used on all Via functions
 
-.. via_opt_parameters_start
+.. via_optionals_start
 
 .. list-table::
    :width: 81
@@ -103,7 +142,7 @@ Via optional parameters
      - ``true``
      - * When ``true`` departing from a visited vertex will not try to avoid
 
-.. via_opt_parameters_end
+.. via_optionals_end
 
 With points optional parameters
 ...............................................................................
@@ -112,7 +151,7 @@ Used on
 
 * :doc:`pgr_withPointsVia`
 
-.. withPoints_parameters_start
+.. via_withPoints_optionals_start
 
 .. list-table::
    :width: 81
@@ -137,16 +176,12 @@ Used on
      - - When ``true`` the results will include the points that are in the path.
        - When ``false`` the results will not include the points that are in the path.
 
-.. withPoints_parameters_end
-
-|
+.. via_withPoints_optionals_end
 
 Inner query
 -------------------------------------------------------------------------------
 
 Depending on the function one or more inner queries are needed.
-
-|
 
 Edges SQL
 ...............................................................................
@@ -156,7 +191,6 @@ Edges SQL
 .. include:: pgRouting-concepts.rst
     :start-after: basic_edges_sql_start
     :end-before: basic_edges_sql_end
-|
 
 Restrictions SQL
 ...............................................................................
@@ -168,7 +202,6 @@ Used on
 .. include:: TRSP-family.rst
    :start-after: restrictions_columns_start
    :end-before: restrictions_columns_end
-|
 
 Points SQL
 ...............................................................................
@@ -180,12 +213,16 @@ Used on
 .. include:: withPoints-category.rst
     :start-after: points_sql_start
     :end-before: points_sql_end
-|
 
 Return Columns
 -------------------------------------------------------------------------------
 
-.. result columns start
+**Used on:**
+
+* :doc:`pgr_dijkstraVia`
+* :doc:`pgr_trspVia`
+
+.. result via start
 
 .. list-table::
    :width: 81
@@ -231,12 +268,78 @@ Return Columns
      - ``FLOAT``
      - Total cost from ``start_vid`` of ``seq = 1`` to ``end_vid`` of the current ``seq``.
 
-.. result columns end
+.. result via end
+
+**Used on:**
+
+* :doc:`pgr_withPointsVia`
+* :doc:`pgr_trspVia_withPoints`
+
+.. result via withPoints start
+
+.. list-table::
+   :width: 81
+   :widths: 12 14 60
+   :header-rows: 1
+
+   * - Column
+     - Type
+     - Description
+   * - ``seq``
+     - ``INTEGER``
+     - Sequential value starting from **1**.
+   * - ``path_id``
+     - ``INTEGER``
+     - Identifier of a path. Has value **1** for the first path.
+   * - ``path_seq``
+     - ``INTEGER``
+     - Relative position in the path. Has value **1** for the beginning of a path.
+   * - ``start_vid``
+     - ``BIGINT``
+     - Identifier of the starting vertex or point of the path.
+
+       * When positive it is a vertex identifier
+       * When negative it is a point identifier
+   * - ``end_vid``
+     - ``BIGINT``
+     - Identifier of the ending vertex or point of the path.
+
+       * When positive it is a vertex identifier
+       * When negative it is a point identifier
+   * - ``node``
+     - ``BIGINT``
+     - Identifier of the node in the path from ``start_vid`` to ``end_vid``.
+
+       * When positive it is a vertex identifier
+       * When negative it is a point identifier
+   * - ``edge``
+     - ``BIGINT``
+     - Identifier of the edge used to go from ``node`` to the next node in the
+       path sequence.
+
+       * :math:`-1` for the last row of the path.
+       * :math:`-2` for the last row of the route.
+   * - ``cost``
+     - ``FLOAT``
+     - Cost to traverse from ``node`` using ``edge`` to the next node in the
+       path sequence.
+   * - ``agg_cost``
+     - ``FLOAT``
+     - Aggregate cost from ``start_vid`` to ``node``.
+
+       * :math:`0` on the first row of the path.
+   * - ``route_agg_cost``
+     - ``FLOAT``
+     - Total cost from the first row of the route up to the current node.
+
+       * :math:`0` on the first row of the route.
+
+.. result via withPoints end
 
 |
 
 See Also
-................
+-------------------------------------------------------------------------------
 
 * :doc:`pgr_dijkstraVia`
 * :doc:`pgr_trspVia`

--- a/doc/src/withPoints-category.rst
+++ b/doc/src/withPoints-category.rst
@@ -32,9 +32,6 @@ When points are added to the graph.
 
 .. proposed end
 
-.. contents:: Contents
-   :local:
-
 Introduction
 -------------------------------------------------------------------------------
 
@@ -91,82 +88,86 @@ All this functions consider as many traits from the "real world" as possible:
     - positive sign is a vertex of the original graph
     - negative sign is a point of the `Points SQL`_
 
-Details about points
+Parameters
 -------------------------------------------------------------------------------
 
-For this section the following city (see :doc:`sampledata`) some interesing
-points such as restaurant, supermarket, post office, etc. will be used as
-example.
+.. withPoints_parameters_start
 
-.. figure:: /images/Fig1-originalData.png
-   :scale: 50%
+.. list-table::
+   :width: 81
+   :widths: 14 14 44
+   :header-rows: 1
 
-- The graph is **directed**
-- Red arrows show the ``(source, target)`` of the edge on the edge table
-- Blue arrows show the ``(target, source)`` of the edge on the edge table
-- Each point location shows where it is located with relation of the edge
-  ``(source, target)``
+   * - Column
+     - Type
+     - Description
+   * - `Edges SQL`_
+     - ``TEXT``
+     - `Edges SQL`_ as described below
+   * - `Points SQL`_
+     - ``TEXT``
+     - `Points SQL`_ as described below
+   * - `Combinations SQL`_
+     - ``TEXT``
+     - `Combinations SQL`_ as described below
+   * - **start vid**
+     - ``BIGINT``
+     - Identifier of the starting vertex of the path. Negative value is for
+       point’s identifier.
+   * - **start vids**
+     - ``ARRAY[BIGINT]``
+     - Array of identifiers of starting vertices. Negative values are for
+       point’s identifiers.
+   * - **end vid**
+     - ``BIGINT``
+     - Identifier of the ending vertex of the path. Negative value is for point’s identifier.
+   * - **end vids**
+     - ``ARRAY[BIGINT]``
+     - Array of identifiers of ending vertices. Negative values are for point’s
+       identifiers.
 
-  - On the right for points **2** and **4**.
-  - On the left for points **1**, **3** and **5**.
-  - On both sides for point **6**.
+.. withPoints_parameters_end
 
-The representation on the data base follows the `Points SQL`_ description, and
-for this example:
-
-.. literalinclude:: withPoints-category.queries
-   :start-after: --q1
-   :end-before: --q2
-
-Driving side
+Optional parameters
 ...............................................................................
 
-In the the folowwing images:
+.. withPoints_optionals_start
 
-- The squared vertices are the temporary vertices,
-- The temporary vertices are added according to the driving side,
-- visually showing the differences on how depending on the driving side the data
-  is interpreted.
+.. list-table::
+   :width: 81
+   :widths: 14 7 7 60
+   :header-rows: 1
 
-.. rubric:: Right driving side
+   * - Parameter
+     - Type
+     - Default
+     - Description
+   * - ``driving_side``
+     - ``CHAR``
+     - ``r``
+     - Value in [``r``, ``l``] indicating if the driving side is:
 
-.. image:: images/rightDrivingSide.png
-    :scale: 50%
+       - ``r`` for right driving side
+       - ``l`` for left driving side
+       - Any other value will be considered as ``r``
+   * - ``details``
+     - ``BOOLEAN``
+     - ``false``
+     - - When ``true`` the results will include the points that are in the path.
+       - When ``false`` the results will not include the points that are in the
+         path.
 
-- Point **1** located on edge ``(2, 1)``
-- Point **2** located on edge ``(9, 12)``
-- Point **3** located on edge ``(10, 11)``
-- Point **4** located on edge ``(7, 8)``
-- Point **5** located on edge ``(3, 6)``
-- Point **6** located on edges ``(2, 5)`` and ``(5, 2)``
+.. withPoints_optionals_end
 
-.. rubric:: Left driving side
+Inner queries
+-------------------------------------------------------------------------------
 
-.. image:: images/leftDrivingSide.png
-    :scale: 50%
+Edges SQL
+...............................................................................
 
-- Point **1** located on edge ``(1, 2)``
-- Point **2** located on edge ``(12, 9)``
-- Point **3** located on edge ``(10, 11)``
-- Point **4** located on edge ``(8, 7)``
-- Point **5** located on edge ``(3, 6)``
-- Point **6** located on edges ``(2, 5)`` and ``(5, 2)``
-
-.. rubric:: Both driving side (or does not matter)
-
-- Like having all points to be considered in both sides ``b``
-- Prefered usage on **undirected** graphs
-- On the :doc:`TRSP-family` this option is not valid
-
-.. image:: images/noMatterDrivingSide.png
-    :scale: 50%
-
-- Point **1** located on edges ``(1, 2)`` and ``(2, 1)``
-- Point **2** located on edges ``(12, 9)`` and ``(9, 12)``
-- Point **3** located on edge ``(10, 11)``
-- Point **4** located on edges ``(8, 7)`` and ``(7, 8)``
-- Point **5** located on edge ``(3, 6)``
-- Point **6** located on edges ``(2, 5)`` and ``(5, 2)``
+.. include:: pgRouting-concepts.rst
+    :start-after: basic_edges_sql_start
+    :end-before: basic_edges_sql_end
 
 Points SQL
 ...............................................................................
@@ -208,7 +209,7 @@ Points SQL
 
        * In the right ``r``,
        * In the left ``l``,
-       * In both ``b``, ``NULL``
+       * In both sides ``b``, ``NULL``
 
 Where:
 
@@ -217,8 +218,104 @@ Where:
 
 .. points_sql_end
 
-Creating temporary vertices
+Combinations SQL
+...............................................................................
+
+.. include:: pgRouting-concepts.rst
+    :start-after: basic_combinations_sql_start
+    :end-before: basic_combinations_sql_end
+
+Advanced documentation
 -------------------------------------------------------------------------------
+
+.. advanced_documentation_start
+
+.. contents:: Contents
+   :local:
+
+About points
+...............................................................................
+
+For this section the following city (see :doc:`sampledata`) some interesing
+points such as restaurant, supermarket, post office, etc. will be used as
+example.
+
+.. figure:: /images/Fig1-originalData.png
+   :scale: 50%
+
+- The graph is **directed**
+- Red arrows show the ``(source, target)`` of the edge on the edge table
+- Blue arrows show the ``(target, source)`` of the edge on the edge table
+- Each point location shows where it is located with relation of the edge
+  ``(source, target)``
+
+  - On the right for points **2** and **4**.
+  - On the left for points **1**, **3** and **5**.
+  - On both sides for point **6**.
+
+The representation on the data base follows the `Points SQL`_ description, and
+for this example:
+
+.. literalinclude:: withPoints-category.queries
+   :start-after: --q1
+   :end-before: --q2
+
+Driving side
+...............................................................................
+
+In the the folowwing images:
+
+- The squared vertices are the temporary vertices,
+- The temporary vertices are added according to the driving side,
+- visually showing the differences on how depending on the driving side the data
+  is interpreted.
+
+Right driving side
+_______________________________________________________________________________
+
+.. image:: images/rightDrivingSide.png
+    :scale: 50%
+
+- Point **1** located on edge ``(2, 1)``
+- Point **2** located on edge ``(9, 12)``
+- Point **3** located on edge ``(10, 11)``
+- Point **4** located on edge ``(7, 8)``
+- Point **5** located on edge ``(3, 6)``
+- Point **6** located on edges ``(2, 5)`` and ``(5, 2)``
+
+Left driving side
+_______________________________________________________________________________
+
+.. image:: images/leftDrivingSide.png
+    :scale: 50%
+
+- Point **1** located on edge ``(1, 2)``
+- Point **2** located on edge ``(12, 9)``
+- Point **3** located on edge ``(10, 11)``
+- Point **4** located on edge ``(8, 7)``
+- Point **5** located on edge ``(3, 6)``
+- Point **6** located on edges ``(2, 5)`` and ``(5, 2)``
+
+Driving side does not matter
+_______________________________________________________________________________
+
+- Like having all points to be considered in both sides ``b``
+- Prefered usage on **undirected** graphs
+- On the :doc:`TRSP-family` this option is not valid
+
+.. image:: images/noMatterDrivingSide.png
+    :scale: 50%
+
+- Point **1** located on edges ``(1, 2)`` and ``(2, 1)``
+- Point **2** located on edges ``(12, 9)`` and ``(9, 12)``
+- Point **3** located on edge ``(10, 11)``
+- Point **4** located on edges ``(8, 7)`` and ``(7, 8)``
+- Point **5** located on edge ``(3, 6)``
+- Point **6** located on edges ``(2, 5)`` and ``(5, 2)``
+
+
+Creating temporary vertices
+...............................................................................
 
 This section will demonstrate how a temporary vertex is created internally on
 the graph.
@@ -238,7 +335,7 @@ insert point:
    :end-before: --q4
 
 On a right hand side driving network
-...............................................................................
+_______________________________________________________________________________
 
 .. rubric:: Right driving side
 
@@ -258,7 +355,7 @@ On a right hand side driving network
 - If more points are on the same edge, the process is repeated recursevly.
 
 On a left hand side driving network
-...............................................................................
+_______________________________________________________________________________
 
 .. rubric:: Left driving side
 
@@ -288,7 +385,7 @@ On a left hand side driving network
 - The total cost of the additional edges is equal to the original cost.
 
 When driving side does not matter
-...............................................................................
+_______________________________________________________________________________
 
 .. image:: images/noMatterDrivingSide.png
     :scale: 50%
@@ -314,10 +411,12 @@ When driving side does not matter
     - Edge ``(-2, 12)`` becomes ``(12, -2)`` with cost ``0.6`` and is added to
       the graph.
 
+.. advanced_documentation_end
+
 See Also
 -------------------------------------------------------------------------------
 
-* :doc:`withPoints-category`
+* :doc:`withPoints-family`
 
 .. rubric:: Indices and tables
 

--- a/doc/trsp/pgr_trspVia.rst
+++ b/doc/trsp/pgr_trspVia.rst
@@ -16,7 +16,7 @@
 ``pgr_trspVia`` - Proposed
 ===============================================================================
 
-``pgr_trspVia`` Via vertices routing with restrictions.
+``pgr_trspVia`` Route that goes through a list of vertices with restrictions.
 
 .. include:: proposed.rst
    :start-after: stable-begin-warning
@@ -32,8 +32,6 @@
 * Version 3.4.0
 
   * New **proposed** function ``pgr_trspVia`` (`One Via`_)
-
-|
 
 Description
 -------------------------------------------------------------------------------
@@ -53,25 +51,11 @@ The general algorithm is as follows:
   * **NOTE** when this is done, ``U_turn_on_edge`` flag is ignored.
 
 
-|
-
 Signatures
 -------------------------------------------------------------------------------
 
-.. rubric:: Summary
-
 .. index::
     single: trspVia - Proposed on v3.4
-
-.. parsed-literal::
-
-    pgr_trspVia(`Edges SQL`_, `Restrictions SQL`_, **via vertices**
-               [, directed] [, strict] [, U_turn_on_edge]) -- Proposed on v3.4
-    RETURNS SET OF (seq, path_pid, path_seq, start_vid, end_vid,
-                    node, edge, cost, agg_cost, route_agg_cost)
-    OR EMPTY SET
-
-|
 
 One Via
 ...............................................................................
@@ -79,7 +63,7 @@ One Via
 .. parsed-literal::
 
     pgr_trspVia(`Edges SQL`_, `Restrictions SQL`_, **via vertices**
-               [, directed] [, strict] [, U_turn_on_edge]) -- Proposed on v3.4
+               [, directed] [, strict] [, U_turn_on_edge]) - Proposed on v3.4
     RETURNS SET OF (seq, path_pid, path_seq, start_vid, end_vid,
                     node, edge, cost, agg_cost, route_agg_cost)
     OR EMPTY SET
@@ -91,8 +75,6 @@ One Via
     :start-after: -- q0
     :end-before: -- q1
 
-|
-
 Parameters
 -------------------------------------------------------------------------------
 
@@ -100,21 +82,22 @@ Parameters
     :start-after: via_parameters_start
     :end-before: via_parameters_end
 
-|
+Optional parameters
+...............................................................................
+
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_optionals_start
+    :end-before: dijkstra_optionals_end
 
 Via optional parameters
 ...............................................................................
 
 .. include:: via-category.rst
-    :start-after: via_opt_parameters_start
-    :end-before: via_opt_parameters_end
-
-|
+    :start-after: via_optionals_start
+    :end-before: via_optionals_end
 
 Inner query
 -------------------------------------------------------------------------------
-
-|
 
 Edges SQL
 ...............................................................................
@@ -123,8 +106,6 @@ Edges SQL
     :start-after: basic_edges_sql_start
     :end-before: basic_edges_sql_end
 
-|
-
 Restrictions SQL
 ...............................................................................
 
@@ -132,16 +113,12 @@ Restrictions SQL
    :start-after: restrictions_columns_start
    :end-before: restrictions_columns_end
 
-|
-
 Return Columns
 -------------------------------------------------------------------------------
 
 .. include:: via-category.rst
-    :start-after: result columns start
-    :end-before: result columns end
-
-|
+    :start-after: result via start
+    :end-before: result via end
 
 Additional Examples
 -------------------------------------------------------------------------------

--- a/doc/trsp/pgr_trspVia_withPoints.rst
+++ b/doc/trsp/pgr_trspVia_withPoints.rst
@@ -16,7 +16,8 @@
 ``pgr_trspVia_withPoints`` - Proposed
 ===============================================================================
 
-``pgr_trspVia_withPoints`` Via vertices/points routing with restrictions.
+``pgr_trspVia_withPoints`` - Route that goes through a list of vertices and/or
+points with restrictions.
 
 .. include:: proposed.rst
    :start-after: stable-begin-warning
@@ -32,8 +33,6 @@
 * Version 3.4.0
 
   * New **proposed** function ``pgr_trspVia_withPoints`` (`One Via`_)
-
-|
 
 Description
 -------------------------------------------------------------------------------
@@ -62,25 +61,11 @@ The general algorithm is as follows:
 
 .. Note:: Do not use negative values on identifiers of the inner queries.
 
-|
-
 Signatures
 -------------------------------------------------------------------------------
 
-.. rubric:: Summary
-
 .. index::
     single: trspVia - Proposed on v3.4
-
-.. parsed-literal::
-
-    pgr_trspVia_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Points SQL`_, **via vertices**
-               [, directed] [, strict] [, U_turn_on_edge]) -- Proposed on v3.4
-    RETURNS SET OF (seq, path_pid, path_seq, start_vid, end_vid,
-                    node, edge, cost, agg_cost, route_agg_cost)
-    OR EMPTY SET
-
-|
 
 One Via
 ...............................................................................
@@ -100,55 +85,26 @@ One Via
     :start-after: -- q0
     :end-before: -- q1
 
-|
-
 Parameters
 -------------------------------------------------------------------------------
 
-.. list-table::
-   :width: 81
-   :widths: 14 20 7 40
-   :header-rows: 1
+.. include:: via-category.rst
+    :start-after: via_withPoints_parameters_start
+    :end-before: via_withPoints_parameters_end
 
-   * - Parameter
-     - Type
-     - Default
-     - Description
-   * - `Edges SQL`_
-     - ``TEXT``
-     -
-     - SQL query as described.
-   * - `Restrictions SQL`_
-     - ``TEXT``
-     -
-     - SQL query as described.
-   * - `Points SQL`_
-     - ``TEXT``
-     -
-     - SQL query as described.
-   * - **via vertices**
-     - ``ARRAY[`` **ANY-INTEGER** ``]``
-     -
-     - Array of ordered vertices identifiers that are going to be visited.
+Optional parameters
+...............................................................................
 
-       * When positive it is considered a vertex identifier
-       * When negative it is considered a point identifier
-   * - ``directed``
-     - ``BOOLEAN``
-     - ``true``
-     - - When ``true`` Graph is considered `Directed`
-       - When ``false`` the graph is considered as Undirected.
-
-|
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_optionals_start
+    :end-before: dijkstra_optionals_end
 
 Via optional parameters
 ...............................................................................
 
 .. include:: via-category.rst
-    :start-after: via_opt_parameters_start
-    :end-before: via_opt_parameters_end
-
-|
+    :start-after: via_optionals_start
+    :end-before: via_optionals_end
 
 With points optional parameters
 ...............................................................................
@@ -157,12 +113,8 @@ With points optional parameters
     :start-after: withPoints_parameters_start
     :end-before: withPoints_parameters_end
 
-|
-
 Inner query
 -------------------------------------------------------------------------------
-
-|
 
 Edges SQL
 ...............................................................................
@@ -171,16 +123,12 @@ Edges SQL
     :start-after: basic_edges_sql_start
     :end-before: basic_edges_sql_end
 
-|
-
 Restrictions SQL
 ...............................................................................
 
 .. include:: TRSP-family.rst
    :start-after: restrictions_columns_start
    :end-before: restrictions_columns_end
-
-|
 
 Points SQL
 ...............................................................................
@@ -189,16 +137,12 @@ Points SQL
     :start-after: points_sql_start
     :end-before: points_sql_end
 
-|
-
 Return Columns
 -------------------------------------------------------------------------------
 
 .. include:: via-category.rst
-    :start-after: result columns start
-    :end-before: result columns end
-
-|
+    :start-after: result via withPoints start
+    :end-before: result via withPoints end
 
 Additional Examples
 -------------------------------------------------------------------------------

--- a/doc/withPoints/pgr_withPoints.rst
+++ b/doc/withPoints/pgr_withPoints.rst
@@ -154,7 +154,8 @@ Many to Many
    pgr_withPoints(`Edges SQL`_, **start vids**, **end vids** [, directed] [, driving_side] [, details])
    RETURNS SET OF (seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)
 
-:Example: From point :math:`1` and vertex :math:`2`  to point :math:`3` and vertex :math:`7`
+:Example: From point :math:`1` and vertex :math:`2`  to point :math:`3` and
+          vertex :math:`7`
 
 .. literalinclude:: doc-pgr_withPoints.queries
    :start-after: --e5

--- a/doc/withPoints/pgr_withPoints.rst
+++ b/doc/withPoints/pgr_withPoints.rst
@@ -22,7 +22,7 @@
   `2.3 <https://docs.pgrouting.org/2.3/en/src/withPoints/doc/pgr_withPoints.html>`__
   `2.2 <https://docs.pgrouting.org/2.2/en/src/withPoints/doc/pgr_withPoints.html>`__
 
-pgr_withPoints - Proposed
+``pgr_withPoints`` - Proposed
 ===============================================================================
 
 ``pgr_withPoints`` - Returns the shortest path in a graph with additional temporary vertices.
@@ -47,20 +47,6 @@ pgr_withPoints - Proposed
 * Version 2.2.0
 
   * New **proposed** function
-
-.. rubric:: Support
-
-* **Supported versions:**
-  current(`3.2 <https://docs.pgrouting.org/3.2/en/pgr_withPoints.html>`__)
-  `3.1 <https://docs.pgrouting.org/3.1/en/pgr_withPoints.html>`__)
-  `3.0 <https://docs.pgrouting.org/3.0/en/pgr_withPoints.html>`__
-
-* **Unsupported versions:**
-  `2.6 <https://docs.pgrouting.org/2.6/en/pgr_withPoints.html>`__
-  `2.5 <https://docs.pgrouting.org/2.5/en/pgr_withPoints.html>`__
-  `2.4 <https://docs.pgrouting.org/2.4/en/pgr_withPoints.html>`__
-  `2.3 <https://docs.pgrouting.org/2.3/en/src/withPoints/doc/pgr_withPoints.html>`__
-  `2.2 <https://docs.pgrouting.org/2.2/en/src/withPoints/doc/pgr_withPoints.html>`__
 
 Description
 -------------------------------------------------------------------------------
@@ -96,31 +82,14 @@ Signatures
 
 .. rubric:: Summary
 
-.. code-block:: none
+.. parsed-literal::
 
-   pgr_withPoints(edges_sql, points_sql, from_vid,  to_vid  [, directed] [, driving_side] [, details])
-   pgr_withPoints(edges_sql, points_sql, from_vid,  to_vids [, directed] [, driving_side] [, details])
-   pgr_withPoints(edges_sql, points_sql, from_vids, to_vid  [, directed] [, driving_side] [, details])
-   pgr_withPoints(edges_sql, points_sql, from_vids, to_vids [, directed] [, driving_side] [, details])
-   pgr_withPoints(Edges SQL, Points SQL, Combinations SQL [, directed] [, driving_side] [, details])
+   pgr_withPoints(`Edges SQL`_, **start vid**, **end vid**  [, directed] [, driving_side] [, details])
+   pgr_withPoints(`Edges SQL`_, **start vid**, **end vids** [, directed] [, driving_side] [, details])
+   pgr_withPoints(`Edges SQL`_, **start vids**, **end vid**  [, directed] [, driving_side] [, details])
+   pgr_withPoints(`Edges SQL`_, **start vids**, **end vids** [, directed] [, driving_side] [, details])
+   pgr_withPoints(`Edges SQL`_, `Combinations SQL`_ [, directed] [, driving_side] [, details])
    RETURNS SET OF (seq, path_seq, [start_vid,] [end_vid,] node, edge, cost, agg_cost)
-
-.. rubric:: Using defaults
-
-.. code-block:: none
-
-    pgr_withPoints(edges_sql, points_sql, from_vid, to_vid)
-    RETURNS SET OF (seq, path_seq, node, edge, cost, agg_cost)
-
-:Example: From point :math:`1` to point :math:`3`
-
-    - For a **directed** graph.
-    - The driving side is set as **b** both. So arriving/departing to/from the point(s) can be in any direction.
-    - No **details** are given about distance of other points of points_sql query.
-
-.. literalinclude:: doc-pgr_withPoints.queries
-   :start-after: --e1
-   :end-before: --e2
 
 .. index::
     single: withPoints(One to One) - Proposed on v2.2
@@ -128,10 +97,10 @@ Signatures
 One to One
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_withPoints(edges_sql, points_sql, from_vid,  to_vid  [, directed] [, driving_side] [, details])
-    RETURNS SET OF (seq, path_seq, node, edge, cost, agg_cost)
+   pgr_withPoints(`Edges SQL`_, **start vid**, **end vid**  [, directed] [, driving_side] [, details])
+   RETURNS SET OF (seq, path_seq, node, edge, cost, agg_cost)
 
 :Example: From point :math:`1` to vertex :math:`3` with details of passing points
 
@@ -145,10 +114,10 @@ One to One
 One to Many
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_withPoints(edges_sql, points_sql, from_vid,  to_vids [, directed] [, driving_side] [, details])
-    RETURNS SET OF (seq, path_seq, end_vid, node, edge, cost, agg_cost)
+   pgr_withPoints(`Edges SQL`_, **start vid**, **end vids** [, directed] [, driving_side] [, details])
+   RETURNS SET OF (seq, path_seq, end_vid, node, edge, cost, agg_cost)
 
 :Example: From point :math:`1` to point :math:`3` and vertex :math:`5`
 
@@ -162,10 +131,10 @@ One to Many
 Many to One
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_withPoints(edges_sql, points_sql, from_vids, to_vid  [, directed] [, driving_side] [, details])
-    RETURNS SET OF (seq, path_seq, start_vid, node, edge, cost, agg_cost)
+   pgr_withPoints(`Edges SQL`_, **start vids**, **end vid**  [, directed] [, driving_side] [, details])
+   RETURNS SET OF (seq, path_seq, start_vid, node, edge, cost, agg_cost)
 
 :Example: From point :math:`1` and vertex :math:`2` to point :math:`3`
 
@@ -179,10 +148,10 @@ Many to One
 Many to Many
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_withPoints(edges_sql, points_sql, from_vids, to_vids [, directed] [, driving_side] [, details])
-    RETURNS SET OF (seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)
+   pgr_withPoints(`Edges SQL`_, **start vids**, **end vids** [, directed] [, driving_side] [, details])
+   RETURNS SET OF (seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)
 
 :Example: From point :math:`1` and vertex :math:`2`  to point :math:`3` and vertex :math:`7`
 
@@ -193,16 +162,18 @@ Many to Many
 .. index::
     single: withPoints(Combinations) - Proposed on v3.2
 
-Combinations SQL
+Combinations
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_withPoints(Edges SQL, Points SQL, Combinations SQL [, directed] [, driving_side] [, details])
-    RETURNS SET OF (seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)
+   pgr_withPoints(`Edges SQL`_, `Combinations SQL`_ [, directed] [, driving_side] [, details])
+   RETURNS SET OF (seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)
 
-:Example: Two (source, target) combinations: (from point :math:`1` to vertex :math:`3`), and (from vertex :math:`2` to point :math:`3`) with **right** side driving topology.
+:Example: Two (source, target) combinations
 
+From point :math:`1` to vertex :math:`3`, and from vertex :math:`2` to point
+:math:`3` with **right** side driving topology.
 
 .. literalinclude:: doc-pgr_withPoints.queries
    :start-after: --q5
@@ -211,47 +182,42 @@ Combinations SQL
 Parameters
 -------------------------------------------------------------------------------
 
-====================== ====================== =================================================
-Parameter              Type                   Description
-====================== ====================== =================================================
-**Edges SQL**          ``TEXT``               `Edges query` as described above.
-**Points SQL**         ``TEXT``               `Points query` as described above.
-**Combinations SQL**   ``TEXT``               `Combinations query` as described below.
-**start_vid**          ``ANY-INTEGER``        Starting vertex identifier. When negative: is a point's pid.
-**end_vid**            ``ANY-INTEGER``        Ending vertex identifier. When negative: is a point's pid.
-**start_vids**         ``ARRAY[ANY-INTEGER]`` Array of identifiers of starting vertices. When negative: is a point's pid.
-**end_vids**           ``ARRAY[ANY-INTEGER]`` Array of identifiers of ending vertices. When negative: is a point's pid.
-**directed**           ``BOOLEAN``            (optional). When ``false`` the graph is considered as Undirected. Default is ``true`` which considers the graph as Directed.
-**driving_side**       ``CHAR``               (optional) Value in ['b', 'r', 'l', NULL] indicating if the driving side is:
-                                                - In the right or left or
-                                                - If it doesn't matter with 'b' or NULL.
-                                                - If column not present 'b' is considered.
+.. include:: withPoints-category.rst
+    :start-after: withPoints_parameters_start
+    :end-before: withPoints_parameters_end
 
-**details**            ``BOOLEAN``            (optional). When ``true`` the results will include the points in points_sql that are in the path.
-                                              Default is ``false`` which ignores other points of the points_sql.
-====================== ====================== =================================================
+Optional parameters
+...............................................................................
+
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_optionals_start
+    :end-before: dijkstra_optionals_end
+
+With points optional parameters
+...............................................................................
+
+.. include:: withPoints-family.rst
+    :start-after: withPoints_optionals_start
+    :end-before: withPoints_optionals_end
 
 Inner query
 -------------------------------------------------------------------------------
 
-..
-    description of the sql queries
-
-Edges query
+Edges SQL
 ...............................................................................
 
 .. include:: pgRouting-concepts.rst
     :start-after: basic_edges_sql_start
     :end-before: basic_edges_sql_end
 
-Points query
+Points SQL
 ...............................................................................
 
 .. include:: withPoints-category.rst
     :start-after: points_sql_start
     :end-before: points_sql_end
 
-Combinations query
+Combinations SQL
 ...............................................................................
 
 .. include:: pgRouting-concepts.rst
@@ -261,44 +227,29 @@ Combinations query
 Result Columns
 -------------------------------------------------------------------------------
 
-============= =========== =================================================
-Column           Type              Description
-============= =========== =================================================
-**seq**       ``INTEGER`` Row sequence.
-**path_seq**  ``INTEGER`` Path sequence that indicates the relative position on the path.
-**start_vid** ``BIGINT``  Identifier of the starting vertex. When negative: is a point's pid.
-**end_vid**   ``BIGINT``  Identifier of the ending vertex. When negative: is a point's pid.
-**node**      ``BIGINT``  Identifier of the node:
-                            - A positive value indicates the node is a vertex of edges_sql.
-                            - A negative value indicates the node is a point of points_sql.
-
-**edge**      ``BIGINT``  Identifier of the edge used to go from ``node`` to the next node in the path sequence.
-                            - ``-1`` for the last row in the path sequence.
-
-**cost**      ``FLOAT``   Cost to traverse from ``node`` using ``edge`` to the next ``node`` in the path sequence.
-                            - ``0`` for the last row in the path sequence.
-
-**agg_cost**  ``FLOAT``   Aggregate cost from ``start_pid`` to ``node``.
-                            - ``0`` for the first row in the path sequence.
-
-============= =========== =================================================
+.. include:: pgRouting-concepts.rst
+    :start-after: return_withpoint_path_short_start
+    :end-before: return_withpoint_path_short_end
 
 Additional Examples
 -------------------------------------------------------------------------------
 
-:Example: Which path (if any) passes in front of point :math:`6` or vertex :math:`6` with **right** side driving topology.
+:Example: Which path (if any) passes in front of point :math:`6` or vertex
+          :math:`6` with **right** side driving topology.
 
 .. literalinclude:: doc-pgr_withPoints.queries
    :start-after: --q2
    :end-before: --q3
 
-:Example: Which path (if any) passes in front of point :math:`6` or vertex :math:`6` with **left** side driving topology.
+:Example: Which path (if any) passes in front of point :math:`6` or vertex
+          :math:`6` with **left** side driving topology.
 
 .. literalinclude:: doc-pgr_withPoints.queries
    :start-after: --q3
    :end-before: --q4
 
-:Example: From point :math:`1` and vertex :math:`2` to point :math:`3` to vertex :math:`7` on an **undirected** graph, with details.
+:Example: From point :math:`1` and vertex :math:`2` to point :math:`3` to vertex
+          :math:`7` on an **undirected** graph, with details.
 
 .. literalinclude:: doc-pgr_withPoints.queries
    :start-after: --q4
@@ -310,6 +261,7 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`withPoints-family`
+* :doc:`withPoints-category`
 
 .. rubric:: Indices and tables
 

--- a/doc/withPoints/pgr_withPoints.rst
+++ b/doc/withPoints/pgr_withPoints.rst
@@ -102,7 +102,7 @@ One to One
    pgr_withPoints(`Edges SQL`_, **start vid**, **end vid**  [, directed] [, driving_side] [, details])
    RETURNS SET OF (seq, path_seq, node, edge, cost, agg_cost)
 
-:Example: From point :math:`1` to vertex :math:`3` with details of passing points
+:Example: From point :math:`1` to vertex :math:`3` with details
 
 .. literalinclude:: doc-pgr_withPoints.queries
    :start-after: --e2
@@ -119,7 +119,8 @@ One to Many
    pgr_withPoints(`Edges SQL`_, **start vid**, **end vids** [, directed] [, driving_side] [, details])
    RETURNS SET OF (seq, path_seq, end_vid, node, edge, cost, agg_cost)
 
-:Example: From point :math:`1` to point :math:`3` and vertex :math:`5`
+:Example: From point :math:`1` to point :math:`3` and vertex :math:`5` on an
+          undirected graph
 
 .. literalinclude:: doc-pgr_withPoints.queries
    :start-after: --e3
@@ -157,7 +158,7 @@ Many to Many
 
 .. literalinclude:: doc-pgr_withPoints.queries
    :start-after: --e5
-   :end-before: --q2
+   :end-before: --e6
 
 .. index::
     single: withPoints(Combinations) - Proposed on v3.2
@@ -170,14 +171,14 @@ Combinations
    pgr_withPoints(`Edges SQL`_, `Combinations SQL`_ [, directed] [, driving_side] [, details])
    RETURNS SET OF (seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)
 
-:Example: Two (source, target) combinations
+:Example: Two combinations
 
 From point :math:`1` to vertex :math:`3`, and from vertex :math:`2` to point
-:math:`3` with **right** side driving topology.
+:math:`3` with **right** side driving.
 
 .. literalinclude:: doc-pgr_withPoints.queries
-   :start-after: --q5
-   :end-before: --q6
+   :start-after: --e6
+   :end-before: --e7
 
 Parameters
 -------------------------------------------------------------------------------
@@ -234,26 +235,32 @@ Result Columns
 Additional Examples
 -------------------------------------------------------------------------------
 
+:Example: Paths that passes in front or visits point :math:`6` or vertex
+          :math:`6` with **right** side driving.
+
+Traveling from point 1 and vertex 1 to points :math:`\{2, 3, 6\}` and vertices
+:math:`\{3, 6\}`
+
+.. literalinclude:: doc-pgr_withPoints.queries
+   :start-after: --q1
+   :end-before: --q2
+
 :Example: Which path (if any) passes in front of point :math:`6` or vertex
-          :math:`6` with **right** side driving topology.
+          :math:`6` with **left** side.
+
+Traveling from point 1 and vertex 1 to points :math:`\{2, 3, 6\}` and vertices
+:math:`\{3, 6\}`
 
 .. literalinclude:: doc-pgr_withPoints.queries
    :start-after: --q2
    :end-before: --q3
 
-:Example: Which path (if any) passes in front of point :math:`6` or vertex
-          :math:`6` with **left** side driving topology.
+:Example: From point :math:`1` and vertex :math:`2` to point :math:`3` and to
+          vertex :math:`7` on an **undirected** graph, with details.
 
 .. literalinclude:: doc-pgr_withPoints.queries
    :start-after: --q3
    :end-before: --q4
-
-:Example: From point :math:`1` and vertex :math:`2` to point :math:`3` to vertex
-          :math:`7` on an **undirected** graph, with details.
-
-.. literalinclude:: doc-pgr_withPoints.queries
-   :start-after: --q4
-   :end-before: --q5
 
 The queries use the :doc:`sampledata` network
 

--- a/doc/withPoints/pgr_withPointsCost.rst
+++ b/doc/withPoints/pgr_withPointsCost.rst
@@ -218,6 +218,8 @@ Optional parameters
 With points optional parameters
 ...............................................................................
 
+.. withpoints_short_optionals_start
+
 .. list-table::
    :width: 81
    :widths: 14 7 7 60
@@ -235,6 +237,8 @@ With points optional parameters
        - ``r`` for right driving side.
        - ``l`` for left driving side.
        - ``b`` for both.
+
+.. withpoints_short_optionals_end
 
 Inner queries
 -------------------------------------------------------------------------------

--- a/doc/withPoints/pgr_withPointsCost.rst
+++ b/doc/withPoints/pgr_withPointsCost.rst
@@ -22,10 +22,12 @@
   `2.3 <https://docs.pgrouting.org/2.3/en/src/withPoints/doc/pgr_withPointsCost.html>`__
   `2.2 <https://docs.pgrouting.org/2.2/en/src/withPoints/doc/pgr_withPointsCost.html>`__
 
-pgr_withPointsCost - Proposed
+``pgr_withPointsCost`` - Proposed
 ===============================================================================
 
-``pgr_withPointsCost`` - Calculates the shortest path and returns only the aggregate cost of the shortest path(s) found, for the combination of points given.
+``pgr_withPointsCost`` - Calculates the shortest path and returns only the
+aggregate cost of the shortest path(s) found, for the combination of points
+given.
 
 .. include:: proposed.rst
    :start-after: begin-warning
@@ -97,199 +99,203 @@ Signatures
 
 .. rubric:: Summary
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_withPointsCost(edges_sql, points_sql, from_vid,  to_vid  [, directed] [, driving_side])
-    pgr_withPointsCost(edges_sql, points_sql, from_vid,  to_vids [, directed] [, driving_side])
-    pgr_withPointsCost(edges_sql, points_sql, from_vids, to_vid  [, directed] [, driving_side])
-    pgr_withPointsCost(edges_sql, points_sql, from_vids, to_vids [, directed] [, driving_side])
-    pgr_withPointsCost(Edges SQL, Points SQL, Combinations SQL  [, directed] [, driving_side] [, details])
+    pgr_withPointsCost(`Edges SQL`_, **start vid**, **end vid**  [, directed] [, driving_side])
+    pgr_withPointsCost(`Edges SQL`_, **start vid**, **end vids** [, directed] [, driving_side])
+    pgr_withPointsCost(`Edges SQL`_, **start vids**, **end vid**  [, directed] [, driving_side])
+    pgr_withPointsCost(`Edges SQL`_, **start vids**, **end vids** [, directed] [, driving_side])
+    pgr_withPointsCost(`Edges SQL`_, `Combinations SQL`_ [, directed] [, driving_side])
     RETURNS SET OF (start_vid, end_vid, agg_cost)
 
-.. note:: There is no **details** flag, unlike the other members of the withPoints family of functions.
-
-.. rubric:: Using defaults
-
-.. code-block:: none
-
-    pgr_withPointsCost(edges_sql, points_sql, start_vid, end_vid)
-    RETURNS SET OF (start_vid, end_vid, agg_cost)
-
-:Example: From point :math:`1` to point :math:`3`
-
-- For a **directed** graph.
-- The driving side is set as **b** both. So arriving/departing to/from the point(s) can be in any direction.
-
-
-.. literalinclude:: doc-pgr_withPointsCost.queries
-   :start-after: --e1
-   :end-before: --e2
+.. note:: There is no **details** flag, unlike the other members of the
+   withPoints family of functions.
 
 .. index::
-    single: withPointsCost(One To One) - proposed on v2.2
+    single: withPointsCost(One To One) - Proposed on v2.2
 
 One to One
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_withPointsCost(edges_sql, points_sql, from_vid,  to_vid  [, directed] [, driving_side])
-    RETURNS SET OF (seq, node, edge, cost, agg_cost)
+    pgr_withPointsCost(`Edges SQL`_, **start vid**, **end vid**  [, directed] [, driving_side])
+    RETURNS SET OF (start_vid, end_vid, agg_cost)
 
-:Example: From point :math:`1` to vertex :math:`3` on an **undirected** graph.
+:Example: From point :math:`1` to vertex :math:`3` with defaults
 
 .. literalinclude:: doc-pgr_withPointsCost.queries
    :start-after: --e2
    :end-before: --e3
 
 .. index::
-    single: withPointsCost(One To Many) - proposed on v2.2
+    single: withPointsCost(One To Many) - Proposed on v2.2
 
 One to Many
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_withPointsCost(edges_sql, points_sql, from_vid,  to_vids [, directed] [, driving_side])
+    pgr_withPointsCost(`Edges SQL`_, **start vid**, **end vids** [, directed] [, driving_side])
     RETURNS SET OF (start_vid, end_vid, agg_cost)
 
-:Example: From point :math:`1` to point :math:`3` and vertex :math:`5` on a **directed** graph.
+:Example: From point :math:`1` to point :math:`3` and vertex :math:`5` on an
+          undirected graph
 
 .. literalinclude:: doc-pgr_withPointsCost.queries
    :start-after: --e3
    :end-before: --e4
 
 .. index::
-    single: withPointsCost(Many To One) - proposed on v2.2
+    single: withPointsCost(Many To One) - Proposed on v2.2
 
 Many to One
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_withPointsCost(edges_sql, points_sql, from_vids, to_vid  [, directed] [, driving_side])
+    pgr_withPointsCost(`Edges SQL`_, **start vids**, **end vid**  [, directed] [, driving_side])
     RETURNS SET OF (start_vid, end_vid, agg_cost)
 
-:Example: From point :math:`1` and vertex :math:`2` to point :math:`3` on a **directed** graph.
+:Example: From point :math:`1` and vertex :math:`2` to point :math:`3`
 
 .. literalinclude:: doc-pgr_withPointsCost.queries
    :start-after: --e4
    :end-before: --e5
 
 .. index::
-    single: withPointsCost(Many To Many) - proposed on v2.2
+    single: withPointsCost(Many To Many) - Proposed on v2.2
 
 Many to Many
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_withPointsCost(edges_sql, points_sql, from_vids, to_vids [, directed] [, driving_side])
+    pgr_withPointsCost(`Edges SQL`_, **start vids**, **end vids** [, directed] [, driving_side])
     RETURNS SET OF (start_vid, end_vid, agg_cost)
 
-:Example: From point :math:`1` and vertex :math:`2` to point :math:`3` and vertex :math:`7` on a **directed** graph.
+:Example: From point :math:`1` and vertex :math:`2`  to point :math:`3` and
+          vertex :math:`7`
 
 .. literalinclude:: doc-pgr_withPointsCost.queries
    :start-after: --e5
-   :end-before: --q2
+   :end-before: --e6
 
 .. index::
     single: withPointsCost(Combinations) -- Proposed on v3.2
 
-Combinations SQL
+Combinations
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_withPointsCost(Edges SQL, Points SQL, Combinations SQL [, directed] [, driving_side] [, details])
+    pgr_withPointsCost(`Edges SQL`_, `Combinations SQL`_ [, directed] [, driving_side])
     RETURNS SET OF (seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)
 
-:Example: Two (source, target) combinations: (from point :math:`1` to vertex :math:`3`), and (from vertex :math:`2` to point :math:`3`) with **right** side driving topology.
+:Example: Two combinations
 
+From point :math:`1` to vertex :math:`3`, and from vertex :math:`2` to point
+:math:`3` with **right** side driving.
 
 .. literalinclude:: doc-pgr_withPointsCost.queries
-   :start-after: --q5
-   :end-before: --q6
-
+   :start-after: --e6
+   :end-before: --e7
 
 Parameters
 -------------------------------------------------------------------------------
 
-====================== ====================== =================================================
-Parameter              Type                   Description
-====================== ====================== =================================================
-**Edges SQL**          ``TEXT``               `Edges query` as described above.
-**Points SQL**         ``TEXT``               `Points query` as described above.
-**Combinations SQL**   ``TEXT``               `Combinations query` as described below.
-**start_vid**          ``ANY-INTEGER``        Starting vertex identifier. When negative: is a point's pid.
-**end_vid**            ``ANY-INTEGER``        Ending vertex identifier. When negative: is a point's pid.
-**start_vids**         ``ARRAY[ANY-INTEGER]`` Array of identifiers of starting vertices. When negative: is a point's pid.
-**end_vids**           ``ARRAY[ANY-INTEGER]`` Array of identifiers of ending vertices. When negative: is a point's pid.
-**directed**           ``BOOLEAN``            (optional). When ``false`` the graph is considered as Undirected. Default is ``true`` which considers the graph as Directed.
-**driving_side**       ``CHAR``               (optional) Value in ['b', 'r', 'l', NULL] indicating if the driving side is:
-                                                - In the right or left or
-                                                - If it doesn't matter with 'b' or NULL.
-                                                - If column not present 'b' is considered.
+.. include:: withPoints-category.rst
+    :start-after: withPoints_parameters_start
+    :end-before: withPoints_parameters_end
 
-====================== ====================== =================================================
+Optional parameters
+...............................................................................
 
-Inner query
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_optionals_start
+    :end-before: dijkstra_optionals_end
+
+With points optional parameters
+...............................................................................
+
+.. list-table::
+   :width: 81
+   :widths: 14 7 7 60
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Default
+     - Description
+   * - ``driving_side``
+     - ``CHAR``
+     - ``b``
+     - Value in [``r``, ``l``, ``b``] indicating if the driving side is:
+
+       - ``r`` for right driving side.
+       - ``l`` for left driving side.
+       - ``b`` for both.
+
+Inner queries
 -------------------------------------------------------------------------------
-..
-    description of the sql queries
 
-Edges query
+Edges SQL
 ...............................................................................
 
 .. include:: pgRouting-concepts.rst
     :start-after: basic_edges_sql_start
     :end-before: basic_edges_sql_end
 
-Points query
+Points SQL
 ...............................................................................
 
 .. include:: withPoints-category.rst
     :start-after: points_sql_start
     :end-before: points_sql_end
 
-Combinations query
+Combinations SQL
 ...............................................................................
 
 .. include:: pgRouting-concepts.rst
     :start-after: basic_combinations_sql_start
     :end-before: basic_combinations_sql_end
 
-Result Columns
+Return Columns
 -------------------------------------------------------------------------------
 
-============= =========== =================================================
-Column           Type              Description
-============= =========== =================================================
-**start_vid** ``BIGINT``  Identifier of the starting vertex. When negative: is a point's pid.
-**end_vid**   ``BIGINT``  Identifier of the ending point. When negative: is a point's pid.
-**agg_cost**  ``FLOAT``   Aggregate cost from ``start_vid`` to ``end_vid``.
-============= =========== =================================================
+.. include:: pgRouting-concepts.rst
+    :start-after: return_cost_withPoints_start
+    :end-before: return_cost_withPoints_end
 
 Additional Examples
 -------------------------------------------------------------------------------
 
-:Example: From point :math:`1` and vertex :math:`2` to point :math:`3` and vertex :math:`7`, with **right** side driving topology
+:Example: **Right** side driving topology
+
+Traveling from point 1 and vertex 1 to points :math:`\{2, 3, 6\}` and vertices
+:math:`\{3, 6\}`
+
+.. literalinclude:: doc-pgr_withPointsCost.queries
+   :start-after: --q1
+   :end-before: --q2
+
+:Example: **Left** side driving topology
+
+Traveling from point 1 and vertex 1 to points :math:`\{2, 3, 6\}` and vertices
+:math:`\{3, 6\}`
 
 .. literalinclude:: doc-pgr_withPointsCost.queries
    :start-after: --q2
    :end-before: --q3
 
-:Example: From point :math:`1` and vertex :math:`2` to point :math:`3` and vertex :math:`7`, with **left** side driving topology
+:Example: Does not matter driving side driving topology
+
+Traveling from point 1 and vertex 1 to points :math:`\{2, 3, 6\}` and vertices
+:math:`\{3, 6\}`
 
 .. literalinclude:: doc-pgr_withPointsCost.queries
    :start-after: --q3
    :end-before: --q4
-
-:Example: From point :math:`1` and vertex :math:`2` to point :math:`3` and vertex :math:`7`, does not matter driving side.
-
-.. literalinclude:: doc-pgr_withPointsCost.queries
-   :start-after: --q4
-   :end-before: --q5
 
 The queries use the :doc:`sampledata` network.
 

--- a/doc/withPoints/pgr_withPointsCostMatrix.rst
+++ b/doc/withPoints/pgr_withPointsCostMatrix.rst
@@ -21,10 +21,12 @@
   `2.4 <https://docs.pgrouting.org/2.4/en/pgr_withPointsCostMatrix.html>`__
   `2.3 <https://docs.pgrouting.org/2.3/en/src/costMatrix/doc/pgr_withPointsCostMatrix.html>`__
 
-pgr_withPointsCostMatrix - proposed
+``pgr_withPointsCostMatrix`` - proposed
 ===============================================================================
 
-``pgr_withPointsCostMatrix`` - Calculates the shortest path and returns only the aggregate cost of the shortest path(s) found, for the combination of points given.
+``pgr_withPointsCostMatrix`` - Calculates the shortest path and returns only the
+aggregate cost of the shortest path(s) found, for the combination of points
+given.
 
 .. include:: proposed.rst
    :start-after: begin-warning
@@ -52,44 +54,16 @@ Signatures
 
 .. rubric:: Summary
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_withPointsCostMatrix(edges_sql, points_sql, start_vids [, directed] [, driving_side])
+    pgr_withPointsCostMatrix(`Edges SQL`_, `Points SQL`_, **start vids**, [, directed] [, driving_side])
     RETURNS SET OF (start_vid, end_vid, agg_cost)
 
-.. note:: There is no **details** flag, unlike the other members of the withPoints family of functions.
+.. note:: There is no **details** flag, unlike the other members of the
+   withPoints family of functions.
 
-.. rubric:: Using default
-
-The minimal signature:
-    - Is for a **directed** graph.
-    - The driving side is set as **b** both. So arriving/departing to/from the point(s) can be in any direction.
-
-.. code-block:: none
-
-    pgr_withPointsCostMatrix(edges_sql, points_sql, start_vid)
-    RETURNS SET OF (start_vid, end_vid, agg_cost)
-
-:Example: Cost matrix for points :math:`\{1, 6\}` and vertices :math:`\{3, 6\}` on a **directed** graph
-
-
-.. literalinclude:: doc-pgr_withPointsCostMatrix.queries
-   :start-after: -- withPoints q1
-   :end-before: -- withPoints q2
-
-.. index::
-    single: withPointsCostMatrix - Proposed on v2.2
-
-Complete Signature
-...............................................................................
-
-.. code-block:: none
-
-    pgr_withPointsCostMatrix(edges_sql, points_sql, start_vids,
-        directed:=true, driving_side:='b')
-    RETURNS SET OF (start_vid, end_vid, agg_cost)
-
-:Example: Cost matrix for points :math:`\{1, 6\}` and vertices :math:`\{3, 6\}` on an **undirected** graph
+:Example: Cost matrix for points :math:`\{1, 6\}` and vertices :math:`\{3, 6\}`
+          on an **undirected** graph
 
 * Returning a **symmetrical** cost matrix
 * Using the default **side** value on the **points_sql** query
@@ -102,42 +76,54 @@ Complete Signature
 Parameters
 -------------------------------------------------------------------------------
 
-================ ====================== =================================================
-Parameter        Type                   Description
-================ ====================== =================================================
-**edges_sql**    ``TEXT``               Edges SQL query as described above.
-**points_sql**   ``TEXT``               Points SQL query as described above.
-**start_vids**   ``ARRAY[ANY-INTEGER]`` Array of identifiers of starting vertices. When negative: is a point's pid.
-**directed**     ``BOOLEAN``            (optional). When ``false`` the graph is considered as Undirected. Default is ``true`` which considers the graph as Directed.
-**driving_side** ``CHAR``               (optional) Value in ['b', 'r', 'l', NULL] indicating if the driving side is:
-                                          - In the right or left or
-                                          - If it doesn't matter with 'b' or NULL.
-                                          - If column not present 'b' is considered.
+.. include:: costMatrix-category.rst
+    :start-after: costMatrix_withPoints_parameters_start
+    :end-before: costMatrix_withPoints_parameters_end
 
-================ ====================== =================================================
+Optional parameters
+...............................................................................
 
-.. include:: pgRouting-concepts.rst
-    :start-after: return_cost_start
-    :end-before: return_cost_end
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_optionals_start
+    :end-before: dijkstra_optionals_end
+
+With points optional parameters
+...............................................................................
+
+.. include:: pgr_withPointsCost.rst
+    :start-after: withpoints_short_optionals_start
+    :end-before: withpoints_short_optionals_end
 
 Inner query
 -------------------------------------------------------------------------------
 
-..
-    description of the sql queries
+Edges SQL
+...............................................................................
 
 .. include:: pgRouting-concepts.rst
     :start-after: basic_edges_sql_start
     :end-before: basic_edges_sql_end
 
+Points SQL
+...............................................................................
+
 .. include:: withPoints-category.rst
     :start-after: points_sql_start
     :end-before: points_sql_end
 
+Return Columns
+-------------------------------------------------------------------------------
+
+.. include:: pgRouting-concepts.rst
+    :start-after: return_cost_withPoints_start
+    :end-before: return_cost_withPoints_end
+
 Additional Examples
 -------------------------------------------------------------------------------
 
-:Example: :doc:`pgr_TSP` using ``pgr_withPointsCostMatrix`` for points :math:`\{1, 6\}` and vertices :math:`\{3, 6\}` on an **undirected** graph
+:Example: :doc:`pgr_TSP` using ``pgr_withPointsCostMatrix`` for points
+          :math:`\{1, 6\}` and vertices :math:`\{3, 6\}` on an **undirected**
+          graph
 
 .. literalinclude:: doc-pgr_withPointsCostMatrix.queries
    :start-after: -- withPoints q3

--- a/doc/withPoints/pgr_withPointsVia.rst
+++ b/doc/withPoints/pgr_withPointsVia.rst
@@ -16,7 +16,7 @@
 ``pgr_withPointsVia`` - Proposed
 ===============================================================================
 
-``pgr_withPointsVia`` Via points/vertices routing.
+``pgr_withPointsVia`` - Route that goes through a list of vertices and/or points.
 
 .. include:: proposed.rst
    :start-after: stable-begin-warning
@@ -32,9 +32,6 @@
 * Version 3.4.0
 
   * New **proposed** function ``pgr_withPointsVia`` (`One Via`_)
-
-
-|
 
 Description
 -------------------------------------------------------------------------------
@@ -56,27 +53,11 @@ The general algorithm is as follows:
 
 * Execute a :doc:`pgr_dijkstraVia`.
 
-.. Note:: Do not use negative values on identifiers of the inner queries.
-
-|
-
 Signatures
 -------------------------------------------------------------------------------
 
-.. rubric:: Summary
-
 .. index::
     single: withPointsVia - Proposed on v3.4
-
-.. parsed-literal::
-
-    pgr_withPointsVia(`Edges SQL`_, `Points SQL`_, **via vertices**
-               [, directed] [, strict] [, U_turn_on_edge]) -- Proposed on v3.4
-    RETURNS SET OF (seq, path_pid, path_seq, start_vid, end_vid,
-                    node, edge, cost, agg_cost, route_agg_cost)
-    OR EMPTY SET
-
-|
 
 One Via
 ...............................................................................
@@ -96,65 +77,36 @@ One Via
     :start-after: -- q0
     :end-before: -- q1
 
-|
-
 Parameters
 -------------------------------------------------------------------------------
 
-.. list-table::
-   :width: 81
-   :widths: 14 20 7 40
-   :header-rows: 1
+.. include:: via-category.rst
+    :start-after: via_withPoints_parameters_start
+    :end-before: via_withPoints_parameters_end
 
-   * - Parameter
-     - Type
-     - Default
-     - Description
-   * - `Edges SQL`_
-     - ``TEXT``
-     -
-     - SQL query as described.
-   * - `Points SQL`_
-     - ``TEXT``
-     -
-     - SQL query as described.
-   * - **via vertices**
-     - ``ARRAY[`` **ANY-INTEGER** ``]``
-     -
-     - Array of ordered vertices identifiers that are going to be visited.
+Optional parameters
+...............................................................................
 
-       * When positive it is considered a vertex identifier
-       * When negative it is considered a point identifier
-   * - ``directed``
-     - ``BOOLEAN``
-     - ``true``
-     - - When ``true`` Graph is considered `Directed`
-       - When ``false`` the graph is considered as Undirected.
-
-|
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_optionals_start
+    :end-before: dijkstra_optionals_end
 
 Via optional parameters
 ...............................................................................
 
 .. include:: via-category.rst
-    :start-after: via_opt_parameters_start
-    :end-before: via_opt_parameters_end
-
-|
+    :start-after: via_optionals_start
+    :end-before: via_optionals_end
 
 With points optional parameters
 ...............................................................................
 
 .. include:: via-category.rst
-    :start-after: withPoints_parameters_start
-    :end-before: withPoints_parameters_end
-
-|
+    :start-after: via_withPoints_optionals_start
+    :end-before: via_withPoints_optionals_end
 
 Inner query
 -------------------------------------------------------------------------------
-
-|
 
 Edges SQL
 ...............................................................................
@@ -163,8 +115,6 @@ Edges SQL
     :start-after: basic_edges_sql_start
     :end-before: basic_edges_sql_end
 
-|
-
 Points SQL
 ...............................................................................
 
@@ -172,18 +122,12 @@ Points SQL
     :start-after: points_sql_start
     :end-before: points_sql_end
 
-|
-
 Return Columns
 -------------------------------------------------------------------------------
 
 .. include:: via-category.rst
-    :start-after: result columns start
-    :end-before: result columns end
-
-.. Note:: When ``start_vid`` or ``end_vid`` is negative, then it is a point.
-
-|
+    :start-after: result via withPoints start
+    :end-before: result via withPoints end
 
 Additional Examples
 -------------------------------------------------------------------------------
@@ -231,6 +175,7 @@ Additional Examples
 See Also
 -------------------------------------------------------------------------------
 
+* :doc:`withPoints-family`
 * :doc:`via-category`
 * :doc:`sampledata` network.
 

--- a/doc/withPoints/withPoints-family.rst
+++ b/doc/withPoints/withPoints-family.rst
@@ -52,9 +52,6 @@ When points are also given as input:
     pgr_withPointsDD
     pgr_withPointsVia
 
-.. contents:: Contents
-   :local:
-
 Introduction
 -------------------------------------------------------------------------------
 
@@ -70,9 +67,81 @@ Depending on the name:
 - pgr_withPointsDD is pgr_drivingDistance **with points**
 - pgr_withPointsvia is pgr_dijkstraVia **with points**
 
+Parameters
+-------------------------------------------------------------------------------
+
 .. include:: withPoints-category.rst
-   :start-after: not involving vehicles
-   :end-before: See Also
+    :start-after: withPoints_parameters_start
+    :end-before: withPoints_parameters_end
+
+Optional parameters
+...............................................................................
+
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_optionals_start
+    :end-before: dijkstra_optionals_end
+
+With points optional parameters
+...............................................................................
+
+.. withPoints_optionals_start
+
+.. list-table::
+   :width: 81
+   :widths: 14 7 7 60
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Default
+     - Description
+   * - ``driving_side``
+     - ``CHAR``
+     - ``b``
+     - Value in [``r``, ``l``, ``b``] indicating if the driving side is:
+
+       - ``r`` for right driving side.
+       - ``l`` for left driving side.
+       - ``b`` for both.
+   * - ``details``
+     - ``BOOLEAN``
+     - ``false``
+     - - When ``true`` the results will include the points that are in the path.
+       - When ``false`` the results will not include the points that are in the
+         path.
+
+.. withPoints_optionals_end
+
+Inner queries
+-------------------------------------------------------------------------------
+
+Edges SQL
+...............................................................................
+
+.. include:: pgRouting-concepts.rst
+    :start-after: basic_edges_sql_start
+    :end-before: basic_edges_sql_end
+
+Points SQL
+...............................................................................
+
+.. include:: withPoints-category.rst
+    :start-after: points_sql_start
+    :end-before: points_sql_end
+
+Combinations SQL
+...............................................................................
+
+.. include:: pgRouting-concepts.rst
+    :start-after: basic_combinations_sql_start
+    :end-before: basic_combinations_sql_end
+
+Advanced Documentation
+-------------------------------------------------------------------------------
+
+.. include:: withPoints-category.rst
+   :start-after: advanced_documentation_start
+   :end-before: advanced_documentation_end
 
 See Also
 -------------------------------------------------------------------------------

--- a/docqueries/withPoints/doc-pgr_withPoints.result
+++ b/docqueries/withPoints/doc-pgr_withPoints.result
@@ -6,9 +6,9 @@ SET extra_float_digits=-3;
 SET
 /* --e1 */
 SELECT * FROM pgr_withPoints(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    -1, -3);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  -1, -3);
  seq | path_seq | node | edge | cost | agg_cost
 -----+----------+------+------+------+----------
    1 |        1 |   -1 |    1 |  0.6 |        0
@@ -20,10 +20,10 @@ SELECT * FROM pgr_withPoints(
 
 /* --e2 */
 SELECT * FROM pgr_withPoints(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    -1, 3,
-    details := true);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  -1, 3,
+  details := true);
  seq | path_seq | node | edge | cost | agg_cost
 -----+----------+------+------+------+----------
    1 |        1 |   -1 |    1 |  0.6 |        0
@@ -38,9 +38,9 @@ SELECT * FROM pgr_withPoints(
 
 /* --e3 */
 SELECT * FROM pgr_withPoints(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    -1, ARRAY[-3,5]);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  -1, ARRAY[-3, 5]);
  seq | path_seq | end_pid | node | edge | cost | agg_cost
 -----+----------+---------+------+------+------+----------
    1 |        1 |      -3 |   -1 |    1 |  0.6 |        0
@@ -55,9 +55,9 @@ SELECT * FROM pgr_withPoints(
 
 /* --e4 */
 SELECT * FROM pgr_withPoints(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    ARRAY[-1,2], -3);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[-1, 2], -3);
  seq | path_seq | start_pid | node | edge | cost | agg_cost
 -----+----------+-----------+------+------+------+----------
    1 |        1 |        -1 |   -1 |    1 |  0.6 |        0
@@ -73,9 +73,9 @@ SELECT * FROM pgr_withPoints(
 
 /* --e5 */
 SELECT * FROM pgr_withPoints(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    ARRAY[-1,2], ARRAY[-3,7]);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[-1, 2], ARRAY[-3, 7]);
  seq | path_seq | start_pid | end_pid | node | edge | cost | agg_cost
 -----+----------+-----------+---------+------+------+------+----------
    1 |        1 |        -1 |      -3 |   -1 |    1 |  0.6 |        0
@@ -100,20 +100,20 @@ SELECT * FROM pgr_withPoints(
 
 /* --q2 */
 SELECT ('(' || start_pid || ' => ' || end_pid ||') at ' || path_seq || 'th step:')::TEXT AS path_at,
-        CASE WHEN edge = -1 THEN ' visits'
-            ELSE ' passes in front of'
-        END as status,
-        CASE WHEN node < 0 THEN 'Point'
-            ELSE 'Vertex'
-        END as is_a,
-        abs(node) as id
-    FROM pgr_withPoints(
-        'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-        'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-        ARRAY[1,-1], ARRAY[-2,-3,-6,3,6],
-        driving_side := 'r',
-        details := true)
-    WHERE node IN (-6,6);
+  CASE WHEN edge = -1 THEN ' visits'
+      ELSE ' passes in front of'
+  END as status,
+  CASE WHEN node < 0 THEN 'Point'
+      ELSE 'Vertex'
+  END as is_a,
+  abs(node) as id
+FROM pgr_withPoints(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[1,-1], ARRAY[-2, -3, -6, 3, 6],
+  driving_side := 'r',
+  details := true)
+WHERE node IN (-6,6);
          path_at         |       status        |  is_a  | id
 -------------------------+---------------------+--------+----
  (-1 => -6) at 4th step: |  visits             | Point  |  6
@@ -136,20 +136,20 @@ SELECT ('(' || start_pid || ' => ' || end_pid ||') at ' || path_seq || 'th step:
 
 /* --q3 */
 SELECT ('(' || start_pid || ' => ' || end_pid ||') at ' || path_seq || 'th step:')::TEXT AS path_at,
-        CASE WHEN edge = -1 THEN ' visits'
-            ELSE ' passes in front of'
-        END as status,
-        CASE WHEN node < 0 THEN 'Point'
-            ELSE 'Vertex'
-        END as is_a,
-        abs(node) as id
-    FROM pgr_withPoints(
-        'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-        'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-        ARRAY[1,-1], ARRAY[-2,-3,-6,3,6],
-        driving_side := 'l',
-        details := true)
-    WHERE node IN (-6,6);
+  CASE WHEN edge = -1 THEN ' visits'
+      ELSE ' passes in front of'
+  END as status,
+  CASE WHEN node < 0 THEN 'Point'
+        ELSE 'Vertex'
+    END as is_a,
+    abs(node) as id
+FROM pgr_withPoints(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[1, -1], ARRAY[-2, -3, -6, 3, 6],
+  driving_side := 'l',
+  details := true)
+WHERE node IN (-6,6);
          path_at         |       status        |  is_a  | id
 -------------------------+---------------------+--------+----
  (-1 => -6) at 3th step: |  visits             | Point  |  6
@@ -172,11 +172,11 @@ SELECT ('(' || start_pid || ' => ' || end_pid ||') at ' || path_seq || 'th step:
 
 /* --q4 */
 SELECT * FROM pgr_withPoints(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    ARRAY[-1,2], ARRAY[-3,7],
-    directed := false,
-    details := true);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[-1, 2], ARRAY[-3, 7],
+  directed := false,
+  details := true);
  seq | path_seq | start_pid | end_pid | node | edge | cost | agg_cost
 -----+----------+-----------+---------+------+------+------+----------
    1 |        1 |        -1 |      -3 |   -1 |    1 |  0.6 |        0
@@ -207,11 +207,11 @@ SELECT * FROM pgr_withPoints(
 
 /* --q5 */
 SELECT * FROM pgr_withPoints(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    'SELECT * FROM ( VALUES (-1, 3), (2, -3) ) AS t(source, target)',
-    driving_side => 'r',
-    details => true);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  'SELECT * FROM (VALUES (-1, 3), (2, -3)) AS combinations(source, target)',
+  driving_side => 'r',
+  details => true);
  seq | path_seq | start_pid | end_pid | node | edge | cost | agg_cost
 -----+----------+-----------+---------+------+------+------+----------
    1 |        1 |        -1 |       3 |   -1 |    1 |  0.4 |        0

--- a/docqueries/withPoints/doc-pgr_withPoints.result
+++ b/docqueries/withPoints/doc-pgr_withPoints.result
@@ -4,26 +4,12 @@ SET client_min_messages TO NOTICE;
 SET
 SET extra_float_digits=-3;
 SET
-/* --e1 */
-SELECT * FROM pgr_withPoints(
-  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-  -1, -3);
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |   -1 |    1 |  0.6 |        0
-   2 |        2 |    2 |    4 |    1 |      0.6
-   3 |        3 |    5 |   10 |    1 |      1.6
-   4 |        4 |   10 |   12 |  0.6 |      2.6
-   5 |        5 |   -3 |   -1 |    0 |      3.2
-(5 rows)
-
 /* --e2 */
 SELECT * FROM pgr_withPoints(
   'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
   'SELECT pid, edge_id, fraction, side from pointsOfInterest',
   -1, 3,
-  details := true);
+  details => true);
  seq | path_seq | node | edge | cost | agg_cost
 -----+----------+------+------+------+----------
    1 |        1 |   -1 |    1 |  0.6 |        0
@@ -40,7 +26,8 @@ SELECT * FROM pgr_withPoints(
 SELECT * FROM pgr_withPoints(
   'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
   'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-  -1, ARRAY[-3, 5]);
+  -1, ARRAY[-3, 5],
+  directed => false);
  seq | path_seq | end_pid | node | edge | cost | agg_cost
 -----+----------+---------+------+------+------+----------
    1 |        1 |      -3 |   -1 |    1 |  0.6 |        0
@@ -98,8 +85,33 @@ SELECT * FROM pgr_withPoints(
   18 |        4 |         2 |       7 |    7 |   -1 |    0 |        3
 (18 rows)
 
-/* --q2 */
-SELECT ('(' || start_pid || ' => ' || end_pid ||') at ' || path_seq || 'th step:')::TEXT AS path_at,
+/* --e6 */
+SELECT * FROM pgr_withPoints(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  'SELECT * FROM (VALUES (-1, 3), (2, -3)) AS combinations(source, target)',
+  driving_side => 'r', details => true);
+ seq | path_seq | start_pid | end_pid | node | edge | cost | agg_cost
+-----+----------+-----------+---------+------+------+------+----------
+   1 |        1 |        -1 |       3 |   -1 |    1 |  0.4 |        0
+   2 |        2 |        -1 |       3 |    1 |    1 |    1 |      0.4
+   3 |        3 |        -1 |       3 |    2 |    4 |  0.7 |      1.4
+   4 |        4 |        -1 |       3 |   -6 |    4 |  0.3 |      2.1
+   5 |        5 |        -1 |       3 |    5 |    8 |    1 |      2.4
+   6 |        6 |        -1 |       3 |    6 |    9 |    1 |      3.4
+   7 |        7 |        -1 |       3 |    9 |   16 |    1 |      4.4
+   8 |        8 |        -1 |       3 |    4 |    3 |    1 |      5.4
+   9 |        9 |        -1 |       3 |    3 |   -1 |    0 |      6.4
+  10 |        1 |         2 |      -3 |    2 |    4 |  0.7 |        0
+  11 |        2 |         2 |      -3 |   -6 |    4 |  0.3 |      0.7
+  12 |        3 |         2 |      -3 |    5 |   10 |    1 |        1
+  13 |        4 |         2 |      -3 |   10 |   12 |  0.6 |        2
+  14 |        5 |         2 |      -3 |   -3 |   -1 |    0 |      2.6
+(14 rows)
+
+/* --e7 */
+/* --q1 */
+SELECT (start_pid || ' -> ' || end_pid ||' at ' || path_seq || 'th step')::TEXT AS path_at,
   CASE WHEN edge = -1 THEN ' visits'
       ELSE ' passes in front of'
   END as status,
@@ -110,32 +122,31 @@ SELECT ('(' || start_pid || ' => ' || end_pid ||') at ' || path_seq || 'th step:
 FROM pgr_withPoints(
   'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
   'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-  ARRAY[1,-1], ARRAY[-2, -3, -6, 3, 6],
-  driving_side := 'r',
-  details := true)
-WHERE node IN (-6,6);
-         path_at         |       status        |  is_a  | id
--------------------------+---------------------+--------+----
- (-1 => -6) at 4th step: |  visits             | Point  |  6
- (-1 => -3) at 4th step: |  passes in front of | Point  |  6
- (-1 => -2) at 4th step: |  passes in front of | Point  |  6
- (-1 => -2) at 6th step: |  passes in front of | Vertex |  6
- (-1 => 3) at 4th step:  |  passes in front of | Point  |  6
- (-1 => 3) at 6th step:  |  passes in front of | Vertex |  6
- (-1 => 6) at 4th step:  |  passes in front of | Point  |  6
- (-1 => 6) at 6th step:  |  visits             | Vertex |  6
- (1 => -6) at 3th step:  |  visits             | Point  |  6
- (1 => -3) at 3th step:  |  passes in front of | Point  |  6
- (1 => -2) at 3th step:  |  passes in front of | Point  |  6
- (1 => -2) at 5th step:  |  passes in front of | Vertex |  6
- (1 => 3) at 3th step:   |  passes in front of | Point  |  6
- (1 => 3) at 5th step:   |  passes in front of | Vertex |  6
- (1 => 6) at 3th step:   |  passes in front of | Point  |  6
- (1 => 6) at 5th step:   |  visits             | Vertex |  6
+  ARRAY[1, -1], ARRAY[-2, -3, -6, 3, 6],
+  driving_side => 'r', details => true)
+WHERE node IN (-6, 6);
+       path_at        |       status        |  is_a  | id
+----------------------+---------------------+--------+----
+ -1 -> -6 at 4th step |  visits             | Point  |  6
+ -1 -> -3 at 4th step |  passes in front of | Point  |  6
+ -1 -> -2 at 4th step |  passes in front of | Point  |  6
+ -1 -> -2 at 6th step |  passes in front of | Vertex |  6
+ -1 -> 3 at 4th step  |  passes in front of | Point  |  6
+ -1 -> 3 at 6th step  |  passes in front of | Vertex |  6
+ -1 -> 6 at 4th step  |  passes in front of | Point  |  6
+ -1 -> 6 at 6th step  |  visits             | Vertex |  6
+ 1 -> -6 at 3th step  |  visits             | Point  |  6
+ 1 -> -3 at 3th step  |  passes in front of | Point  |  6
+ 1 -> -2 at 3th step  |  passes in front of | Point  |  6
+ 1 -> -2 at 5th step  |  passes in front of | Vertex |  6
+ 1 -> 3 at 3th step   |  passes in front of | Point  |  6
+ 1 -> 3 at 5th step   |  passes in front of | Vertex |  6
+ 1 -> 6 at 3th step   |  passes in front of | Point  |  6
+ 1 -> 6 at 5th step   |  visits             | Vertex |  6
 (16 rows)
 
-/* --q3 */
-SELECT ('(' || start_pid || ' => ' || end_pid ||') at ' || path_seq || 'th step:')::TEXT AS path_at,
+/* --q2 */
+SELECT (start_pid || ' => ' || end_pid ||' at ' || path_seq || 'th step')::TEXT AS path_at,
   CASE WHEN edge = -1 THEN ' visits'
       ELSE ' passes in front of'
   END as status,
@@ -147,36 +158,34 @@ FROM pgr_withPoints(
   'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
   'SELECT pid, edge_id, fraction, side from pointsOfInterest',
   ARRAY[1, -1], ARRAY[-2, -3, -6, 3, 6],
-  driving_side := 'l',
-  details := true)
-WHERE node IN (-6,6);
-         path_at         |       status        |  is_a  | id
--------------------------+---------------------+--------+----
- (-1 => -6) at 3th step: |  visits             | Point  |  6
- (-1 => -3) at 3th step: |  passes in front of | Point  |  6
- (-1 => -2) at 3th step: |  passes in front of | Point  |  6
- (-1 => -2) at 5th step: |  passes in front of | Vertex |  6
- (-1 => 3) at 3th step:  |  passes in front of | Point  |  6
- (-1 => 3) at 5th step:  |  passes in front of | Vertex |  6
- (-1 => 6) at 3th step:  |  passes in front of | Point  |  6
- (-1 => 6) at 5th step:  |  visits             | Vertex |  6
- (1 => -6) at 4th step:  |  visits             | Point  |  6
- (1 => -3) at 4th step:  |  passes in front of | Point  |  6
- (1 => -2) at 4th step:  |  passes in front of | Point  |  6
- (1 => -2) at 6th step:  |  passes in front of | Vertex |  6
- (1 => 3) at 4th step:   |  passes in front of | Point  |  6
- (1 => 3) at 6th step:   |  passes in front of | Vertex |  6
- (1 => 6) at 4th step:   |  passes in front of | Point  |  6
- (1 => 6) at 6th step:   |  visits             | Vertex |  6
+  driving_side => 'l', details => true)
+WHERE node IN (-6, 6);
+       path_at        |       status        |  is_a  | id
+----------------------+---------------------+--------+----
+ -1 => -6 at 3th step |  visits             | Point  |  6
+ -1 => -3 at 3th step |  passes in front of | Point  |  6
+ -1 => -2 at 3th step |  passes in front of | Point  |  6
+ -1 => -2 at 5th step |  passes in front of | Vertex |  6
+ -1 => 3 at 3th step  |  passes in front of | Point  |  6
+ -1 => 3 at 5th step  |  passes in front of | Vertex |  6
+ -1 => 6 at 3th step  |  passes in front of | Point  |  6
+ -1 => 6 at 5th step  |  visits             | Vertex |  6
+ 1 => -6 at 4th step  |  visits             | Point  |  6
+ 1 => -3 at 4th step  |  passes in front of | Point  |  6
+ 1 => -2 at 4th step  |  passes in front of | Point  |  6
+ 1 => -2 at 6th step  |  passes in front of | Vertex |  6
+ 1 => 3 at 4th step   |  passes in front of | Point  |  6
+ 1 => 3 at 6th step   |  passes in front of | Vertex |  6
+ 1 => 6 at 4th step   |  passes in front of | Point  |  6
+ 1 => 6 at 6th step   |  visits             | Vertex |  6
 (16 rows)
 
-/* --q4 */
+/* --q3 */
 SELECT * FROM pgr_withPoints(
   'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
   'SELECT pid, edge_id, fraction, side from pointsOfInterest',
   ARRAY[-1, 2], ARRAY[-3, 7],
-  directed := false,
-  details := true);
+  directed => false, details => true);
  seq | path_seq | start_pid | end_pid | node | edge | cost | agg_cost
 -----+----------+-----------+---------+------+------+------+----------
    1 |        1 |        -1 |      -3 |   -1 |    1 |  0.6 |        0
@@ -205,31 +214,6 @@ SELECT * FROM pgr_withPoints(
   24 |        6 |         2 |       7 |    7 |   -1 |    0 |        3
 (24 rows)
 
-/* --q5 */
-SELECT * FROM pgr_withPoints(
-  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-  'SELECT * FROM (VALUES (-1, 3), (2, -3)) AS combinations(source, target)',
-  driving_side => 'r',
-  details => true);
- seq | path_seq | start_pid | end_pid | node | edge | cost | agg_cost
------+----------+-----------+---------+------+------+------+----------
-   1 |        1 |        -1 |       3 |   -1 |    1 |  0.4 |        0
-   2 |        2 |        -1 |       3 |    1 |    1 |    1 |      0.4
-   3 |        3 |        -1 |       3 |    2 |    4 |  0.7 |      1.4
-   4 |        4 |        -1 |       3 |   -6 |    4 |  0.3 |      2.1
-   5 |        5 |        -1 |       3 |    5 |    8 |    1 |      2.4
-   6 |        6 |        -1 |       3 |    6 |    9 |    1 |      3.4
-   7 |        7 |        -1 |       3 |    9 |   16 |    1 |      4.4
-   8 |        8 |        -1 |       3 |    4 |    3 |    1 |      5.4
-   9 |        9 |        -1 |       3 |    3 |   -1 |    0 |      6.4
-  10 |        1 |         2 |      -3 |    2 |    4 |  0.7 |        0
-  11 |        2 |         2 |      -3 |   -6 |    4 |  0.3 |      0.7
-  12 |        3 |         2 |      -3 |    5 |   10 |    1 |        1
-  13 |        4 |         2 |      -3 |   10 |   12 |  0.6 |        2
-  14 |        5 |         2 |      -3 |   -3 |   -1 |    0 |      2.6
-(14 rows)
-
-/* --q6 */
+/* --q4 */
 ROLLBACK;
 ROLLBACK

--- a/docqueries/withPoints/doc-pgr_withPoints.test.sql
+++ b/docqueries/withPoints/doc-pgr_withPoints.test.sql
@@ -2,77 +2,75 @@ SET extra_float_digits=-3;
 
 /* --e1 */
 SELECT * FROM pgr_withPoints(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    -1, -3);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  -1, -3);
 /* --e2 */
 SELECT * FROM pgr_withPoints(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    -1, 3,
-    details := true);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  -1, 3,
+  details := true);
 /* --e3 */
 SELECT * FROM pgr_withPoints(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    -1, ARRAY[-3,5]);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  -1, ARRAY[-3, 5]);
 /* --e4 */
 SELECT * FROM pgr_withPoints(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    ARRAY[-1,2], -3);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[-1, 2], -3);
 /* --e5 */
 SELECT * FROM pgr_withPoints(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    ARRAY[-1,2], ARRAY[-3,7]);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[-1, 2], ARRAY[-3, 7]);
 
 /* --q2 */
 SELECT ('(' || start_pid || ' => ' || end_pid ||') at ' || path_seq || 'th step:')::TEXT AS path_at,
-        CASE WHEN edge = -1 THEN ' visits'
-            ELSE ' passes in front of'
-        END as status,
-        CASE WHEN node < 0 THEN 'Point'
-            ELSE 'Vertex'
-        END as is_a,
-        abs(node) as id
-    FROM pgr_withPoints(
-        'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-        'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-        ARRAY[1,-1], ARRAY[-2,-3,-6,3,6],
-        driving_side := 'r',
-        details := true)
-    WHERE node IN (-6,6);
+  CASE WHEN edge = -1 THEN ' visits'
+      ELSE ' passes in front of'
+  END as status,
+  CASE WHEN node < 0 THEN 'Point'
+      ELSE 'Vertex'
+  END as is_a,
+  abs(node) as id
+FROM pgr_withPoints(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[1,-1], ARRAY[-2, -3, -6, 3, 6],
+  driving_side := 'r',
+  details := true)
+WHERE node IN (-6,6);
 /* --q3 */
 SELECT ('(' || start_pid || ' => ' || end_pid ||') at ' || path_seq || 'th step:')::TEXT AS path_at,
-        CASE WHEN edge = -1 THEN ' visits'
-            ELSE ' passes in front of'
-        END as status,
-        CASE WHEN node < 0 THEN 'Point'
-            ELSE 'Vertex'
-        END as is_a,
-        abs(node) as id
-    FROM pgr_withPoints(
-        'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-        'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-        ARRAY[1,-1], ARRAY[-2,-3,-6,3,6],
-        driving_side := 'l',
-        details := true)
-    WHERE node IN (-6,6);
+  CASE WHEN edge = -1 THEN ' visits'
+      ELSE ' passes in front of'
+  END as status,
+  CASE WHEN node < 0 THEN 'Point'
+        ELSE 'Vertex'
+    END as is_a,
+    abs(node) as id
+FROM pgr_withPoints(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[1, -1], ARRAY[-2, -3, -6, 3, 6],
+  driving_side := 'l',
+  details := true)
+WHERE node IN (-6,6);
 /* --q4 */
 SELECT * FROM pgr_withPoints(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    ARRAY[-1,2], ARRAY[-3,7],
-    directed := false,
-    details := true);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[-1, 2], ARRAY[-3, 7],
+  directed := false,
+  details := true);
 /* --q5 */
-
-
 SELECT * FROM pgr_withPoints(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    'SELECT * FROM ( VALUES (-1, 3), (2, -3) ) AS t(source, target)',
-    driving_side => 'r',
-    details => true);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  'SELECT * FROM (VALUES (-1, 3), (2, -3)) AS combinations(source, target)',
+  driving_side => 'r',
+  details => true);
 /* --q6 */

--- a/docqueries/withPoints/doc-pgr_withPoints.test.sql
+++ b/docqueries/withPoints/doc-pgr_withPoints.test.sql
@@ -1,21 +1,17 @@
 SET extra_float_digits=-3;
 
-/* --e1 */
-SELECT * FROM pgr_withPoints(
-  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-  -1, -3);
 /* --e2 */
 SELECT * FROM pgr_withPoints(
   'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
   'SELECT pid, edge_id, fraction, side from pointsOfInterest',
   -1, 3,
-  details := true);
+  details => true);
 /* --e3 */
 SELECT * FROM pgr_withPoints(
   'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
   'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-  -1, ARRAY[-3, 5]);
+  -1, ARRAY[-3, 5],
+  directed => false);
 /* --e4 */
 SELECT * FROM pgr_withPoints(
   'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
@@ -26,9 +22,15 @@ SELECT * FROM pgr_withPoints(
   'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
   'SELECT pid, edge_id, fraction, side from pointsOfInterest',
   ARRAY[-1, 2], ARRAY[-3, 7]);
-
-/* --q2 */
-SELECT ('(' || start_pid || ' => ' || end_pid ||') at ' || path_seq || 'th step:')::TEXT AS path_at,
+/* --e6 */
+SELECT * FROM pgr_withPoints(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  'SELECT * FROM (VALUES (-1, 3), (2, -3)) AS combinations(source, target)',
+  driving_side => 'r', details => true);
+/* --e7 */
+/* --q1 */
+SELECT (start_pid || ' -> ' || end_pid ||' at ' || path_seq || 'th step')::TEXT AS path_at,
   CASE WHEN edge = -1 THEN ' visits'
       ELSE ' passes in front of'
   END as status,
@@ -39,12 +41,11 @@ SELECT ('(' || start_pid || ' => ' || end_pid ||') at ' || path_seq || 'th step:
 FROM pgr_withPoints(
   'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
   'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-  ARRAY[1,-1], ARRAY[-2, -3, -6, 3, 6],
-  driving_side := 'r',
-  details := true)
-WHERE node IN (-6,6);
-/* --q3 */
-SELECT ('(' || start_pid || ' => ' || end_pid ||') at ' || path_seq || 'th step:')::TEXT AS path_at,
+  ARRAY[1, -1], ARRAY[-2, -3, -6, 3, 6],
+  driving_side => 'r', details => true)
+WHERE node IN (-6, 6);
+/* --q2 */
+SELECT (start_pid || ' => ' || end_pid ||' at ' || path_seq || 'th step')::TEXT AS path_at,
   CASE WHEN edge = -1 THEN ' visits'
       ELSE ' passes in front of'
   END as status,
@@ -56,21 +57,12 @@ FROM pgr_withPoints(
   'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
   'SELECT pid, edge_id, fraction, side from pointsOfInterest',
   ARRAY[1, -1], ARRAY[-2, -3, -6, 3, 6],
-  driving_side := 'l',
-  details := true)
-WHERE node IN (-6,6);
-/* --q4 */
+  driving_side => 'l', details => true)
+WHERE node IN (-6, 6);
+/* --q3 */
 SELECT * FROM pgr_withPoints(
   'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
   'SELECT pid, edge_id, fraction, side from pointsOfInterest',
   ARRAY[-1, 2], ARRAY[-3, 7],
-  directed := false,
-  details := true);
-/* --q5 */
-SELECT * FROM pgr_withPoints(
-  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-  'SELECT * FROM (VALUES (-1, 3), (2, -3)) AS combinations(source, target)',
-  driving_side => 'r',
-  details => true);
-/* --q6 */
+  directed => false, details => true);
+/* --q4 */

--- a/docqueries/withPoints/doc-pgr_withPointsCost.result
+++ b/docqueries/withPoints/doc-pgr_withPointsCost.result
@@ -4,32 +4,22 @@ SET client_min_messages TO NOTICE;
 SET
 SET extra_float_digits=-3;
 SET
-/* --e1 */
-SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    -1, -3);
- start_pid | end_pid | agg_cost
------------+---------+----------
-        -1 |      -3 |      3.2
-(1 row)
-
 /* --e2 */
 SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    -1, 3,
-    directed := false);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  -1, 3);
  start_pid | end_pid | agg_cost
 -----------+---------+----------
-        -1 |       3 |      1.6
+        -1 |       3 |      5.6
 (1 row)
 
 /* --e3 */
 SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    -1, ARRAY[-3,5]);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  -1, ARRAY[-3, 5],
+  directed => false);
  start_pid | end_pid | agg_cost
 -----------+---------+----------
         -1 |      -3 |      3.2
@@ -38,9 +28,9 @@ SELECT * FROM pgr_withPointsCost(
 
 /* --e4 */
 SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    ARRAY[-1,2], -3);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[-1, 2], -3);
  start_pid | end_pid | agg_cost
 -----------+---------+----------
         -1 |      -3 |      3.2
@@ -49,9 +39,9 @@ SELECT * FROM pgr_withPointsCost(
 
 /* --e5 */
 SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    ARRAY[-1,2], ARRAY[-3,7]);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[-1, 2], ARRAY[-3, 7]);
  start_pid | end_pid | agg_cost
 -----------+---------+----------
         -1 |      -3 |      3.2
@@ -60,60 +50,78 @@ SELECT * FROM pgr_withPointsCost(
          2 |       7 |        3
 (4 rows)
 
-/* --q2 */
+/* --e6 */
 SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    ARRAY[-1,2], ARRAY[-3,7],
-    driving_side := 'l');
- start_pid | end_pid | agg_cost
------------+---------+----------
-        -1 |      -3 |      3.2
-        -1 |       7 |      3.6
-         2 |      -3 |      2.6
-         2 |       7 |        3
-(4 rows)
-
-/* --q3 */
-SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    ARRAY[-1,2], ARRAY[-3,7],
-    driving_side := 'r');
- start_pid | end_pid | agg_cost
------------+---------+----------
-        -1 |      -3 |        4
-        -1 |       7 |      4.4
-         2 |      -3 |      2.6
-         2 |       7 |        3
-(4 rows)
-
-/* --q4 */
-SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    ARRAY[-1,2], ARRAY[-3,7],
-    driving_side := 'b');
- start_pid | end_pid | agg_cost
------------+---------+----------
-        -1 |      -3 |      3.2
-        -1 |       7 |      3.6
-         2 |      -3 |      2.6
-         2 |       7 |        3
-(4 rows)
-
-/* --q5 */
-SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    'SELECT * FROM ( VALUES (-1, 3), (2, -3) ) AS t(source, target)',
-    driving_side => 'r');
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  'SELECT * FROM (VALUES (-1, 3), (2, -3)) AS combinations(source, target)',
+  driving_side => 'r');
  start_pid | end_pid | agg_cost
 -----------+---------+----------
         -1 |       3 |      6.4
          2 |      -3 |      2.6
 (2 rows)
 
-/* --q6 */
+/* --e7 */
+/* --q1 */
+SELECT * FROM pgr_withPointsCost(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[1, -1], ARRAY[-2, -3, -6, 3, 6],
+  driving_side => 'r');
+ start_pid | end_pid | agg_cost
+-----------+---------+----------
+        -1 |      -6 |      2.1
+        -1 |      -3 |        4
+        -1 |      -2 |      4.8
+        -1 |       3 |      6.4
+        -1 |       6 |      3.4
+         1 |      -6 |      1.7
+         1 |      -3 |      3.6
+         1 |      -2 |      4.4
+         1 |       3 |        6
+         1 |       6 |        3
+(10 rows)
+
+/* --q2 */
+SELECT * FROM pgr_withPointsCost(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[1, -1], ARRAY[-2, -3, -6, 3, 6],
+  driving_side => 'l');
+ start_pid | end_pid | agg_cost
+-----------+---------+----------
+        -1 |      -6 |      1.3
+        -1 |      -3 |      3.2
+        -1 |      -2 |      5.2
+        -1 |       3 |      5.6
+        -1 |       6 |      2.6
+         1 |      -6 |      1.7
+         1 |      -3 |      3.6
+         1 |      -2 |      5.6
+         1 |       3 |        6
+         1 |       6 |        3
+(10 rows)
+
+/* --q3 */
+SELECT * FROM pgr_withPointsCost(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[1, -1], ARRAY[-2, -3, -6, 3, 6]);
+ start_pid | end_pid | agg_cost
+-----------+---------+----------
+        -1 |      -6 |      1.3
+        -1 |      -3 |      3.2
+        -1 |      -2 |        4
+        -1 |       3 |      5.6
+        -1 |       6 |      2.6
+         1 |      -6 |      1.7
+         1 |      -3 |      3.6
+         1 |      -2 |      4.4
+         1 |       3 |        6
+         1 |       6 |        3
+(10 rows)
+
+/* --q4 */
 ROLLBACK;
 ROLLBACK

--- a/docqueries/withPoints/doc-pgr_withPointsCost.test.sql
+++ b/docqueries/withPoints/doc-pgr_withPointsCost.test.sql
@@ -1,56 +1,48 @@
 SET extra_float_digits=-3;
 
-/* --e1 */
-SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    -1, -3);
 /* --e2 */
 SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    -1, 3,
-    directed := false);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  -1, 3);
 /* --e3 */
 SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    -1, ARRAY[-3,5]);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  -1, ARRAY[-3, 5],
+  directed => false);
 /* --e4 */
 SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    ARRAY[-1,2], -3);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[-1, 2], -3);
 /* --e5 */
 SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    ARRAY[-1,2], ARRAY[-3,7]);
-
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[-1, 2], ARRAY[-3, 7]);
+/* --e6 */
+SELECT * FROM pgr_withPointsCost(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  'SELECT * FROM (VALUES (-1, 3), (2, -3)) AS combinations(source, target)',
+  driving_side => 'r');
+/* --e7 */
+/* --q1 */
+SELECT * FROM pgr_withPointsCost(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[1, -1], ARRAY[-2, -3, -6, 3, 6],
+  driving_side => 'r');
 /* --q2 */
 SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    ARRAY[-1,2], ARRAY[-3,7],
-    driving_side := 'l');
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[1, -1], ARRAY[-2, -3, -6, 3, 6],
+  driving_side => 'l');
 /* --q3 */
 SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    ARRAY[-1,2], ARRAY[-3,7],
-    driving_side := 'r');
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction, side from pointsOfInterest',
+  ARRAY[1, -1], ARRAY[-2, -3, -6, 3, 6]);
 /* --q4 */
-SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    ARRAY[-1,2], ARRAY[-3,7],
-    driving_side := 'b');
-/* --q5 */
-
-
-SELECT * FROM pgr_withPointsCost(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    'SELECT * FROM ( VALUES (-1, 3), (2, -3) ) AS t(source, target)',
-    driving_side => 'r');
-/* --q6 */

--- a/docqueries/withPoints/doc-pgr_withPointsCostMatrix.result
+++ b/docqueries/withPoints/doc-pgr_withPointsCostMatrix.result
@@ -4,34 +4,11 @@ SET client_min_messages TO NOTICE;
 SET
 SET extra_float_digits=-3;
 SET
-SET client_min_messages to WARNING;
-SET
-/* -- withPoints q1 */
-SELECT * FROM pgr_withPointsCostMatrix(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction from pointsOfInterest',
-    array[-1, 3, 6, -6]);
- start_vid | end_vid | agg_cost
------------+---------+----------
-        -6 |      -1 |      1.3
-        -6 |       3 |      4.3
-        -6 |       6 |      1.3
-        -1 |      -6 |      1.3
-        -1 |       3 |      5.6
-        -1 |       6 |      2.6
-         3 |      -6 |      1.7
-         3 |      -1 |      1.6
-         3 |       6 |        1
-         6 |      -6 |      1.3
-         6 |      -1 |      2.6
-         6 |       3 |        3
-(12 rows)
-
 /* -- withPoints q2 */
 SELECT * FROM pgr_withPointsCostMatrix(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction from pointsOfInterest',
-    array[-1, 3, 6, -6], directed := false);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction from pointsOfInterest',
+  array[-1, 3, 6, -6], directed := false);
  start_vid | end_vid | agg_cost
 -----------+---------+----------
         -6 |      -1 |      1.3
@@ -50,13 +27,15 @@ SELECT * FROM pgr_withPointsCostMatrix(
 
 /* -- withPoints q3 */
 SELECT * FROM pgr_TSP(
-    $$
-    SELECT * FROM pgr_withPointsCostMatrix(
-        'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-        'SELECT pid, edge_id, fraction from pointsOfInterest',
-        array[-1, 3, 6, -6], directed := false);
-    $$
+  $$
+  SELECT * FROM pgr_withPointsCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    'SELECT pid, edge_id, fraction from pointsOfInterest',
+    array[-1, 3, 6, -6], directed := false);
+  $$
 );
+NOTICE:  pgr_TSP no longer solving with simulated annaeling
+HINT:  Ignoring annaeling parameters
  seq | node | cost | agg_cost
 -----+------+------+----------
    1 |   -6 |    0 |        0

--- a/docqueries/withPoints/doc-pgr_withPointsCostMatrix.test.sql
+++ b/docqueries/withPoints/doc-pgr_withPointsCostMatrix.test.sql
@@ -1,26 +1,16 @@
-------------------------
--- withPoints
-------------------------
 SET extra_float_digits=-3;
-SET client_min_messages to WARNING;
-
-/* -- withPoints q1 */
-SELECT * FROM pgr_withPointsCostMatrix(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    'SELECT pid, edge_id, fraction from pointsOfInterest',
-    array[-1, 3, 6, -6]);
 /* -- withPoints q2 */
 SELECT * FROM pgr_withPointsCostMatrix(
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+  'SELECT pid, edge_id, fraction from pointsOfInterest',
+  array[-1, 3, 6, -6], directed := false);
+/* -- withPoints q3 */
+SELECT * FROM pgr_TSP(
+  $$
+  SELECT * FROM pgr_withPointsCostMatrix(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     'SELECT pid, edge_id, fraction from pointsOfInterest',
     array[-1, 3, 6, -6], directed := false);
-/* -- withPoints q3 */
-SELECT * FROM pgr_TSP(
-    $$
-    SELECT * FROM pgr_withPointsCostMatrix(
-        'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-        'SELECT pid, edge_id, fraction from pointsOfInterest',
-        array[-1, 3, 6, -6], directed := false);
-    $$
+  $$
 );
 /* -- withPoints q4 */


### PR DESCRIPTION
Fixes #2244 .

Changes proposed in this pull request:
Using parsed literal and there is also refinement of the documentation.
- pgr_withPoints
- pgr_withPointsCost
- pgr_withPointsCostMatrix
- pgr_withPointsVia
- via-category

More refinement (for consistency) will be needed after all the withPoints family of functions are finished.

@pgRouting/admins
