### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/locale/es/LC_MESSAGES/BFS-category.po
+++ b/locale/es/LC_MESSAGES/BFS-category.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-25 12:55-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:45+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "bfs-category/es/>\n"
@@ -354,7 +354,7 @@ msgstr "``agg_cost``"
 
 #: ../../build/doc/BFS-category.rst:156
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado desde ``start_vid`` al ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/BFS-category.rst:166
 msgid "See Also"

--- a/locale/es/LC_MESSAGES/TSP-family.po
+++ b/locale/es/LC_MESSAGES/TSP-family.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-06 19:21+0000\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:51+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "tsp-family/es/>\n"
@@ -276,7 +276,7 @@ msgstr ""
 
 #: ../../build/doc/TSP-family.rst:139
 msgid "Last visiting vertex before returning to ``start_vid``."
-msgstr ""
+msgstr "Último vértice visitado antes de regresar a ``start_vid``."
 
 #: ../../build/doc/TSP-family.rst:141
 msgid ""

--- a/locale/es/LC_MESSAGES/VRP-category.po
+++ b/locale/es/LC_MESSAGES/VRP-category.po
@@ -13,7 +13,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-28 00:12+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "vrp-category/es/>\n"
@@ -1485,9 +1485,8 @@ msgid "Conversion"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:719 ../../build/doc/VRP-category.rst:752
-#, fuzzy
 msgid "Factor"
-msgstr "**factor**"
+msgstr "Factor"
 
 #: ../../build/doc/VRP-category.rst:720
 #, fuzzy
@@ -1496,7 +1495,7 @@ msgstr "5"
 
 #: ../../build/doc/VRP-category.rst:721
 msgid "1 longitude degree is (78846.81m)/(25m/s)"
-msgstr ""
+msgstr "1 grado de longitud es (78846.81m)/(25m/s)"
 
 #: ../../build/doc/VRP-category.rst:722
 msgid "3153 s"

--- a/locale/es/LC_MESSAGES/allpairs-family.po
+++ b/locale/es/LC_MESSAGES/allpairs-family.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:35+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "allpairs-family/es/>\n"
@@ -167,7 +167,7 @@ msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/allpairs-family.rst:90
 msgid "``TEXT``"
-msgstr ""
+msgstr "``TEXT``"
 
 #: ../../build/doc/allpairs-family.rst:92
 msgid "`Edges SQL`_ as described below."

--- a/locale/es/LC_MESSAGES/bdAstar-family.po
+++ b/locale/es/LC_MESSAGES/bdAstar-family.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-06 19:21+0000\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:50+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "bdastar-family/es/>\n"
@@ -119,7 +119,7 @@ msgstr "primero por ``start_vid`` (si existe)"
 
 #: ../../build/doc/aStar-family.rst:7
 msgid "then by ``end_vid``"
-msgstr ""
+msgstr "luego por ``end_vid``"
 
 #: ../../build/doc/aStar-family.rst:9
 msgid "Values are returned when there is a path."
@@ -147,7 +147,7 @@ msgstr ""
 
 #: ../../build/doc/aStar-family.rst:20
 msgid "``agg_cost`` from `v` to `u` is :math:`0`"
-msgstr ""
+msgstr "``agg_cost`` de `v` a `u` es :math:`0`"
 
 #: ../../build/doc/aStar-family.rst:22
 msgid "When :math:`(x,y)` coordinates for the same vertex identifier differ:"

--- a/locale/es/LC_MESSAGES/contraction-family.po
+++ b/locale/es/LC_MESSAGES/contraction-family.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-06 19:21+0000\n"
-"PO-Revision-Date: 2022-06-27 13:19+0000\n"
+"PO-Revision-Date: 2022-06-28 00:27+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "contraction-family/es/>\n"
@@ -422,9 +422,8 @@ msgid "It's not possible to go :math:`z \\rightarrow c \\rightarrow y`"
 msgstr ""
 
 #: ../../build/doc/contraction-family.rst:337
-#, fuzzy
 msgid "Is symmetrical?"
-msgstr "La linealidad es simétrica"
+msgstr "Es simétrico?"
 
 #: ../../build/doc/contraction-family.rst:339
 msgid ":math:`\\{u, v\\}`"
@@ -511,8 +510,8 @@ msgid ""
 "A new edge :math:`u \\rightarrow z` is inserted represented with red "
 "color."
 msgstr ""
-"Se inserta un nuevo arista :math:`u \\rightarrow z`  y se representa con "
-"color rojo.  "
+"Se inserta un nuevo arista :math:`u \\rightarrow z` y se representa con "
+"color rojo."
 
 #: ../../build/doc/contraction-family.rst:412
 msgid ""
@@ -647,7 +646,7 @@ msgstr "**contracted_vertices**"
 
 #: ../../build/doc/contraction-family.rst:507
 msgid "The vertices set belonging to the vertex/edge"
-msgstr "El conjunto de vértices que pertenecen al vértice/arista "
+msgstr "El conjunto de vértices que pertenecen al vértice/arista"
 
 #: ../../build/doc/contraction-family.rst:508
 #, fuzzy

--- a/locale/es/LC_MESSAGES/costMatrix-category.po
+++ b/locale/es/LC_MESSAGES/costMatrix-category.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-28 00:24+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "costmatrix-category/es/>\n"
@@ -70,9 +70,8 @@ msgstr ":doc:`pgr_aStarCostMatrix`"
 
 #: ../../build/doc/costMatrix-category.rst:31
 #: ../../build/doc/costMatrix-category.rst:33
-#, fuzzy
 msgid ":doc:`pgr_bdDijkstraCostMatrix`"
-msgstr ":doc:`pgr_dijkstraCostMatrix`"
+msgstr ":doc:`pgr_bdDijkstraCostMatrix`"
 
 #: ../../build/doc/costMatrix-category.rst:32
 #: ../../build/doc/costMatrix-category.rst:123
@@ -161,11 +160,12 @@ msgid "Can be used as input to :doc:`pgr_TSP`."
 msgstr "Se puede utilizar como entrada para :doc:`pgr_TSP`."
 
 #: ../../build/doc/costMatrix-category.rst:71
-#, fuzzy
 msgid ""
 "Use directly when the resulting matrix is symmetric and there is no "
 ":math:`\\infty` value."
-msgstr "cuando la matriz resultante es simétrica y no hay valor :math:`\\infty` "
+msgstr ""
+"Usar directamente cuando la matriz resultante es simétrica y no hay valor "
+":math:`\\infty`."
 
 #: ../../build/doc/costMatrix-category.rst:73
 msgid "It will be the users responsibility to make the matrix symmetric."
@@ -335,7 +335,7 @@ msgstr "`SQL Aristas`_"
 #: ../../build/doc/costMatrix-category.rst:159
 #: ../../build/doc/costMatrix-category.rst:162
 msgid "``TEXT``"
-msgstr ""
+msgstr "``TEXT``"
 
 #: ../../build/doc/costMatrix-category.rst:137
 #: ../../build/doc/costMatrix-category.rst:160
@@ -558,7 +558,7 @@ msgstr "``CHAR``"
 
 #: ../../build/doc/withPoints-category.rst:33
 msgid "``b``"
-msgstr ""
+msgstr "``b``"
 
 #: ../../build/doc/withPoints-category.rst:34
 msgid "Value in [``b``, ``r``, ``l``, ``NULL``] indicating if the point is:"

--- a/locale/es/LC_MESSAGES/dijkstra-family.po
+++ b/locale/es/LC_MESSAGES/dijkstra-family.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-28 00:12+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "dijkstra-family/es/>\n"
@@ -264,7 +264,7 @@ msgstr "`SQL Aristas`_"
 #: ../../build/doc/dijkstra-family.rst:127
 #: ../../build/doc/dijkstra-family.rst:130
 msgid "``TEXT``"
-msgstr ""
+msgstr "``TEXT``"
 
 #: ../../build/doc/dijkstra-family.rst:128
 msgid "`Edges SQL`_ as described below"
@@ -464,9 +464,8 @@ msgid "Identifier of the arrival vertex."
 msgstr "Identificador del vértice de llegada."
 
 #: ../../build/doc/dijkstra-family.rst:187
-#, fuzzy
 msgid "Advanced documentation"
-msgstr "La definición de problema (Documentación avanzada)"
+msgstr "Documentación avanzada"
 
 #: ../../build/doc/dijkstra-family.rst:190
 msgid "The problem definition (Advanced documentation)"

--- a/locale/es/LC_MESSAGES/drivingDistance-category.po
+++ b/locale/es/LC_MESSAGES/drivingDistance-category.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-06 19:21+0000\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "drivingdistance-category/es/>\n"
@@ -180,11 +180,11 @@ msgstr ""
 
 #: ../../build/doc/drivingDistance-category.rst:86
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/drivingDistance-category.rst:87
 msgid "``TEXT``"
-msgstr ""
+msgstr "``TEXT``"
 
 #: ../../build/doc/drivingDistance-category.rst:88
 msgid "Edges SQL as described below."
@@ -334,6 +334,8 @@ msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst
 msgid "ANY-NUMERICAL"

--- a/locale/es/LC_MESSAGES/experimental.po
+++ b/locale/es/LC_MESSAGES/experimental.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-06 19:21+0000\n"
-"PO-Revision-Date: 2022-06-25 17:58+0000\n"
+"PO-Revision-Date: 2022-06-28 00:15+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "experimental/es/>\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.12.2\n"
+"X-Generator: Weblate 4.13\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: ../../build/doc/experimental.rst:12
@@ -204,9 +204,8 @@ msgstr ""
 "grafo de líneas a partir de cada vértice en el grafo de entrada."
 
 #: ../../build/doc/experimental.rst:81
-#, fuzzy
 msgid ":doc:`traversal-family`"
-msgstr ":doc:`transformation-family`"
+msgstr ":doc:`traversal-family`"
 
 #: ../../build/doc/traversal-family.rst:3
 msgid ""

--- a/locale/es/LC_MESSAGES/index.po
+++ b/locale/es/LC_MESSAGES/index.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-25 12:55-0500\n"
-"PO-Revision-Date: 2022-06-27 13:19+0000\n"
+"PO-Revision-Date: 2022-06-28 00:26+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/index/"
 "es/>\n"
@@ -60,7 +60,7 @@ msgstr "Este es el manual para pgRouting |release|."
 
 #: ../../build/doc/index.rst:None
 msgid "Creative Commons Attribution-Share Alike 3.0 License"
-msgstr "Licencia de Creative Commons Attribution-Share Alike 3.0 "
+msgstr "Licencia de Creative Commons Attribution-Share Alike 3.0"
 
 #: ../../build/doc/index.rst:42
 msgid "The pgRouting Manual is licensed under a `Creative Commons Attribution-Share Alike 3.0 License <https://creativecommons.org/licenses/by-sa/3.0/>`_. Feel free to use this material any way you like, but we ask that you attribute credit to the pgRouting Project and wherever possible, a link back to https://pgrouting.org. For other licenses used in pgRouting see the :ref:`license` page."

--- a/locale/es/LC_MESSAGES/migration.po
+++ b/locale/es/LC_MESSAGES/migration.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-25 12:55-0500\n"
-"PO-Revision-Date: 2022-06-24 16:38+0000\n"
-"Last-Translator: Pedro Jose Rios Vergara <jose@georepublic.de>\n"
+"PO-Revision-Date: 2022-06-27 23:54+0000\n"
+"Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "migration/es/>\n"
 "Language: es\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.12.2\n"
+"X-Generator: Weblate 4.13\n"
 
 #: ../../build/doc/migration.rst:12
 msgid ""
@@ -186,7 +186,7 @@ msgstr ""
 
 #: ../../build/doc/sampledata.rst:9
 msgid "Adding the restrictions"
-msgstr ""
+msgstr "Agregando las restricciones"
 
 #: ../../build/doc/sampledata.rst:16
 msgid "Restrictions data"

--- a/locale/es/LC_MESSAGES/pgRouting-concepts.po
+++ b/locale/es/LC_MESSAGES/pgRouting-concepts.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-28 00:26+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgrouting-concepts/es/>\n"
@@ -1655,7 +1655,7 @@ msgstr "Cuando se rutea desde:"
 #: ../../build/doc/pgRouting-concepts.rst:980
 #: ../../build/doc/pgRouting-concepts.rst:988
 msgid "From **one** starting vertex"
-msgstr "Desde el vértice inicial **one** "
+msgstr "Desde **un** vértice inicial"
 
 #: ../../build/doc/pgRouting-concepts.rst:981
 #: ../../build/doc/pgRouting-concepts.rst:997
@@ -1832,7 +1832,7 @@ msgstr ""
 #: ../../build/doc/pgRouting-concepts.rst:1101
 #: ../../build/doc/pgRouting-concepts.rst:1816
 msgid ":doc:`allpairs-family`"
-msgstr ""
+msgstr ":doc:`allpairs-family`"
 
 #: ../../build/doc/pgRouting-concepts.rst:1125
 #: ../../build/doc/pgRouting-concepts.rst:1175
@@ -2025,9 +2025,8 @@ msgid ""
 msgstr ""
 
 #: ../../build/doc/pgRouting-concepts.rst:1368
-#, fuzzy
 msgid "``Cost``"
-msgstr "``true``"
+msgstr "``Cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:1370
 msgid "Cost of taking the forbidden path."
@@ -2103,9 +2102,8 @@ msgid "``CHAR``"
 msgstr "``CHAR``"
 
 #: ../../build/doc/withPoints-category.rst:33
-#, fuzzy
 msgid "``b``"
-msgstr "``INT``"
+msgstr "``b``"
 
 #: ../../build/doc/withPoints-category.rst:34
 msgid "Value in [``b``, ``r``, ``l``, ``NULL``] indicating if the point is:"
@@ -2371,8 +2369,8 @@ msgid ""
 "Relative position in the path. Has value **1** for the beginning of a "
 "path."
 msgstr ""
-"Posición relativa en la ruta. Tiene el valor **1** para el principio de "
-"una ruta."
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
+"ruta."
 
 #: ../../build/doc/pgRouting-concepts.rst:1542
 #: ../../build/doc/pgRouting-concepts.rst:1663
@@ -2515,7 +2513,7 @@ msgstr "``agg_cost``"
 #: ../../build/doc/pgRouting-concepts.rst:1749
 #: ../../build/doc/pgRouting-concepts.rst:1805
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado desde ``start_vid`` al ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/pgRouting-concepts.rst:1574
 #: ../../build/doc/pgRouting-concepts.rst:1641

