### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/boost_version.yml
+++ b/.github/workflows/boost_version.yml
@@ -47,6 +47,9 @@ on:
     branches-ignore:
       - 'gh-pages'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Ubuntu Boost

--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -12,6 +12,9 @@ name: Check files
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   Signature_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-queries.yml
+++ b/.github/workflows/check-queries.yml
@@ -40,6 +40,9 @@ on:
     branches-ignore:
       - 'gh-pages'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Check queries

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -37,6 +37,9 @@ on:
     branches-ignore:
       - 'gh-pages'
 
+permissions:
+  contents: read
+
 jobs:
   Test_clang:
     name: Ubuntu clang

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -37,6 +37,9 @@ on:
     branches-ignore:
       - 'gh-pages'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: documentation

--- a/.github/workflows/locale-and-website.yml
+++ b/.github/workflows/locale-and-website.yml
@@ -7,8 +7,13 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   release:
+    permissions:
+      contents: write  # for Git to git push
     name: Update Locale and Website
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'pgRouting' }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,6 +6,9 @@ name: Build for macOS
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: macos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,13 @@ on:
       - 'v*.*.*'
 
 
+permissions:
+  contents: read
+
 jobs:
   release:
+    permissions:
+      contents: write  # for Git to git push
     name: Release
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,6 +7,9 @@ name: Build for Ubuntu
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Ubuntu psql

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
 
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
