### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/locale/es/LC_MESSAGES/migration.po
+++ b/locale/es/LC_MESSAGES/migration.po
@@ -10,20 +10,19 @@ msgstr ""
 "POT-Creation-Date: 2022-07-07 10:07-0500\n"
 "PO-Revision-Date: 2022-07-03 18:57+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
+"Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
+"migration/es/>\n"
 "Language: es\n"
-"Language-Team: Spanish "
-"<https://weblate.osgeo.org/projects/pgrouting/migration/es/>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: ../../build/doc/migration.rst:12
 msgid ""
-"**Supported versions:** `Latest "
-"<https://docs.pgrouting.org/latest/en/pgr_trsp.html>`__ (`3.4 "
-"<https://docs.pgrouting.org/3.4/en/pgr_trsp.html>`__)"
+"**Supported versions:** `Latest <https://docs.pgrouting.org/latest/en/"
+"pgr_trsp.html>`__ (`3.4 <https://docs.pgrouting.org/3.4/en/pgr_trsp.html>`__)"
 msgstr ""
 
 #: ../../build/doc/migration.rst:17
@@ -46,15 +45,15 @@ msgstr ""
 
 #: ../../build/doc/migration.rst:26
 msgid ""
-":doc:`pgr_maxCardinalityMatch` works only for undirected graphs, "
-"therefore the ``directed`` flag has been removed."
+":doc:`pgr_maxCardinalityMatch` works only for undirected graphs, therefore "
+"the ``directed`` flag has been removed."
 msgstr ""
 
 #: ../../build/doc/migration.rst:29
 msgid ""
-":doc:`pgr_trsp` signatures have changed and many issues have been fixed "
-"in the new signatures. This section will show how to migrate from the old"
-" signatures to the new replacement functions. This also affects the "
+":doc:`pgr_trsp` signatures have changed and many issues have been fixed in "
+"the new signatures. This section will show how to migrate from the old "
+"signatures to the new replacement functions. This also affects the "
 "restrictions."
 msgstr ""
 
@@ -104,14 +103,14 @@ msgstr ""
 msgid "The optional flag ``directed`` is removed."
 msgstr ""
 
-#: ../../build/doc/migration.rst
+#: ../../build/doc/migration.rst:0
 msgid "Before migration"
 msgstr ""
 
 #: ../../build/doc/migration.rst:64
 msgid ""
-"Columns used are ``going`` and ``coming`` to represent the existence of "
-"an edge."
+"Columns used are ``going`` and ``coming`` to represent the existence of an "
+"edge."
 msgstr ""
 
 #: ../../build/doc/migration.rst:66
@@ -130,14 +129,14 @@ msgid ""
 "**undirected**."
 msgstr ""
 
-#: ../../build/doc/migration.rst ../../build/doc/migration.rst:169
+#: ../../build/doc/migration.rst:0 ../../build/doc/migration.rst:169
 msgid "Migration"
 msgstr ""
 
 #: ../../build/doc/migration.rst:76
 msgid ""
-"Use the columns ``cost`` and ``reverse_cost`` to represent the existence "
-"of an edge."
+"Use the columns ``cost`` and ``reverse_cost`` to represent the existence of "
+"an edge."
 msgstr ""
 
 #: ../../build/doc/migration.rst:78
@@ -292,8 +291,8 @@ msgstr "Datos de restricciones"
 
 #: ../../build/doc/migration.rst:163
 msgid ""
-"The restriction with ``rid = 2`` represents the path :math:`3 "
-"\\rightarrow5 \\rightarrow9`."
+"The restriction with ``rid = 2`` represents the path :math:`3 \\rightarrow5 "
+"\\rightarrow9`."
 msgstr ""
 
 #: ../../build/doc/migration.rst:166
@@ -301,7 +300,8 @@ msgid "By inspection the path is clear."
 msgstr ""
 
 #: ../../build/doc/migration.rst:171
-msgid "To transform the old restrictions table to the new restrictions structure,"
+msgid ""
+"To transform the old restrictions table to the new restrictions structure,"
 msgstr ""
 
 #: ../../build/doc/migration.rst:173
@@ -314,8 +314,8 @@ msgstr ""
 
 #: ../../build/doc/migration.rst:177
 msgid ""
-"For this migration pgRouting supplies an auxiliary function for reversal "
-"of an array ``_pgr_array_reverse`` needed for the migration."
+"For this migration pgRouting supplies an auxiliary function for reversal of "
+"an array ``_pgr_array_reverse`` needed for the migration."
 msgstr ""
 
 #: ../../build/doc/migration.rst:180
@@ -369,8 +369,8 @@ msgstr ""
 #: ../../build/doc/migration.rst:217 ../../build/doc/migration.rst:346
 #: ../../build/doc/migration.rst:482 ../../build/doc/migration.rst:613
 msgid ""
-"User must be careful to match the existence of the column with the value "
-"of ``has_rcost`` parameter."
+"User must be careful to match the existence of the column with the value of "
+"``has_rcost`` parameter."
 msgstr ""
 
 #: ../../build/doc/migration.rst:220 ../../build/doc/migration.rst:349
@@ -485,8 +485,8 @@ msgstr ""
 #: ../../build/doc/migration.rst:263 ../../build/doc/migration.rst:315
 #: ../../build/doc/migration.rst:527 ../../build/doc/migration.rst:581
 msgid ""
-"When the need of using strictly the same (meaningless) names and types of"
-" the function been migrated then:"
+"When the need of using strictly the same (meaningless) names and types of "
+"the function been migrated then:"
 msgstr ""
 
 #: ../../build/doc/migration.rst:270 ../../build/doc/migration.rst:322
@@ -586,8 +586,8 @@ msgstr ""
 #: ../../build/doc/migration.rst:397 ../../build/doc/migration.rst:451
 #: ../../build/doc/migration.rst:666 ../../build/doc/migration.rst:720
 msgid ""
-"When the need of using strictly the same (meaningless) names and types, "
-"and node values of the function been migrated then:"
+"When the need of using strictly the same (meaningless) names and types, and "
+"node values of the function been migrated then:"
 msgstr ""
 
 #: ../../build/doc/migration.rst:409
@@ -663,8 +663,8 @@ msgstr ""
 
 #: ../../build/doc/migration.rst:624
 msgid ""
-"And will travel thru the following Via points "
-":math:`4\\rightarrow3\\rightarrow6`"
+"And will travel thru the following Via points :math:"
+"`4\\rightarrow3\\rightarrow6`"
 msgstr ""
 
 #: ../../build/doc/migration.rst:628
@@ -722,4 +722,3 @@ msgstr ":ref:`genindex`"
 #: ../../build/doc/migration.rst:740
 msgid ":ref:`search`"
 msgstr ":ref:`search`"
-

--- a/locale/zh_Hans/LC_MESSAGES/migration.po
+++ b/locale/zh_Hans/LC_MESSAGES/migration.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-25 12:55-0500\n"
+"POT-Creation-Date: 2022-07-07 10:07-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -28,152 +28,249 @@ msgstr ""
 
 #: ../../build/doc/migration.rst:19
 msgid ""
-"``pgr_trsp`` signatures have changed and many issues have been fixed in the "
-"new signatures. This section will show how to migrate from the old "
-"signatures to the new replacement functions."
+"Several functions are having changes on the signatures, and/or have been "
+"replaced by new functions."
 msgstr ""
 
-#: ../../build/doc/migration.rst:23
+#: ../../build/doc/migration.rst:22
+msgid "Results can be different because of the changes."
+msgstr ""
+
+#: ../../build/doc/migration.rst:24
+msgid "Migrating functions:"
+msgstr ""
+
+#: ../../build/doc/migration.rst:26
 msgid ""