--- a/locale/es/LC_MESSAGES/pgRouting-introduction.po
+++ b/locale/es/LC_MESSAGES/pgRouting-introduction.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-10 13:47+0000\n"
-"PO-Revision-Date: 2022-06-25 17:58+0000\n"
+"PO-Revision-Date: 2022-06-28 00:26+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgrouting-introduction/es/>\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.12.2\n"
+"X-Generator: Weblate 4.13\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: ../../build/doc/pgRouting-introduction.rst:12
@@ -154,7 +154,7 @@ msgstr ""
 
 #: ../../build/doc/pgRouting-introduction.rst:67
 msgid "Creative Commons Attribution-Share Alike 3.0 License"
-msgstr "Licencia de Creative Commons Attribution-Share Alike 3.0 "
+msgstr "Licencia de Creative Commons Attribution-Share Alike 3.0"
 
 #: ../../build/doc/pgRouting-introduction.rst:68
 msgid ""

--- a/locale/es/LC_MESSAGES/pgr_KSP.po
+++ b/locale/es/LC_MESSAGES/pgr_KSP.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:47+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/pgr_ksp/"
 "es/>\n"
@@ -145,9 +145,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/pgr_KSP.rst:89
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "**edges_sql**"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgr_KSP.rst:90
 msgid "``TEXT``"
@@ -159,9 +158,8 @@ msgid "SQL query as described."
 msgstr "Consulta SQL como se describió anteriormente."
 
 #: ../../build/doc/pgr_KSP.rst:92
-#, fuzzy
 msgid "**start vid**"
-msgstr "``start_vid``"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/pgRouting-concepts.rst:13
 #: ../../build/doc/pgRouting-concepts.rst:17
@@ -239,7 +237,7 @@ msgstr "**heap_paths**"
 
 #: ../../build/doc/pgr_KSP.rst:131
 msgid "``false``"
-msgstr ""
+msgstr "``false``"
 
 #: ../../build/doc/pgr_KSP.rst:132
 msgid "When ``false`` Returns at most K paths"
@@ -317,13 +315,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst
 msgid "ANY-NUMERICAL"
@@ -375,13 +372,12 @@ msgid "``path_seq``"
 msgstr "``path_seq``"
 
 #: ../../build/doc/pgr_KSP.rst:177
-#, fuzzy
 msgid ""
 "Relative position in the path. Has value **1** for the beginning of a "
 "path."
 msgstr ""
-"Posición relativa en la ruta de ``node`` y ``edge``. El valor es **1** "
-"para el inicio de una ruta."
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
+"ruta."
 
 #: ../../build/doc/pgr_KSP.rst:179
 msgid "``node``"

--- a/locale/es/LC_MESSAGES/pgr_TSP.po
+++ b/locale/es/LC_MESSAGES/pgr_TSP.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:51+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/pgr_tsp/"
 "es/>\n"
@@ -421,7 +421,7 @@ msgstr ""
 
 #: ../../build/doc/TSP-family.rst:22
 msgid "Last visiting vertex before returning to ``start_vid``."
-msgstr "Último vértice visitado antes de regresar a '``start_vid``."
+msgstr "Último vértice visitado antes de regresar a ``start_vid``."
 
 #: ../../build/doc/TSP-family.rst:24
 msgid ""

--- a/locale/es/LC_MESSAGES/pgr_TSPeuclidean.po
+++ b/locale/es/LC_MESSAGES/pgr_TSPeuclidean.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:51+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_tspeuclidean/es/>\n"
@@ -302,7 +302,7 @@ msgstr ""
 
 #: ../../build/doc/TSP-family.rst:22
 msgid "Last visiting vertex before returning to ``start_vid``."
-msgstr "Último vértice visitado antes de regresar a '``start_vid``."
+msgstr "Último vértice visitado antes de regresar a ``start_vid``."
 
 #: ../../build/doc/TSP-family.rst:24
 msgid ""

--- a/locale/es/LC_MESSAGES/pgr_aStar.po
+++ b/locale/es/LC_MESSAGES/pgr_aStar.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:50+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_astar/es/>\n"
@@ -351,9 +351,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/dijkstra-family.rst:11
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "edges_sql"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/dijkstra-family.rst:12
 #: ../../build/doc/dijkstra-family.rst:15
@@ -374,9 +373,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/dijkstra-family.rst:17
-#, fuzzy
 msgid "**start vid**"
-msgstr "``start_vid``"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/dijkstra-family.rst:18
 #: ../../build/doc/dijkstra-family.rst:24
@@ -415,9 +413,8 @@ msgid "Identifier of the ending vertex of the path."
 msgstr "Identificador del primer vértice de la arista."
 
 #: ../../build/doc/dijkstra-family.rst:26
-#, fuzzy
 msgid "**end vids**"
-msgstr "``end_vid``"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/dijkstra-family.rst:28
 msgid "Array of identifiers of ending vertices."
@@ -626,13 +623,12 @@ msgid "Weight of the edge (``target``, ``source``),"
 msgstr "Peso de la arista `(target, source)`,"
 
 #: ../../build/doc/pgRouting-concepts.rst:36
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:38
 #, fuzzy
@@ -738,8 +734,8 @@ msgid ""
 "Relative position in the path. Has value **1** for the beginning of a "
 "path."
 msgstr ""
-"Posición relativa en la ruta. Tiene el valor **1** para el principio de "
-"una ruta."
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
+"ruta."
 
 #: ../../build/doc/pgRouting-concepts.rst:21
 msgid "``start_vid``"
@@ -812,9 +808,8 @@ msgid "``agg_cost``"
 msgstr "``agg_cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:48
-#, fuzzy
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado de ``start_v`` to ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/pgr_aStar.rst:265
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_aStarCostMatrix.po
+++ b/locale/es/LC_MESSAGES/pgr_aStarCostMatrix.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:49+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_astarcostmatrix/es/>\n"
@@ -176,9 +176,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/costMatrix-category.rst:11
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "edges_sql"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/costMatrix-category.rst:12
 msgid "``TEXT``"
@@ -396,13 +395,12 @@ msgid "Weight of the edge (``target``, ``source``),"
 msgstr "Peso de la arista `(target, source)`,"
 
 #: ../../build/doc/pgRouting-concepts.rst:36
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:38
 #, fuzzy
@@ -499,7 +497,7 @@ msgstr "``agg_cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:21
 msgid "Aggregate cost from ``start_vid`` to ``end_vid``."
-msgstr "Coste agregado de ``start_vid`` a ``end_vid``."
+msgstr "Costo afregado desde ``start_vid`` hasta ``end_vid``."
 
 #: ../../build/doc/pgr_aStarCostMatrix.rst:126
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_bdAstar.po
+++ b/locale/es/LC_MESSAGES/pgr_bdAstar.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:45+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_bdastar/es/>\n"
@@ -352,9 +352,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/dijkstra-family.rst:11
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "edges_sql"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/dijkstra-family.rst:12
 #: ../../build/doc/dijkstra-family.rst:15
@@ -375,9 +374,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/dijkstra-family.rst:17
-#, fuzzy
 msgid "**start vid**"
-msgstr "``start_vid``"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/dijkstra-family.rst:18
 #: ../../build/doc/dijkstra-family.rst:24
@@ -416,9 +414,8 @@ msgid "Identifier of the ending vertex of the path."
 msgstr "Identificador del primer vértice de la arista."
 
 #: ../../build/doc/dijkstra-family.rst:26
-#, fuzzy
 msgid "**end vids**"
-msgstr "``end_vid``"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/dijkstra-family.rst:28
 msgid "Array of identifiers of ending vertices."
@@ -627,13 +624,12 @@ msgid "Weight of the edge (``target``, ``source``),"
 msgstr "Peso de la arista `(target, source)`,"
 
 #: ../../build/doc/pgRouting-concepts.rst:36
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:38
 #, fuzzy
@@ -740,8 +736,8 @@ msgid ""
 "Relative position in the path. Has value **1** for the beginning of a "
 "path."
 msgstr ""
-"Posición relativa en la ruta. Tiene el valor **1** para el principio de "
-"una ruta."
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
+"ruta."
 
 #: ../../build/doc/pgRouting-concepts.rst:21
 msgid "``start_vid``"
@@ -814,9 +810,8 @@ msgid "``agg_cost``"
 msgstr "``agg_cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:48
-#, fuzzy
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado de ``start_v`` to ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/pgr_bdAstar.rst:262
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_bdAstarCost.po
+++ b/locale/es/LC_MESSAGES/pgr_bdAstarCost.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:49+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_bdastarcost/es/>\n"
@@ -111,8 +111,8 @@ msgid ""
 "The ``pgr_bdAstarCost`` function sumarizes of the cost of the shortest "
 "path(s) using the bidirectional A* algorithm."
 msgstr ""
-"la función ``pgr_bdAstarCost`` Sumariza el costo del camon(s) más corto "
-"utilizando el algoritmo :doc:`pgr_aStar`."
+"La función ``pgr_bdAstarCost`` Sumariza el costo del camon(s) más corto "
+"utilizando el algoritmo bidireccional A*."
 
 #: ../../build/doc/pgr_bdAstarCost.rst:56
 msgid "**The main characteristics are:**"
@@ -312,9 +312,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/dijkstra-family.rst:11
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "edges_sql"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/dijkstra-family.rst:12
 #: ../../build/doc/dijkstra-family.rst:15
@@ -335,9 +334,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/dijkstra-family.rst:17
-#, fuzzy
 msgid "**start vid**"
-msgstr "``start_vid``"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/dijkstra-family.rst:18
 #: ../../build/doc/dijkstra-family.rst:24
@@ -375,9 +373,8 @@ msgid "Identifier of the ending vertex of the path."
 msgstr "Identificador del vértice final."
 
 #: ../../build/doc/dijkstra-family.rst:26
-#, fuzzy
 msgid "**end vids**"
-msgstr "``end_vid``"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/dijkstra-family.rst:28
 #, fuzzy
@@ -583,13 +580,12 @@ msgid "Weight of the edge (``target``, ``source``),"
 msgstr "Peso de la arista `(target, source)`,"
 
 #: ../../build/doc/pgRouting-concepts.rst:36
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:38
 #, fuzzy
@@ -696,7 +692,7 @@ msgstr "``agg_cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:21
 msgid "Aggregate cost from ``start_vid`` to ``end_vid``."
-msgstr "Coste agregado de ``start_vid`` a ``end_vid``."
+msgstr "Costo afregado desde ``start_vid`` hasta ``end_vid``."
 
 #: ../../build/doc/pgr_bdAstarCost.rst:251
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_bdAstarCostMatrix.po
+++ b/locale/es/LC_MESSAGES/pgr_bdAstarCostMatrix.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:49+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_bdastarcostmatrix/es/>\n"
@@ -34,7 +34,7 @@ msgid ""
 "`3.1 <https://docs.pgrouting.org/3.1/en/pgr_bdAstarCostMatrix.html>`__ "
 "`3.0 <https://docs.pgrouting.org/3.0/en/pgr_bdAstarCostMatrix.html>`__"
 msgstr ""
-"**Versiones soportadas:** ``Ultima <https://docs.pgrouting.org/latest/es/"
+"**Versiones soportadas:** `Ultima <https://docs.pgrouting.org/latest/es/"
 "pgr_bdAstarCostMatrix.html>`__ (`3.4 <https://docs.pgrouting.org/3.4/es/"
 "pgr_bdAstarCostMatrix.html>`__) `3.3 <https://docs.pgrouting.org/3.3/es/"
 "pgr_bdAstarCostMatrix.html>`__ `3.2 <https://docs.pgrouting.org/3.2/es/"
@@ -182,9 +182,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/costMatrix-category.rst:11
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "edges_sql"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/costMatrix-category.rst:12
 msgid "``TEXT``"
@@ -402,13 +401,12 @@ msgid "Weight of the edge (``target``, ``source``),"
 msgstr "Peso de la arista `(target, source)`,"
 
 #: ../../build/doc/pgRouting-concepts.rst:36
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:38
 #, fuzzy
@@ -505,7 +503,7 @@ msgstr "``agg_cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:21
 msgid "Aggregate cost from ``start_vid`` to ``end_vid``."
-msgstr "Coste agregado de ``start_vid`` a ``end_vid``."
+msgstr "Costo afregado desde ``start_vid`` hasta ``end_vid``."
 
 #: ../../build/doc/pgr_bdAstarCostMatrix.rst:125
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_bdDijkstra.po
+++ b/locale/es/LC_MESSAGES/pgr_bdDijkstra.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:49+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_bddijkstra/es/>\n"
@@ -207,11 +207,12 @@ msgstr ""
 "ninguna ruta:"
 
 #: ../../build/doc/bdDijkstra-family.rst:18
-#, fuzzy
 msgid ""
 "The **aggregate cost** the non included values :math:`(u, v)` is "
 ":math:`\\infty`"
-msgstr "El ``agg_cost`` de los valores no incluídos ``(u, v)`` es :math: `\\infty`"
+msgstr ""
+"El **costo agregado** de los valores no incluídos :math:`(u, v)` es :math: `"
+"\\infty`"
 
 #: ../../build/doc/bdDijkstra-family.rst:21
 msgid ""
@@ -328,7 +329,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/dijkstra-family.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/dijkstra-family.rst:12
 #: ../../build/doc/dijkstra-family.rst:15
@@ -349,9 +350,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/dijkstra-family.rst:17
-#, fuzzy
 msgid "**start vid**"
-msgstr "``start_vid``"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/dijkstra-family.rst:18
 #: ../../build/doc/dijkstra-family.rst:24
@@ -388,9 +388,8 @@ msgid "Identifier of the ending vertex of the path."
 msgstr "Identificador del vértice final de la ruta."
 
 #: ../../build/doc/dijkstra-family.rst:26
-#, fuzzy
 msgid "**end vids**"
-msgstr "``end_vids``"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/dijkstra-family.rst:28
 msgid "Array of identifiers of ending vertices."
@@ -496,13 +495,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:36
@@ -578,8 +576,8 @@ msgid ""
 "Relative position in the path. Has value **1** for the beginning of a "
 "path."
 msgstr ""
-"Posición relativa en la ruta. Tiene el valor **1** para el principio de "
-"una ruta."
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
+"ruta."
 
 #: ../../build/doc/pgRouting-concepts.rst:21
 msgid "``start_vid``"
