### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/locale/es/LC_MESSAGES/TRSP-family.po
+++ b/locale/es/LC_MESSAGES/TRSP-family.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-25 12:55-0500\n"
-"PO-Revision-Date: 2022-07-04 00:20+0000\n"
+"PO-Revision-Date: 2022-07-06 23:33+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "trsp-family/es/>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.13\n"
+"X-Generator: Weblate 4.13.1\n"
 
 #: ../../build/doc/TRSP-family.rst:12
 msgid ""
@@ -210,6 +210,9 @@ msgid ""
 "in order to find out if the attempted path has a restriction. This allows "
 "the algorithm to pass twice on the same vertex."
 msgstr ""
+"Wl algoritmo interno TRSP realiza una búsqueda de avanzada sobre el "
+"algoritmo de Dijkstra para encontrar un camino que contenga una restricción. "
+"Esto permite que el algoritmo pase dos veces sobre el mismo vértice."
 
 #: ../../build/doc/TRSP-family.rst:81
 msgid "Parameters"
@@ -246,7 +249,7 @@ msgstr "`SQL de restricciones`_"
 
 #: ../../build/doc/TRSP-family.rst:98
 msgid "`Restrictions SQL`_ query as described."
-msgstr ""
+msgstr "`SQL restricciones`_ consulta como se describe."
 
 #: ../../build/doc/TRSP-family.rst:99
 msgid "**via vertices**"
@@ -284,6 +287,8 @@ msgid ""
 "On road networks, there are restrictions such as left or right turn "
 "restrictions, no U turn restrictions."
 msgstr ""
+"En redes de caminos, hay restricciones como vuelta a la izquierda o derecha, "
+"no vuelta en U."
 
 #: ../../build/doc/TRSP-family.rst:115
 msgid ""

--- a/locale/es/LC_MESSAGES/pgr_trspVia.po
+++ b/locale/es/LC_MESSAGES/pgr_trspVia.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-25 12:55-0500\n"
-"PO-Revision-Date: 2022-07-04 00:20+0000\n"
+"PO-Revision-Date: 2022-07-06 23:33+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_trspvia/es/>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.13\n"
+"X-Generator: Weblate 4.13.1\n"
 
 #: ../../build/doc/pgr_trspVia.rst:12
 msgid ""
@@ -178,7 +178,7 @@ msgstr "`SQL de restricciones`_"
 
 #: ../../build/doc/TRSP-family.rst:16
 msgid "`Restrictions SQL`_ query as described."