-"Results might be different as the deprecated function's code is different "
-"from the replacement function."
-msgstr ""
-
-#: ../../build/doc/migration.rst:27
-msgid "All deprecated functions will be removed on next mayor version 4.0.0"
+":doc:`pgr_maxCardinalityMatch` works only for undirected graphs, therefore "
+"the ``directed`` flag has been removed."
 msgstr ""
 
 #: ../../build/doc/migration.rst:29
-msgid "Contents"
-msgstr ""
-
-#: ../../build/doc/migration.rst:32
-msgid "Migration of restrictions"
+msgid ""
+":doc:`pgr_trsp` signatures have changed and many issues have been fixed in "
+"the new signatures. This section will show how to migrate from the old "
+"signatures to the new replacement functions. This also affects the "
+"restrictions."
 msgstr ""
 
 #: ../../build/doc/migration.rst:34
-msgid "The structure of the restrictions have changed:"
+msgid "All deprecated functions will be removed on next mayor version 4.0.0"
 msgstr ""
 
-#: ../../build/doc/migration.rst:37
-msgid "Old restrictions structure"
+#: ../../build/doc/migration.rst:36
+msgid "Contents"
 msgstr ""
 
 #: ../../build/doc/migration.rst:39
-msgid "On the deprecated signatures:"
+msgid "Migration of ``pgr_maxCardinalityMatch``"
 msgstr ""
 
-#: ../../build/doc/migration.rst:41
-msgid "Column ``rid`` is ignored"
-msgstr ""
-
-#: ../../build/doc/migration.rst:42
-msgid "``via_path``"
-msgstr ""
-
-#: ../../build/doc/migration.rst:44
-msgid "Must be in reverse order."
-msgstr ""
-
-#: ../../build/doc/migration.rst:45
-msgid "Is of type ``TEXT``."
-msgstr ""
-
-#: ../../build/doc/migration.rst:46
-msgid "When more than one via edge must be separated with ``,``."
+#: ../../build/doc/migration.rst:41 ../../build/doc/migration.rst:200
+#: ../../build/doc/migration.rst:328 ../../build/doc/migration.rst:464
+#: ../../build/doc/migration.rst:595
+msgid "Signature to be migrated:"
 msgstr ""
 
 #: ../../build/doc/migration.rst:48
-msgid "``target_id``"
+msgid "Migration is needed, because:"
 msgstr ""
 
 #: ../../build/doc/migration.rst:50
-msgid "Is the last edge of the forbidden path."
+msgid "Use ``cost`` and ``reverse_cost`` on the inner query"
 msgstr ""
 
 #: ../../build/doc/migration.rst:51
-msgid "Is of type ``INTEGER``."
+msgid "Results are ordered"
+msgstr ""
+
+#: ../../build/doc/migration.rst:52
+msgid "Works for undirected graphs."
 msgstr ""
 
 #: ../../build/doc/migration.rst:53
-msgid "``to_cost``"
+msgid "New signature"
 msgstr ""
 
 #: ../../build/doc/migration.rst:55
-msgid "Is of type ``FLOAT``."
+msgid "``pgr_maxCardinalityMatch(text)`` returns only ``edge`` column."
 msgstr ""
 
-#: ../../build/doc/migration.rst:57
-msgid "Creation of the old restrictions table"
+#: ../../build/doc/migration.rst:56
+msgid "The optional flag ``directed`` is removed."
 msgstr ""
 
-#: ../../build/doc/migration.rst:63
-msgid "Old restrictions fillup"
+#: ../../build/doc/migration.rst:0
+msgid "Before migration"
 msgstr ""
 
-#: ../../build/doc/migration.rst:70
-msgid "Old restrictions contents"
+#: ../../build/doc/migration.rst:64
+msgid ""
+"Columns used are ``going`` and ``coming`` to represent the existence of an "
+"edge."
+msgstr ""
+
+#: ../../build/doc/migration.rst:66
+msgid ""
+"Flag ``directed`` was used to indicate if it was for a **directed** or "
+"**undirected** graph."
+msgstr ""
+
+#: ../../build/doc/migration.rst:69
+msgid "The flag ``directed`` is ignored."
+msgstr ""
+
+#: ../../build/doc/migration.rst:71
+msgid ""
+"Regardless of it's value it gives the result considering the graph as "
+"**undirected**."
+msgstr ""
+
+#: ../../build/doc/migration.rst:0 ../../build/doc/migration.rst:169
+msgid "Migration"
 msgstr ""
 
 #: ../../build/doc/migration.rst:76
+msgid ""
+"Use the columns ``cost`` and ``reverse_cost`` to represent the existence of "
+"an edge."
+msgstr ""
+
+#: ../../build/doc/migration.rst:78
+msgid "Do not use the flag ``directed``."
+msgstr ""
+
+#: ../../build/doc/migration.rst:79
+msgid "In the query returns only ``edge`` column."
+msgstr ""
+
+#: ../../build/doc/migration.rst:86
+msgid "Migration of restrictions"
+msgstr ""
+
+#: ../../build/doc/migration.rst:88
+msgid "The structure of the restrictions have changed:"
+msgstr ""
+
+#: ../../build/doc/migration.rst:91
+msgid "Old restrictions structure"
+msgstr ""
+
+#: ../../build/doc/migration.rst:93
+msgid "On the deprecated signatures:"
+msgstr ""
+
+#: ../../build/doc/migration.rst:95
+msgid "Column ``rid`` is ignored"
+msgstr ""
+
+#: ../../build/doc/migration.rst:96
+msgid "``via_path``"
+msgstr ""
+
+#: ../../build/doc/migration.rst:98
+msgid "Must be in reverse order."
+msgstr ""
+
+#: ../../build/doc/migration.rst:99
+msgid "Is of type ``TEXT``."
+msgstr ""
+
+#: ../../build/doc/migration.rst:100
+msgid "When more than one via edge must be separated with ``,``."
+msgstr ""
+
+#: ../../build/doc/migration.rst:102
+msgid "``target_id``"
+msgstr ""
+
+#: ../../build/doc/migration.rst:104
+msgid "Is the last edge of the forbidden path."
+msgstr ""
+
+#: ../../build/doc/migration.rst:105
+msgid "Is of type ``INTEGER``."
+msgstr ""
+
+#: ../../build/doc/migration.rst:107
+msgid "``to_cost``"
+msgstr ""
+
+#: ../../build/doc/migration.rst:109
+msgid "Is of type ``FLOAT``."
+msgstr ""
+
+#: ../../build/doc/migration.rst:111
+msgid "Creation of the old restrictions table"
+msgstr ""
+
+#: ../../build/doc/migration.rst:117
+msgid "Old restrictions fill up"
+msgstr ""
+
+#: ../../build/doc/migration.rst:124
+msgid "Old restrictions contents"
+msgstr ""
+
+#: ../../build/doc/migration.rst:130
 msgid ""
 "The restriction with ``rid = 2`` is representing :math:`3 \\rightarrow 5 "
 "\\rightarrow9`"
 msgstr ""
 
-#: ../../build/doc/migration.rst:79
+#: ../../build/doc/migration.rst:133
 msgid ":math:`3\\rightarrow5`"
 msgstr ""
 
-#: ../../build/doc/migration.rst:81
+#: ../../build/doc/migration.rst:135
 msgid "is on column ``via_path`` in reverse order"
 msgstr ""
 
-#: ../../build/doc/migration.rst:82
+#: ../../build/doc/migration.rst:136
 msgid "is of type ``TEXT``"
 msgstr ""
 
-#: ../../build/doc/migration.rst:84
+#: ../../build/doc/migration.rst:138
 msgid ":math:`9`"
 msgstr ""
 
-#: ../../build/doc/migration.rst:86
+#: ../../build/doc/migration.rst:140
 msgid "is on column ``target_id``"
 msgstr ""
 