@@ -657,9 +655,8 @@ msgid "``agg_cost``"
 msgstr "``agg_cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:48
-#, fuzzy
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado de ``start_v`` to ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/pgr_bdDijkstra.rst:234
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_bdDijkstraCost.po
+++ b/locale/es/LC_MESSAGES/pgr_bdDijkstraCost.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:49+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_bddijkstracost/es/>\n"
@@ -153,11 +153,12 @@ msgstr ""
 "ninguna ruta:"
 
 #: ../../build/doc/bdDijkstra-family.rst:18
-#, fuzzy
 msgid ""
 "The **aggregate cost** the non included values :math:`(u, v)` is "
 ":math:`\\infty`"
-msgstr "El ``agg_cost`` de los valores no incluídos ``(u, v)`` es :math: `\\infty`"
+msgstr ""
+"El **costo agregado** de los valores no incluídos :math:`(u, v)` es :math: `"
+"\\infty`"
 
 #: ../../build/doc/bdDijkstra-family.rst:21
 msgid ""
@@ -318,7 +319,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/dijkstra-family.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/dijkstra-family.rst:12
 #: ../../build/doc/dijkstra-family.rst:15
@@ -339,9 +340,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/dijkstra-family.rst:17
-#, fuzzy
 msgid "**start vid**"
-msgstr "``start_vid``"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/dijkstra-family.rst:18
 #: ../../build/doc/dijkstra-family.rst:24
@@ -376,9 +376,8 @@ msgid "Identifier of the ending vertex of the path."
 msgstr "Identificador del vértice final de la ruta."
 
 #: ../../build/doc/dijkstra-family.rst:26
-#, fuzzy
 msgid "**end vids**"
-msgstr "``end_vids``"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/dijkstra-family.rst:28
 msgid "Array of identifiers of ending vertices."
@@ -483,13 +482,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:36
@@ -564,7 +562,7 @@ msgstr "``FLOAT``"
 
 #: ../../build/doc/pgRouting-concepts.rst:21
 msgid "Aggregate cost from ``start_vid`` to ``end_vid``."
-msgstr "Coste agregado de ``start_vid`` a ``end_vid``."
+msgstr "Costo afregado desde ``start_vid`` hasta ``end_vid``."
 
 #: ../../build/doc/pgr_bdDijkstraCost.rst:220
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_bdDijkstraCostMatrix.po
+++ b/locale/es/LC_MESSAGES/pgr_bdDijkstraCostMatrix.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-28 00:24+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_bddijkstracostmatrix/es/>\n"
@@ -140,11 +140,12 @@ msgstr ""
 "ninguna ruta:"
 
 #: ../../build/doc/bdDijkstra-family.rst:18
-#, fuzzy
 msgid ""
 "The **aggregate cost** the non included values :math:`(u, v)` is "
 ":math:`\\infty`"
-msgstr "El ``agg_cost`` de los valores no incluídos ``(u, v)`` es :math: `\\infty`"
+msgstr ""
+"El **costo agregado** de los valores no incluídos :math:`(u, v)` es :math: `"
+"\\infty`"
 
 #: ../../build/doc/bdDijkstra-family.rst:21
 msgid ""
@@ -184,6 +185,8 @@ msgid ""
 "Use directly when the resulting matrix is symmetric and there is no "
 ":math:`\\infty` value."
 msgstr ""
+"Usar directamente cuando la matriz resultante es simétrica y no hay valor "
+":math:`\\infty`."
 
 #: ../../build/doc/costMatrix-category.rst:9
 msgid "It will be the users responsibility to make the matrix symmetric."
@@ -327,9 +330,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/costMatrix-category.rst:11
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "**edges_sql**"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/costMatrix-category.rst:12
 msgid "``TEXT``"
@@ -447,13 +449,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"
@@ -514,7 +515,7 @@ msgstr "``FLOAT``"
 
 #: ../../build/doc/pgRouting-concepts.rst:21
 msgid "Aggregate cost from ``start_vid`` to ``end_vid``."
-msgstr "Coste agregado de ``start_vid`` a ``end_vid``."
+msgstr "Costo afregado desde ``start_vid`` hasta ``end_vid``."
 
 #: ../../build/doc/pgr_bdDijkstraCostMatrix.rst:110
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_bellmanFord.po
+++ b/locale/es/LC_MESSAGES/pgr_bellmanFord.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:45+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_bellmanford/es/>\n"
@@ -364,7 +364,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/dijkstra-family.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/dijkstra-family.rst:12
 #: ../../build/doc/dijkstra-family.rst:15
@@ -385,9 +385,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/dijkstra-family.rst:17
-#, fuzzy
 msgid "**start vid**"
-msgstr "``start_vid``"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/dijkstra-family.rst:18
 #: ../../build/doc/dijkstra-family.rst:24
@@ -424,9 +423,8 @@ msgid "Identifier of the ending vertex of the path."
 msgstr "Identificador del vértice final de la ruta."
 
 #: ../../build/doc/dijkstra-family.rst:26
-#, fuzzy
 msgid "**end vids**"
-msgstr "``end_vids``"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/dijkstra-family.rst:28
 msgid "Array of identifiers of ending vertices."
@@ -531,13 +529,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:36
@@ -612,8 +609,8 @@ msgid ""
 "Relative position in the path. Has value **1** for the beginning of a "
 "path."
 msgstr ""
-"Posición relativa en la ruta. Tiene el valor **1** para el principio de "
-"una ruta."
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
+"ruta."
 
 #: ../../build/doc/pgRouting-concepts.rst:21
 msgid "``start_vid``"
@@ -691,9 +688,8 @@ msgid "``agg_cost``"
 msgstr "``agg_cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:48
-#, fuzzy
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado de ``start_v`` to ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/pgr_bellmanFord.rst:244
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_biconnectedComponents.po
+++ b/locale/es/LC_MESSAGES/pgr_biconnectedComponents.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_biconnectedcomponents/es/>\n"
@@ -192,7 +192,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/pgRouting-concepts.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
 msgid "``TEXT``"
@@ -277,13 +277,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"

--- a/locale/es/LC_MESSAGES/pgr_binaryBreadthFirstSearch.po
+++ b/locale/es/LC_MESSAGES/pgr_binaryBreadthFirstSearch.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:45+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_binarybreadthfirstsearch/es/>\n"
@@ -364,7 +364,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/dijkstra-family.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/dijkstra-family.rst:12
 #: ../../build/doc/dijkstra-family.rst:15
@@ -385,9 +385,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/dijkstra-family.rst:17
-#, fuzzy
 msgid "**start vid**"
-msgstr "``start_vid``"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/dijkstra-family.rst:18
 #: ../../build/doc/dijkstra-family.rst:24
@@ -424,9 +423,8 @@ msgid "Identifier of the ending vertex of the path."
 msgstr "Identificador del vértice final de la ruta."
 
 #: ../../build/doc/dijkstra-family.rst:26
-#, fuzzy
 msgid "**end vids**"
-msgstr "``end_vids``"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/dijkstra-family.rst:28
 msgid "Array of identifiers of ending vertices."
@@ -532,13 +530,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:36
@@ -629,8 +626,8 @@ msgid ""
 "Relative position in the path. Has value **1** for the beginning of a "
 "path."
 msgstr ""
-"Posición relativa en la ruta. Tiene el valor **1** para el principio de "
-"una ruta."
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
+"ruta."
 
 #: ../../build/doc/pgRouting-concepts.rst:27
 msgid "``start_vid``"
@@ -714,9 +711,8 @@ msgid "``agg_cost``"
 msgstr "``agg_cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:56
-#, fuzzy
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado de ``start_v`` to ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/pgr_binaryBreadthFirstSearch.rst:254
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_bipartite.po
+++ b/locale/es/LC_MESSAGES/pgr_bipartite.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_bipartite/es/>\n"
@@ -209,7 +209,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/pgRouting-concepts.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
 msgid "``TEXT``"
@@ -294,11 +294,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
-msgstr "Cuando es negativo: el borde `(destino, origen)` no existe en el grafo."
+msgstr ""
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"

--- a/locale/es/LC_MESSAGES/pgr_breadthFirstSearch.po
+++ b/locale/es/LC_MESSAGES/pgr_breadthFirstSearch.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_breadthfirstsearch/es/>\n"
@@ -232,7 +232,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/BFS-category.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/BFS-category.rst:12
 msgid "``TEXT``"
@@ -428,13 +428,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:38
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``"

--- a/locale/es/LC_MESSAGES/pgr_bridges.po
+++ b/locale/es/LC_MESSAGES/pgr_bridges.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_bridges/es/>\n"
@@ -151,7 +151,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/pgRouting-concepts.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
 msgid "``TEXT``"
@@ -235,13 +235,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"

--- a/locale/es/LC_MESSAGES/pgr_chinesePostman.po
+++ b/locale/es/LC_MESSAGES/pgr_chinesePostman.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_chinesepostman/es/>\n"
@@ -189,9 +189,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/pgRouting-concepts.rst:11
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "**edges_sql**"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
 msgid "``TEXT``"
@@ -284,13 +283,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"

--- a/locale/es/LC_MESSAGES/pgr_chinesePostmanCost.po
+++ b/locale/es/LC_MESSAGES/pgr_chinesePostmanCost.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_chinesepostmancost/es/>\n"
@@ -182,9 +182,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/pgRouting-concepts.rst:11
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "**edges_sql**"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
 msgid "``TEXT``"
@@ -276,13 +275,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"

--- a/locale/es/LC_MESSAGES/pgr_connectedComponents.po
+++ b/locale/es/LC_MESSAGES/pgr_connectedComponents.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_connectedcomponents/es/>\n"
@@ -172,7 +172,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/pgRouting-concepts.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
 msgid "``TEXT``"
@@ -257,13 +257,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"

--- a/locale/es/LC_MESSAGES/pgr_contraction.po
+++ b/locale/es/LC_MESSAGES/pgr_contraction.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_contraction/es/>\n"
@@ -223,7 +223,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/pgr_contraction.rst:115
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgr_contraction.rst:116
 #: ../../build/doc/pgr_contraction.rst:180
@@ -403,13 +403,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"

--- a/locale/es/LC_MESSAGES/pgr_dagShortestPath.po
+++ b/locale/es/LC_MESSAGES/pgr_dagShortestPath.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:45+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_dagshortestpath/es/>\n"
@@ -327,7 +327,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/dijkstra-family.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/dijkstra-family.rst:12
 #: ../../build/doc/dijkstra-family.rst:15
@@ -348,9 +348,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/dijkstra-family.rst:17
-#, fuzzy
 msgid "**start vid**"
-msgstr "``start_vid``"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/dijkstra-family.rst:18
 #: ../../build/doc/dijkstra-family.rst:24
@@ -387,9 +386,8 @@ msgid "Identifier of the ending vertex of the path."
 msgstr "Identificador del vértice final de la ruta."
 
 #: ../../build/doc/dijkstra-family.rst:26
-#, fuzzy
 msgid "**end vids**"
-msgstr "``end_vids``"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/dijkstra-family.rst:28
 msgid "Array of identifiers of ending vertices."
@@ -468,13 +466,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:36
@@ -550,8 +547,8 @@ msgid ""
 "Relative position in the path. Has value **1** for the beginning of a "
 "path."
 msgstr ""
-"Posición relativa en la ruta. Tiene el valor **1** para el principio de "
-"una ruta."
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
+"ruta."
 
 #: ../../build/doc/pgRouting-concepts.rst:21
 msgid "``start_vid``"
@@ -629,9 +626,8 @@ msgid "``agg_cost``"
 msgstr "``agg_cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:48
-#, fuzzy
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado de ``start_v`` to ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/pgr_dagShortestPath.rst:237
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_depthFirstSearch.po
+++ b/locale/es/LC_MESSAGES/pgr_depthFirstSearch.po
@@ -13,7 +13,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:45+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_depthfirstsearch/es/>\n"
@@ -536,7 +536,7 @@ msgstr "``agg_cost``"
 
 #: ../../build/doc/BFS-category.rst:40
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado desde ``start_vid`` al ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/pgr_depthFirstSearch.rst:154
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_dijkstra.po
+++ b/locale/es/LC_MESSAGES/pgr_dijkstra.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:45+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_dijkstra/es/>\n"
@@ -551,8 +551,8 @@ msgid ""
 "Relative position in the path. Has value **1** for the beginning of a "
 "path."
 msgstr ""
-"Posición relativa en la ruta. Tiene el valor **1** para el principio de "
-"una ruta."
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
+"ruta."
 
 #: ../../build/doc/pgRouting-concepts.rst:21
 msgid "``start_vid``"
@@ -630,7 +630,7 @@ msgstr "``agg_cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:48
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado desde ``start_vid`` al ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/pgr_dijkstra.rst:237
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_dijkstraCostMatrix.po
+++ b/locale/es/LC_MESSAGES/pgr_dijkstraCostMatrix.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-28 00:24+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_dijkstracostmatrix/es/>\n"
@@ -127,6 +127,8 @@ msgid ""
 "Use directly when the resulting matrix is symmetric and there is no "
 ":math:`\\infty` value."
 msgstr ""
+"Usar directamente cuando la matriz resultante es simétrica y no hay valor "
+":math:`\\infty`."
 
 #: ../../build/doc/costMatrix-category.rst:9
 msgid "It will be the users responsibility to make the matrix symmetric."
@@ -278,9 +280,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/costMatrix-category.rst:11
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "**edges_sql**"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/costMatrix-category.rst:12
 msgid "``TEXT``"
@@ -398,13 +399,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"
@@ -466,7 +466,7 @@ msgstr "``FLOAT``"
 
 #: ../../build/doc/pgRouting-concepts.rst:21
 msgid "Aggregate cost from ``start_vid`` to ``end_vid``."
-msgstr "Coste agregado de ``start_vid`` a ``end_vid``."
+msgstr "Costo afregado desde ``start_vid`` hasta ``end_vid``."
 
 #: ../../build/doc/pgr_dijkstraCostMatrix.rst:110
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_dijkstraNear.po
+++ b/locale/es/LC_MESSAGES/pgr_dijkstraNear.po
@@ -13,7 +13,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:45+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_dijkstranear/es/>\n"
@@ -456,7 +456,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/dijkstra-family.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/dijkstra-family.rst:12
 #: ../../build/doc/dijkstra-family.rst:15
