### PR TITLE
Spanntree parsed literal

### DIFF
--- a/doc/coloring/coloring-family.rst
+++ b/doc/coloring/coloring-family.rst
@@ -52,30 +52,6 @@ Coloring - Family of functions
     pgr_edgeColoring
 
 
-Parameters
--------------------------------------------------------------------------------
-
-.. parameters start
-
-=================== ====================== =================================================
-Parameter           Type                   Description
-=================== ====================== =================================================
-**Edges SQL**       ``TEXT``               Inner query as described below.
-=================== ====================== =================================================
-
-.. parameters end
-
-Inner query
--------------------------------------------------------------------------------
-
-:Edges SQL: an SQL query of an **undirected** graph, which should return
-            a set of rows with the following columns:
-
-.. include:: traversal-family.rst
-   :start-after: edges_sql_start
-   :end-before: edges_sql_end
-
-
 Result Columns
 -------------------------------------------------------------------------------
 

--- a/doc/coloring/pgr_bipartite.rst
+++ b/doc/coloring/pgr_bipartite.rst
@@ -71,26 +71,22 @@ Signatures
    :start-after: --q1
    :end-before: --q2
 
-
-
-.. Parameters, Inner query & result columns
-
 Parameters
 -------------------------------------------------------------------------------
 
-.. include:: coloring-family.rst
-    :start-after: parameters start
-    :end-before: parameters end
+.. include:: pgRouting-concepts.rst
+   :start-after: only_edge_param_start
+   :end-before: only_edge_param_end
 
-Inner query
+Inner queries
 -------------------------------------------------------------------------------
 
-:Edges SQL: an SQL query of an **undirected** graph, which should return
-            a set of rows with the following columns:
+Edges SQL
+...............................................................................
 
-.. include:: traversal-family.rst
-   :start-after: edges_sql_start
-   :end-before: edges_sql_end
+.. include:: pgRouting-concepts.rst
+   :start-after: basic_edges_sql_start
+   :end-before: basic_edges_sql_end
 
 Result Columns
 -------------------------------------------------------------------------------

--- a/doc/coloring/pgr_edgeColoring.rst
+++ b/doc/coloring/pgr_edgeColoring.rst
@@ -81,19 +81,19 @@ Signatures
 Parameters
 -------------------------------------------------------------------------------
 
-.. include:: coloring-family.rst
-    :start-after: parameters start
-    :end-before: parameters end
+.. include:: pgRouting-concepts.rst
+   :start-after: only_edge_param_start
+   :end-before: only_edge_param_end
 
-Inner query
+Inner queries
 -------------------------------------------------------------------------------
 
-:Edges SQL: an SQL query of an **undirected** graph, which should return
-            a set of rows with the following columns:
+Edges SQL
+...............................................................................
 
-.. include:: traversal-family.rst
-   :start-after: edges_sql_start
-   :end-before: edges_sql_end
+.. include:: pgRouting-concepts.rst
+   :start-after: basic_edges_sql_start
+   :end-before: basic_edges_sql_end
 
 Result Columns
 -------------------------------------------------------------------------------

--- a/doc/coloring/pgr_sequentialVertexColoring.rst
+++ b/doc/coloring/pgr_sequentialVertexColoring.rst
@@ -88,19 +88,19 @@ Signatures
 Parameters
 -------------------------------------------------------------------------------
 
-.. include:: coloring-family.rst
-    :start-after: parameters start
-    :end-before: parameters end
+.. include:: pgRouting-concepts.rst
+   :start-after: only_edge_param_start
+   :end-before: only_edge_param_end
 
-Inner query
+Inner queries
 -------------------------------------------------------------------------------
 
-:Edges SQL: an SQL query of an **undirected** graph, which should return
-            a set of rows with the following columns:
+Edges SQL
+...............................................................................
 
-.. include:: traversal-family.rst
-   :start-after: edges_sql_start
-   :end-before: edges_sql_end
+.. include:: pgRouting-concepts.rst
+   :start-after: basic_edges_sql_start
+   :end-before: basic_edges_sql_end
 
 Result Columns
 -------------------------------------------------------------------------------
@@ -126,4 +126,3 @@ See Also
 
 * :ref:`genindex`
 * :ref:`search`