-#: ../../build/doc/migration.rst:87
+#: ../../build/doc/migration.rst:141
 msgid "is of type ``INTEGER``"
 msgstr ""
 
-#: ../../build/doc/migration.rst:91
+#: ../../build/doc/migration.rst:145
 msgid "New restrictions structure"
 msgstr ""
 
-#: ../../build/doc/migration.rst:93
+#: ../../build/doc/migration.rst:147
 msgid "Column ``id`` is ignored"
 msgstr ""
 
-#: ../../build/doc/migration.rst:94
+#: ../../build/doc/migration.rst:148
 msgid "Column ``path``"
 msgstr ""
 
-#: ../../build/doc/migration.rst:96
+#: ../../build/doc/migration.rst:150
 msgid "Is of type ``ARRAY[ANY-INTEGER]``."
 msgstr ""
 
-#: ../../build/doc/migration.rst:97
+#: ../../build/doc/migration.rst:151
 msgid "Contains all the edges involved on the restriction."
 msgstr ""
 
-#: ../../build/doc/migration.rst:98
+#: ../../build/doc/migration.rst:152
 msgid "The array has the ordered edges of the restriction."
 msgstr ""
 
-#: ../../build/doc/migration.rst:100
+#: ../../build/doc/migration.rst:154
 msgid "Column ``cost``"
 msgstr ""
 
-#: ../../build/doc/migration.rst:102
+#: ../../build/doc/migration.rst:156
 msgid "Is of type ``ANY-NUMERICAL``"
 msgstr ""
 
@@ -189,445 +286,436 @@ msgstr ""
 msgid "Restrictions data"
 msgstr ""
 
-#: ../../build/doc/migration.rst:109
+#: ../../build/doc/migration.rst:163
 msgid ""
 "The restriction with ``rid = 2`` represents the path :math:`3 \\rightarrow5 "
 "\\rightarrow9`."
 msgstr ""
 
-#: ../../build/doc/migration.rst:112
+#: ../../build/doc/migration.rst:166
 msgid "By inspection the path is clear."
 msgstr ""
 
-#: ../../build/doc/migration.rst:115
-msgid "Migration"
-msgstr ""
-
-#: ../../build/doc/migration.rst:117
+#: ../../build/doc/migration.rst:171
 msgid ""
 "To transform the old restrictions table to the new restrictions structure,"
 msgstr ""
 
-#: ../../build/doc/migration.rst:119
+#: ../../build/doc/migration.rst:173
 msgid "Create a new table with the new restrictions structure."
 msgstr ""
 
-#: ../../build/doc/migration.rst:121
+#: ../../build/doc/migration.rst:175
 msgid "In this migration guide ``new_restrictions`` is been used."
 msgstr ""
 
-#: ../../build/doc/migration.rst:123
+#: ../../build/doc/migration.rst:177
 msgid ""
-"For this migration pgRuoting supllies an auxilary function for reversal of "
+"For this migration pgRouting supplies an auxiliary function for reversal of "
 "an array ``_pgr_array_reverse`` needed for the migration."
 msgstr ""
 
-#: ../../build/doc/migration.rst:126
+#: ../../build/doc/migration.rst:180
 msgid "``_pgr_array_reverse``:"
 msgstr ""
 
-#: ../../build/doc/migration.rst:128
-msgid "Was created temporarly for this migration"
+#: ../../build/doc/migration.rst:182
+msgid "Was created temporally for this migration"
 msgstr ""
 
-#: ../../build/doc/migration.rst:129
+#: ../../build/doc/migration.rst:183
 msgid "Is not documented."
 msgstr ""
 
-#: ../../build/doc/migration.rst:130
+#: ../../build/doc/migration.rst:184
 msgid "Will be removed on the next mayor version 4.0.0"
 msgstr ""
 
-#: ../../build/doc/migration.rst:136
+#: ../../build/doc/migration.rst:190
 msgid "The migrated table contents:"
 msgstr ""
 
-#: ../../build/doc/migration.rst:144
+#: ../../build/doc/migration.rst:198
 msgid "Migration of ``pgr_trsp`` (Vertices)"
 msgstr ""
 
-#: ../../build/doc/migration.rst:146 ../../build/doc/migration.rst:274
-#: ../../build/doc/migration.rst:410 ../../build/doc/migration.rst:541
-msgid "Signature to be migrated:"
-msgstr ""
-
-#: ../../build/doc/migration.rst:155
+#: ../../build/doc/migration.rst:209
 msgid "The integral type of the ``Edges SQL`` can only be ``INTEGER``."
 msgstr ""
 
-#: ../../build/doc/migration.rst:156 ../../build/doc/migration.rst:421
-#: ../../build/doc/migration.rst:552
+#: ../../build/doc/migration.rst:210 ../../build/doc/migration.rst:475
+#: ../../build/doc/migration.rst:606
 msgid "The floating point type of the ``Edges SQL`` can only be ``FLOAT``."
 msgstr ""
 
-#: ../../build/doc/migration.rst:157 ../../build/doc/migration.rst:286
-#: ../../build/doc/migration.rst:422 ../../build/doc/migration.rst:553
+#: ../../build/doc/migration.rst:211 ../../build/doc/migration.rst:340
+#: ../../build/doc/migration.rst:476 ../../build/doc/migration.rst:607
 msgid "``directed`` flag is compulsory."
 msgstr ""
 
-#: ../../build/doc/migration.rst:159 ../../build/doc/migration.rst:288
-#: ../../build/doc/migration.rst:424 ../../build/doc/migration.rst:555
+#: ../../build/doc/migration.rst:213 ../../build/doc/migration.rst:342
+#: ../../build/doc/migration.rst:478 ../../build/doc/migration.rst:609
 msgid "Does not have a default value."
 msgstr ""
 
-#: ../../build/doc/migration.rst:161 ../../build/doc/migration.rst:290
-#: ../../build/doc/migration.rst:426 ../../build/doc/migration.rst:557
+#: ../../build/doc/migration.rst:215 ../../build/doc/migration.rst:344
+#: ../../build/doc/migration.rst:480 ../../build/doc/migration.rst:611
 msgid "Does not autodetect if ``reverse_cost`` column exist."
 msgstr ""
 
-#: ../../build/doc/migration.rst:163 ../../build/doc/migration.rst:292
-#: ../../build/doc/migration.rst:428 ../../build/doc/migration.rst:559
+#: ../../build/doc/migration.rst:217 ../../build/doc/migration.rst:346
+#: ../../build/doc/migration.rst:482 ../../build/doc/migration.rst:613
 msgid ""
-"User must be carefull to match the existance of the column with the value of "
+"User must be careful to match the existence of the column with the value of "
 "``has_rcost`` parameter."
 msgstr ""
 
-#: ../../build/doc/migration.rst:166 ../../build/doc/migration.rst:295
-#: ../../build/doc/migration.rst:431 ../../build/doc/migration.rst:562
+#: ../../build/doc/migration.rst:220 ../../build/doc/migration.rst:349
+#: ../../build/doc/migration.rst:485 ../../build/doc/migration.rst:616
 msgid "The restrictions inner query is optional."
 msgstr ""
 
-#: ../../build/doc/migration.rst:167
+#: ../../build/doc/migration.rst:221
 msgid "The output column names are meaningless"
 msgstr ""
 
-#: ../../build/doc/migration.rst:169 ../../build/doc/migration.rst:303
-#: ../../build/doc/migration.rst:434 ../../build/doc/migration.rst:572
+#: ../../build/doc/migration.rst:223 ../../build/doc/migration.rst:357
+#: ../../build/doc/migration.rst:488 ../../build/doc/migration.rst:626
 msgid "Migrate by using:"
 msgstr ""
 