@@ -477,9 +477,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/dijkstra-family.rst:17
-#, fuzzy
 msgid "**start vid**"
-msgstr "``start_vid``"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/dijkstra-family.rst:18
 #: ../../build/doc/dijkstra-family.rst:24
@@ -517,9 +516,8 @@ msgid "Identifier of the ending vertex of the path."
 msgstr "Identificador del vértice final de la ruta."
 
 #: ../../build/doc/dijkstra-family.rst:26
-#, fuzzy
 msgid "**end vids**"
-msgstr "**End vids**"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/dijkstra-family.rst:28
 msgid "Array of identifiers of ending vertices."
@@ -664,13 +662,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:36
@@ -741,6 +738,8 @@ msgid ""
 "Relative position in the path. Has value **1** for the beginning of a "
 "path."
 msgstr ""
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
+"ruta."
 
 #: ../../build/doc/pgRouting-concepts.rst:20
 msgid "``start_vid``"
@@ -797,7 +796,7 @@ msgstr "``agg_cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:39
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr ""
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/pgr_dijkstraNear.rst:323
 msgid "See Also"

--- a/locale/es/LC_MESSAGES/pgr_dijkstraVia.po
+++ b/locale/es/LC_MESSAGES/pgr_dijkstraVia.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-06 19:21+0000\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:48+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_dijkstravia/es/>\n"
@@ -175,11 +175,11 @@ msgstr "x Defecto"
 
 #: ../../build/doc/via-category.rst:12
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/via-category.rst:13
 msgid "``TEXT``"
-msgstr ""
+msgstr "``TEXT``"
 
 #: ../../build/doc/via-category.rst:15
 msgid "SQL query as described."
@@ -258,7 +258,7 @@ msgstr ""
 
 #: ../../build/doc/via-category.rst:14
 msgid "``false``"
-msgstr ""
+msgstr "``false``"
 
 #: ../../build/doc/via-category.rst:15
 msgid "When ``true`` if a path is missing stops and returns **EMPTY SET**"
@@ -347,6 +347,8 @@ msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:38
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``"
@@ -390,6 +392,8 @@ msgid ""
 "Relative position in the path. Has value **1** for the beginning of a "
 "path."
 msgstr ""
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
+"ruta."
 
 #: ../../build/doc/via-category.rst:21
 msgid "``start_vid``"
@@ -457,7 +461,7 @@ msgstr "``agg_cost``"
 
 #: ../../build/doc/via-category.rst:43
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr ""
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/via-category.rst:44
 msgid "``route_agg_cost``"
@@ -521,7 +525,7 @@ msgstr ""
 
 #: ../../build/doc/pgr_dijkstraVia.rst:174
 msgid ":doc:`sampledata` network."
-msgstr ""
+msgstr ":doc:`sampledata` ."
 
 #: ../../build/doc/pgr_dijkstraVia.rst:175
 #, python-format

--- a/locale/es/LC_MESSAGES/pgr_drivingDistance.po
+++ b/locale/es/LC_MESSAGES/pgr_drivingDistance.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_drivingdistance/es/>\n"
@@ -171,9 +171,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/drivingDistance-category.rst:11
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "**edges_sql**"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/drivingDistance-category.rst:12
 msgid "``TEXT``"
@@ -389,13 +388,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst
 msgid "ANY-NUMERICAL"

--- a/locale/es/LC_MESSAGES/pgr_edgeDisjointPaths.po
+++ b/locale/es/LC_MESSAGES/pgr_edgeDisjointPaths.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:45+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_edgedisjointpaths/es/>\n"
@@ -236,7 +236,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/dijkstra-family.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/dijkstra-family.rst:12
 #: ../../build/doc/dijkstra-family.rst:15
@@ -257,9 +257,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/dijkstra-family.rst:17
-#, fuzzy
 msgid "**start vid**"
-msgstr "``start_vid``"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/dijkstra-family.rst:18
 #: ../../build/doc/dijkstra-family.rst:24
@@ -296,9 +295,8 @@ msgid "Identifier of the ending vertex of the path."
 msgstr "Identificador del vértice final de la ruta."
 
 #: ../../build/doc/dijkstra-family.rst:26
-#, fuzzy
 msgid "**end vids**"
-msgstr "``end_vids``"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/dijkstra-family.rst:28
 msgid "Array of identifiers of ending vertices."
@@ -404,13 +402,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:36
@@ -500,8 +497,8 @@ msgid ""
 "Relative position in the path. Has value **1** for the beginning of a "
 "path."
 msgstr ""
-"Posición relativa en la ruta. Tiene el valor **1** para el principio de "
-"una ruta."
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
+"ruta."
 
 #: ../../build/doc/pgRouting-concepts.rst:27
 msgid "``start_vid``"
@@ -585,9 +582,8 @@ msgid "``agg_cost``"
 msgstr "``agg_cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:56
-#, fuzzy
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado de ``start_v`` to ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/pgr_edgeDisjointPaths.rst:235
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_edmondsKarp.po
+++ b/locale/es/LC_MESSAGES/pgr_edmondsKarp.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_edmondskarp/es/>\n"
@@ -281,7 +281,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/dijkstra-family.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/dijkstra-family.rst:12
 #: ../../build/doc/dijkstra-family.rst:15
@@ -302,9 +302,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/dijkstra-family.rst:17
-#, fuzzy
 msgid "**start vid**"
-msgstr "``start_vid``"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/dijkstra-family.rst:18
 #: ../../build/doc/dijkstra-family.rst:24 ../../build/doc/flow-family.rst:7
@@ -342,9 +341,8 @@ msgid "Identifier of the ending vertex of the path."
 msgstr "Identificador del vértice final del flujo."
 
 #: ../../build/doc/dijkstra-family.rst:26
-#, fuzzy
 msgid "**end vids**"
-msgstr "``end_vid``"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/dijkstra-family.rst:28
 #, fuzzy
@@ -423,13 +421,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:36

--- a/locale/es/LC_MESSAGES/pgr_edwardMoore.po
+++ b/locale/es/LC_MESSAGES/pgr_edwardMoore.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:45+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_edwardmoore/es/>\n"
@@ -363,7 +363,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/dijkstra-family.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/dijkstra-family.rst:12
 #: ../../build/doc/dijkstra-family.rst:15
@@ -384,9 +384,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/dijkstra-family.rst:17
-#, fuzzy
 msgid "**start vid**"
-msgstr "``start_vid``"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/dijkstra-family.rst:18
 #: ../../build/doc/dijkstra-family.rst:24
@@ -423,9 +422,8 @@ msgid "Identifier of the ending vertex of the path."
 msgstr "Identificador del vértice final de la ruta."
 
 #: ../../build/doc/dijkstra-family.rst:26
-#, fuzzy
 msgid "**end vids**"
-msgstr "``end_vids``"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/dijkstra-family.rst:28
 msgid "Array of identifiers of ending vertices."
@@ -531,13 +529,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:36
@@ -613,8 +610,8 @@ msgid ""
 "Relative position in the path. Has value **1** for the beginning of a "
 "path."
 msgstr ""
-"Posición relativa en la ruta. Tiene el valor **1** para el principio de "
-"una ruta."
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
+"ruta."
 
 #: ../../build/doc/pgRouting-concepts.rst:21
 msgid "``start_vid``"
@@ -692,9 +689,8 @@ msgid "``agg_cost``"
 msgstr "``agg_cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:48
-#, fuzzy
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado de ``start_v`` to ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/pgr_edwardMoore.rst:244
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_extractVertices.po
+++ b/locale/es/LC_MESSAGES/pgr_extractVertices.po
@@ -13,7 +13,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-23 16:16+0000\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:47+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_extractvertices/es/>\n"
@@ -166,7 +166,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/pgr_extractVertices.rst:75
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgr_extractVertices.rst:75
 msgid "``TEXT``"
@@ -195,9 +195,8 @@ msgid "``BOOLEAN``"
 msgstr "``BOOLEAN``"
 
 #: ../../build/doc/pgr_extractVertices.rst:84
-#, fuzzy
 msgid "``false``"
-msgstr "``target``"
+msgstr "``false``"
 
 #: ../../build/doc/pgr_extractVertices.rst:84
 #, fuzzy

--- a/locale/es/LC_MESSAGES/pgr_floydWarshall.po
+++ b/locale/es/LC_MESSAGES/pgr_floydWarshall.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-06 19:21+0000\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:49+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_floydwarshall/es/>\n"
@@ -232,9 +232,8 @@ msgid "Default"
 msgstr "x Defecto"
 
 #: ../../build/doc/allpairs-family.rst:12
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "edges_sql"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/allpairs-family.rst:13
 msgid "``TEXT``"
@@ -332,13 +331,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:29
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:32
 msgid "Where:"
@@ -402,9 +400,8 @@ msgid "``FLOAT``"
 msgstr "``FLOAT``"
 
 #: ../../build/doc/pgRouting-concepts.rst:21
-#, fuzzy
 msgid "Aggregate cost from ``start_vid`` to ``end_vid``."
-msgstr "Costo total de ``start_vid`` a ``end_vid``."
+msgstr "Costo afregado desde ``start_vid`` hasta ``end_vid``."
 
 #: ../../build/doc/pgr_floydWarshall.rst:113
 msgid "See Also"

--- a/locale/es/LC_MESSAGES/pgr_johnson.po
+++ b/locale/es/LC_MESSAGES/pgr_johnson.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-06 19:21+0000\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:49+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_johnson/es/>\n"
@@ -229,9 +229,8 @@ msgid "Default"
 msgstr "x Defecto"
 
 #: ../../build/doc/allpairs-family.rst:12
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "edges_sql"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/allpairs-family.rst:13
 msgid "``TEXT``"
@@ -329,13 +328,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:29
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:32
 msgid "Where:"
@@ -399,9 +397,8 @@ msgid "``FLOAT``"
 msgstr "``FLOAT``"
 
 #: ../../build/doc/pgRouting-concepts.rst:21
-#, fuzzy
 msgid "Aggregate cost from ``start_vid`` to ``end_vid``."
-msgstr "Costo total de ``start_vid`` a ``end_vid``."
+msgstr "Costo afregado desde ``start_vid`` hasta ``end_vid``."
 
 #: ../../build/doc/pgr_johnson.rst:112
 msgid "See Also"

--- a/locale/es/LC_MESSAGES/pgr_kruskal.po
+++ b/locale/es/LC_MESSAGES/pgr_kruskal.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_kruskal/es/>\n"
@@ -161,7 +161,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/pgRouting-concepts.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
 msgid "``TEXT``"
@@ -246,13 +246,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"

--- a/locale/es/LC_MESSAGES/pgr_kruskalBFS.po
+++ b/locale/es/LC_MESSAGES/pgr_kruskalBFS.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_kruskalbfs/es/>\n"
@@ -177,7 +177,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/BFS-category.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/BFS-category.rst:12
 msgid "``TEXT``"
@@ -346,13 +346,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:38
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``"

--- a/locale/es/LC_MESSAGES/pgr_kruskalDD.po
+++ b/locale/es/LC_MESSAGES/pgr_kruskalDD.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:45+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_kruskaldd/es/>\n"
@@ -442,7 +442,7 @@ msgstr "``agg_cost``"
 
 #: ../../build/doc/BFS-category.rst:40
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado desde ``start_vid`` al ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/BFS-category.rst:44
 msgid "SMALLINT, INTEGER, BIGINT"

--- a/locale/es/LC_MESSAGES/pgr_kruskalDFS.po
+++ b/locale/es/LC_MESSAGES/pgr_kruskalDFS.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_kruskaldfs/es/>\n"
@@ -178,7 +178,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/BFS-category.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/BFS-category.rst:12
 msgid "``TEXT``"
@@ -348,13 +348,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:38
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``"

--- a/locale/es/LC_MESSAGES/pgr_lengauerTarjanDominatorTree.po
+++ b/locale/es/LC_MESSAGES/pgr_lengauerTarjanDominatorTree.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_lengauertarjandominatortree/es/>\n"
@@ -309,13 +309,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"

--- a/locale/es/LC_MESSAGES/pgr_lineGraph.po
+++ b/locale/es/LC_MESSAGES/pgr_lineGraph.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_linegraph/es/>\n"
@@ -200,9 +200,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/pgRouting-concepts.rst:11
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "**edges_sql**"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
 msgid "``TEXT``"
@@ -318,13 +317,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"Cuando `negative`: la arista (`target`, `source`) no existe, por lo tanto"
-" no es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"

--- a/locale/es/LC_MESSAGES/pgr_lineGraphFull.po
+++ b/locale/es/LC_MESSAGES/pgr_lineGraphFull.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_linegraphfull/es/>\n"
@@ -249,7 +249,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/pgRouting-concepts.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
 msgid "``TEXT``"
@@ -338,13 +338,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"

--- a/locale/es/LC_MESSAGES/pgr_makeConnected.po
+++ b/locale/es/LC_MESSAGES/pgr_makeConnected.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_makeconnected/es/>\n"
@@ -216,7 +216,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/pgRouting-concepts.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
 msgid "``TEXT``"
@@ -303,11 +303,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
-msgstr "En caso negativo: la arista `(destino, origen)` no forma parte del grafo."
+msgstr ""
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"

--- a/locale/es/LC_MESSAGES/pgr_maxFlow.po
+++ b/locale/es/LC_MESSAGES/pgr_maxFlow.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_maxflow/es/>\n"
@@ -232,7 +232,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/dijkstra-family.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/dijkstra-family.rst:12
 #: ../../build/doc/dijkstra-family.rst:15
@@ -253,9 +253,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/dijkstra-family.rst:17
-#, fuzzy
 msgid "**start vid**"
-msgstr "**objetivo**"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/dijkstra-family.rst:18
 #: ../../build/doc/dijkstra-family.rst:24 ../../build/doc/pgr_maxFlow.rst:206
@@ -291,9 +290,8 @@ msgid "Identifier of the ending vertex of the path."
 msgstr "Identificador del vértice final del flujo."
 
 #: ../../build/doc/dijkstra-family.rst:26
-#, fuzzy
 msgid "**end vids**"
-msgstr "**id**"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/dijkstra-family.rst:28
 #, fuzzy
@@ -372,13 +370,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:36

--- a/locale/es/LC_MESSAGES/pgr_maxFlowMinCost.po
+++ b/locale/es/LC_MESSAGES/pgr_maxFlowMinCost.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_maxflowmincost/es/>\n"
@@ -332,7 +332,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/dijkstra-family.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/dijkstra-family.rst:12
 #: ../../build/doc/dijkstra-family.rst:15