-msgstr ""
+msgstr "`SQL restricciones`_ consulta como se describe."
 
 #: ../../build/doc/TRSP-family.rst:17
 msgid "**via vertices**"


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [pgRouting/index](https://weblate.osgeo.org/projects/pgrouting/index/).


It also includes following components:

* [pgRouting/bdAstar-family](https://weblate.osgeo.org/projects/pgrouting/bdastar-family/)

* [pgRouting/pgr_TSPeuclidean](https://weblate.osgeo.org/projects/pgrouting/pgr_tspeuclidean/)

* [pgRouting/pgr_version](https://weblate.osgeo.org/projects/pgrouting/pgr_version/)

* [pgRouting/release_notes](https://weblate.osgeo.org/projects/pgrouting/release_notes/)

* [pgRouting/pgr_analyzeGraph](https://weblate.osgeo.org/projects/pgrouting/pgr_analyzegraph/)

* [pgRouting/pgr_full_version](https://weblate.osgeo.org/projects/pgrouting/pgr_full_version/)

* [pgRouting/migration](https://weblate.osgeo.org/projects/pgrouting/migration/)

* [pgRouting/contraction-family](https://weblate.osgeo.org/projects/pgrouting/contraction-family/)

* [pgRouting/support](https://weblate.osgeo.org/projects/pgrouting/support/)

* [pgRouting/pgr_depthFirstSearch](https://weblate.osgeo.org/projects/pgrouting/pgr_depthfirstsearch/)

* [pgRouting/spanningTree-family](https://weblate.osgeo.org/projects/pgrouting/spanningtree-family/)

* [pgRouting/pgr_pickDeliver](https://weblate.osgeo.org/projects/pgrouting/pgr_pickdeliver/)

* [pgRouting/pgr_boykovKolmogorov](https://weblate.osgeo.org/projects/pgrouting/pgr_boykovkolmogorov/)

* [pgRouting/pgr_extractVertices](https://weblate.osgeo.org/projects/pgrouting/pgr_extractvertices/)

* [pgRouting/reference](https://weblate.osgeo.org/projects/pgrouting/reference/)

* [pgRouting/pgr_createVerticesTable](https://weblate.osgeo.org/projects/pgrouting/pgr_createverticestable/)

* [pgRouting/pgr_vrpOneDepot](https://weblate.osgeo.org/projects/pgrouting/pgr_vrponedepot/)

* [pgRouting/cost-category](https://weblate.osgeo.org/projects/pgrouting/cost-category/)

* [pgRouting/topology-functions](https://weblate.osgeo.org/projects/pgrouting/topology-functions/)

* [pgRouting/pgr_edwardMoore](https://weblate.osgeo.org/projects/pgrouting/pgr_edwardmoore/)

* [pgRouting/proposed](https://weblate.osgeo.org/projects/pgrouting/proposed/)

* [pgRouting/KSP-category](https://weblate.osgeo.org/projects/pgrouting/ksp-category/)

* [pgRouting/pgr_trsp](https://weblate.osgeo.org/projects/pgrouting/pgr_trsp/)

* [pgRouting/pgRouting-installation](https://weblate.osgeo.org/projects/pgrouting/pgrouting-installation/)

* [pgRouting/pgr_bellmanFord](https://weblate.osgeo.org/projects/pgrouting/pgr_bellmanford/)

* [pgRouting/transformation-family](https://weblate.osgeo.org/projects/pgrouting/transformation-family/)

* [pgRouting/traversal-family](https://weblate.osgeo.org/projects/pgrouting/traversal-family/)

* [pgRouting/pgr_kruskalBFS](https://weblate.osgeo.org/projects/pgrouting/pgr_kruskalbfs/)

* [pgRouting/components-family](https://weblate.osgeo.org/projects/pgrouting/components-family/)

* [pgRouting/pgr_chinesePostmanCost](https://weblate.osgeo.org/projects/pgrouting/pgr_chinesepostmancost/)

* [pgRouting/pgr_aStarCost](https://weblate.osgeo.org/projects/pgrouting/pgr_astarcost/)

* [pgRouting/pgr_strongComponents](https://weblate.osgeo.org/projects/pgrouting/pgr_strongcomponents/)

* [pgRouting/coloring-family](https://weblate.osgeo.org/projects/pgrouting/coloring-family/)

* [pgRouting/pgr_drivingDistance](https://weblate.osgeo.org/projects/pgrouting/pgr_drivingdistance/)

* [pgRouting/pgr_sequentialVertexColoring](https://weblate.osgeo.org/projects/pgrouting/pgr_sequentialvertexcoloring/)

* [pgRouting/pgr_createTopology](https://weblate.osgeo.org/projects/pgrouting/pgr_createtopology/)

* [pgRouting/pgr_nodeNetwork](https://weblate.osgeo.org/projects/pgrouting/pgr_nodenetwork/)

* [pgRouting/pgRouting-concepts](https://weblate.osgeo.org/projects/pgrouting/pgrouting-concepts/)

* [pgRouting/pgRouting-introduction](https://weblate.osgeo.org/projects/pgrouting/pgrouting-introduction/)

* [pgRouting/pgr_turnRestrictedPath](https://weblate.osgeo.org/projects/pgrouting/pgr_turnrestrictedpath/)

* [pgRouting/aStar-family](https://weblate.osgeo.org/projects/pgrouting/astar-family/)

* [pgRouting/pgr_breadthFirstSearch](https://weblate.osgeo.org/projects/pgrouting/pgr_breadthfirstsearch/)

* [pgRouting/VRP-category](https://weblate.osgeo.org/projects/pgrouting/vrp-category/)

* [pgRouting/pgr_johnson](https://weblate.osgeo.org/projects/pgrouting/pgr_johnson/)

* [pgRouting/routingFunctions](https://weblate.osgeo.org/projects/pgrouting/routingfunctions/)

* [pgRouting/pgr_maxFlowMinCost_Cost](https://weblate.osgeo.org/projects/pgrouting/pgr_maxflowmincost_cost/)

* [pgRouting/pgr_dijkstraNearCost](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstranearcost/)

* [pgRouting/allpairs-family](https://weblate.osgeo.org/projects/pgrouting/allpairs-family/)

* [pgRouting/pgr_dagShortestPath](https://weblate.osgeo.org/projects/pgrouting/pgr_dagshortestpath/)

* [pgRouting/DFS-category](https://weblate.osgeo.org/projects/pgrouting/dfs-category/)

* [pgRouting/pgr_maxCardinalityMatch](https://weblate.osgeo.org/projects/pgrouting/pgr_maxcardinalitymatch/)

* [pgRouting/pgr_makeConnected](https://weblate.osgeo.org/projects/pgrouting/pgr_makeconnected/)

* [pgRouting/pgr_topologicalSort](https://weblate.osgeo.org/projects/pgrouting/pgr_topologicalsort/)

* [pgRouting/pgr_edgeColoring](https://weblate.osgeo.org/projects/pgrouting/pgr_edgecoloring/)

* [pgRouting/pgr_primDD](https://weblate.osgeo.org/projects/pgrouting/pgr_primdd/)

* [pgRouting/pgr_biconnectedComponents](https://weblate.osgeo.org/projects/pgrouting/pgr_biconnectedcomponents/)

* [pgRouting/BFS-category](https://weblate.osgeo.org/projects/pgrouting/bfs-category/)

* [pgRouting/pgr_lineGraph](https://weblate.osgeo.org/projects/pgrouting/pgr_linegraph/)

* [pgRouting/withPoints-family](https://weblate.osgeo.org/projects/pgrouting/withpoints-family/)

* [pgRouting/kruskal-family](https://weblate.osgeo.org/projects/pgrouting/kruskal-family/)

* [pgRouting/pgr_prim](https://weblate.osgeo.org/projects/pgrouting/pgr_prim/)

* [pgRouting/costMatrix-category](https://weblate.osgeo.org/projects/pgrouting/costmatrix-category/)

* [pgRouting/pgr_withPointsCost](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointscost/)

* [pgRouting/pgr_bipartite](https://weblate.osgeo.org/projects/pgrouting/pgr_bipartite/)

* [pgRouting/pgr_dijkstraCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstracostmatrix/)

* [pgRouting/pgr_withPoints](https://weblate.osgeo.org/projects/pgrouting/pgr_withpoints/)

* [pgRouting/pgr_bridges](https://weblate.osgeo.org/projects/pgrouting/pgr_bridges/)

* [pgRouting/pgr_isPlanar](https://weblate.osgeo.org/projects/pgrouting/pgr_isplanar/)

* [pgRouting/pgr_chinesePostman](https://weblate.osgeo.org/projects/pgrouting/pgr_chinesepostman/)

* [pgRouting/pgr_dijkstraVia](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstravia/)

* [pgRouting/chinesePostmanProblem-family](https://weblate.osgeo.org/projects/pgrouting/chinesepostmanproblem-family/)

* [pgRouting/via-category](https://weblate.osgeo.org/projects/pgrouting/via-category/)

* [pgRouting/prim-family](https://weblate.osgeo.org/projects/pgrouting/prim-family/)

* [pgRouting/pgr_stoerWagner](https://weblate.osgeo.org/projects/pgrouting/pgr_stoerwagner/)

* [pgRouting/pgr_trspVia_withPoints](https://weblate.osgeo.org/projects/pgrouting/pgr_trspvia_withpoints/)

* [pgRouting/dijkstra-family](https://weblate.osgeo.org/projects/pgrouting/dijkstra-family/)

* [pgRouting/pgr_withPointsKSP](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointsksp/)

* [pgRouting/pgr_analyzeOneWay](https://weblate.osgeo.org/projects/pgrouting/pgr_analyzeoneway/)

* [pgRouting/bdDijkstra-family](https://weblate.osgeo.org/projects/pgrouting/bddijkstra-family/)

* [pgRouting/pgr_aStarCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_astarcostmatrix/)

* [pgRouting/sampledata](https://weblate.osgeo.org/projects/pgrouting/sampledata/)

* [pgRouting/pgr_bdAstar](https://weblate.osgeo.org/projects/pgrouting/pgr_bdastar/)

* [pgRouting/pgr_kruskalDD](https://weblate.osgeo.org/projects/pgrouting/pgr_kruskaldd/)

* [pgRouting/pgr_transitiveClosure](https://weblate.osgeo.org/projects/pgrouting/pgr_transitiveclosure/)

* [pgRouting/pgr_connectedComponents](https://weblate.osgeo.org/projects/pgrouting/pgr_connectedcomponents/)

* [pgRouting/pgr_withPointsCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointscostmatrix/)

* [pgRouting/TSP-family](https://weblate.osgeo.org/projects/pgrouting/tsp-family/)

* [pgRouting/pgr_dijkstraCost](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstracost/)

* [pgRouting/pgr_articulationPoints](https://weblate.osgeo.org/projects/pgrouting/pgr_articulationpoints/)

* [pgRouting/pgr_floydWarshall](https://weblate.osgeo.org/projects/pgrouting/pgr_floydwarshall/)

* [pgRouting/pgr_withPointsDD](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointsdd/)

* [pgRouting/flow-family](https://weblate.osgeo.org/projects/pgrouting/flow-family/)

* [pgRouting/TRSP-family](https://weblate.osgeo.org/projects/pgrouting/trsp-family/)

* [pgRouting/pgr_trsp_withPoints](https://weblate.osgeo.org/projects/pgrouting/pgr_trsp_withpoints/)

* [pgRouting/pgr_trspVia](https://weblate.osgeo.org/projects/pgrouting/pgr_trspvia/)

* [pgRouting/pgr_withPointsVia](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointsvia/)

* [pgRouting/withPoints-category](https://weblate.osgeo.org/projects/pgrouting/withpoints-category/)

* [pgRouting/pgr_degree](https://weblate.osgeo.org/projects/pgrouting/pgr_degree/)

* [pgRouting/pgr_findCloseEdges](https://weblate.osgeo.org/projects/pgrouting/pgr_findcloseedges/)

* [pgRouting/pgr_maxFlow](https://weblate.osgeo.org/projects/pgrouting/pgr_maxflow/)

* [pgRouting/pgr_KSP](https://weblate.osgeo.org/projects/pgrouting/pgr_ksp/)

* [pgRouting/pgr_dijkstraNear](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstranear/)

* [pgRouting/experimental](https://weblate.osgeo.org/projects/pgrouting/experimental/)

* [pgRouting/pgr_TSP](https://weblate.osgeo.org/projects/pgrouting/pgr_tsp/)

* [pgRouting/drivingDistance-category](https://weblate.osgeo.org/projects/pgrouting/drivingdistance-category/)

* [pgRouting/pgr_primBFS](https://weblate.osgeo.org/projects/pgrouting/pgr_primbfs/)

* [pgRouting/pgr_lineGraphFull](https://weblate.osgeo.org/projects/pgrouting/pgr_linegraphfull/)

* [pgRouting/pgr_alphaShape](https://weblate.osgeo.org/projects/pgrouting/pgr_alphashape/)

* [pgRouting/pgr_kruskal](https://weblate.osgeo.org/projects/pgrouting/pgr_kruskal/)

* [pgRouting/pgr_bdAstarCost](https://weblate.osgeo.org/projects/pgrouting/pgr_bdastarcost/)

* [pgRouting/pgr_contraction](https://weblate.osgeo.org/projects/pgrouting/pgr_contraction/)

* [pgRouting/pgr_binaryBreadthFirstSearch](https://weblate.osgeo.org/projects/pgrouting/pgr_binarybreadthfirstsearch/)

* [pgRouting/pgr_pushRelabel](https://weblate.osgeo.org/projects/pgrouting/pgr_pushrelabel/)

* [pgRouting/pgr_primDFS](https://weblate.osgeo.org/projects/pgrouting/pgr_primdfs/)

* [pgRouting/pgr_edmondsKarp](https://weblate.osgeo.org/projects/pgrouting/pgr_edmondskarp/)

* [pgRouting/pgr_dijkstra](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstra/)

* [pgRouting/pgr_bdDijkstra](https://weblate.osgeo.org/projects/pgrouting/pgr_bddijkstra/)

* [pgRouting/pgr_lengauerTarjanDominatorTree](https://weblate.osgeo.org/projects/pgrouting/pgr_lengauertarjandominatortree/)

* [pgRouting/pgr_bdAstarCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_bdastarcostmatrix/)

* [pgRouting/pgr_bdDijkstraCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_bddijkstracostmatrix/)

* [pgRouting/pgr_aStar](https://weblate.osgeo.org/projects/pgrouting/pgr_astar/)

* [pgRouting/pgr_edgeDisjointPaths](https://weblate.osgeo.org/projects/pgrouting/pgr_edgedisjointpaths/)

* [pgRouting/pgr_kruskalDFS](https://weblate.osgeo.org/projects/pgrouting/pgr_kruskaldfs/)

* [pgRouting/pgr_bdDijkstraCost](https://weblate.osgeo.org/projects/pgrouting/pgr_bddijkstracost/)

* [pgRouting/pgr_pickDeliverEuclidean](https://weblate.osgeo.org/projects/pgrouting/pgr_pickdelivereuclidean/)

* [pgRouting/pgr_maxFlowMinCost](https://weblate.osgeo.org/projects/pgrouting/pgr_maxflowmincost/)



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widgets/pgrouting/-/index/horizontal-auto.svg)