-#: ../../build/doc/migration.rst:171
+#: ../../build/doc/migration.rst:225
 msgid ":doc:`pgr_dijkstra` when there are no restrictions,"
 msgstr ""
 
-#: ../../build/doc/migration.rst:172
+#: ../../build/doc/migration.rst:226
 msgid ":doc:`pgr_trsp` (One to One) when there are restrictions."
 msgstr ""
 
-#: ../../build/doc/migration.rst:176
+#: ../../build/doc/migration.rst:230
 msgid "Migrating ``pgr_trsp`` (Vertices) using ``pgr_dijkstra``"
 msgstr ""
 
-#: ../../build/doc/migration.rst:178 ../../build/doc/migration.rst:311
-#: ../../build/doc/migration.rst:442 ../../build/doc/migration.rst:580
+#: ../../build/doc/migration.rst:232 ../../build/doc/migration.rst:365
+#: ../../build/doc/migration.rst:496 ../../build/doc/migration.rst:634
 msgid "The following query does not have restrictions."
 msgstr ""
 
-#: ../../build/doc/migration.rst:184 ../../build/doc/migration.rst:229
-#: ../../build/doc/migration.rst:317 ../../build/doc/migration.rst:363
-#: ../../build/doc/migration.rst:448 ../../build/doc/migration.rst:494
-#: ../../build/doc/migration.rst:586 ../../build/doc/migration.rst:632
+#: ../../build/doc/migration.rst:238 ../../build/doc/migration.rst:283
+#: ../../build/doc/migration.rst:371 ../../build/doc/migration.rst:417
+#: ../../build/doc/migration.rst:502 ../../build/doc/migration.rst:548
+#: ../../build/doc/migration.rst:640 ../../build/doc/migration.rst:686
 msgid "A message about deprecation is shown"
 msgstr ""
 
-#: ../../build/doc/migration.rst:186 ../../build/doc/migration.rst:231
-#: ../../build/doc/migration.rst:319 ../../build/doc/migration.rst:365
-#: ../../build/doc/migration.rst:450 ../../build/doc/migration.rst:496
-#: ../../build/doc/migration.rst:588 ../../build/doc/migration.rst:634
+#: ../../build/doc/migration.rst:240 ../../build/doc/migration.rst:285
+#: ../../build/doc/migration.rst:373 ../../build/doc/migration.rst:419
+#: ../../build/doc/migration.rst:504 ../../build/doc/migration.rst:550
+#: ../../build/doc/migration.rst:642 ../../build/doc/migration.rst:688
 msgid "Deprecated functions will be removed on the next mayor version 4.0.0"
 msgstr ""
 
-#: ../../build/doc/migration.rst:188
+#: ../../build/doc/migration.rst:242
 msgid "Use :doc:`pgr_dijkstra` instead."
 msgstr ""
 
-#: ../../build/doc/migration.rst:195 ../../build/doc/migration.rst:247
-#: ../../build/doc/migration.rst:327 ../../build/doc/migration.rst:381
-#: ../../build/doc/migration.rst:458 ../../build/doc/migration.rst:512
-#: ../../build/doc/migration.rst:596 ../../build/doc/migration.rst:650
+#: ../../build/doc/migration.rst:249 ../../build/doc/migration.rst:301
+#: ../../build/doc/migration.rst:381 ../../build/doc/migration.rst:435
+#: ../../build/doc/migration.rst:512 ../../build/doc/migration.rst:566
+#: ../../build/doc/migration.rst:650 ../../build/doc/migration.rst:704
 msgid "The types casting has been removed."
 msgstr ""
 
-#: ../../build/doc/migration.rst:196
+#: ../../build/doc/migration.rst:250
 msgid ":doc:`pgr_dijkstra`:"
 msgstr ""
 
-#: ../../build/doc/migration.rst:198 ../../build/doc/migration.rst:250
-#: ../../build/doc/migration.rst:331 ../../build/doc/migration.rst:385
-#: ../../build/doc/migration.rst:461 ../../build/doc/migration.rst:515
-#: ../../build/doc/migration.rst:600 ../../build/doc/migration.rst:654
+#: ../../build/doc/migration.rst:252 ../../build/doc/migration.rst:304
+#: ../../build/doc/migration.rst:385 ../../build/doc/migration.rst:439
+#: ../../build/doc/migration.rst:515 ../../build/doc/migration.rst:569
+#: ../../build/doc/migration.rst:654 ../../build/doc/migration.rst:708
 msgid "Autodetects if ``reverse_cost`` column is in the edges SQL."
 msgstr ""
 
-#: ../../build/doc/migration.rst:200 ../../build/doc/migration.rst:252
-#: ../../build/doc/migration.rst:333 ../../build/doc/migration.rst:387
-#: ../../build/doc/migration.rst:463 ../../build/doc/migration.rst:517
-#: ../../build/doc/migration.rst:602 ../../build/doc/migration.rst:656
+#: ../../build/doc/migration.rst:254 ../../build/doc/migration.rst:306
+#: ../../build/doc/migration.rst:387 ../../build/doc/migration.rst:441
+#: ../../build/doc/migration.rst:517 ../../build/doc/migration.rst:571
+#: ../../build/doc/migration.rst:656 ../../build/doc/migration.rst:710
 msgid "Accepts ``ANY-INTEGER`` on integral types"
 msgstr ""
 
-#: ../../build/doc/migration.rst:201 ../../build/doc/migration.rst:253
-#: ../../build/doc/migration.rst:334 ../../build/doc/migration.rst:388
-#: ../../build/doc/migration.rst:464 ../../build/doc/migration.rst:518
-#: ../../build/doc/migration.rst:603 ../../build/doc/migration.rst:657
+#: ../../build/doc/migration.rst:255 ../../build/doc/migration.rst:307
+#: ../../build/doc/migration.rst:388 ../../build/doc/migration.rst:442
+#: ../../build/doc/migration.rst:518 ../../build/doc/migration.rst:572
+#: ../../build/doc/migration.rst:657 ../../build/doc/migration.rst:711
 msgid "Accepts ``ANY-NUMERICAL`` on floating point types"
 msgstr ""
 
-#: ../../build/doc/migration.rst:202 ../../build/doc/migration.rst:254
-#: ../../build/doc/migration.rst:335 ../../build/doc/migration.rst:389
-#: ../../build/doc/migration.rst:465 ../../build/doc/migration.rst:519
-#: ../../build/doc/migration.rst:604 ../../build/doc/migration.rst:658
+#: ../../build/doc/migration.rst:256 ../../build/doc/migration.rst:308
+#: ../../build/doc/migration.rst:389 ../../build/doc/migration.rst:443
+#: ../../build/doc/migration.rst:519 ../../build/doc/migration.rst:573
+#: ../../build/doc/migration.rst:658 ../../build/doc/migration.rst:712
 msgid "``directed`` flag has a default value of ``true``."
 msgstr ""
 
-#: ../../build/doc/migration.rst:204 ../../build/doc/migration.rst:256
-#: ../../build/doc/migration.rst:337 ../../build/doc/migration.rst:391
-#: ../../build/doc/migration.rst:467 ../../build/doc/migration.rst:521
-#: ../../build/doc/migration.rst:606 ../../build/doc/migration.rst:660
+#: ../../build/doc/migration.rst:258 ../../build/doc/migration.rst:310
+#: ../../build/doc/migration.rst:391 ../../build/doc/migration.rst:445
+#: ../../build/doc/migration.rst:521 ../../build/doc/migration.rst:575
+#: ../../build/doc/migration.rst:660 ../../build/doc/migration.rst:714
 msgid "Use the same value that on the original query."
 msgstr ""
 