@@ -353,9 +353,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/dijkstra-family.rst:17
-#, fuzzy
 msgid "**start vid**"
-msgstr "**objetivo**"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/dijkstra-family.rst:18
 #: ../../build/doc/dijkstra-family.rst:24 ../../build/doc/flow-family.rst:7
@@ -393,9 +392,8 @@ msgid "Identifier of the ending vertex of the path."
 msgstr "Identificador del vértice final del flujo."
 
 #: ../../build/doc/dijkstra-family.rst:26
-#, fuzzy
 msgid "**end vids**"
-msgstr "**id**"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/dijkstra-family.rst:28
 #, fuzzy
@@ -463,13 +461,12 @@ msgstr "Capacidad de la arista `(origen, destino)`"
 
 #: ../../build/doc/pgRouting-concepts.rst:29
 #: ../../build/doc/pgRouting-concepts.rst:36
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:31
 #, fuzzy

--- a/locale/es/LC_MESSAGES/pgr_maxFlowMinCost_Cost.po
+++ b/locale/es/LC_MESSAGES/pgr_maxFlowMinCost_Cost.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_maxflowmincost_cost/es/>\n"
@@ -329,7 +329,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/dijkstra-family.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/dijkstra-family.rst:12
 #: ../../build/doc/dijkstra-family.rst:15
@@ -350,9 +350,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/dijkstra-family.rst:17
-#, fuzzy
 msgid "**start vid**"
-msgstr "**objetivo**"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/dijkstra-family.rst:18
 #: ../../build/doc/dijkstra-family.rst:24
@@ -388,9 +387,8 @@ msgid "Identifier of the ending vertex of the path."
 msgstr "Identificador del vértice final del flujo."
 
 #: ../../build/doc/dijkstra-family.rst:26
-#, fuzzy
 msgid "**end vids**"
-msgstr "**id**"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/dijkstra-family.rst:28
 #, fuzzy
@@ -458,13 +456,12 @@ msgstr "Capacidad de la arista `(origen, destino)`"
 
 #: ../../build/doc/pgRouting-concepts.rst:29
 #: ../../build/doc/pgRouting-concepts.rst:36
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:31
 #, fuzzy

--- a/locale/es/LC_MESSAGES/pgr_prim.po
+++ b/locale/es/LC_MESSAGES/pgr_prim.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_prim/es/>\n"
@@ -152,7 +152,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/pgRouting-concepts.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
 msgid "``TEXT``"
@@ -235,13 +235,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"

--- a/locale/es/LC_MESSAGES/pgr_primBFS.po
+++ b/locale/es/LC_MESSAGES/pgr_primBFS.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_primbfs/es/>\n"
@@ -176,7 +176,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/BFS-category.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/BFS-category.rst:12
 msgid "``TEXT``"
@@ -345,13 +345,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:38
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``"

--- a/locale/es/LC_MESSAGES/pgr_primDD.po
+++ b/locale/es/LC_MESSAGES/pgr_primDD.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_primdd/es/>\n"
@@ -212,7 +212,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/drivingDistance-category.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/drivingDistance-category.rst:12
 msgid "``TEXT``"
@@ -372,13 +372,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst
 msgid "ANY-NUMERICAL"

--- a/locale/es/LC_MESSAGES/pgr_primDFS.po
+++ b/locale/es/LC_MESSAGES/pgr_primDFS.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_primdfs/es/>\n"
@@ -178,7 +178,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/BFS-category.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/BFS-category.rst:12
 msgid "``TEXT``"
@@ -348,13 +348,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:38
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``"

--- a/locale/es/LC_MESSAGES/pgr_pushRelabel.po
+++ b/locale/es/LC_MESSAGES/pgr_pushRelabel.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_pushrelabel/es/>\n"
@@ -280,7 +280,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/dijkstra-family.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/dijkstra-family.rst:12
 #: ../../build/doc/dijkstra-family.rst:15
@@ -301,9 +301,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/dijkstra-family.rst:17
-#, fuzzy
 msgid "**start vid**"
-msgstr "``start_vid``"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/dijkstra-family.rst:18
 #: ../../build/doc/dijkstra-family.rst:24 ../../build/doc/flow-family.rst:7
@@ -341,9 +340,8 @@ msgid "Identifier of the ending vertex of the path."
 msgstr "Identificador del vértice final del flujo."
 
 #: ../../build/doc/dijkstra-family.rst:26
-#, fuzzy
 msgid "**end vids**"
-msgstr "``end_vid``"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/dijkstra-family.rst:28
 #, fuzzy
@@ -422,13 +420,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:36

--- a/locale/es/LC_MESSAGES/pgr_sequentialVertexColoring.po
+++ b/locale/es/LC_MESSAGES/pgr_sequentialVertexColoring.po
@@ -13,7 +13,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_sequentialvertexcoloring/es/>\n"
@@ -229,7 +229,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/pgRouting-concepts.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
 msgid "``TEXT``"
@@ -314,11 +314,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
-msgstr "Cuando es negativo: la arista `(destino, origen)` no existe en el grafo."
+msgstr ""
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"

--- a/locale/es/LC_MESSAGES/pgr_stoerWagner.po
+++ b/locale/es/LC_MESSAGES/pgr_stoerWagner.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_stoerwagner/es/>\n"
@@ -256,9 +256,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/pgRouting-concepts.rst:11
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "edges_sql"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
 msgid "``TEXT``"
@@ -343,13 +342,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"

--- a/locale/es/LC_MESSAGES/pgr_topologicalSort.po
+++ b/locale/es/LC_MESSAGES/pgr_topologicalSort.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:44+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_topologicalsort/es/>\n"
@@ -211,9 +211,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/pgRouting-concepts.rst:11
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "edges_sql"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
 msgid "``TEXT``"
@@ -298,13 +297,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 msgid "Where:"

--- a/locale/es/LC_MESSAGES/pgr_trsp.po
+++ b/locale/es/LC_MESSAGES/pgr_trsp.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:53+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_trsp/es/>\n"
@@ -314,13 +314,13 @@ msgstr "Tipo"
 
 #: ../../build/doc/pgRouting-concepts.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
 #: ../../build/doc/pgRouting-concepts.rst:15
 #: ../../build/doc/pgRouting-concepts.rst:18
 msgid "``TEXT``"
-msgstr ""
+msgstr "``TEXT``"
 
 #: ../../build/doc/pgRouting-concepts.rst:13
 #: ../../build/doc/pgRouting-concepts.rst:16
@@ -342,7 +342,7 @@ msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/pgRouting-concepts.rst:20
 msgid "**start vid**"
-msgstr ""
+msgstr "**vid de salida**"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
 #: ../../build/doc/pgRouting-concepts.rst:13
@@ -380,7 +380,7 @@ msgstr "**vid destino**"
 
 #: ../../build/doc/pgRouting-concepts.rst:29
 msgid "**end vids**"
-msgstr ""
+msgstr "**vids destinos**"
 
 #: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:21
@@ -495,6 +495,8 @@ msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst
 msgid "ANY-NUMERICAL"
@@ -522,9 +524,8 @@ msgid ""
 msgstr ""
 
 #: ../../build/doc/pgRouting-concepts.rst:17
-#, fuzzy
 msgid "``Cost``"
-msgstr "Costo"
+msgstr "``Cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:19
 msgid "Cost of taking the forbidden path."
@@ -590,6 +591,8 @@ msgid ""
 "Relative position in the path. Has value **1** for the beginning of a "
 "path."
 msgstr ""
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
+"ruta."
 
 #: ../../build/doc/pgRouting-concepts.rst:27
 msgid "``start_vid``"
@@ -651,7 +654,7 @@ msgstr "``agg_cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:46
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr ""
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/pgr_trsp.rst:256
 msgid "See Also"

--- a/locale/es/LC_MESSAGES/pgr_trspVia.po
+++ b/locale/es/LC_MESSAGES/pgr_trspVia.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-25 12:55-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:45+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_trspvia/es/>\n"
@@ -414,7 +414,7 @@ msgstr "``path_seq``"
 msgid ""
 "Relative position in the path. Has value **1** for the beginning of a path."
 msgstr ""
-"Posición relativa en la ruta. Tiene el valor **1** para el principio de una "
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
 "ruta."
 
 #: ../../build/doc/via-category.rst:21
@@ -485,7 +485,7 @@ msgstr "``agg_cost``"
 
 #: ../../build/doc/via-category.rst:43
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado desde ``start_vid`` al ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/via-category.rst:44
 msgid "``route_agg_cost``"

--- a/locale/es/LC_MESSAGES/pgr_trspVia_withPoints.po
+++ b/locale/es/LC_MESSAGES/pgr_trspVia_withPoints.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-25 12:55-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:45+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_trspvia_withpoints/es/>\n"
@@ -595,7 +595,7 @@ msgstr "``path_seq``"
 msgid ""
 "Relative position in the path. Has value **1** for the beginning of a path."
 msgstr ""
-"Posición relativa en la ruta. Tiene el valor **1** para el principio de una "
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
 "ruta."
 
 #: ../../build/doc/via-category.rst:21
@@ -666,7 +666,7 @@ msgstr "``agg_cost``"
 
 #: ../../build/doc/via-category.rst:43
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado desde ``start_vid`` al ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/via-category.rst:44
 msgid "``route_agg_cost``"

--- a/locale/es/LC_MESSAGES/pgr_trsp_withPoints.po
+++ b/locale/es/LC_MESSAGES/pgr_trsp_withPoints.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-25 12:55-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:45+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_trsp_withpoints/es/>\n"
@@ -679,7 +679,7 @@ msgstr "``path_seq``"
 msgid ""
 "Relative position in the path. Has value **1** for the beginning of a path."
 msgstr ""
-"Posición relativa en la ruta. Tiene el valor **1** para el principio de una "
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
 "ruta."
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:290
@@ -752,7 +752,7 @@ msgstr "``agg_cost``"
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:313
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado desde ``start_vid`` al ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:315
 msgid "``0`` for the first row in the path sequence."

--- a/locale/es/LC_MESSAGES/pgr_turnRestrictedPath.po
+++ b/locale/es/LC_MESSAGES/pgr_turnRestrictedPath.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:53+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_turnrestrictedpath/es/>\n"
@@ -172,11 +172,11 @@ msgstr "Tipo"
 
 #: ../../build/doc/pgr_KSP.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgr_KSP.rst:12
 msgid "``TEXT``"
-msgstr ""
+msgstr "``TEXT``"
 
 #: ../../build/doc/pgr_KSP.rst:13
 msgid "SQL query as described."
@@ -184,7 +184,7 @@ msgstr ""
 
 #: ../../build/doc/pgr_KSP.rst:14
 msgid "**start vid**"
-msgstr ""
+msgstr "**vid de salida**"
 
 #: ../../build/doc/pgRouting-concepts.rst:13
 #: ../../build/doc/pgRouting-concepts.rst:17
@@ -268,7 +268,7 @@ msgstr ""
 #: ../../build/doc/pgr_KSP.rst:14
 #: ../../build/doc/pgr_turnRestrictedPath.rst:101
 msgid "``false``"
-msgstr ""
+msgstr "``false``"
 
 #: ../../build/doc/pgr_KSP.rst:15
 msgid "When ``false`` Returns at most K paths"
@@ -380,6 +380,8 @@ msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst
 msgid "ANY-NUMERICAL"
@@ -411,7 +413,7 @@ msgstr ""
 
 #: ../../build/doc/pgRouting-concepts.rst:17
 msgid "``Cost``"
-msgstr ""
+msgstr "``Cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:19
 msgid "Cost of taking the forbidden path."
@@ -465,6 +467,8 @@ msgid ""
 "Relative position in the path. Has value **1** for the beginning of a "
 "path."
 msgstr ""
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
+"ruta."
 
 #: ../../build/doc/pgRouting-concepts.rst:27
 msgid "``start_vid``"
@@ -526,7 +530,7 @@ msgstr "``agg_cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:46
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr ""
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/pgr_turnRestrictedPath.rst:131
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_withPoints.po
+++ b/locale/es/LC_MESSAGES/pgr_withPoints.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:48+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_withpoints/es/>\n"
@@ -310,7 +310,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/withPoints-category.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/withPoints-category.rst:12
 #: ../../build/doc/withPoints-category.rst:15
@@ -340,9 +340,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/withPoints-category.rst:20
-#, fuzzy
 msgid "**start vid**"
-msgstr "``start_vid``"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/pgRouting-concepts.rst:23
 #: ../../build/doc/pgRouting-concepts.rst:30
@@ -393,9 +392,8 @@ msgstr ""
 "punto."
 
 #: ../../build/doc/withPoints-category.rst:32
-#, fuzzy
 msgid "**end vids**"
-msgstr "``end_vids``"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/withPoints-category.rst:34
 #, fuzzy
@@ -460,9 +458,8 @@ msgstr "``CHAR``"
 
 #: ../../build/doc/withPoints-category.rst:33
 #: ../../build/doc/withPoints-family.rst:14
-#, fuzzy
 msgid "``b``"
-msgstr "``TEXT``"
+msgstr "``b``"
 
 #: ../../build/doc/withPoints-family.rst:15
 #, fuzzy
@@ -489,7 +486,7 @@ msgstr "``details``"
 
 #: ../../build/doc/withPoints-family.rst:22
 msgid "``false``"
-msgstr ""
+msgstr "``false``"
 
 #: ../../build/doc/withPoints-family.rst:23
 msgid "When ``true`` the results will include the points that are in the path."
@@ -574,13 +571,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:36
@@ -839,9 +835,8 @@ msgid "``agg_cost``"
 msgstr "``agg_cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:56
-#, fuzzy
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado de ``start_pid`` a ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/pgr_withPoints.rst:251
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_withPointsCost.po
+++ b/locale/es/LC_MESSAGES/pgr_withPointsCost.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:49+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_withpointscost/es/>\n"
@@ -365,7 +365,7 @@ msgstr "Tipo"
 
 #: ../../build/doc/withPoints-category.rst:11
 msgid "`Edges SQL`_"
-msgstr ""
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/withPoints-category.rst:12
 #: ../../build/doc/withPoints-category.rst:15
@@ -395,9 +395,8 @@ msgid "`Combinations SQL`_ as described below"
 msgstr "`SQL Combinaciones`_ como se describe a abajo"
 
 #: ../../build/doc/withPoints-category.rst:20