-

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -323,6 +323,11 @@ linkcheck_ignore = [
     'https://docs.pgrouting.org/latest/en/pgr_trspVia_withPoints.html',
     'https://docs.pgrouting.org/latest/en/withPoints-category.html',
     'https://docs.pgrouting.org/latest/en/trsp_migration.html',
+    'https://docs.pgrouting.org/latest/en/BFS-category.html',
+    'https://docs.pgrouting.org/latest/en/DFS-category.html',
+
+    'https://docs.pgrouting.org/3.4/en/BFS-category.html',
+    'https://docs.pgrouting.org/3.4/en/DFS-category.html',
 
     # link failing used in contraction-family
     'https://algo2.iti.kit.edu/documents/routeplanning/geisberger_dipl.pdf'

--- a/doc/driving_distance/drivingDistance-category.rst
+++ b/doc/driving_distance/drivingDistance-category.rst
@@ -52,6 +52,70 @@ Driving Distance - Category
     pgr_alphaShape.rst
 
 
+Calculate nodes that are within a distance.
+
+.. dd_traits_start
+
+*  Extracts all the nodes that have costs less than or equal to the value distance.
+*  The edges extracted will conform to the corresponding spanning tree.
+   Edge
+* Edge :math:`(u, v)` will not be included when:
+
+  * The distance from the **root** to :math:`u` > limit distance.
+  * The distance from the **root** to :math:`v` > limit distance.
+  * No new nodes are created on the graph, so when is within the limit and is
+    not within the limit, the edge is not included.
+
+.. dd_traits_end
+
+Parameters
+-------------------------------------------------------------------------------
+
+.. mst-dd-params_start
+
+.. list-table::
+   :width: 81
+   :widths: 14 20 46
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Description
+   * - `Edges SQL`_
+     - ``TEXT``
+     - Edges SQL as described below.
+   * - Root vid
+     - ``BIGINT``
+     - Identifier of the root vertex of the tree.
+   * - Root vids
+     - ``ARRAY[ANY-INTEGER]``
+     - Array of identifiers of the root vertices.
+
+       - :math:`0` values are ignored
+       - For optimization purposes, any duplicated value is ignored.
+   * - distance
+     - ``FLOAT``
+     - Upper limit for the inclusion of a node in the result.
+
+       - When the value is Negative **throws** error
+
+Where:
+
+:ANY-INTEGER: ``SMALLINT``, ``INTEGER``, ``BIGINT``
+:ANY-NUMERIC: ``SMALLINT``, ``INTEGER``, ``BIGINT``, ``REAL``, ``FLOAT``, ``NUMERIC``
+
+.. mst-dd-params_end
+
+Inner queries
+-------------------------------------------------------------------------------
+
+Edges SQL
+..............................................................................
+
+.. include:: pgRouting-concepts.rst
+   :start-after: basic_edges_sql_start
+   :end-before: basic_edges_sql_end
+
 See Also
 -------------------------------------------------------------------------------
 

--- a/doc/spanningTree/kruskal-family.rst
+++ b/doc/spanningTree/kruskal-family.rst
@@ -33,7 +33,6 @@ Kruskal - Family of functions
 
    Boost Graph Inside
 
-
 .. toctree::
     :hidden:
 
@@ -41,7 +40,6 @@ Kruskal - Family of functions
     pgr_kruskalBFS
     pgr_kruskalDD
     pgr_kruskalDFS
-
 
 Description
 -------------------------------------------------------------------------------
@@ -54,18 +52,11 @@ two trees in the forest.
 
 .. kruskal-description-start
 
-- It's implementation is only on **undirected** graph.
-- Process is done only on edges with positive costs.
+.. include:: spanningTree-family.rst
+   :start-after: spanntree_traits_start
+   :end-before: spanntree_traits_end
+
 - The total weight of all the edges in the tree or forest is minimized.
-- When the graph is connected
-
-  - The resulting edges make up a tree
-
-- When the graph is not connected,
-
-  - Finds a minimum spanning tree for each connected component.
-  - The resulting edges make up a forest.
-
 - Kruskal's running time: :math:`O(E * log E)`
 
 .. kruskal-description-end
@@ -77,12 +68,11 @@ Inner query
    :start-after: basic_edges_sql_start
    :end-before: basic_edges_sql_end
 
-
 See Also
 -------------------------------------------------------------------------------
 
 * :doc:`spanningTree-family`
-* `Boost: Kruskal's algorithm documentation <https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html>`__
+* `Boost: Kruskal's algorithm <https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html>`__
 * `Wikipedia: Kruskal's algorithm <https://en.wikipedia.org/wiki/Kruskal's_algorithm>`__
 
 .. rubric:: Indices and tables

--- a/doc/spanningTree/pgr_kruskal.rst
+++ b/doc/spanningTree/pgr_kruskal.rst
@@ -16,10 +16,10 @@
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_kruskal.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_kruskal.html>`__
 
-pgr_kruskal
+``pgr_kruskal``
 ===============================================================================
 
-``pgr_kruskal`` — Returns the minimum spanning tree of graph using Kruskal algorithm.
+``pgr_kruskal`` — Minimum spanning tree of a graph using Kruskal's algorithm.
 
 .. figure:: images/boost-inside.jpeg
    :target: https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html
@@ -55,33 +55,30 @@ Signatures
 
 .. rubric:: Summary
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_kruskal(edges_sql)
-
-    RETURNS SET OF (seq, edge, cost)
+    pgr_kruskal(`Edges SQL`_)
+    RETURNS SET OF (edge, cost)
     OR EMPTY SET
 
-
-:Example: Minimum Spanning Forest
+:Example: Minimum spanning forest
 
 .. literalinclude:: doc-pgr_kruskal.queries
    :start-after: -- q1
    :end-before: -- q2
 
-.. mst_information_start
-
 Parameters
 -------------------------------------------------------------------------------
 
-=================== ====================== =================================================
-Parameter           Type                   Description
-=================== ====================== =================================================
-**Edges SQL**       ``TEXT``               SQL query described in `Inner query`_.
-=================== ====================== =================================================
+.. include:: pgRouting-concepts.rst
+   :start-after: only_edge_param_start
+   :end-before: only_edge_param_end
 
 Inner query
 -------------------------------------------------------------------------------
+
+Edges SQL
+...............................................................................
 
 .. include:: pgRouting-concepts.rst
    :start-after: basic_edges_sql_start
@@ -90,18 +87,9 @@ Inner query
 Result Columns
 -------------------------------------------------------------------------------
 
-
-Returns SET OF ``(edge, cost)``
-
-===============  =========== ====================================================
-Column           Type        Description
-===============  =========== ====================================================
-**edge**         ``BIGINT``  Identifier of the edge.
-**cost**         ``FLOAT``   Cost to traverse the edge.
-===============  =========== ====================================================
-
-.. mst_information_end
-
+.. include:: pgRouting-concepts.rst
+   :start-after: r-edge-cost-start
+   :end-before: r-edge-cost-end
 
 See Also
 -------------------------------------------------------------------------------
@@ -109,8 +97,10 @@ See Also
 * :doc:`spanningTree-family`
 * :doc:`kruskal-family`
 * The queries use the :doc:`sampledata` network.
-* `Boost: Kruskal's algorithm documentation <https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html>`__
-* `Wikipedia: Kruskal's algorithm <https://en.wikipedia.org/wiki/Kruskal's_algorithm>`__
+* `Boost: Kruskal's algorithm documentation
+  <https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html>`__
+* `Wikipedia: Kruskal's algorithm
+  <https://en.wikipedia.org/wiki/Kruskal's_algorithm>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/spanningTree/pgr_kruskalBFS.rst
+++ b/doc/spanningTree/pgr_kruskalBFS.rst
@@ -16,11 +16,11 @@
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_kruskalBFS.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_kruskalBFS.html>`__
 
-pgr_kruskalBFS
+``pgr_kruskalBFS``
 ===============================================================================
 
-``pgr_kruskalBFS`` — Prim algorithm for Minimum Spanning Tree with Depth First
-Search ordering.
+``pgr_kruskalBFS`` — Kruskal's algorithm for Minimum Spanning Tree with breadth
+First Search ordering.
 
 .. figure:: images/boost-inside.jpeg
    :target: https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html
@@ -38,7 +38,7 @@ Description
 -------------------------------------------------------------------------------
 
 Visits and extracts the nodes information in Breath First Search ordering
-of the Minimum Spanning Tree created using Prims's algorithm.
+of the Minimum Spanning Tree created using Kruskal's algorithm.
 
 **The main Characteristics are:**
 
@@ -52,11 +52,10 @@ of the Minimum Spanning Tree created using Prims's algorithm.
 Signatures
 -------------------------------------------------------------------------------
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_kruskalBFS(Edges SQL, Root vid [, max_depth])
-    pgr_kruskalBFS(Edges SQL, Root vids [, max_depth])
-
+    pgr_kruskalBFS(`Edges SQL`_, **Root vid** [, max_depth])
+    pgr_kruskalBFS(`Edges SQL`_, **Root vids** [, max_depth])
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
 .. index::
@@ -65,10 +64,9 @@ Signatures
 Single vertex
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_kruskalBFS(Edges SQL, Root vid [, max_depth])
-
+    pgr_kruskalBFS(`Edges SQL`_, **Root vid** [, max_depth])
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
 :Example: The Minimum Spanning Tree having as root vertex :math:`2`
@@ -83,33 +81,59 @@ Single vertex
 Multiple vertices
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_kruskalBFS(Edges SQL, Root vids [, max_depth])
-
+    pgr_kruskalBFS(`Edges SQL`_, **Root vids** [, max_depth])
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
-:Example: The Minimum Spanning Tree starting on vertices :math:`\{13, 2\}` with :math:`depth <= 3`
+:Example: The Minimum Spanning Tree starting on vertices :math:`\{13, 2\}` with
+          :math:`depth <= 3`
 
 .. literalinclude:: doc-pgr_kruskalBFS.queries
    :start-after: --q2
    :end-before: --q3
 
-.. Parameters, Inner query & result columns
+Parameters
+-------------------------------------------------------------------------------
 
-.. include:: pgr_kruskalDFS.rst
-   :start-after: mstfs-information-start
-   :end-before: mstfs-information-end
+.. include:: BFS-category.rst
+   :start-after: mst-bfs-dfs-params_start
+   :end-before: mst-bfs-dfs-params_end
 
+BFS optional parameters
+...............................................................................
+
+.. include:: BFS-category.rst
+   :start-after: max-depth-optional-start
+   :end-before: max-depth-optional-end
+
+Inner queries
+-------------------------------------------------------------------------------
+
+Edges SQL
+...............................................................................
+
+.. include:: pgRouting-concepts.rst
+   :start-after: basic_edges_sql_start
+   :end-before: basic_edges_sql_end
+
+Result Columns
+-------------------------------------------------------------------------------
+
+.. include:: BFS-category.rst
+   :start-after: mst-bfs-dfs-dd-result-columns-start
+   :end-before: mst-bfs-dfs-dd-result-columns-end
 
 See Also
 -------------------------------------------------------------------------------
 
 * :doc:`spanningTree-family`
 * :doc:`kruskal-family`
-* The queries use the :doc:`sampledata` network.
-* `Boost: Kruskal's algorithm documentation <https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html>`__
-* `Wikipedia: Kruskal's algorithm <https://en.wikipedia.org/wiki/Kruskal's_algorithm>`__
+* :doc:`sampledata`
+* `Boost: Kruskal's algorithm documentation
+  <https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html>`__
+* `Wikipedia: Kruskal's algorithm
+  <https://en.wikipedia.org/wiki/Kruskal's_algorithm>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/spanningTree/pgr_kruskalDD.rst
+++ b/doc/spanningTree/pgr_kruskalDD.rst
@@ -16,7 +16,7 @@
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_kruskalDD.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_kruskalDD.html>`__
 
-pgr_kruskalDD
+``pgr_kruskalDD``
 ===============================================================================
 
 ``pgr_kruskalDD`` — Catchament nodes using Kruskal's algorithm.
@@ -36,9 +36,9 @@ pgr_kruskalDD
 Description
 -------------------------------------------------------------------------------
 
-Using Kruskal's algorithm, extracts the nodes that have aggregate costs less than
-or equal to the value ``Distance`` from a **root** vertex (or vertices) within
-the calculated minimum spanning tree.
+Using Kruskal's algorithm, extracts the nodes that have aggregate costs less
+than or equal to a **distance** from a **root** vertex (or vertices) within the
+calculated minimum spanning tree.
 
 
 **The main Characteristics are:**
@@ -47,17 +47,21 @@ the calculated minimum spanning tree.
    :start-after: kruskal-description-start
    :end-before: kruskal-description-end
 
+.. include:: drivingDistance-category.rst
+   :start-after: dd_traits_start
+   :end-before: dd_traits_end
+
 - Returned tree nodes from a root vertex are on Depth First Search order.
 - Depth First Search running time: :math:`O(E + V)`
+
 
 Signatures
 -------------------------------------------------------------------------------
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_kruskalDD(edges_sql, root_vid, distance)
-    pgr_kruskalDD(edges_sql, root_vids, distance)
-
+    pgr_kruskalDD(`Edges SQL`_, **Root vid**, **distance**)
+    pgr_kruskalDD(`Edges SQL`_, **Root vids**, **distance**)
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
 .. index::
@@ -66,13 +70,13 @@ Signatures
 Single vertex
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_kruskalDD(edges_sql, root_vid, distance)
-
+    pgr_kruskalDD(`Edges SQL`_, **Root vid**, **distance**)
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
-:Example: The Minimum Spanning Tree starting on vertex :math:`2` with :math:`agg\_cost <= 3.5`
+:Example: The Minimum Spanning Tree starting on vertex :math:`2` with
+          **distance** :math:`<= 3.5`
 
 .. literalinclude:: doc-pgr_kruskalDD.queries
    :start-after: -- q1
@@ -84,53 +88,30 @@ Single vertex
 Multiple vertices
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_kruskalDD(edges_sql, root_vids, distance)
-
+    pgr_kruskalDD(`Edges SQL`_, **Root vids**, **distance**)
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
-:Example: The Minimum Spanning Tree starting on vertices :math:`\{13, 2\}` with :math:`agg\_cost <= 3.5`;
+:Example: The Minimum Spanning Tree starting on vertices :math:`\{13, 2\}` with
+          **distance** :math:`<= 3.5`
 
 .. literalinclude:: doc-pgr_kruskalDD.queries
    :start-after: -- q2
    :end-before: -- q3
 
-.. mstDD-information-start
-
 Parameters
 -------------------------------------------------------------------------------
 
-=================== ====================== =================================================
-Parameter           Type                   Description
-=================== ====================== =================================================
-**Edges SQL**       ``TEXT``               SQL query described in `Inner query`_.
-**Root vid**        ``BIGINT``             Identifier of the root vertex of the tree.
-
-                                           - Used on `Single vertex`_
-                                           - When :math:`0` gets the spanning forest
-                                             starting in aleatory nodes for each tree.
-
-**Root vids**       ``ARRAY[ANY-INTEGER]`` Array of identifiers of the root vertices.
-
-                                           - Used on `Multiple vertices`_
-                                           - :math:`0` values are ignored
-                                           - For optimization purposes, any duplicated value is ignored.
-
-**Distance**        ``ANY-NUMERIC``        Upper limit for the inclusion of the node in the result.
-
-                                           - When the value is Negative **throws error**
-=================== ====================== =================================================
-
-Where:
-
-:ANY-INTEGER: SMALLINT, INTEGER, BIGINT
-:ANY-NUMERIC: SMALLINT, INTEGER, BIGINT, REAL, FLOAT, NUMERIC
+.. include:: drivingDistance-category.rst
+   :start-after: mst-dd-params_start
+   :end-before: mst-dd-params_end
 
 Inner query
 -------------------------------------------------------------------------------
 
-.. rubric::edges_sql
+Edges SQL
+..............................................................................
 
 .. include:: pgRouting-concepts.rst
    :start-after: basic_edges_sql_start
@@ -139,43 +120,20 @@ Inner query
 Result Columns
 -------------------------------------------------------------------------------
 
-.. result columns start
-
-Returns SET OF ``(seq, depth, start_vid, node, edge, cost, agg_cost)``
-
-===============  =========== ====================================================
-Column           Type        Description
-===============  =========== ====================================================
-**seq**          ``BIGINT``  Sequential value starting from :math:`1`.
-**depth**        ``BIGINT``  Depth of the ``node``.
-
-                             - :math:`0`  when ``node`` = ``start_vid``.
-
-**start_vid**    ``BIGINT``  Identifier of the root vertex.
-
-                             - In `Multiple Vertices`_ results are in ascending order.
-
-**node**         ``BIGINT``  Identifier of ``node`` reached using ``edge``.
-**edge**         ``BIGINT``  Identifier of the ``edge`` used to arrive to ``node``.
-
-                             - :math:`-1`  when ``node`` = ``start_vid``.
-
-**cost**         ``FLOAT``   Cost to traverse ``edge``.
-**agg_cost**     ``FLOAT``   Aggregate cost from ``start_vid`` to ``node``.
-===============  =========== ====================================================
-
-.. result columns end
-
-.. mstDD-information-end
+.. include:: BFS-category.rst
+   :start-after: mst-bfs-dfs-dd-result-columns-start
+   :end-before: mst-bfs-dfs-dd-result-columns-end
 
 See Also
 -------------------------------------------------------------------------------
 
 * :doc:`spanningTree-family`
 * :doc:`kruskal-family`
-* The queries use the :doc:`sampledata` network.
-* `Boost: Kruskal's algorithm documentation <https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html>`__
-* `Wikipedia: Kruskal's algorithm <https://en.wikipedia.org/wiki/Kruskal's_algorithm>`__
+* :doc:`sampledata`
+* `Boost: Kruskal's algorithm documentation
+  <https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html>`__
+* `Wikipedia: Kruskal's algorithm
+  <https://en.wikipedia.org/wiki/Kruskal's_algorithm>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/spanningTree/pgr_kruskalDFS.rst
+++ b/doc/spanningTree/pgr_kruskalDFS.rst
@@ -16,11 +16,11 @@
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_kruskalDFS.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_kruskalDFS.html>`__
 
-pgr_kruskalDFS
+``pgr_kruskalDFS``
 ===============================================================================
 
-``pgr_kruskalDFS`` — Kruskal algorithm for Minimum Spanning Tree with Depth First
-Search ordering.
+``pgr_kruskalDFS`` — Kruskal's algorithm for Minimum Spanning Tree with Depth
+First Search ordering.
 
 .. figure:: images/boost-inside.jpeg
    :target: https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html
@@ -52,11 +52,10 @@ of the Minimum Spanning Tree created using Kruskal's algorithm.
 Signatures
 -------------------------------------------------------------------------------
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_kruskalDFS(Edges SQL, Root vid [, max_depth])
-    pgr_kruskalDFS(Edges SQL, Root vids [, max_depth])
-
+    pgr_kruskalDFS(`Edges SQL`_, **Root vid** [, max_depth])
+    pgr_kruskalDFS(`Edges SQL`_, **Root vids** [, max_depth])
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
 .. index::
@@ -65,13 +64,12 @@ Signatures
 Single vertex
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_kruskalDFS(Edges SQL, Root vid [, max_depth])
-
+    pgr_kruskalDFS(`Edges SQL`_, **Root vid** [, max_depth])
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
-:Example: The Minimum Spanning Tree starting on vertex :math:`2`
+:Example: The Minimum Spanning Tree having as root vertex :math:`2`
 
 .. literalinclude:: doc-pgr_kruskalDFS.queries
    :start-after: --q1
@@ -83,57 +81,37 @@ Single vertex
 Multiple vertices
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_kruskalDFS(Edges SQL, Root vids [, max_depth])
-
+    pgr_kruskalDFS(`Edges SQL`_, **Root vids** [, max_depth])
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
-:Example: The Minimum Spanning Tree starting on vertices :math:`\{13, 2\}` with :math:`depth <= 3`
+:Example: The Minimum Spanning Tree starting on vertices :math:`\{13, 2\}` with
+          :math:`depth <= 3`
 
 .. literalinclude:: doc-pgr_kruskalDFS.queries
    :start-after: --q2
    :end-before: --q3
 
-
-.. mstfs-information-start
-
 Parameters
 -------------------------------------------------------------------------------
 
-=================== ====================== =================================================
-Parameter           Type                   Description
-=================== ====================== =================================================
-**Edges SQL**       ``TEXT``               SQL query described in `Inner query`_.
-**Root vid**        ``BIGINT``             Identifier of the root vertex of the tree.
+.. include:: BFS-category.rst
+   :start-after: mst-bfs-dfs-params_start
+   :end-before: mst-bfs-dfs-params_end
 
-                                           - Used on `Single vertex`_
-                                           - When value is :math:`0` then gets the spanning forest
-                                             starting in aleatory nodes for each tree in the forest.
-
-**Root vids**       ``ARRAY[ANY-INTEGER]`` Array of identifiers of the root vertices.
-
-                                           - Used on `Multiple vertices`_
-                                           - :math:`0` values are ignored
-                                           - For optimization purposes, any duplicated value is ignored.
-=================== ====================== =================================================
-
-Optional Parameters
+DFS optional parameters
 ...............................................................................
 
+.. include:: BFS-category.rst
+   :start-after: max-depth-optional-start
+   :end-before: max-depth-optional-end
 
-=================== =========== =========================== =================================================
-Parameter           Type        Default                     Description
-=================== =========== =========================== =================================================
-**max_depth**       ``BIGINT``  :math:`9223372036854775807` Upper limit for depth of node in the tree
-
-                                                            - When value is ``Negative`` then **throws error**
-=================== =========== =========================== =================================================
-
-Inner query
+Inner queries
 -------------------------------------------------------------------------------
 
-.. rubric::Edges SQL
+Edges SQL
+...............................................................................
 
 .. include:: pgRouting-concepts.rst
    :start-after: basic_edges_sql_start
@@ -142,20 +120,20 @@ Inner query
 Result Columns
 -------------------------------------------------------------------------------
 
-.. include:: pgr_kruskalDD.rst
-   :start-after: result columns start
-   :end-before: result columns end
-
-.. mstfs-information-end
+.. include:: BFS-category.rst
+   :start-after: mst-bfs-dfs-dd-result-columns-start
+   :end-before: mst-bfs-dfs-dd-result-columns-end
 
 See Also
 -------------------------------------------------------------------------------
 
 * :doc:`spanningTree-family`
 * :doc:`kruskal-family`
-* The queries use the :doc:`sampledata` network.
-* `Boost: Kruskal's algorithm documentation <https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html>`__
-* `Wikipedia: Kruskal's algorithm <https://en.wikipedia.org/wiki/Kruskal's_algorithm>`__
+* :doc:`sampledata`
+* `Boost: Kruskal's algorithm documentation
+  <https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html>`__
+* `Wikipedia: Kruskal's algorithm
+  <https://en.wikipedia.org/wiki/Kruskal's_algorithm>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/spanningTree/pgr_prim.rst
+++ b/doc/spanningTree/pgr_prim.rst
@@ -16,10 +16,10 @@
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_prim.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_prim.html>`__
 
-pgr_prim
+``pgr_prim``
 ===============================================================================
 
-``pgr_prim`` — Minimum spanning forest of graph using Prim algorithm.
+``pgr_prim`` — Minimum spanning forest of a graph using Prim's algorithm.
 
 .. figure:: images/boost-inside.jpeg
    :target: https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html
@@ -31,12 +31,6 @@ pgr_prim
 * Version 3.0.0
 
   * New **Official** function
-
-.. rubric:: Support
-
-* **Supported versions:**
-  current(`3.1 <https://docs.pgrouting.org/3.1/en/pgr_prim.html>`__)
-  `3.0 <https://docs.pgrouting.org/3.0/en/pgr_prim.html>`__
 
 Description
 -------------------------------------------------------------------------------
@@ -61,28 +55,42 @@ Signatures
 
 .. rubric:: Summary
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_prim(edges_sql)
-
+    pgr_prim(`Edges SQL`_)
     RETURNS SET OF (edge, cost)
     OR EMPTY SET
 
 
-:Example: Minimum Spanning Forest of a subgraph
+:Example: Minimum spanning forest of a subgraph
 
 .. literalinclude:: doc-pgr_prim.queries
    :start-after: -- q1
    :end-before: -- q2
 
+Parameters
+-------------------------------------------------------------------------------
 
-.. parameters, inner query & result columns
-   are the same as kruskal's
+.. include:: pgRouting-concepts.rst
+   :start-after: only_edge_param_start
+   :end-before: only_edge_param_end
 
-.. include:: pgr_kruskal.rst
-   :start-after: mst_information_start
-   :end-before: mst_information_end
+Inner query
+-------------------------------------------------------------------------------
 
+Edges SQL
+...............................................................................
+
+.. include:: pgRouting-concepts.rst
+   :start-after: basic_edges_sql_start
+   :end-before: basic_edges_sql_end
+
+Result Columns
+-------------------------------------------------------------------------------
+
+include:: pgRouting-concepts.rst
+   :start-after: r-edge-cost-start
+   :end-before: r-edge-cost-end
 
 See Also
 -------------------------------------------------------------------------------
@@ -90,8 +98,10 @@ See Also
 * :doc:`spanningTree-family`
 * :doc:`prim-family`
 * The queries use the :doc:`sampledata` network.
-* `Boost: Prim's algorithm documentation <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
-* `Wikipedia: Prim's algorithm <https://en.wikipedia.org/wiki/Prim%27s_algorithm>`__
+* `Boost: Prim's algorithm documentation
+  <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
+* `Wikipedia: Prim's algorithm
+  <https://en.wikipedia.org/wiki/Prim%27s_algorithm>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/spanningTree/pgr_primBFS.rst
+++ b/doc/spanningTree/pgr_primBFS.rst
@@ -16,7 +16,7 @@
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_primBFS.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_primBFS.html>`__
 
-pgr_primBFS
+``pgr_primBFS``
 ===============================================================================
 
 ``pgr_primBFS`` — Prim's algorithm for Minimum Spanning Tree with Depth First
@@ -52,11 +52,10 @@ of the Minimum Spanning Tree created with Prims's algorithm.
 Signatures
 -------------------------------------------------------------------------------
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_primBFS(Edges SQL, Root vid [, max_depth])
-    pgr_primBFS(Edges SQL, Root vids [, max_depth])
-
+    pgr_primBFS(`Edges SQL`_, **Root vid** [, max_depth])
+    pgr_primBFS(`Edges SQL`_, **Root vids** [, max_depth])
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
 .. index::
@@ -65,10 +64,9 @@ Signatures
 Single vertex
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_primBFS(Edges SQL, Root vid [, max_depth])
-
+    pgr_primBFS(`Edges SQL`_, **Root vid** [, max_depth])
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
 :Example: The Minimum Spanning Tree having as root vertex :math:`2`
@@ -83,25 +81,48 @@ Single vertex
 Multiple vertices
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_primBFS(Edges SQL, Root vids [, max_depth])
-
+    pgr_primBFS(`Edges SQL`_, **Root vids** [, max_depth])
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
-:Example: The Minimum Spanning Tree starting on vertices :math:`\{13, 2\}` with :math:`depth <= 3`
+:Example: The Minimum Spanning Tree starting on vertices :math:`\{13, 2\}` with
+          :math:`depth <= 3`
 
 .. literalinclude:: doc-pgr_primBFS.queries
    :start-after: --q2
    :end-before: --q3
 
-.. Parameters, Inner query & result columns
-   are the same as kruskal
+Parameters
+-------------------------------------------------------------------------------
 
-.. include:: pgr_kruskalDFS.rst
-   :start-after: mstfs-information-start
-   :end-before: mstfs-information-end
+.. include:: BFS-category.rst
+   :start-after: mst-bfs-dfs-params_start
+   :end-before: mst-bfs-dfs-params_end
 
+BFS optional parameters
+...............................................................................
+
+.. include:: BFS-category.rst
+   :start-after: max-depth-optional-start
+   :end-before: max-depth-optional-end
+
+Inner queries
+-------------------------------------------------------------------------------
+
+Edges SQL
+...............................................................................
+
+.. include:: pgRouting-concepts.rst
+    :start-after: basic_edges_sql_start
+    :end-before: basic_edges_sql_end
+
+Result Columns
+-------------------------------------------------------------------------------
+
+.. include:: BFS-category.rst
+   :start-after: mst-bfs-dfs-dd-result-columns-start
+   :end-before: mst-bfs-dfs-dd-result-columns-end
 
 See Also
 -------------------------------------------------------------------------------
@@ -109,8 +130,10 @@ See Also
 * :doc:`spanningTree-family`
 * :doc:`prim-family`
 * The queries use the :doc:`sampledata` network.
-* `Boost: Prim's algorithm documentation <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
-* `Wikipedia: Prim's algorithm <https://en.wikipedia.org/wiki/Prim%27s_algorithm>`__
+* `Boost: Prim's algorithm documentation
+  <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
+* `Wikipedia: Prim's algorithm
+  <https://en.wikipedia.org/wiki/Prim%27s_algorithm>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/spanningTree/pgr_primDD.rst
+++ b/doc/spanningTree/pgr_primDD.rst
@@ -16,7 +16,7 @@
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_primDD.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_primDD.html>`__
 
-pgr_primDD
+``pgr_primDD``
 ===============================================================================
 
 ``pgr_primDD`` — Catchament nodes using Prim's algorithm.
@@ -36,14 +36,19 @@ pgr_primDD
 Description
 -------------------------------------------------------------------------------
 
-Using Prim algorithm, extracts the nodes that have aggregate costs less than
-or equal to the value ``Distance`` within the calculated minimum spanning tree.
+Using Prim's algorithm, extracts the nodes that have aggregate costs less than
+or equal to a **distance** from a **root** vertex (or vertices) within the
+calculated minimum spanning tree.
 
 **The main Characteristics are:**
 
 .. include:: prim-family.rst
    :start-after: prim-description-start
    :end-before: prim-description-end
+
+.. include:: drivingDistance-category.rst
+   :start-after: dd_traits_start
+   :end-before: dd_traits_end
 
 - Returned tree nodes from a root vertex are on Depth First Search order.
 - Depth First Search running time: :math:`O(E + V)`
@@ -53,11 +58,10 @@ Signatures
 
 .. rubric:: Summary
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_prim(Edges SQL, root vid, distance)
-    pgr_prim(Edges SQL, root vids, distance)
-
+    pgr_primDD(`Edges SQL`_, **Root vid**, **distance**)
+    pgr_primDD(`Edges SQL`_, **Root vids**, **distance**)
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
 .. index::
@@ -66,13 +70,13 @@ Signatures
 Single vertex
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_primDD(Edges SQL, root vid, distance)
-
+    pgr_primDD(`Edges SQL`_, **Root vid**, **distance**)
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
-:Example: The Minimum Spanning Tree starting on vertex :math:`2` with :math:`agg\_cost <= 3.5`
+:Example: The Minimum Spanning Tree starting on vertex :math:`2` with
+          **distance** :math:`<= 3.5`.
 
 .. literalinclude:: doc-pgr_primDD.queries
    :start-after: -- q1
@@ -84,34 +88,52 @@ Single vertex
 Multiple vertices
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_primDD(Edges SQL, root vids, distance)
-
+    pgr_primDD(`Edges SQL`_, **Root vids**, **distance**)
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
-:Example: The Minimum Spanning Tree starting on vertices :math:`\{13, 2\}` with :math:`agg\_cost <= 3.5`;
+:Example: The Minimum Spanning Tree starting on vertices :math:`\{13, 2\}` with
+          **distance** :math:`<= 3.5`.
 
 .. literalinclude:: doc-pgr_primDD.queries
    :start-after: -- q2
    :end-before: -- q3
 
+Parameters
+-------------------------------------------------------------------------------
 
-.. Parameters, Inner query & result columns
+.. include:: drivingDistance-category.rst
+   :start-after: mst-dd-params_start
+   :end-before: mst-dd-params_end
 
-.. include:: pgr_kruskalDD.rst
-   :start-after: mstDD-information-start
-   :end-before: mstDD-information-end
+Inner query
+-------------------------------------------------------------------------------
 
+Edges SQL
+..............................................................................
+
+.. include:: pgRouting-concepts.rst
+   :start-after: basic_edges_sql_start
+   :end-before: basic_edges_sql_end
+
+Result Columns
+-------------------------------------------------------------------------------
+
+.. include:: BFS-category.rst
+   :start-after: mst-bfs-dfs-dd-result-columns-start
+   :end-before: mst-bfs-dfs-dd-result-columns-end
 
 See Also
 -------------------------------------------------------------------------------
 
 * :doc:`spanningTree-family`
 * :doc:`prim-family`
-* The queries use the :doc:`sampledata` network.
-* `Boost: Prim's algorithm documentation <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
-* `Wikipedia: Prim's algorithm <https://en.wikipedia.org/wiki/Prim%27s_algorithm>`__
+* :doc:`sampledata`
+* `Boost: Prim's algorithm documentation
+  <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
+* `Wikipedia: Prim's algorithm
+  <https://en.wikipedia.org/wiki/Prim%27s_algorithm>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/spanningTree/pgr_primDFS.rst
+++ b/doc/spanningTree/pgr_primDFS.rst
@@ -16,7 +16,7 @@
   `3.1 <https://docs.pgrouting.org/3.1/en/pgr_primDFS.html>`__
   `3.0 <https://docs.pgrouting.org/3.0/en/pgr_primDFS.html>`__
 
-pgr_primDFS
+``pgr_primDFS``
 ===============================================================================
 
 ``pgr_primDFS`` — Prim algorithm for Minimum Spanning Tree with Depth First
@@ -52,11 +52,10 @@ of the Minimum Spanning Tree created using Prims's algorithm.
 Signatures
 -------------------------------------------------------------------------------
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_primDFS(Edges SQL, Root vid [, max_depth])
-    pgr_primDFS(Edges SQL, Root vids [, max_depth])
-
+    pgr_primDFS(`Edges SQL`_, **Root vid** [, max_depth])
+    pgr_primDFS(`Edges SQL`_, **Root vids** [, max_depth])
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
 .. index::
@@ -65,10 +64,9 @@ Signatures
 Single vertex
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_primDFS(Edges SQL, Root vid [, max_depth])
-
+    pgr_primDFS(`Edges SQL`_, **Root vid** [, max_depth])
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
 :Example: The Minimum Spanning Tree having as root vertex :math:`2`
@@ -83,33 +81,59 @@ Single vertex
 Multiple vertices
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_primDFS(Edges SQL, Root vids [, max_depth])
-
+    pgr_primDFS(`Edges SQL`_, **Root vids** [, max_depth])
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
-:Example: The Minimum Spanning Tree starting on vertices :math:`\{13, 2\}` with :math:`depth <= 3`
+:Example: The Minimum Spanning Tree starting on vertices :math:`\{13, 2\}` with
+          :math:`depth <= 3`
 
 .. literalinclude:: doc-pgr_primDFS.queries
    :start-after: --q2
    :end-before: --q3
 
-.. Parameters, Inner query & result columns
+Parameters
+-------------------------------------------------------------------------------
 
-.. include:: pgr_kruskalDFS.rst
-   :start-after: mstfs-information-start
-   :end-before: mstfs-information-end
+.. include:: BFS-category.rst
+   :start-after: mst-bfs-dfs-params_start
+   :end-before: mst-bfs-dfs-params_end
 
+DFS optional parameters
+...............................................................................
+
+.. include:: BFS-category.rst
+   :start-after: max-depth-optional-start
+   :end-before: max-depth-optional-end
+
+Inner queries
+-------------------------------------------------------------------------------
+
+Edges SQL
+...............................................................................
+
+.. include:: pgRouting-concepts.rst
+   :start-after: basic_edges_sql_start
+   :end-before: basic_edges_sql_end
+
+Result Columns
+-------------------------------------------------------------------------------
+
+.. include:: BFS-category.rst
+   :start-after: mst-bfs-dfs-dd-result-columns-start
+   :end-before: mst-bfs-dfs-dd-result-columns-end
 
 See Also
 -------------------------------------------------------------------------------
 
 * :doc:`spanningTree-family`
 * :doc:`prim-family`
-* The queries use the :doc:`sampledata` network.
-* `Boost: Prim's algorithm documentation <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
-* `Wikipedia: Prim's algorithm <https://en.wikipedia.org/wiki/Prim%27s_algorithm>`__
+* :doc:`sampledata`
+* `Boost: Prim's algorithm documentation
+  <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
+* `Wikipedia: Prim's algorithm
+  <https://en.wikipedia.org/wiki/Prim%27s_algorithm>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/spanningTree/prim-family.rst
+++ b/doc/spanningTree/prim-family.rst
@@ -63,24 +63,18 @@ forest.
 
 .. prim-description-start
 
-- It's implementation is only on **undirected graph**.
-- Process is done only on edges with positive costs.
-- When the graph is connected
+.. include:: spanningTree-family.rst
+   :start-after: spanntree_traits_start
+   :end-before: spanntree_traits_end
 
-  - The resulting edges make up a tree
-
-- When the graph is not connected,
-
-  - Finds a minimum spanning tree for each connected component.
-  - The resulting edges make up a forest.
-
-- Prim's running time: :math:`O(E*log V)`
+- Prim's running time: :math:`O(E * log V)`
 
 .. prim-description-end
 
 
 .. Note:: From boost Graph:
-   "The algorithm as implemented in Boost.Graph does not produce correct results on graphs with parallel edges."
+   "The algorithm as implemented in Boost.Graph does not produce correct results
+   on graphs with parallel edges."
 
 Inner query
 -------------------------------------------------------------------------------
@@ -93,7 +87,7 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`spanningTree-family`
-* `Boost: Prim's algorithm documentation <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
+* `Boost: Prim's algorithm <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
 * `Wikipedia: Prim's algorithm <https://en.wikipedia.org/wiki/Prim%27s_algorithm>`__
 
 .. rubric:: Indices and tables

--- a/doc/spanningTree/spanningTree-family.rst
+++ b/doc/spanningTree/spanningTree-family.rst
@@ -19,7 +19,6 @@
 Spanning Tree - Category
 ===============================================================================
 
-
 .. index from here
 
 * :doc:`kruskal-family`
@@ -39,12 +38,34 @@ consisting of a spanning tree of each connected component.
     kruskal-family
     prim-family
 
+Characteristics:
+
+.. spanntree_traits_start
+
+* It's implementation is only on **undirected** graph.
+* Process is done only on edges with positive costs.
+* When the graph is connected
+
+  * The resulting edges make up a tree
+
+* When the graph is not connected,
+
+  * Finds a minimum spanning tree for each connected component.
+  * The resulting edges make up a forest.
+
+.. spanntree_traits_end
 
 See Also
 -------------------------------------------------------------------------------
 
-* `Boost: Prim's algorithm documentation <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
-* `Wikipedia: Prim's algorithm <https://en.wikipedia.org/wiki/Prim%27s_algorithm>`__
+* `Boost: Prim's algorithm
+  <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
+* `Boost: Kruskal's algorithm
+  <https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html>`__
+* `Wikipedia: Prim's algorithm
+  <https://en.wikipedia.org/wiki/Prim%27s_algorithm>`__
+* `Wikipedia: Kruskal's algorithm
+  <https://en.wikipedia.org/wiki/Kruskal's_algorithm>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/src/pgRouting-concepts.rst
+++ b/doc/src/pgRouting-concepts.rst
@@ -108,8 +108,6 @@ where you should replace 'myroads' with the name of your table storing the edges
 
 * :doc:`pgr_createTopology`
 
-|
-
 Check the Routing Topology
 ...............................................................................
 
@@ -138,9 +136,6 @@ where you should replace 'myroads' with the name of your table storing the edges
 * :doc:`pgr_analyzeGraph`
 * :doc:`pgr_analyzeOneWay`
 * :doc:`pgr_nodeNetwork`
-
-
-|
 
 Compute a Path
 ...............................................................................
@@ -177,8 +172,6 @@ to get more information about each step in the path.
 
 * :doc:`pgr_dijkstra`
 
-|
-
 Group of Functions
 -------------------------------------------------------------------------------
 
@@ -194,8 +187,6 @@ Across this documentation, to indicate which overload we use the following terms
 Depending on the overload are the parameters used, keeping consistency across
 all functions.
 
-|
-
 One to One
 ...............................................................................
 
@@ -203,8 +194,6 @@ When routing from:
 
 * From **one** starting vertex
 * to **one** ending vertex
-
-|
 
 One to Many
 ...............................................................................
@@ -214,8 +203,6 @@ When routing from:
 * From **one** starting vertex
 * to **many** ending vertices
 
-|
-
 Many to One
 ...............................................................................
 
@@ -223,8 +210,6 @@ When routing from:
 
 * From **many** starting vertices
 * to **one** ending vertex
-
-|
 
 Many to Many
 ...............................................................................
@@ -494,10 +479,33 @@ Points SQL
    :start-after: points_sql_start
    :end-before: points_sql_end
 
-|
-
 Parameters
 -------------------------------------------------------------------------------
+
+The main parameter of the majority of the pgRouting functions is a query that
+selects the edges of the graph.
+
+.. only_edge_param_start
+
+.. list-table::
+   :width: 81
+   :widths: auto
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Description
+   * - `Edges SQL`_
+     - ``TEXT``
+     - `Edges SQL`_ as described below.
+
+.. only_edge_param_end
+
+Depending on the family or category of a function it will have additional
+parameters, some of them are compulsory and some are optional.
+
+The compulsory parameters are nameless and must be given in the required order.
+The optional parameters are named parameters and will have a default value.
 
 .. rubric:: Parameters for the Via functions
 
@@ -544,13 +552,6 @@ Parameters
 
 
 .. pgr_dijkstra_via_parameters_end
-
-.. rubric:: Parameters for the Via functions:
-
-* :doc:`pgr_withPointsVia`
-
-
-|
 
 Return columns
 --------------------------------------------------------------------------------
@@ -881,8 +882,35 @@ Return columns for flow functions
     :start-after: result_costFlow_start
     :end-before: result_costFlow_end
 
+Return columns for spanning tree functions
+.....................................................................
 
-.. _advanced_topics:
+
+.. rubric:: Edges SQL for the following
+
+* :doc:`pgr_prim`
+* :doc:`pgr_kruskal`
+
+.. r-edge-cost-start
+
+Returns SET OF ``(edge, cost)``
+
+.. list-table::
+   :width: 81
+   :widths: auto
+   :header-rows: 1
+
+   * - Column
+     - Type
+     - Description
+   * - ``edge``
+     - ``BIGINT``
+     - Identifier of the edge.
+   * - ``cost``
+     - ``FLOAT``
+     - Cost to traverse the edge.
+
+.. r-edge-cost-end
 
 Advanced Topics
 -------------------------------------------------------------------------------

--- a/doc/src/routingFunctions.rst
+++ b/doc/src/routingFunctions.rst
@@ -142,6 +142,18 @@ Functions by categories
    :start-after: index from here
    :end-before: index to here
 
+:doc:`BFS-category`
+
+.. include:: BFS-category.rst
+   :start-after: index from here
+   :end-before: index to here
+
+:doc:`DFS-category`
+
+.. include:: DFS-category.rst
+   :start-after: index from here
+   :end-before: index to here
+
 ..  to-here
 
 .. toctree::
@@ -169,6 +181,7 @@ Functions by categories
     costMatrix-category
     drivingDistance-category
     spanningTree-family
+    BFS-category
 
 See Also
 -------------------------------------------------------------------------------

--- a/doc/traversal/BFS-category.rst
+++ b/doc/traversal/BFS-category.rst
@@ -1,0 +1,179 @@
+..
+   ****************************************************************************
+    pgRouting Manual
+    Copyright(c) pgRouting Contributors
+
+    This documentation is licensed under a Creative Commons Attribution-Share
+    Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
+   ****************************************************************************
+
+|
+
+* **Supported versions:**
+  `Latest <https://docs.pgrouting.org/latest/en/BFS-category.html>`__
+  (`3.4 <https://docs.pgrouting.org/3.4/en/BFS-category.html>`__)
+
+BFS - Category
+===============================================================================
+
+.. index from here
+
+* :doc:`pgr_kruskalBFS`
+* :doc:`pgr_primBFS`
+
+.. index to here
+
+Traversal using breadth first search.
+
+.. spanntree_traits_start
+
+* It's implementation is only on **undirected** graph.
+* Process is done only on edges with positive costs.
+* When the graph is connected
+
+  * The resulting edges make up a tree
+
+* When the graph is not connected,
+
+  * Finds a minimum spanning tree for each connected component.
+  * The resulting edges make up a forest.
+
+.. spanntree_traits_end
+
+Parameters
+-------------------------------------------------------------------------------
+
+.. mst-bfs-dfs-params_start
+
+.. list-table::
+   :width: 81
+   :widths: 10,17,53
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Description
+   * - `Edges SQL`_
+     - ``TEXT``
+     - `Edges SQL`_ as described below.
+   * - **Root vid**
+     - ``BIGINT``
+     - Identifier of the root vertex of the tree.
+
+       * When value is :math:`0` then gets the spanning forest starting in
+         aleatory nodes for each tree in the forest.
+
+   * - **Root vids**
+     - ``ARRAY[ANY-INTEGER]``
+     -  Array of identifiers of the root vertices.
+
+        * :math:`0` values are ignored
+        * For optimization purposes, any duplicated value is ignored.
+
+Where:
+
+:ANY-INTEGER: SMALLINT, INTEGER, BIGINT
+:ANY-NUMERIC: SMALLINT, INTEGER, BIGINT, REAL, FLOAT, NUMERIC
+
+.. mst-bfs-dfs-params_end
+
+BFS optional parameters
+...............................................................................
+
+.. max-depth-optional-start
+
+.. list-table::
+   :width: 81
+   :widths: auto
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Default
+     - Description
+   * - **max_depth**
+     - ``BIGINT``
+     - :math:`9223372036854775807`
+     - Upper limit of the depth of the tree.
+
+       * When ``Negative`` **throws** an error.
+
+.. max-depth-optional-end
+
+Inner queries
+-------------------------------------------------------------------------------
+
+Edges SQL
+...............................................................................
+
+.. include:: pgRouting-concepts.rst
+    :start-after: basic_edges_sql_start
+    :end-before: basic_edges_sql_end
+
+Result Columns
+-------------------------------------------------------------------------------
+
+.. mst-bfs-dfs-dd-result-columns-start
+
+Returns SET OF ``(seq, depth, start_vid, node, edge, cost, agg_cost)``
+
+.. list-table::
+   :width: 81
+   :widths: auto
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Description
+   * - ``seq``
+     - ``BIGINT``
+     - Sequential value starting from :math:`1`.
+   * - ``depth``
+     - ``BIGINT``
+     - Depth of the ``node``.
+
+       - :math:`0`  when ``node`` = ``start_vid``.
+
+   * - ``start_vid``
+     - ``BIGINT``
+     - Identifier of the root vertex.
+
+   * - ``node``
+     - ``BIGINT``
+     - Identifier of ``node`` reached using ``edge``.
+   * - ``edge``
+     - ``BIGINT``
+     - Identifier of the ``edge`` used to arrive to ``node``.
+
+       - :math:`-1`  when ``node`` = ``start_vid``.
+
+   * - ``cost``
+     - ``FLOAT``
+     - Cost to traverse ``edge``.
+   * - ``agg_cost``
+     - ``FLOAT``
+     - Aggregate cost from ``start_vid`` to ``node``.
+
+Where:
+
+:ANY-INTEGER: SMALLINT, INTEGER, BIGINT
+:ANY-NUMERIC: SMALLINT, INTEGER, BIGINT, REAL, FLOAT, NUMERIC
+
+.. mst-bfs-dfs-dd-result-columns-end
+
+See Also
+-------------------------------------------------------------------------------
+
+* `Boost: Prim's algorithm
+  <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
+* `Boost: Kruskal's algorithm
+  <https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html>`__
+* `Wikipedia: Prim's algorithm
+  <https://en.wikipedia.org/wiki/Prim%27s_algorithm>`__
+* `Wikipedia: Kruskal's algorithm
+  <https://en.wikipedia.org/wiki/Kruskal's_algorithm>`__
+
+.. rubric:: Indices and tables
+
+* :ref:`genindex`
+* :ref:`search`

--- a/doc/traversal/CMakeLists.txt
+++ b/doc/traversal/CMakeLists.txt
@@ -1,6 +1,8 @@
 
 SET(LOCAL_FILES
     traversal-family.rst
+    BFS-category.rst
+    DFS-category.rst
     pgr_depthFirstSearch.rst
     )
 

--- a/doc/traversal/DFS-category.rst
+++ b/doc/traversal/DFS-category.rst
@@ -1,0 +1,99 @@
+..
+   ****************************************************************************
+    pgRouting Manual
+    Copyright(c) pgRouting Contributors
+
+    This documentation is licensed under a Creative Commons Attribution-Share
+    Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
+   ****************************************************************************
+
+|
+
+* **Supported versions:**
+  `Latest <https://docs.pgrouting.org/latest/en/DFS-category.html>`__
+  (`3.4 <https://docs.pgrouting.org/3.4/en/DFS-category.html>`__)
+
+DFS - Category
+===============================================================================
+
+Traversal using Depth First Search.
+
+.. index from here
+
+* :doc:`pgr_kruskalDFS`
+* :doc:`pgr_primDFS`
+
+.. index to here
+
+
+.. rubric:: Proposed
+
+.. include:: proposed.rst
+   :start-after: stable-begin-warning
+   :end-before: stable-end-warning
+
+* :doc:`pgr_depthFirstSearch` - Depth first search traversal of the graph.
+
+
+.. spanntree_traits_start
+
+* It's implementation is only on **undirected** graph.
+* Process is done only on edges with positive costs.
+* When the graph is connected
+
+  * The resulting edges make up a tree
+
+* When the graph is not connected,
+
+  * Finds a minimum spanning tree for each connected component.
+  * The resulting edges make up a forest.
+
+.. spanntree_traits_end
+
+Parameters
+-------------------------------------------------------------------------------
+
+.. include:: BFS-category.rst
+   :start-after: mst-bfs-dfs-params_start
+   :end-before: mst-bfs-dfs-params_end
+
+DFS optional parameters
+...............................................................................
+
+.. include:: BFS-category.rst
+   :start-after: max-depth-optional-start
+   :end-before: max-depth-optional-end
+
+Inner queries
+-------------------------------------------------------------------------------
+
+Edges SQL
+...............................................................................
+
+.. include:: pgRouting-concepts.rst
+    :start-after: basic_edges_sql_start
+    :end-before: basic_edges_sql_end
+
+Result Columns
+-------------------------------------------------------------------------------
+
+.. include:: BFS-category.rst
+   :start-after: mst-bfs-dfs-dd-result-columns-start
+   :end-before: mst-bfs-dfs-dd-result-columns-end
+
+See Also
+-------------------------------------------------------------------------------
+
+* `Boost: Prim's algorithm
+  <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
+* `Boost: Kruskal's algorithm
+  <https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html>`__
+* `Wikipedia: Prim's algorithm
+  <https://en.wikipedia.org/wiki/Prim%27s_algorithm>`__
+* `Wikipedia: Kruskal's algorithm
+  <https://en.wikipedia.org/wiki/Kruskal's_algorithm>`__
+
+.. rubric:: Indices and tables
+
+* :ref:`genindex`
+* :ref:`search`

--- a/doc/traversal/pgr_depthFirstSearch.rst
+++ b/doc/traversal/pgr_depthFirstSearch.rst
@@ -14,7 +14,7 @@
   (`3.3 <https://docs.pgrouting.org/3.3/en/pgr_depthFirstSearch.html>`__)
   `3.2 <https://docs.pgrouting.org/3.2/en/pgr_depthFirstSearch.html>`__
 
-pgr_depthFirstSearch - Proposed
+``pgr_depthFirstSearch`` - Proposed
 ===============================================================================
 
 ``pgr_depthFirstSearch`` — Returns a depth first search traversal of the graph.
@@ -67,20 +67,11 @@ Signatures
 
 .. rubric:: Summary
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_depthFirstSearch(Edges SQL, Root vid [, directed] [, max_depth])
-    pgr_depthFirstSearch(Edges SQL, Root vids [, directed] [, max_depth])
-
+    pgr_depthFirstSearch(`Edges SQL`_, **Root vid** [, directed] [, max_depth])
+    pgr_depthFirstSearch(`Edges SQL`_, **Root vids** [, directed] [, max_depth])
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
-
-.. rubric:: Using defaults
-
-:Example: From root vertex :math:`2` on a **directed** graph
-
-.. literalinclude:: doc-pgr_depthFirstSearch.queries
-   :start-after: -- q1
-   :end-before: -- q2
 
 .. index::
     single: depthFirstSearch(Single vertex) - Proposed on v3.3
@@ -88,14 +79,13 @@ Signatures
 Single vertex
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_depthFirstSearch(Edges SQL, Root vid [, directed] [, max_depth])
-
+    pgr_depthFirstSearch(`Edges SQL`_, **Root vid** [, directed] [, max_depth])
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
 :Example: From root vertex :math:`2` on an **undirected** graph,
-          with :math:`depth <= 2`
+          with **depth** :math:`<= 2`
 
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
    :start-after: -- q2
@@ -107,77 +97,60 @@ Single vertex
 Multiple vertices
 ...............................................................................
 
-.. code-block:: none
+.. parsed-literal::
 
-    pgr_depthFirstSearch(Edges SQL, Root vids [, directed] [, max_depth])
-
+    pgr_depthFirstSearch(`Edges SQL`_, **Root vids** [, directed] [, max_depth])
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
 :Example: From root vertices :math:`\{11, 2\}` on an **undirected** graph
-          with :math:`depth <= 2`
+          with **depth** :math:`<= 2` and edges in ascending order
 
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
    :start-after: -- q3
    :end-before: -- q4
 
-.. Parameters, Inner query & result columns
-
 Parameters
 -------------------------------------------------------------------------------
 
-=================== ====================== =================================================
-Parameter           Type                   Description
-=================== ====================== =================================================
-**Edges SQL**       ``TEXT``               SQL query described in `Inner query`_.
-**Root vid**        ``BIGINT``             Identifier of the root vertex of the tree.
+.. include:: BFS-category.rst
+   :start-after: mst-bfs-dfs-params_start
+   :end-before: mst-bfs-dfs-params_end
 
-                                           - Used on `Single Vertex`_.
-
-**Root vids**       ``ARRAY[ANY-INTEGER]`` Array of identifiers of the root vertices.
-
-                                           - Used on `Multiple Vertices`_.
-                                           - For optimization purposes, any duplicated value is ignored.
-=================== ====================== =================================================
-
-Optional Parameters
+Optional parameters
 ...............................................................................
 
-=================== =========== =========================== =================================================
-Parameter           Type        Default                     Description
-=================== =========== =========================== =================================================
-**directed**        ``BOOLEAN`` ``true``                    - When ``true`` Graph is `Directed`
-                                                            - When ``false`` the graph is `Undirected`.
+.. include:: dijkstra-family.rst
+    :start-after: dijkstra_optionals_start
+    :end-before: dijkstra_optionals_end
 
-**max_depth**       ``BIGINT``  :math:`9223372036854775807` Upper limit for the depth of traversal
+DFS optional parameters
+...............................................................................
 
-                                                            - When value is ``Negative`` then **throws error**
-=================== =========== =========================== =================================================
+.. include:: BFS-category.rst
+   :start-after: max-depth-optional-start
+   :end-before: max-depth-optional-end
 
-Inner query
+Inner queries
 -------------------------------------------------------------------------------
 
-.. rubric:: Edges SQL
+Edges SQL
+...............................................................................
 
-.. include:: traversal-family.rst
-   :start-after: edges_sql_start
-   :end-before: edges_sql_end
+.. include:: pgRouting-concepts.rst
+   :start-after: basic_edges_sql_start
+   :end-before: basic_edges_sql_end
 
 Result Columns
 -------------------------------------------------------------------------------
 
-.. include:: pgr_kruskalDD.rst
-   :start-after: result columns start
-   :end-before: result columns end
+.. include:: BFS-category.rst
+   :start-after: mst-bfs-dfs-dd-result-columns-start
+   :end-before: mst-bfs-dfs-dd-result-columns-end
 
 Additional Examples
 -------------------------------------------------------------------------------
 
-The examples of this section are based on the :doc:`sampledata` network.
-
-**Example: No internal ordering on traversal**
-
-In the following query, the inner query of the example: "Using defaults" is modified
-so that the data is entered into the algorithm is given in the reverse ordering of the id.
+:Example: Same as `Single vertex`_ but with edges in descending order.
 
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
    :start-after: -- q4
@@ -185,8 +158,8 @@ so that the data is entered into the algorithm is given in the reverse ordering 
 
 The resulting traversal is different.
 
-The left image shows the result with ascending order of ids and the right image shows
-with descending order of ids:
+The left image shows the result with ascending order of ids and the right image
+shows with descending order of the edge identifiers.
 
 |ascending| |descending|
 
@@ -199,15 +172,14 @@ with descending order of ids:
 See Also
 -------------------------------------------------------------------------------
 
-* The queries use the :doc:`sampledata` network.
-
-.. see also start
-
-* `Boost: Depth First Search algorithm documentation <https://www.boost.org/libs/graph/doc/depth_first_search.html>`__
-* `Boost: Undirected DFS algorithm documentation <https://www.boost.org/libs/graph/doc/undirected_dfs.html>`__
-* `Wikipedia: Depth First Search algorithm <https://en.wikipedia.org/wiki/Depth-first_search>`__
-
-.. see also end
+* :doc:`DFS-category`
+* :doc:`sampledata`
+* `Boost: Depth First Search algorithm documentation
+  <https://www.boost.org/libs/graph/doc/depth_first_search.html>`__
+* `Boost: Undirected DFS algorithm documentation
+  <https://www.boost.org/libs/graph/doc/undirected_dfs.html>`__
+* `Wikipedia: Depth First Search algorithm
+  <https://en.wikipedia.org/wiki/Depth-first_search>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/traversal/traversal-family.rst
+++ b/doc/traversal/traversal-family.rst
@@ -29,6 +29,11 @@ Traversal - Family of functions
 
 .. index to here
 
+Aditionaly there are 2 categories under this family
+
+* :doc:`BFS-category`
+* :doc:`DFS-category`
+
 
 .. toctree::
     :hidden:
@@ -36,42 +41,8 @@ Traversal - Family of functions
     pgr_depthFirstSearch
 
 
-Inner query
--------------------------------------------------------------------------------
-
-.. rubric:: Edges SQL
-
-.. edges_sql_start
-
-================= =================== ======== =================================================
-Column            Type                 Default  Description
-================= =================== ======== =================================================
-**id**            ``ANY-INTEGER``                Identifier of the edge.
-**source**        ``ANY-INTEGER``                Identifier of the first end point vertex of the edge.
-**target**        ``ANY-INTEGER``                Identifier of the second end point vertex of the edge.
-**cost**          ``ANY-NUMERICAL``              - When positive: edge `(source, target)` exist on the graph.
-                                                 - When negative: edge `(source, target)` does not exist on the graph.
-
-**reverse_cost**  ``ANY-NUMERICAL``       -1     - When positive: edge `(target, source)` exist on the graph.
-                                                 - When negative: edge `(target, source)` does not exist on the graph.
-
-================= =================== ======== =================================================
-
-Where:
-
-:ANY-INTEGER: SMALLINT, INTEGER, BIGINT
-:ANY-NUMERICAL: SMALLINT, INTEGER, BIGINT, REAL, FLOAT
-
-.. edges_sql_end
-
-
 See Also
 -------------------------------------------------------------------------------
-
-.. include:: pgr_depthFirstSearch.rst
-    :start-after: see also start
-    :end-before: see also end
-
 
 .. rubric:: Indices and tables
 

--- a/docqueries/traversal/doc-pgr_depthFirstSearch.result
+++ b/docqueries/traversal/doc-pgr_depthFirstSearch.result
@@ -2,12 +2,11 @@ BEGIN;
 BEGIN
 SET client_min_messages TO NOTICE;
 SET
-/* -- q1 */
+/* -- q2 */
 SELECT * FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table
-    ORDER BY id',
-    2
-);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table
+  ORDER BY id',
+  2);
  seq | depth | start_vid | node | edge | cost | agg_cost
 -----+-------+-----------+------+------+------+----------
    1 |     0 |         2 |    2 |   -1 |    0 |        0
@@ -25,30 +24,11 @@ SELECT * FROM pgr_depthFirstSearch(
   13 |     3 |         2 |   13 |   14 |    1 |        3
 (13 rows)
 
-/* -- q2 */
-SELECT * FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table
-    ORDER BY id',
-    2, directed => false, max_depth => 2
-);
- seq | depth | start_vid | node | edge | cost | agg_cost
------+-------+-----------+------+------+------+----------
-   1 |     0 |         2 |    2 |   -1 |    0 |        0
-   2 |     1 |         2 |    1 |    1 |    1 |        1
-   3 |     1 |         2 |    3 |    2 |    1 |        1
-   4 |     2 |         2 |    4 |    3 |    1 |        2
-   5 |     2 |         2 |    6 |    5 |    1 |        2
-   6 |     1 |         2 |    5 |    4 |    1 |        1
-   7 |     2 |         2 |    8 |    7 |    1 |        2
-   8 |     2 |         2 |   10 |   10 |    1 |        2
-(8 rows)
-
 /* -- q3 */
 SELECT * FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table
-    ORDER BY id',
-    ARRAY[11, 2], directed => false, max_depth => 2
-);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table
+  ORDER BY id',
+  ARRAY[11, 2], directed => false, max_depth => 2);
  seq | depth | start_vid | node | edge | cost | agg_cost
 -----+-------+-----------+------+------+------+----------
    1 |     0 |         2 |    2 |   -1 |    0 |        0
@@ -71,10 +51,9 @@ SELECT * FROM pgr_depthFirstSearch(
 
 /* -- q4 */
 SELECT * FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table
-    ORDER BY id DESC',
-    2
-);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table
+  ORDER BY id DESC',
+  2);
  seq | depth | start_vid | node | edge | cost | agg_cost
 -----+-------+-----------+------+------+------+----------
    1 |     0 |         2 |    2 |   -1 |    0 |        0

--- a/docqueries/traversal/doc-pgr_depthFirstSearch.test.sql
+++ b/docqueries/traversal/doc-pgr_depthFirstSearch.test.sql
@@ -1,25 +1,16 @@
-/* -- q1 */
-SELECT * FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table
-    ORDER BY id',
-    2
-);
 /* -- q2 */
 SELECT * FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table
-    ORDER BY id',
-    2, directed => false, max_depth => 2
-);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table
+  ORDER BY id',
+  2);
 /* -- q3 */
 SELECT * FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table
-    ORDER BY id',
-    ARRAY[11, 2], directed => false, max_depth => 2
-);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table
+  ORDER BY id',
+  ARRAY[11, 2], directed => false, max_depth => 2);
 /* -- q4 */
 SELECT * FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost FROM edge_table
-    ORDER BY id DESC',
-    2
-);
+  'SELECT id, source, target, cost, reverse_cost FROM edge_table
+  ORDER BY id DESC',
+  2);
 /* -- q5 */


### PR DESCRIPTION
Fixes #2244 

Using parsed literal and refining documentation:

- doc/spanningTree/spanningTree-family.rst
- doc/spanningTree/prim-family.rst
-  doc/spanningTree/kruskal-family.rst
- doc/spanningTree/pgr_kruskal.rst
- doc/spanningTree/pgr_kruskalBFS.rst
- doc/spanningTree/pgr_kruskalDD.rst
- doc/spanningTree/pgr_kruskalDFS.rst
- doc/spanningTree/pgr_prim.rst
- doc/spanningTree/pgr_primBFS.rst
- doc/spanningTree/pgr_primDD.rst
- doc/spanningTree/pgr_primDFS.rst
- doc/traversal/traversal-family.rst
- doc/traversal/pgr_depthFirstSearch.rst

Creating 2 new categories under traversal:
- DFS-category
- BFS-category

@pgRouting/admins