-#: ../../build/doc/migration.rst:205 ../../build/doc/migration.rst:257
-#: ../../build/doc/migration.rst:338 ../../build/doc/migration.rst:392
-#: ../../build/doc/migration.rst:468 ../../build/doc/migration.rst:522
-#: ../../build/doc/migration.rst:607 ../../build/doc/migration.rst:661
+#: ../../build/doc/migration.rst:259 ../../build/doc/migration.rst:311
+#: ../../build/doc/migration.rst:392 ../../build/doc/migration.rst:446
+#: ../../build/doc/migration.rst:522 ../../build/doc/migration.rst:576
+#: ../../build/doc/migration.rst:661 ../../build/doc/migration.rst:715
 msgid "In this example it is ``true`` which is the default value."
 msgstr ""
 
-#: ../../build/doc/migration.rst:207 ../../build/doc/migration.rst:259
-#: ../../build/doc/migration.rst:340 ../../build/doc/migration.rst:394
-#: ../../build/doc/migration.rst:470 ../../build/doc/migration.rst:524
-#: ../../build/doc/migration.rst:609 ../../build/doc/migration.rst:663
+#: ../../build/doc/migration.rst:261 ../../build/doc/migration.rst:313
+#: ../../build/doc/migration.rst:394 ../../build/doc/migration.rst:448
+#: ../../build/doc/migration.rst:524 ../../build/doc/migration.rst:578
+#: ../../build/doc/migration.rst:663 ../../build/doc/migration.rst:717
 msgid "The flag has been omitted and the default is been used."
 msgstr ""
 
-#: ../../build/doc/migration.rst:209 ../../build/doc/migration.rst:261
-#: ../../build/doc/migration.rst:473 ../../build/doc/migration.rst:527
+#: ../../build/doc/migration.rst:263 ../../build/doc/migration.rst:315
+#: ../../build/doc/migration.rst:527 ../../build/doc/migration.rst:581
 msgid ""
 "When the need of using strictly the same (meaningless) names and types of "
 "the function been migrated then:"
 msgstr ""
 
-#: ../../build/doc/migration.rst:216 ../../build/doc/migration.rst:268
-#: ../../build/doc/migration.rst:350 ../../build/doc/migration.rst:404
+#: ../../build/doc/migration.rst:270 ../../build/doc/migration.rst:322
+#: ../../build/doc/migration.rst:404 ../../build/doc/migration.rst:458
 msgid "``id1`` is the node"
 msgstr ""
 
-#: ../../build/doc/migration.rst:217 ../../build/doc/migration.rst:269
-#: ../../build/doc/migration.rst:351 ../../build/doc/migration.rst:405
+#: ../../build/doc/migration.rst:271 ../../build/doc/migration.rst:323
+#: ../../build/doc/migration.rst:405 ../../build/doc/migration.rst:459
 msgid "``id2`` is the edge"
 msgstr ""
 
-#: ../../build/doc/migration.rst:221
+#: ../../build/doc/migration.rst:275
 msgid "Migrating ``pgr_trsp`` (Vertices) using ``pgr_trsp``"
 msgstr ""
 
-#: ../../build/doc/migration.rst:223 ../../build/doc/migration.rst:357
-#: ../../build/doc/migration.rst:488 ../../build/doc/migration.rst:626
+#: ../../build/doc/migration.rst:277 ../../build/doc/migration.rst:411
+#: ../../build/doc/migration.rst:542 ../../build/doc/migration.rst:680
 msgid "The following query has restrictions."
 msgstr ""
 
-#: ../../build/doc/migration.rst:233 ../../build/doc/migration.rst:367
-#: ../../build/doc/migration.rst:498 ../../build/doc/migration.rst:636
+#: ../../build/doc/migration.rst:287 ../../build/doc/migration.rst:421
+#: ../../build/doc/migration.rst:552 ../../build/doc/migration.rst:690
 msgid "The restrictions are the last parameter of the function"
 msgstr ""
 
-#: ../../build/doc/migration.rst:235 ../../build/doc/migration.rst:369
-#: ../../build/doc/migration.rst:500 ../../build/doc/migration.rst:638
+#: ../../build/doc/migration.rst:289 ../../build/doc/migration.rst:423
+#: ../../build/doc/migration.rst:554 ../../build/doc/migration.rst:692
 msgid "Using the old structure of restrictions"
 msgstr ""
 
-#: ../../build/doc/migration.rst:237
+#: ../../build/doc/migration.rst:291
 msgid "Use :doc:`pgr_trsp` (One to One) instead."
 msgstr ""
 
-#: ../../build/doc/migration.rst:243 ../../build/doc/migration.rst:377
-#: ../../build/doc/migration.rst:508 ../../build/doc/migration.rst:646
+#: ../../build/doc/migration.rst:297 ../../build/doc/migration.rst:431
+#: ../../build/doc/migration.rst:562 ../../build/doc/migration.rst:700
 msgid "The new structure of restrictions is been used."
 msgstr ""
 
-#: ../../build/doc/migration.rst:245 ../../build/doc/migration.rst:379
-#: ../../build/doc/migration.rst:510 ../../build/doc/migration.rst:648
+#: ../../build/doc/migration.rst:299 ../../build/doc/migration.rst:433
+#: ../../build/doc/migration.rst:564 ../../build/doc/migration.rst:702
 msgid "It is the second parameter."
 msgstr ""
 
-#: ../../build/doc/migration.rst:248
+#: ../../build/doc/migration.rst:302
 msgid ":doc:`pgr_trsp`:"
 msgstr ""
 
-#: ../../build/doc/migration.rst:272
+#: ../../build/doc/migration.rst:326
 msgid "Migration of ``pgr_trsp`` (Edges)"
 msgstr ""
 
-#: ../../build/doc/migration.rst:284
+#: ../../build/doc/migration.rst:338
 msgid "The integral types of the ``sql`` can only be ``INTEGER``."
 msgstr ""
 
-#: ../../build/doc/migration.rst:285
+#: ../../build/doc/migration.rst:339
 msgid "The floating point type of the ``sql`` can only be ``FLOAT``."
 msgstr ""
 
-#: ../../build/doc/migration.rst:297 ../../build/doc/migration.rst:564
+#: ../../build/doc/migration.rst:351 ../../build/doc/migration.rst:618
 msgid "For these migration guide the following points will be used:"
 msgstr ""
 
-#: ../../build/doc/migration.rst:305
+#: ../../build/doc/migration.rst:359
 msgid ":doc:`pgr_withPoints` when there are no restrictions,"
 msgstr ""
 
-#: ../../build/doc/migration.rst:306
+#: ../../build/doc/migration.rst:360
 msgid ":doc:`pgr_trsp_withPoints` (One to One) when there are restrictions."
 msgstr ""
 
-#: ../../build/doc/migration.rst:309
+#: ../../build/doc/migration.rst:363
 msgid "Migrating ``pgr_trsp`` (Edges) using ``pgr_withPoints``"
 msgstr ""
 
-#: ../../build/doc/migration.rst:321
+#: ../../build/doc/migration.rst:375
 msgid "Use :doc:`pgr_withPoints` instead."
 msgstr ""
 
-#: ../../build/doc/migration.rst:328 ../../build/doc/migration.rst:382
-#: ../../build/doc/migration.rst:597 ../../build/doc/migration.rst:651
+#: ../../build/doc/migration.rst:382 ../../build/doc/migration.rst:436
+#: ../../build/doc/migration.rst:651 ../../build/doc/migration.rst:705
 msgid "Do not show details, as the deprecated function does not show details."
 msgstr ""
 
-#: ../../build/doc/migration.rst:329
+#: ../../build/doc/migration.rst:383
 msgid ":doc:`pgr_withPoints`:"
 msgstr ""
 