-#, fuzzy
 msgid "**start vid**"
-msgstr "``start_vid``"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/pgr_withPointsCost.rst:295
 #: ../../build/doc/pgr_withPointsCost.rst:301
@@ -446,9 +445,8 @@ msgstr ""
 "punto."
 
 #: ../../build/doc/withPoints-category.rst:32
-#, fuzzy
 msgid "**end vids**"
-msgstr "``end_vids``"
+msgstr "**vids destinos**"
 
 #: ../../build/doc/withPoints-category.rst:34
 #, fuzzy
@@ -512,9 +510,8 @@ msgstr "``CHAR``"
 
 #: ../../build/doc/pgr_withPointsCost.rst:250
 #: ../../build/doc/withPoints-category.rst:33
-#, fuzzy
 msgid "``b``"
-msgstr "``TEXT``"
+msgstr "``b``"
 
 #: ../../build/doc/pgr_withPointsCost.rst:251
 #, fuzzy
@@ -607,13 +604,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:36
@@ -777,7 +773,7 @@ msgstr "``FLOAT``"
 
 #: ../../build/doc/pgr_withPointsCost.rst:308
 msgid "Aggregate cost from ``start_vid`` to ``end_vid``."
-msgstr "Coste agregado de ``start_vid`` a ``end_vid``."
+msgstr "Costo afregado desde ``start_vid`` hasta ``end_vid``."
 
 #: ../../build/doc/pgr_withPointsCost.rst:311
 msgid "Additional Examples"

--- a/locale/es/LC_MESSAGES/pgr_withPointsCostMatrix.po
+++ b/locale/es/LC_MESSAGES/pgr_withPointsCostMatrix.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-28 00:24+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_withpointscostmatrix/es/>\n"
@@ -158,6 +158,8 @@ msgid ""
 "Use directly when the resulting matrix is symmetric and there is no "
 ":math:`\\infty` value."
 msgstr ""
+"Usar directamente cuando la matriz resultante es simétrica y no hay valor "
+":math:`\\infty`."
 
 #: ../../build/doc/costMatrix-category.rst:9
 msgid "It will be the users responsibility to make the matrix symmetric."
@@ -331,9 +333,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/costMatrix-category.rst:11
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "**edges_sql**"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/costMatrix-category.rst:12
 #: ../../build/doc/costMatrix-category.rst:15
@@ -417,9 +418,8 @@ msgstr "``CHAR``"
 
 #: ../../build/doc/pgr_withPointsCost.rst:14
 #: ../../build/doc/withPoints-category.rst:33
-#, fuzzy
 msgid "``b``"
-msgstr "``TEXT``"
+msgstr "``b``"
 
 #: ../../build/doc/pgr_withPointsCost.rst:15
 #, fuzzy
@@ -508,13 +508,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 #: ../../build/doc/withPoints-category.rst:40
@@ -658,7 +657,7 @@ msgstr "``FLOAT``"
 
 #: ../../build/doc/pgRouting-concepts.rst:21
 msgid "Aggregate cost from ``start_vid`` to ``end_vid``."
-msgstr "Coste agregado de ``start_vid`` a ``end_vid``."
+msgstr "Costo afregado desde ``start_vid`` hasta ``end_vid``."
 
 #: ../../build/doc/pgRouting-concepts.rst:4
 msgid ""

--- a/locale/es/LC_MESSAGES/pgr_withPointsDD.po
+++ b/locale/es/LC_MESSAGES/pgr_withPointsDD.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:48+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_withpointsdd/es/>\n"
@@ -202,9 +202,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/pgr_withPointsDD.rst:115
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "**edges_sql**"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgr_withPointsDD.rst:116
 #: ../../build/doc/pgr_withPointsDD.rst:119
@@ -337,9 +336,8 @@ msgstr "``CHAR``"
 
 #: ../../build/doc/withPoints-category.rst:33
 #: ../../build/doc/withPoints-family.rst:14
-#, fuzzy
 msgid "``b``"
-msgstr "``INT``"
+msgstr "``b``"
 
 #: ../../build/doc/withPoints-family.rst:15
 #, fuzzy
@@ -366,7 +364,7 @@ msgstr "``details``"
 
 #: ../../build/doc/withPoints-family.rst:22
 msgid "``false``"
-msgstr ""
+msgstr "``false``"
 
 #: ../../build/doc/withPoints-family.rst:23
 msgid "When ``true`` the results will include the points that are in the path."
@@ -468,13 +466,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst:36
 #: ../../build/doc/pgr_withPointsDD.rst:212

--- a/locale/es/LC_MESSAGES/pgr_withPointsKSP.po
+++ b/locale/es/LC_MESSAGES/pgr_withPointsKSP.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:48+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_withpointsksp/es/>\n"
@@ -202,9 +202,8 @@ msgid "Type"
 msgstr "Tipo"
 
 #: ../../build/doc/pgr_withPointsKSP.rst:89
-#, fuzzy
 msgid "`Edges SQL`_"
-msgstr "**edges_sql**"
+msgstr "`SQL Aristas`_"
 
 #: ../../build/doc/pgr_withPointsKSP.rst:90
 #: ../../build/doc/pgr_withPointsKSP.rst:93
@@ -226,9 +225,8 @@ msgid "`Points SQL`_ query as described."
 msgstr "Consulta SQL de puntos como se describe arriba."
 
 #: ../../build/doc/pgr_withPointsKSP.rst:95
-#, fuzzy
 msgid "**start vid**"
-msgstr "**start_pid**"
+msgstr "**vid de salida**"
 
 #: ../../build/doc/pgRouting-concepts.rst:13
 #: ../../build/doc/pgRouting-concepts.rst:17
@@ -320,7 +318,7 @@ msgstr "**heap_paths**"
 
 #: ../../build/doc/pgr_KSP.rst:14 ../../build/doc/withPoints-family.rst:22
 msgid "``false``"
-msgstr ""
+msgstr "``false``"
 
 #: ../../build/doc/pgr_KSP.rst:15
 msgid "When ``false`` Returns at most K paths"
@@ -359,9 +357,8 @@ msgstr "``CHAR``"
 
 #: ../../build/doc/withPoints-category.rst:33
 #: ../../build/doc/withPoints-family.rst:14
-#, fuzzy
 msgid "``b``"
-msgstr "``TEXT``"
+msgstr "``b``"
 
 #: ../../build/doc/withPoints-family.rst:15
 #, fuzzy
@@ -456,13 +453,12 @@ msgid "Weight of the edge (``target``, ``source``)"
 msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
-#, fuzzy
 msgid ""
 "When negative: edge (``target``, ``source``) does not exist, therefore "
 "it's not part of the graph."
 msgstr ""
-"En caso negativo: la arista `(target, source)` no existe, por lo tanto no"
-" es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
 #: ../../build/doc/pgRouting-concepts.rst
 #: ../../build/doc/withPoints-category.rst
@@ -593,13 +589,12 @@ msgid "``path_seq``"
 msgstr "``path_seq``"
 
 #: ../../build/doc/pgr_KSP.rst:25
-#, fuzzy
 msgid ""
 "Relative position in the path. Has value **1** for the beginning of a "
 "path."
 msgstr ""
-"Posición relativa en la ruta de acceso de nodo y arista. Tiene el valor 1"
-" para el principio de una ruta."
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
+"ruta."
 
 #: ../../build/doc/pgr_KSP.rst:27
 msgid "``node``"

--- a/locale/es/LC_MESSAGES/pgr_withPointsVia.po
+++ b/locale/es/LC_MESSAGES/pgr_withPointsVia.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-25 12:55-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:48+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_withpointsvia/es/>\n"
@@ -543,7 +543,7 @@ msgstr "``path_seq``"
 msgid ""
 "Relative position in the path. Has value **1** for the beginning of a path."
 msgstr ""
-"Posición relativa en la ruta. Tiene el valor **1** para el principio de una "
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
 "ruta."
 
 #: ../../build/doc/via-category.rst:21
@@ -614,7 +614,7 @@ msgstr "``agg_cost``"
 
 #: ../../build/doc/via-category.rst:43
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado desde ``start_vid`` al ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/via-category.rst:44
 msgid "``route_agg_cost``"

--- a/locale/es/LC_MESSAGES/proposed.po
+++ b/locale/es/LC_MESSAGES/proposed.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-20 00:25+0000\n"
-"PO-Revision-Date: 2022-06-27 13:19+0000\n"
+"PO-Revision-Date: 2022-06-28 00:15+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "proposed/es/>\n"
@@ -158,7 +158,7 @@ msgstr ":doc:`traversal-family`"
 
 #: ../../build/doc/TRSP-family.rst:3
 msgid ":doc:`pgr_trsp` - Vertex - Vertex routing with restrictions."
-msgstr ""
+msgstr ":doc:`pgr_trsp` - Ruteo Vértice - Vértice con restricciones."
 
 #: ../../build/doc/TRSP-family.rst:4
 msgid ":doc:`pgr_trspVia` - Via Vertices routing with restrictions."
@@ -265,13 +265,12 @@ msgid ":doc:`pgr_dijkstraVia`"
 msgstr ":doc:`dijkstra-family`"
 
 #: ../../build/doc/via-category.rst:4
-#, fuzzy
 msgid ":doc:`pgr_withPointsVia`"
-msgstr ":doc:`pgr_withPointsCost`"
+msgstr ":doc:`pgr_withPointsVia`"
 
 #: ../../build/doc/via-category.rst:5
 msgid ":doc:`pgr_trspVia`"
-msgstr ""
+msgstr ":doc:`pgr_trspVia`"
 
 #: ../../build/doc/via-category.rst:6
 #, fuzzy
@@ -285,7 +284,7 @@ msgstr ":doc:`cost-category`"
 
 #: ../../build/doc/withPoints-category.rst:3
 msgid ":doc:`withPoints-family` - Functions based on Dijkstra algorithm."
-msgstr ""
+msgstr ":doc:`withPoints-family` - Funciones basadas en el algoritmo Dijkstra."
 
 #: ../../build/doc/withPoints-category.rst:4
 #, fuzzy

--- a/locale/es/LC_MESSAGES/release_notes.po
+++ b/locale/es/LC_MESSAGES/release_notes.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.2.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-20 00:25+0000\n"
-"PO-Revision-Date: 2022-06-27 13:19+0000\n"
+"PO-Revision-Date: 2022-06-28 00:23+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "release_notes/es/>\n"
@@ -521,7 +521,7 @@ msgstr ""
 
 #: ../../build/doc/release_notes.rst:201
 msgid "pgRouting 3.2.0 Release Notes"
-msgstr "Notas del Lanzamiento de pgRouting 3.2.0 "
+msgstr "Notas del Lanzamiento de pgRouting 3.2.0"
 
 #: ../../build/doc/release_notes.rst:203
 #, python-format
@@ -1027,8 +1027,8 @@ msgid ""
 "`#1188 <https://github.com/pgRouting/pgrouting/issues/1188>`__: Removed "
 "CGAL dependency"
 msgstr ""
-"`#1188 <https://github.com/pgRouting/pgrouting/issues/1188>`__: Se "
-"suprimió la dependencia CGAL "
+"`#1188 <https://github.com/pgRouting/pgrouting/issues/1188>`__: Se suprimió "
+"la dependencia CGAL"
 
 #: ../../build/doc/release_notes.rst:486
 msgid ""
@@ -1818,7 +1818,7 @@ msgstr "Limpiado el código interno de withPoints"
 
 #: ../../build/doc/release_notes.rst:758
 msgid "pgRouting 2.5.5 Release Notes"
-msgstr "Notas de la versión de PgRouting 2.5.5 "
+msgstr "Notas de la versión de PgRouting 2.5.5"
 
 #: ../../build/doc/release_notes.rst:760
 #, python-format
@@ -1849,7 +1849,7 @@ msgstr "Arreglos de compilación para python3 y perl5"
 
 #: ../../build/doc/release_notes.rst:772
 msgid "pgRouting 2.5.4 Release Notes"
-msgstr "Notas de la versión de pgRouting 2.5.4 "
+msgstr "Notas de la versión de pgRouting 2.5.4"
 
 #: ../../build/doc/release_notes.rst:774
 #, python-format
@@ -1866,7 +1866,7 @@ msgstr ""
 
 #: ../../build/doc/release_notes.rst:811
 msgid "pgRouting 2.5.3 Release Notes"
-msgstr "Notas de la versión de pgRouting 2.5.3 "
+msgstr "Notas de la versión de pgRouting 2.5.3"
 
 #: ../../build/doc/release_notes.rst:813
 #, python-format
@@ -2040,7 +2040,7 @@ msgstr "pgr_pointToEdgeNode"
 
 #: ../../build/doc/release_notes.rst:915
 msgid "pgRouting 2.4.2 Release Notes"
-msgstr "Notas de la versión de pgRouting 2.4.2 "
+msgstr "Notas de la versión de pgRouting 2.4.2"
 
 #: ../../build/doc/release_notes.rst:917
 #, python-format
@@ -2187,7 +2187,7 @@ msgstr ""
 
 #: ../../build/doc/release_notes.rst:988
 msgid "pgRouting 2.3.2 Release Notes"
-msgstr "Notas de la versión de pgRouting 2.3.2 "
+msgstr "Notas de la versión de pgRouting 2.3.2"
 
 #: ../../build/doc/release_notes.rst:990
 msgid ""
@@ -2368,7 +2368,7 @@ msgstr "pgr_textToPoints"
 
 #: ../../build/doc/release_notes.rst:1077
 msgid "pgRouting 2.2.4 Release Notes"
-msgstr "Notas de la versión de pgRouting 2.2.4 "
+msgstr "Notas de la versión de pgRouting 2.2.4"
 
 #: ../../build/doc/release_notes.rst:1079
 msgid ""
@@ -2396,7 +2396,7 @@ msgstr "Error de regresión pgr_nodeNetwork"
 
 #: ../../build/doc/release_notes.rst:1091
 msgid "pgRouting 2.2.3 Release Notes"
-msgstr "Notas de la versión de pgRouting 2.2.3 "
+msgstr "Notas de la versión de pgRouting 2.2.3"
 
 #: ../../build/doc/release_notes.rst:1093
 msgid ""
@@ -2416,7 +2416,7 @@ msgstr "Problemas de compatibilidad con PostgreSQL 9.6 corregidos."
 
 #: ../../build/doc/release_notes.rst:1103
 msgid "pgRouting 2.2.2 Release Notes"
-msgstr "Notas de la versión de pgRouting 2.2.2 "
+msgstr "Notas de la versión de pgRouting 2.2.2"
 
 #: ../../build/doc/release_notes.rst:1105
 msgid ""
@@ -2924,8 +2924,8 @@ msgid ""
 "New TSP solver that simplifies the code and the build process (pgr_tsp), "
 "dropped \"Gaul Library\" dependency"
 msgstr ""
-"Nuevo solucionador TSP  que simplifica el código donde  el proceso de "
-"compilación (pgr_tsp), ya no dependene de la biblioteca \"Gaul Library\" "
+"Nuevo solucionador TSP que simplifica el código donde el proceso de "
+"compilación (pgr_tsp), ya no dependene de la biblioteca \"Gaul Library\""
 
 #: ../../build/doc/release_notes.rst:1319
 msgid "Turn Restricted shortest path (pgr_trsp) that replaces Shooting Star"
@@ -2989,7 +2989,7 @@ msgstr "Soporte para esquema en los parámetros de las funciones"
 
 #: ../../build/doc/release_notes.rst:1333
 msgid "Support for ``st_`` PostGIS function prefix"
-msgstr "Soporte para el prefijo ``st_`` de las funciones de PostGIS "
+msgstr "Soporte para el prefijo ``st_`` de las funciones de PostGIS"
 
 #: ../../build/doc/release_notes.rst:1334
 msgid "Added ``pgr_`` prefix to functions and types"
@@ -3005,7 +3005,7 @@ msgstr "shooting_star está descontinuado"
 
 #: ../../build/doc/release_notes.rst:1342
 msgid "pgRouting 1.x Release Notes"
-msgstr "Notas de versión de pgRouting 1.x "
+msgstr "Notas de versión de pgRouting 1.x"
 
 #: ../../build/doc/release_notes.rst:1344
 msgid ""
@@ -3060,7 +3060,7 @@ msgstr "Núcleo y funciones adicionales están separadas"
 
 #: ../../build/doc/release_notes.rst:1381
 msgid "Cmake build process"
-msgstr "Proceso de compilación con CMake "
+msgstr "Proceso de compilación con CMake"
 
 #: ../../build/doc/release_notes.rst:1386
 msgid "Changes for release 1.0.0b"

--- a/locale/es/LC_MESSAGES/routingFunctions.po
+++ b/locale/es/LC_MESSAGES/routingFunctions.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-28 00:20+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "routingfunctions/es/>\n"
@@ -352,6 +352,9 @@ msgid ""
 "The following functions modify the database directly therefore the user "
 "must have special permissions given by the administrators to use them."
 msgstr ""
+"Las siguientes funciones modifican la base de datos directamente, por lo que "
+"el usuario debe tener permisos especiales otorgados por un administrador "
+"para usarlos."
 
 #: ../../build/doc/topology-functions.rst:6
 #, fuzzy
@@ -452,9 +455,8 @@ msgstr ":doc:`pgr_aStarCostMatrix`"
 
 #: ../../build/doc/costMatrix-category.rst:5
 #: ../../build/doc/costMatrix-category.rst:7
-#, fuzzy
 msgid ":doc:`pgr_bdDijkstraCostMatrix`"
-msgstr ":doc:`pgr_dijkstraCostMatrix`"
+msgstr ":doc:`pgr_bdDijkstraCostMatrix`"
 
 #: ../../build/doc/costMatrix-category.rst:6
 msgid ":doc:`pgr_dijkstraCostMatrix`"

--- a/locale/es/LC_MESSAGES/sampledata.po
+++ b/locale/es/LC_MESSAGES/sampledata.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-20 14:20+0000\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:54+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "sampledata/es/>\n"
@@ -468,9 +468,8 @@ msgid "The creation of the restrictions table"
 msgstr ""
 
 #: ../../build/doc/sampledata.rst:306
-#, fuzzy
 msgid "Adding the restrictions"
-msgstr "Restricciones"
+msgstr "Agregando las restricciones"
 
 #: ../../build/doc/sampledata.rst:313
 #, fuzzy

--- a/locale/es/LC_MESSAGES/topology-functions.po
+++ b/locale/es/LC_MESSAGES/topology-functions.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-06 19:21+0000\n"
-"PO-Revision-Date: 2022-06-27 13:19+0000\n"
+"PO-Revision-Date: 2022-06-28 00:20+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "topology-functions/es/>\n"
@@ -112,6 +112,9 @@ msgid ""
 "The following functions modify the database directly therefore the user "
 "must have special permissions given by the administrators to use them."
 msgstr ""
+"Las siguientes funciones modifican la base de datos directamente, por lo que "
+"el usuario debe tener permisos especiales otorgados por un administrador "
+"para usarlos."
 
 #: ../../build/doc/topology-functions.rst:56
 #, fuzzy

--- a/locale/es/LC_MESSAGES/via-category.po
+++ b/locale/es/LC_MESSAGES/via-category.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-25 12:55-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-27 23:53+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "via-category/es/>\n"
@@ -404,9 +404,8 @@ msgid ""
 msgstr ""
 
 #: ../../build/doc/pgRouting-concepts.rst:17
-#, fuzzy
 msgid "``Cost``"
-msgstr "``cost``"
+msgstr "``Cost``"
 
 #: ../../build/doc/pgRouting-concepts.rst:19
 msgid "Cost of taking the forbidden path."
@@ -528,7 +527,7 @@ msgstr "``path_seq``"
 msgid ""
 "Relative position in the path. Has value **1** for the beginning of a path."
 msgstr ""
-"Posición relativa en la ruta. Tiene el valor **1** para el principio de una "
+"Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
 "ruta."
 
 #: ../../build/doc/via-category.rst:212
@@ -599,7 +598,7 @@ msgstr "``agg_cost``"
 
 #: ../../build/doc/via-category.rst:234
 msgid "Aggregate cost from ``start_vid`` to ``node``."
-msgstr "Coste agregado desde ``start_vid`` al ``node``."
+msgstr "Costo agregado desde ``start_vid`` hasta ``node``."
 
 #: ../../build/doc/via-category.rst:235
 msgid "``route_agg_cost``"

--- a/locale/es/LC_MESSAGES/withPoints-category.po
+++ b/locale/es/LC_MESSAGES/withPoints-category.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-25 12:55-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-28 00:19+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "withpoints-category/es/>\n"
@@ -75,8 +75,7 @@ msgstr "Es posible que la documentación necesite un refinamiento."
 
 #: ../../build/doc/withPoints-category.rst:27
 msgid ":doc:`withPoints-family` - Functions based on Dijkstra algorithm."
-msgstr ""
-":doc:`withPoints-family` - Funciones que se basan en el algoritmo Dijkstra."
+msgstr ":doc:`withPoints-family` - Funciones basadas en el algoritmo Dijkstra."
 
 #: ../../build/doc/withPoints-category.rst:28
 msgid "From the :doc:`TRSP-family`:"
@@ -668,7 +667,7 @@ msgstr ""
 
 #: ../../build/doc/withPoints-category.rst:267
 msgid "Driving side"
-msgstr ""
+msgstr "Lado de manejo"
 
 #: ../../build/doc/withPoints-category.rst:269
 msgid "In the the folowwing images:"
@@ -770,7 +769,7 @@ msgstr ""
 
 #: ../../build/doc/withPoints-category.rst:320
 msgid "Creating temporary vertices"
-msgstr ""
+msgstr "Creación de vértices temporales"
 
 #: ../../build/doc/withPoints-category.rst:322
 msgid ""
@@ -796,7 +795,7 @@ msgstr "En una red de conducción del lado derecho"
 
 #: ../../build/doc/withPoints-category.rst:347
 msgid "Arrival to point ``-2`` can be achived only via vertex **16**."
-msgstr ""
+msgstr "Llegada al punto ``-2`` se logra solo vía el vértice **16**"
 
 #: ../../build/doc/withPoints-category.rst:348
 msgid "Does not affects edge ``(17, 16)``, therefore the edge is kept."
@@ -843,7 +842,7 @@ msgstr "En una red de conducción del lado izquierdo"
 
 #: ../../build/doc/withPoints-category.rst:367
 msgid "Arrival to point ``-2`` can be achived only via vertex **17**."
-msgstr ""
+msgstr "Llegada al punto ``-2`` se logra solo vía el vértice **17**"
 
 #: ../../build/doc/withPoints-category.rst:368
 msgid "Does not affects edge ``(16, 17)``, therefore the edge is kept."
@@ -889,10 +888,12 @@ msgid ""
 "Affects the edges ``(16, 17)`` and ``(17, 16)``, therefore the edges are "
 "removed."
 msgstr ""
+"Afecta las aristas ``(16, 17)`` y ``(17, 16)`` por lo que esas aristas se "
+"eliminan."
 
 #: ../../build/doc/withPoints-category.rst:397
 msgid "Create four new edges:"
-msgstr ""
+msgstr "Crear cuatro nuevas aristas:"
 
 #: ../../build/doc/withPoints-category.rst:407
 msgid "Flip the Edges and add all the edges to the graph:"

--- a/locale/es/LC_MESSAGES/withPoints-family.po
+++ b/locale/es/LC_MESSAGES/withPoints-family.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-06-27 17:01+0000\n"
+"PO-Revision-Date: 2022-06-28 00:19+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "withpoints-family/es/>\n"
@@ -208,7 +208,7 @@ msgstr "`SQL Aristas`_"
 #: ../../build/doc/withPoints-category.rst:15
 #: ../../build/doc/withPoints-category.rst:18
 msgid "``TEXT``"
-msgstr ""
+msgstr "``TEXT``"
 
 #: ../../build/doc/withPoints-category.rst:13
 msgid "`Edges SQL`_ as described below"
@@ -336,7 +336,7 @@ msgstr "``CHAR``"
 #: ../../build/doc/withPoints-category.rst:33
 #: ../../build/doc/withPoints-family.rst:101
 msgid "``b``"
-msgstr ""
+msgstr "``b``"
 
 #: ../../build/doc/withPoints-family.rst:102
 msgid "Value in [``r``, ``l``, ``b``] indicating if the driving side is:"
@@ -361,7 +361,7 @@ msgstr "``details``"
 
 #: ../../build/doc/withPoints-family.rst:109
 msgid "``false``"
-msgstr ""
+msgstr "``false``"
 
 #: ../../build/doc/withPoints-family.rst:110
 msgid "When ``true`` the results will include the points that are in the path."
@@ -566,7 +566,7 @@ msgstr ""
 
 #: ../../build/doc/withPoints-category.rst:4
 msgid "Contents"
-msgstr ""
+msgstr "Contenido"
 
 #: ../../build/doc/withPoints-category.rst:7
 msgid "About points"
@@ -616,9 +616,8 @@ msgid ""
 msgstr ""
 
 #: ../../build/doc/withPoints-category.rst:34
-#, fuzzy
 msgid "Driving side"
-msgstr "Lado de conducción izquierdo"
+msgstr "Lado de manejo"
 
 #: ../../build/doc/withPoints-category.rst:36
 msgid "In the the folowwing images:"
@@ -721,9 +720,8 @@ msgid "Point **4** located on edge ``(3, 1)`` and ``(1, 3)``"
 msgstr ""
 
 #: ../../build/doc/withPoints-category.rst:87
-#, fuzzy
 msgid "Creating temporary vertices"
-msgstr "Creación de Vértices Temporales en el grafo"
+msgstr "Creación de vértices temporales"
 
 #: ../../build/doc/withPoints-category.rst:89
 msgid ""
@@ -748,9 +746,8 @@ msgid "On a right hand side driving network"
 msgstr "En una red de conducción del lado derecho"
 
 #: ../../build/doc/withPoints-category.rst:114
-#, fuzzy
 msgid "Arrival to point ``-2`` can be achived only via vertex **16**."
-msgstr "Podemos llegar al punto sólo a través del vértice 12."
+msgstr "Llegada al punto ``-2`` se logra solo vía el vértice **16**"
 
 #: ../../build/doc/withPoints-category.rst:115
 msgid "Does not affects edge ``(17, 16)``, therefore the edge is kept."
@@ -797,9 +794,8 @@ msgid "On a left hand side driving network"
 msgstr "En una red de conducción del lado izquierdo"
 
 #: ../../build/doc/withPoints-category.rst:134
-#, fuzzy
 msgid "Arrival to point ``-2`` can be achived only via vertex **17**."
-msgstr "Podemos llegar al punto sólo a través del vértice 12."
+msgstr "Llegada al punto ``-2`` se logra solo vía el vértice **17**"
 
 #: ../../build/doc/withPoints-category.rst:135
 msgid "Does not affects edge ``(16, 17)``, therefore the edge is kept."
@@ -842,16 +838,16 @@ msgid "Arrival to point ``-2`` can be achived via vertices **16** or **17**."
 msgstr ""
 
 #: ../../build/doc/withPoints-category.rst:163
-#, fuzzy
 msgid ""
 "Affects the edges ``(16, 17)`` and ``(17, 16)``, therefore the edges are "
 "removed."
-msgstr "Sólo afecta a la arista (15, 12,9 20) por lo que esa arista se elimina."
+msgstr ""
+"Afecta las aristas ``(16, 17)`` y ``(17, 16)`` por lo que esas aristas se "
+"eliminan."
 
 #: ../../build/doc/withPoints-category.rst:164
-#, fuzzy
 msgid "Create four new edges:"