-#: ../../build/doc/migration.rst:341 ../../build/doc/migration.rst:395
-#: ../../build/doc/migration.rst:471 ../../build/doc/migration.rst:525
-#: ../../build/doc/migration.rst:610 ../../build/doc/migration.rst:664
+#: ../../build/doc/migration.rst:395 ../../build/doc/migration.rst:449
+#: ../../build/doc/migration.rst:525 ../../build/doc/migration.rst:579
+#: ../../build/doc/migration.rst:664 ../../build/doc/migration.rst:718
 msgid "On the points query do not include the ``side`` column."
 msgstr ""
 
-#: ../../build/doc/migration.rst:343 ../../build/doc/migration.rst:397
-#: ../../build/doc/migration.rst:612 ../../build/doc/migration.rst:666
+#: ../../build/doc/migration.rst:397 ../../build/doc/migration.rst:451
+#: ../../build/doc/migration.rst:666 ../../build/doc/migration.rst:720
 msgid ""
 "When the need of using strictly the same (meaningless) names and types, and "
 "node values of the function been migrated then:"
 msgstr ""
 
-#: ../../build/doc/migration.rst:355
+#: ../../build/doc/migration.rst:409
 msgid "Migrating ``pgr_trsp`` (Edges) using ``pgr_trsp_withPoints``"
 msgstr ""
 
-#: ../../build/doc/migration.rst:371
+#: ../../build/doc/migration.rst:425
 msgid "Use :doc:`pgr_trsp_withPoints` instead."
 msgstr ""
 
-#: ../../build/doc/migration.rst:383
+#: ../../build/doc/migration.rst:437
 msgid ":doc:`pgr_trsp_withPoints`:"
 msgstr ""
 
-#: ../../build/doc/migration.rst:408
+#: ../../build/doc/migration.rst:462
 msgid "Migration of ``pgr_trspViaVertices``"
 msgstr ""
 
-#: ../../build/doc/migration.rst:420 ../../build/doc/migration.rst:551
+#: ../../build/doc/migration.rst:474 ../../build/doc/migration.rst:605
 msgid "The integral types of the ``Edges SQL`` can only be ``INTEGER``."
 msgstr ""
 
-#: ../../build/doc/migration.rst:436
+#: ../../build/doc/migration.rst:490
 msgid ":doc:`pgr_dijkstraVia` when there are no restrictions,"
 msgstr ""
 
-#: ../../build/doc/migration.rst:437
+#: ../../build/doc/migration.rst:491
 msgid ":doc:`pgr_trspVia` when there are restrictions."
 msgstr ""
 
-#: ../../build/doc/migration.rst:440
+#: ../../build/doc/migration.rst:494
 msgid "Migrating ``pgr_trspViaVertices`` using ``pgr_dijkstraVia``"
 msgstr ""
 
-#: ../../build/doc/migration.rst:452
+#: ../../build/doc/migration.rst:506
 msgid "Use :doc:`pgr_dijkstraVia` instead."
 msgstr ""
 
-#: ../../build/doc/migration.rst:459
+#: ../../build/doc/migration.rst:513
 msgid ":doc:`pgr_dijkstraVia`:"
 msgstr ""
 
-#: ../../build/doc/migration.rst:480 ../../build/doc/migration.rst:534
-#: ../../build/doc/migration.rst:619 ../../build/doc/migration.rst:673
+#: ../../build/doc/migration.rst:534 ../../build/doc/migration.rst:588
+#: ../../build/doc/migration.rst:673 ../../build/doc/migration.rst:727
 msgid "``id1`` is the path identifier"
 msgstr ""
 
-#: ../../build/doc/migration.rst:481 ../../build/doc/migration.rst:535
-#: ../../build/doc/migration.rst:620 ../../build/doc/migration.rst:674
+#: ../../build/doc/migration.rst:535 ../../build/doc/migration.rst:589
+#: ../../build/doc/migration.rst:674 ../../build/doc/migration.rst:728
 msgid "``id2`` is the node"
 msgstr ""
 
-#: ../../build/doc/migration.rst:482 ../../build/doc/migration.rst:536
-#: ../../build/doc/migration.rst:621 ../../build/doc/migration.rst:675
+#: ../../build/doc/migration.rst:536 ../../build/doc/migration.rst:590
+#: ../../build/doc/migration.rst:675 ../../build/doc/migration.rst:729
 msgid "``id3`` is the edge"
 msgstr ""
 
-#: ../../build/doc/migration.rst:486
+#: ../../build/doc/migration.rst:540
 msgid "Migrating ``pgr_trspViaVertices`` using ``pgr_trspVia``"
 msgstr ""
 
-#: ../../build/doc/migration.rst:502
+#: ../../build/doc/migration.rst:556
 msgid "Use :doc:`pgr_trspVia` instead."
 msgstr ""
 
-#: ../../build/doc/migration.rst:513
+#: ../../build/doc/migration.rst:567
 msgid ":doc:`pgr_trspVia`:"
 msgstr ""
 
-#: ../../build/doc/migration.rst:539
+#: ../../build/doc/migration.rst:593
 msgid "Migration of ``pgr_trspViaEdges``"
 msgstr ""
 
-#: ../../build/doc/migration.rst:570
+#: ../../build/doc/migration.rst:624
 msgid ""
-"And will travel thru the follwoing Via points :math:"
+"And will travel thru the following Via points :math:"
 "`4\\rightarrow3\\rightarrow6`"
 msgstr ""
 
-#: ../../build/doc/migration.rst:574
+#: ../../build/doc/migration.rst:628
 msgid ":doc:`pgr_withPointsVia` when there are no restrictions,"
 msgstr ""
 
-#: ../../build/doc/migration.rst:575
+#: ../../build/doc/migration.rst:629
 msgid ":doc:`pgr_trspVia_withPoints` when there are restrictions."
 msgstr ""
 
-#: ../../build/doc/migration.rst:578
+#: ../../build/doc/migration.rst:632
 msgid "Migrating ``pgr_trspViaEdges`` using ``pgr_withPointsVia``"
 msgstr ""
 
-#: ../../build/doc/migration.rst:590
+#: ../../build/doc/migration.rst:644
 msgid "Use :doc:`pgr_withPointsVia` instead."
 msgstr ""
 
-#: ../../build/doc/migration.rst:598
+#: ../../build/doc/migration.rst:652
 msgid ":doc:`pgr_withPointsVia`:"
 msgstr ""
 
-#: ../../build/doc/migration.rst:624
+#: ../../build/doc/migration.rst:678
 msgid "Migrating ``pgr_trspViaEdges`` using ``pgr_trspVia_withPoints``"
 msgstr ""
 
-#: ../../build/doc/migration.rst:640
+#: ../../build/doc/migration.rst:694
 msgid "Use :doc:`pgr_trspVia_withPoints` instead."
 msgstr ""
 
-#: ../../build/doc/migration.rst:652
+#: ../../build/doc/migration.rst:706
 msgid ":doc:`pgr_trspVia_withPoints`:"
 msgstr ""
 
-#: ../../build/doc/migration.rst:678
+#: ../../build/doc/migration.rst:732
 msgid "See Also"
 msgstr ""
 
-#: ../../build/doc/migration.rst:680
+#: ../../build/doc/migration.rst:734
 msgid ":doc:`TRSP-family`"
 msgstr ""
 
-#: ../../build/doc/migration.rst:681
+#: ../../build/doc/migration.rst:735
 msgid ":doc:`withPoints-category`"
 msgstr ""
 
-#: ../../build/doc/migration.rst:684
+#: ../../build/doc/migration.rst:738
 msgid "Indices and tables"
 msgstr ""
 
-#: ../../build/doc/migration.rst:685
+#: ../../build/doc/migration.rst:739
 msgid ":ref:`genindex`"
 msgstr ""
 