-msgstr "Crear nuevas aristas:"
+msgstr "Crear cuatro nuevas aristas:"
 
 #: ../../build/doc/withPoints-category.rst:174
 msgid "Flip the Edges and add all the edges to the graph:"


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [pgRouting/index](https://weblate.osgeo.org/projects/pgrouting/index/).


It also includes following components:

* [pgRouting/pgr_chinesePostman](https://weblate.osgeo.org/projects/pgrouting/pgr_chinesepostman/)

* [pgRouting/pgr_kruskalBFS](https://weblate.osgeo.org/projects/pgrouting/pgr_kruskalbfs/)

* [pgRouting/pgr_johnson](https://weblate.osgeo.org/projects/pgrouting/pgr_johnson/)

* [pgRouting/bdAstar-family](https://weblate.osgeo.org/projects/pgrouting/bdastar-family/)

* [pgRouting/allpairs-family](https://weblate.osgeo.org/projects/pgrouting/allpairs-family/)

* [pgRouting/pgr_version](https://weblate.osgeo.org/projects/pgrouting/pgr_version/)

* [pgRouting/pgRouting-installation](https://weblate.osgeo.org/projects/pgrouting/pgrouting-installation/)

* [pgRouting/traversal-family](https://weblate.osgeo.org/projects/pgrouting/traversal-family/)

* [pgRouting/aStar-family](https://weblate.osgeo.org/projects/pgrouting/astar-family/)

* [pgRouting/pgr_dijkstraVia](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstravia/)

* [pgRouting/pgr_maxCardinalityMatch](https://weblate.osgeo.org/projects/pgrouting/pgr_maxcardinalitymatch/)

* [pgRouting/pgr_drivingDistance](https://weblate.osgeo.org/projects/pgrouting/pgr_drivingdistance/)

* [pgRouting/pgr_TSPeuclidean](https://weblate.osgeo.org/projects/pgrouting/pgr_tspeuclidean/)

* [pgRouting/proposed](https://weblate.osgeo.org/projects/pgrouting/proposed/)

* [pgRouting/release_notes](https://weblate.osgeo.org/projects/pgrouting/release_notes/)

* [pgRouting/cost-category](https://weblate.osgeo.org/projects/pgrouting/cost-category/)

* [pgRouting/pgr_sequentialVertexColoring](https://weblate.osgeo.org/projects/pgrouting/pgr_sequentialvertexcoloring/)

* [pgRouting/DFS-category](https://weblate.osgeo.org/projects/pgrouting/dfs-category/)

* [pgRouting/pgr_analyzeGraph](https://weblate.osgeo.org/projects/pgrouting/pgr_analyzegraph/)

* [pgRouting/pgr_edgeColoring](https://weblate.osgeo.org/projects/pgrouting/pgr_edgecoloring/)

* [pgRouting/pgr_full_version](https://weblate.osgeo.org/projects/pgrouting/pgr_full_version/)

* [pgRouting/pgr_strongComponents](https://weblate.osgeo.org/projects/pgrouting/pgr_strongcomponents/)

* [pgRouting/transformation-family](https://weblate.osgeo.org/projects/pgrouting/transformation-family/)

* [pgRouting/pgr_vrpOneDepot](https://weblate.osgeo.org/projects/pgrouting/pgr_vrponedepot/)

* [pgRouting/pgr_biconnectedComponents](https://weblate.osgeo.org/projects/pgrouting/pgr_biconnectedcomponents/)

* [pgRouting/topology-functions](https://weblate.osgeo.org/projects/pgrouting/topology-functions/)

* [pgRouting/support](https://weblate.osgeo.org/projects/pgrouting/support/)

* [pgRouting/contraction-family](https://weblate.osgeo.org/projects/pgrouting/contraction-family/)

* [pgRouting/spanningTree-family](https://weblate.osgeo.org/projects/pgrouting/spanningtree-family/)

* [pgRouting/migration](https://weblate.osgeo.org/projects/pgrouting/migration/)

* [pgRouting/pgr_aStarCost](https://weblate.osgeo.org/projects/pgrouting/pgr_astarcost/)

* [pgRouting/BFS-category](https://weblate.osgeo.org/projects/pgrouting/bfs-category/)

* [pgRouting/pgr_createVerticesTable](https://weblate.osgeo.org/projects/pgrouting/pgr_createverticestable/)

* [pgRouting/reference](https://weblate.osgeo.org/projects/pgrouting/reference/)

* [pgRouting/pgr_dagShortestPath](https://weblate.osgeo.org/projects/pgrouting/pgr_dagshortestpath/)

* [pgRouting/components-family](https://weblate.osgeo.org/projects/pgrouting/components-family/)

* [pgRouting/pgRouting-introduction](https://weblate.osgeo.org/projects/pgrouting/pgrouting-introduction/)

* [pgRouting/KSP-category](https://weblate.osgeo.org/projects/pgrouting/ksp-category/)

* [pgRouting/coloring-family](https://weblate.osgeo.org/projects/pgrouting/coloring-family/)

* [pgRouting/pgr_createTopology](https://weblate.osgeo.org/projects/pgrouting/pgr_createtopology/)

* [pgRouting/pgr_nodeNetwork](https://weblate.osgeo.org/projects/pgrouting/pgr_nodenetwork/)

* [pgRouting/withPoints-family](https://weblate.osgeo.org/projects/pgrouting/withpoints-family/)

* [pgRouting/costMatrix-category](https://weblate.osgeo.org/projects/pgrouting/costmatrix-category/)

* [pgRouting/VRP-category](https://weblate.osgeo.org/projects/pgrouting/vrp-category/)

* [pgRouting/routingFunctions](https://weblate.osgeo.org/projects/pgrouting/routingfunctions/)

* [pgRouting/pgr_chinesePostmanCost](https://weblate.osgeo.org/projects/pgrouting/pgr_chinesepostmancost/)

* [pgRouting/pgr_trsp](https://weblate.osgeo.org/projects/pgrouting/pgr_trsp/)

* [pgRouting/via-category](https://weblate.osgeo.org/projects/pgrouting/via-category/)

* [pgRouting/pgr_dijkstraNearCost](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstranearcost/)

* [pgRouting/pgr_edwardMoore](https://weblate.osgeo.org/projects/pgrouting/pgr_edwardmoore/)

* [pgRouting/pgr_turnRestrictedPath](https://weblate.osgeo.org/projects/pgrouting/pgr_turnrestrictedpath/)

* [pgRouting/pgr_makeConnected](https://weblate.osgeo.org/projects/pgrouting/pgr_makeconnected/)

* [pgRouting/pgr_topologicalSort](https://weblate.osgeo.org/projects/pgrouting/pgr_topologicalsort/)

* [pgRouting/pgr_breadthFirstSearch](https://weblate.osgeo.org/projects/pgrouting/pgr_breadthfirstsearch/)

* [pgRouting/pgr_primDD](https://weblate.osgeo.org/projects/pgrouting/pgr_primdd/)

* [pgRouting/pgr_lineGraph](https://weblate.osgeo.org/projects/pgrouting/pgr_linegraph/)

* [pgRouting/kruskal-family](https://weblate.osgeo.org/projects/pgrouting/kruskal-family/)

* [pgRouting/pgr_prim](https://weblate.osgeo.org/projects/pgrouting/pgr_prim/)

* [pgRouting/pgr_boykovKolmogorov](https://weblate.osgeo.org/projects/pgrouting/pgr_boykovkolmogorov/)

* [pgRouting/pgr_bipartite](https://weblate.osgeo.org/projects/pgrouting/pgr_bipartite/)

* [pgRouting/pgr_bridges](https://weblate.osgeo.org/projects/pgrouting/pgr_bridges/)

* [pgRouting/pgr_isPlanar](https://weblate.osgeo.org/projects/pgrouting/pgr_isplanar/)

* [pgRouting/pgr_bellmanFord](https://weblate.osgeo.org/projects/pgrouting/pgr_bellmanford/)

* [pgRouting/pgr_pickDeliver](https://weblate.osgeo.org/projects/pgrouting/pgr_pickdeliver/)

* [pgRouting/pgr_withPoints](https://weblate.osgeo.org/projects/pgrouting/pgr_withpoints/)

* [pgRouting/pgr_extractVertices](https://weblate.osgeo.org/projects/pgrouting/pgr_extractvertices/)

* [pgRouting/chinesePostmanProblem-family](https://weblate.osgeo.org/projects/pgrouting/chinesepostmanproblem-family/)

* [pgRouting/pgr_depthFirstSearch](https://weblate.osgeo.org/projects/pgrouting/pgr_depthfirstsearch/)

* [pgRouting/prim-family](https://weblate.osgeo.org/projects/pgrouting/prim-family/)

* [pgRouting/pgr_stoerWagner](https://weblate.osgeo.org/projects/pgrouting/pgr_stoerwagner/)

* [pgRouting/dijkstra-family](https://weblate.osgeo.org/projects/pgrouting/dijkstra-family/)

* [pgRouting/pgr_maxFlowMinCost_Cost](https://weblate.osgeo.org/projects/pgrouting/pgr_maxflowmincost_cost/)

* [pgRouting/pgr_withPointsKSP](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointsksp/)

* [pgRouting/pgr_withPointsCost](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointscost/)

* [pgRouting/pgr_analyzeOneWay](https://weblate.osgeo.org/projects/pgrouting/pgr_analyzeoneway/)

* [pgRouting/bdDijkstra-family](https://weblate.osgeo.org/projects/pgrouting/bddijkstra-family/)

* [pgRouting/pgr_aStarCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_astarcostmatrix/)

* [pgRouting/sampledata](https://weblate.osgeo.org/projects/pgrouting/sampledata/)

* [pgRouting/pgr_bdAstar](https://weblate.osgeo.org/projects/pgrouting/pgr_bdastar/)

* [pgRouting/pgr_kruskalDD](https://weblate.osgeo.org/projects/pgrouting/pgr_kruskaldd/)

* [pgRouting/pgr_transitiveClosure](https://weblate.osgeo.org/projects/pgrouting/pgr_transitiveclosure/)

* [pgRouting/pgr_connectedComponents](https://weblate.osgeo.org/projects/pgrouting/pgr_connectedcomponents/)

* [pgRouting/pgRouting-concepts](https://weblate.osgeo.org/projects/pgrouting/pgrouting-concepts/)

* [pgRouting/pgr_withPointsCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointscostmatrix/)

* [pgRouting/TSP-family](https://weblate.osgeo.org/projects/pgrouting/tsp-family/)

* [pgRouting/pgr_dijkstraCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstracostmatrix/)

* [pgRouting/pgr_dijkstraCost](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstracost/)

* [pgRouting/pgr_articulationPoints](https://weblate.osgeo.org/projects/pgrouting/pgr_articulationpoints/)

* [pgRouting/pgr_floydWarshall](https://weblate.osgeo.org/projects/pgrouting/pgr_floydwarshall/)

* [pgRouting/pgr_withPointsDD](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointsdd/)

* [pgRouting/flow-family](https://weblate.osgeo.org/projects/pgrouting/flow-family/)

* [pgRouting/TRSP-family](https://weblate.osgeo.org/projects/pgrouting/trsp-family/)

* [pgRouting/pgr_trsp_withPoints](https://weblate.osgeo.org/projects/pgrouting/pgr_trsp_withpoints/)

* [pgRouting/pgr_trspVia](https://weblate.osgeo.org/projects/pgrouting/pgr_trspvia/)

* [pgRouting/pgr_withPointsVia](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointsvia/)

* [pgRouting/pgr_trspVia_withPoints](https://weblate.osgeo.org/projects/pgrouting/pgr_trspvia_withpoints/)

* [pgRouting/withPoints-category](https://weblate.osgeo.org/projects/pgrouting/withpoints-category/)

* [pgRouting/pgr_degree](https://weblate.osgeo.org/projects/pgrouting/pgr_degree/)

* [pgRouting/pgr_findCloseEdges](https://weblate.osgeo.org/projects/pgrouting/pgr_findcloseedges/)

* [pgRouting/pgr_maxFlow](https://weblate.osgeo.org/projects/pgrouting/pgr_maxflow/)

* [pgRouting/pgr_KSP](https://weblate.osgeo.org/projects/pgrouting/pgr_ksp/)

* [pgRouting/pgr_dijkstraNear](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstranear/)

* [pgRouting/experimental](https://weblate.osgeo.org/projects/pgrouting/experimental/)

* [pgRouting/pgr_TSP](https://weblate.osgeo.org/projects/pgrouting/pgr_tsp/)

* [pgRouting/drivingDistance-category](https://weblate.osgeo.org/projects/pgrouting/drivingdistance-category/)

* [pgRouting/pgr_primBFS](https://weblate.osgeo.org/projects/pgrouting/pgr_primbfs/)

* [pgRouting/pgr_lineGraphFull](https://weblate.osgeo.org/projects/pgrouting/pgr_linegraphfull/)

* [pgRouting/pgr_alphaShape](https://weblate.osgeo.org/projects/pgrouting/pgr_alphashape/)

* [pgRouting/pgr_kruskal](https://weblate.osgeo.org/projects/pgrouting/pgr_kruskal/)

* [pgRouting/pgr_bdAstarCost](https://weblate.osgeo.org/projects/pgrouting/pgr_bdastarcost/)

* [pgRouting/pgr_contraction](https://weblate.osgeo.org/projects/pgrouting/pgr_contraction/)

* [pgRouting/pgr_binaryBreadthFirstSearch](https://weblate.osgeo.org/projects/pgrouting/pgr_binarybreadthfirstsearch/)

* [pgRouting/pgr_pushRelabel](https://weblate.osgeo.org/projects/pgrouting/pgr_pushrelabel/)

* [pgRouting/pgr_primDFS](https://weblate.osgeo.org/projects/pgrouting/pgr_primdfs/)

* [pgRouting/pgr_edmondsKarp](https://weblate.osgeo.org/projects/pgrouting/pgr_edmondskarp/)

* [pgRouting/pgr_dijkstra](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstra/)

* [pgRouting/pgr_bdDijkstra](https://weblate.osgeo.org/projects/pgrouting/pgr_bddijkstra/)

* [pgRouting/pgr_lengauerTarjanDominatorTree](https://weblate.osgeo.org/projects/pgrouting/pgr_lengauertarjandominatortree/)

* [pgRouting/pgr_bdAstarCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_bdastarcostmatrix/)

* [pgRouting/pgr_bdDijkstraCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_bddijkstracostmatrix/)

* [pgRouting/pgr_aStar](https://weblate.osgeo.org/projects/pgrouting/pgr_astar/)

* [pgRouting/pgr_edgeDisjointPaths](https://weblate.osgeo.org/projects/pgrouting/pgr_edgedisjointpaths/)

* [pgRouting/pgr_kruskalDFS](https://weblate.osgeo.org/projects/pgrouting/pgr_kruskaldfs/)

* [pgRouting/pgr_bdDijkstraCost](https://weblate.osgeo.org/projects/pgrouting/pgr_bddijkstracost/)

* [pgRouting/pgr_pickDeliverEuclidean](https://weblate.osgeo.org/projects/pgrouting/pgr_pickdelivereuclidean/)

* [pgRouting/pgr_maxFlowMinCost](https://weblate.osgeo.org/projects/pgrouting/pgr_maxflowmincost/)



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widgets/pgrouting/-/index/horizontal-auto.svg)