-#: ../../build/doc/migration.rst:686
+#: ../../build/doc/migration.rst:740
 msgid ":ref:`search`"
 msgstr ""


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [pgRouting/index](https://weblate.osgeo.org/projects/pgrouting/index/).


It also includes following components:

* [pgRouting/pgr_nodeNetwork](https://weblate.osgeo.org/projects/pgrouting/pgr_nodenetwork/)

* [pgRouting/pgRouting-concepts](https://weblate.osgeo.org/projects/pgrouting/pgrouting-concepts/)

* [pgRouting/pgr_johnson](https://weblate.osgeo.org/projects/pgrouting/pgr_johnson/)

* [pgRouting/allpairs-family](https://weblate.osgeo.org/projects/pgrouting/allpairs-family/)

* [pgRouting/pgr_maxCardinalityMatch](https://weblate.osgeo.org/projects/pgrouting/pgr_maxcardinalitymatch/)

* [pgRouting/BFS-category](https://weblate.osgeo.org/projects/pgrouting/bfs-category/)

* [pgRouting/costMatrix-category](https://weblate.osgeo.org/projects/pgrouting/costmatrix-category/)

* [pgRouting/pgr_isPlanar](https://weblate.osgeo.org/projects/pgrouting/pgr_isplanar/)

* [pgRouting/pgr_trspVia_withPoints](https://weblate.osgeo.org/projects/pgrouting/pgr_trspvia_withpoints/)

* [pgRouting/pgr_withPointsKSP](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointsksp/)

* [pgRouting/pgr_transitiveClosure](https://weblate.osgeo.org/projects/pgrouting/pgr_transitiveclosure/)

* [pgRouting/bdAstar-family](https://weblate.osgeo.org/projects/pgrouting/bdastar-family/)

* [pgRouting/pgRouting-introduction](https://weblate.osgeo.org/projects/pgrouting/pgrouting-introduction/)

* [pgRouting/pgr_version](https://weblate.osgeo.org/projects/pgrouting/pgr_version/)

* [pgRouting/pgr_pickDeliver](https://weblate.osgeo.org/projects/pgrouting/pgr_pickdeliver/)

* [pgRouting/bdDijkstra-family](https://weblate.osgeo.org/projects/pgrouting/bddijkstra-family/)

* [pgRouting/pgr_aStarCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_astarcostmatrix/)

* [pgRouting/pgr_TSPeuclidean](https://weblate.osgeo.org/projects/pgrouting/pgr_tspeuclidean/)

* [pgRouting/release_notes](https://weblate.osgeo.org/projects/pgrouting/release_notes/)

* [pgRouting/pgr_analyzeGraph](https://weblate.osgeo.org/projects/pgrouting/pgr_analyzegraph/)

* [pgRouting/pgr_full_version](https://weblate.osgeo.org/projects/pgrouting/pgr_full_version/)

* [pgRouting/migration](https://weblate.osgeo.org/projects/pgrouting/migration/)

* [pgRouting/contraction-family](https://weblate.osgeo.org/projects/pgrouting/contraction-family/)

* [pgRouting/support](https://weblate.osgeo.org/projects/pgrouting/support/)

* [pgRouting/pgr_depthFirstSearch](https://weblate.osgeo.org/projects/pgrouting/pgr_depthfirstsearch/)

* [pgRouting/spanningTree-family](https://weblate.osgeo.org/projects/pgrouting/spanningtree-family/)

* [pgRouting/pgr_boykovKolmogorov](https://weblate.osgeo.org/projects/pgrouting/pgr_boykovkolmogorov/)

* [pgRouting/pgr_extractVertices](https://weblate.osgeo.org/projects/pgrouting/pgr_extractvertices/)

* [pgRouting/reference](https://weblate.osgeo.org/projects/pgrouting/reference/)

* [pgRouting/pgr_createVerticesTable](https://weblate.osgeo.org/projects/pgrouting/pgr_createverticestable/)

* [pgRouting/pgr_vrpOneDepot](https://weblate.osgeo.org/projects/pgrouting/pgr_vrponedepot/)

* [pgRouting/cost-category](https://weblate.osgeo.org/projects/pgrouting/cost-category/)

* [pgRouting/topology-functions](https://weblate.osgeo.org/projects/pgrouting/topology-functions/)

* [pgRouting/pgr_edwardMoore](https://weblate.osgeo.org/projects/pgrouting/pgr_edwardmoore/)

* [pgRouting/proposed](https://weblate.osgeo.org/projects/pgrouting/proposed/)

* [pgRouting/KSP-category](https://weblate.osgeo.org/projects/pgrouting/ksp-category/)

* [pgRouting/pgr_trsp](https://weblate.osgeo.org/projects/pgrouting/pgr_trsp/)

* [pgRouting/pgRouting-installation](https://weblate.osgeo.org/projects/pgrouting/pgrouting-installation/)

* [pgRouting/pgr_bellmanFord](https://weblate.osgeo.org/projects/pgrouting/pgr_bellmanford/)

* [pgRouting/transformation-family](https://weblate.osgeo.org/projects/pgrouting/transformation-family/)

* [pgRouting/traversal-family](https://weblate.osgeo.org/projects/pgrouting/traversal-family/)

* [pgRouting/pgr_kruskalBFS](https://weblate.osgeo.org/projects/pgrouting/pgr_kruskalbfs/)

* [pgRouting/components-family](https://weblate.osgeo.org/projects/pgrouting/components-family/)

* [pgRouting/pgr_chinesePostmanCost](https://weblate.osgeo.org/projects/pgrouting/pgr_chinesepostmancost/)

* [pgRouting/pgr_aStarCost](https://weblate.osgeo.org/projects/pgrouting/pgr_astarcost/)

* [pgRouting/pgr_strongComponents](https://weblate.osgeo.org/projects/pgrouting/pgr_strongcomponents/)

* [pgRouting/coloring-family](https://weblate.osgeo.org/projects/pgrouting/coloring-family/)

* [pgRouting/pgr_drivingDistance](https://weblate.osgeo.org/projects/pgrouting/pgr_drivingdistance/)

* [pgRouting/pgr_sequentialVertexColoring](https://weblate.osgeo.org/projects/pgrouting/pgr_sequentialvertexcoloring/)

* [pgRouting/pgr_createTopology](https://weblate.osgeo.org/projects/pgrouting/pgr_createtopology/)

* [pgRouting/pgr_turnRestrictedPath](https://weblate.osgeo.org/projects/pgrouting/pgr_turnrestrictedpath/)

* [pgRouting/aStar-family](https://weblate.osgeo.org/projects/pgrouting/astar-family/)

* [pgRouting/pgr_breadthFirstSearch](https://weblate.osgeo.org/projects/pgrouting/pgr_breadthfirstsearch/)

* [pgRouting/VRP-category](https://weblate.osgeo.org/projects/pgrouting/vrp-category/)

* [pgRouting/routingFunctions](https://weblate.osgeo.org/projects/pgrouting/routingfunctions/)

* [pgRouting/pgr_maxFlowMinCost_Cost](https://weblate.osgeo.org/projects/pgrouting/pgr_maxflowmincost_cost/)

* [pgRouting/pgr_dijkstraNearCost](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstranearcost/)

* [pgRouting/pgr_dagShortestPath](https://weblate.osgeo.org/projects/pgrouting/pgr_dagshortestpath/)

* [pgRouting/DFS-category](https://weblate.osgeo.org/projects/pgrouting/dfs-category/)

* [pgRouting/pgr_makeConnected](https://weblate.osgeo.org/projects/pgrouting/pgr_makeconnected/)

* [pgRouting/pgr_topologicalSort](https://weblate.osgeo.org/projects/pgrouting/pgr_topologicalsort/)

* [pgRouting/pgr_edgeColoring](https://weblate.osgeo.org/projects/pgrouting/pgr_edgecoloring/)

* [pgRouting/pgr_primDD](https://weblate.osgeo.org/projects/pgrouting/pgr_primdd/)

* [pgRouting/pgr_biconnectedComponents](https://weblate.osgeo.org/projects/pgrouting/pgr_biconnectedcomponents/)

* [pgRouting/pgr_lineGraph](https://weblate.osgeo.org/projects/pgrouting/pgr_linegraph/)

* [pgRouting/withPoints-family](https://weblate.osgeo.org/projects/pgrouting/withpoints-family/)

* [pgRouting/kruskal-family](https://weblate.osgeo.org/projects/pgrouting/kruskal-family/)

* [pgRouting/pgr_prim](https://weblate.osgeo.org/projects/pgrouting/pgr_prim/)

* [pgRouting/pgr_withPointsCost](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointscost/)

* [pgRouting/pgr_bipartite](https://weblate.osgeo.org/projects/pgrouting/pgr_bipartite/)

* [pgRouting/pgr_dijkstraCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstracostmatrix/)

* [pgRouting/pgr_withPoints](https://weblate.osgeo.org/projects/pgrouting/pgr_withpoints/)

* [pgRouting/pgr_bridges](https://weblate.osgeo.org/projects/pgrouting/pgr_bridges/)

* [pgRouting/pgr_chinesePostman](https://weblate.osgeo.org/projects/pgrouting/pgr_chinesepostman/)

* [pgRouting/pgr_dijkstraVia](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstravia/)

* [pgRouting/chinesePostmanProblem-family](https://weblate.osgeo.org/projects/pgrouting/chinesepostmanproblem-family/)

* [pgRouting/via-category](https://weblate.osgeo.org/projects/pgrouting/via-category/)

* [pgRouting/prim-family](https://weblate.osgeo.org/projects/pgrouting/prim-family/)

* [pgRouting/pgr_stoerWagner](https://weblate.osgeo.org/projects/pgrouting/pgr_stoerwagner/)

* [pgRouting/dijkstra-family](https://weblate.osgeo.org/projects/pgrouting/dijkstra-family/)

* [pgRouting/pgr_analyzeOneWay](https://weblate.osgeo.org/projects/pgrouting/pgr_analyzeoneway/)

* [pgRouting/sampledata](https://weblate.osgeo.org/projects/pgrouting/sampledata/)

* [pgRouting/pgr_bdAstar](https://weblate.osgeo.org/projects/pgrouting/pgr_bdastar/)

* [pgRouting/pgr_kruskalDD](https://weblate.osgeo.org/projects/pgrouting/pgr_kruskaldd/)

* [pgRouting/pgr_connectedComponents](https://weblate.osgeo.org/projects/pgrouting/pgr_connectedcomponents/)

* [pgRouting/pgr_withPointsCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointscostmatrix/)

* [pgRouting/TSP-family](https://weblate.osgeo.org/projects/pgrouting/tsp-family/)

* [pgRouting/pgr_dijkstraCost](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstracost/)

* [pgRouting/pgr_articulationPoints](https://weblate.osgeo.org/projects/pgrouting/pgr_articulationpoints/)

* [pgRouting/pgr_floydWarshall](https://weblate.osgeo.org/projects/pgrouting/pgr_floydwarshall/)

* [pgRouting/pgr_withPointsDD](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointsdd/)

* [pgRouting/flow-family](https://weblate.osgeo.org/projects/pgrouting/flow-family/)

* [pgRouting/TRSP-family](https://weblate.osgeo.org/projects/pgrouting/trsp-family/)

* [pgRouting/pgr_trsp_withPoints](https://weblate.osgeo.org/projects/pgrouting/pgr_trsp_withpoints/)

* [pgRouting/pgr_trspVia](https://weblate.osgeo.org/projects/pgrouting/pgr_trspvia/)

* [pgRouting/pgr_withPointsVia](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointsvia/)

* [pgRouting/withPoints-category](https://weblate.osgeo.org/projects/pgrouting/withpoints-category/)

* [pgRouting/pgr_degree](https://weblate.osgeo.org/projects/pgrouting/pgr_degree/)

* [pgRouting/pgr_findCloseEdges](https://weblate.osgeo.org/projects/pgrouting/pgr_findcloseedges/)

* [pgRouting/pgr_maxFlow](https://weblate.osgeo.org/projects/pgrouting/pgr_maxflow/)

* [pgRouting/pgr_KSP](https://weblate.osgeo.org/projects/pgrouting/pgr_ksp/)

* [pgRouting/pgr_dijkstraNear](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstranear/)

* [pgRouting/experimental](https://weblate.osgeo.org/projects/pgrouting/experimental/)

* [pgRouting/pgr_TSP](https://weblate.osgeo.org/projects/pgrouting/pgr_tsp/)

* [pgRouting/drivingDistance-category](https://weblate.osgeo.org/projects/pgrouting/drivingdistance-category/)

* [pgRouting/pgr_primBFS](https://weblate.osgeo.org/projects/pgrouting/pgr_primbfs/)

* [pgRouting/pgr_lineGraphFull](https://weblate.osgeo.org/projects/pgrouting/pgr_linegraphfull/)

* [pgRouting/pgr_alphaShape](https://weblate.osgeo.org/projects/pgrouting/pgr_alphashape/)

* [pgRouting/pgr_kruskal](https://weblate.osgeo.org/projects/pgrouting/pgr_kruskal/)

* [pgRouting/pgr_bdAstarCost](https://weblate.osgeo.org/projects/pgrouting/pgr_bdastarcost/)

* [pgRouting/pgr_contraction](https://weblate.osgeo.org/projects/pgrouting/pgr_contraction/)

* [pgRouting/pgr_binaryBreadthFirstSearch](https://weblate.osgeo.org/projects/pgrouting/pgr_binarybreadthfirstsearch/)

* [pgRouting/pgr_pushRelabel](https://weblate.osgeo.org/projects/pgrouting/pgr_pushrelabel/)

* [pgRouting/pgr_primDFS](https://weblate.osgeo.org/projects/pgrouting/pgr_primdfs/)

* [pgRouting/pgr_edmondsKarp](https://weblate.osgeo.org/projects/pgrouting/pgr_edmondskarp/)

* [pgRouting/pgr_dijkstra](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstra/)

* [pgRouting/pgr_bdDijkstra](https://weblate.osgeo.org/projects/pgrouting/pgr_bddijkstra/)

* [pgRouting/pgr_lengauerTarjanDominatorTree](https://weblate.osgeo.org/projects/pgrouting/pgr_lengauertarjandominatortree/)

* [pgRouting/pgr_bdAstarCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_bdastarcostmatrix/)

* [pgRouting/pgr_bdDijkstraCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_bddijkstracostmatrix/)

* [pgRouting/pgr_aStar](https://weblate.osgeo.org/projects/pgrouting/pgr_astar/)

* [pgRouting/pgr_edgeDisjointPaths](https://weblate.osgeo.org/projects/pgrouting/pgr_edgedisjointpaths/)

* [pgRouting/pgr_kruskalDFS](https://weblate.osgeo.org/projects/pgrouting/pgr_kruskaldfs/)

* [pgRouting/pgr_bdDijkstraCost](https://weblate.osgeo.org/projects/pgrouting/pgr_bddijkstracost/)

* [pgRouting/pgr_pickDeliverEuclidean](https://weblate.osgeo.org/projects/pgrouting/pgr_pickdelivereuclidean/)

* [pgRouting/pgr_maxFlowMinCost](https://weblate.osgeo.org/projects/pgrouting/pgr_maxflowmincost/)



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widgets/pgrouting/-/index/horizontal-auto.svg)