### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/locale/es/LC_MESSAGES/TRSP-family.po
+++ b/locale/es/LC_MESSAGES/TRSP-family.po
@@ -10,24 +10,24 @@ msgstr ""
 "POT-Creation-Date: 2022-07-11 18:25-0500\n"
 "PO-Revision-Date: 2022-07-07 16:48+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
+"Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/trsp-"
+"family/es/>\n"
 "Language: es\n"
-"Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting"
-"/trsp-family/es/>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: ../../build/doc/TRSP-family.rst:12
 msgid ""
-"**Supported versions:** `Latest <https://docs.pgrouting.org/latest/en"
-"/TRSP-family.html>`__ (`3.4 <https://docs.pgrouting.org/3.4/en/TRSP-"
-"family.html>`__)"
+"**Supported versions:** `Latest <https://docs.pgrouting.org/latest/en/TRSP-"
+"family.html>`__ (`3.4 <https://docs.pgrouting.org/3.4/en/TRSP-family."
+"html>`__)"
 msgstr ""
-"**Versiones Soportadas:** `Latest <https://docs.pgrouting.org/latest/es"
-"/TRSP-family.html>`__ (`3.4 <https://docs.pgrouting.org/3.4/es/TRSP-"
-"family.html>`__)"
+"**Versiones Soportadas:** `Latest <https://docs.pgrouting.org/latest/es/TRSP-"
+"family.html>`__ (`3.4 <https://docs.pgrouting.org/3.4/es/TRSP-family."
+"html>`__)"
 
 #: ../../build/doc/TRSP-family.rst:17
 msgid "TRSP - Family of functions"
@@ -91,17 +91,17 @@ msgstr ":doc:`pgr_trsp_withPoints` - Ruteo de Punto/Vértice con restricciones."
 
 #: ../../build/doc/TRSP-family.rst:32
 msgid ""
-":doc:`pgr_trspVia_withPoints` - Via Vertex/point routing with "
-"restrictions."
-msgstr ":doc:`pgr_trspVia_withPoints` - Ruteo Vía Punto/Vértice con restricciones."
+":doc:`pgr_trspVia_withPoints` - Via Vertex/point routing with restrictions."
+msgstr ""
+":doc:`pgr_trspVia_withPoints` - Ruteo Vía Punto/Vértice con restricciones."
 
 #: ../../build/doc/TRSP-family.rst:36
 msgid ""
 "Read the :doc:`migration` about how to migrate from the deprecated TRSP "
 "functionality to the new signatures or replacement functions."
 msgstr ""
-"Leer :doc:`migration` sobre como migrar de la funcionalidad obsoleta de "
-"TRSP a las nuevas firmas o funciones que las reemplazan."
+"Leer :doc:`migration` sobre como migrar de la funcionalidad obsoleta de TRSP "
+"a las nuevas firmas o funciones que las reemplazan."
 
 #: ../../build/doc/TRSP-family.rst:40
 msgid "Experimental"
@@ -188,19 +188,18 @@ msgstr "Introducción"
 #: ../../build/doc/TRSP-family.rst:63
 #, fuzzy
 msgid ""
-"Road restrictions are a sequence of road segments that can not be taken "
-"in a sequential manner. Some restrictions are implicit on a directed "
-"graph, for example, one way roads where the wrong way edge is not even "
-"inserted on the graph. But normally on turns like no left turn or no "
-"right turn, hence the name turn restrictions, there are sometimes "
-"restrictions."
+"Road restrictions are a sequence of road segments that can not be taken in a "
+"sequential manner. Some restrictions are implicit on a directed graph, for "
+"example, one way roads where the wrong way edge is not even inserted on the "
+"graph. But normally on turns like no left turn or no right turn, hence the "
+"name turn restrictions, there are sometimes restrictions."
 msgstr ""
-"Las restricciones viales son una secuencia de tramos viales que no se "
-"pueden tomar de manera secuencial. Algunas restricciones están implícitas"
-" en un grafo dirigido, por ejemplo, caminos de un solo sentido donde el "
-"sentido contrario ni siquiera se inserta en el grafo. Pero normalmente en"
-" giros como **giro a la izquierda** o **giro a la derecha**, de ahí el "
-"nombre de restricciones de giro, a veces hay restricciones."
+"Las restricciones viales son una secuencia de tramos viales que no se pueden "
+"tomar de manera secuencial. Algunas restricciones están implícitas en un "
+"grafo dirigido, por ejemplo, caminos de un solo sentido donde el sentido "
+"contrario ni siquiera se inserta en el grafo. Pero normalmente en giros como "
+"**giro a la izquierda** o **giro a la derecha**, de ahí el nombre de "
+"restricciones de giro, a veces hay restricciones."
 
 #: ../../build/doc/TRSP-family.rst:74
 msgid "TRSP algorithm"
@@ -208,14 +207,13 @@ msgstr "Algoritmo TRSP"
 
 #: ../../build/doc/TRSP-family.rst:76
 msgid ""
-"The internal TRSP algorithm performs a lookahead over the dijkstra "
-"algorithm in order to find out if the attempted path has a restriction. "
-"This allows the algorithm to pass twice on the same vertex."
+"The internal TRSP algorithm performs a lookahead over the dijkstra algorithm "
+"in order to find out if the attempted path has a restriction. This allows "
+"the algorithm to pass twice on the same vertex."
 msgstr ""
 "Wl algoritmo interno TRSP realiza una búsqueda de avanzada sobre el "
-"algoritmo de Dijkstra para encontrar un camino que contenga una "
-"restricción. Esto permite que el algoritmo pase dos veces sobre el mismo "
-"vértice."
+"algoritmo de Dijkstra para encontrar un camino que contenga una restricción. "
+"Esto permite que el algoritmo pase dos veces sobre el mismo vértice."
 
 #: ../../build/doc/TRSP-family.rst:81
 msgid "Parameters"
@@ -229,8 +227,8 @@ msgstr "Parámetro"
 msgid "Type"
 msgstr "Tipo"
 
-#: ../../build/doc/TRSP-family.rst:92 ../../build/doc/pgRouting-concepts.rst:10
-#: ../../build/doc/pgRouting-concepts.rst:11
+#: ../../build/doc/TRSP-family.rst:92 ../../build/doc/pgRouting-concepts.rst:11
+#: ../../build/doc/pgRouting-concepts.rst:10
 msgid "Description"
 msgstr "Descripción"
 
@@ -268,12 +266,12 @@ msgid "Array of ordered vertices identifiers that are going to be visited."
 msgstr "Arreglo ordenado de identificadores de vértices que serán visitados."
 
 #: ../../build/doc/TRSP-family.rst:103
-#: ../../build/doc/pgRouting-concepts.rst:21
 #: ../../build/doc/pgRouting-concepts.rst:36
+#: ../../build/doc/pgRouting-concepts.rst:21
 msgid "Where:"
 msgstr "Donde:"
 
-#: ../../build/doc/TRSP-family.rst ../../build/doc/pgRouting-concepts.rst
+#: ../../build/doc/TRSP-family.rst:0 ../../build/doc/pgRouting-concepts.rst:0
 msgid "ANY-INTEGER"
 msgstr "ENTEROS"
 
@@ -290,8 +288,8 @@ msgid ""
 "On road networks, there are restrictions such as left or right turn "
 "restrictions, no U turn restrictions."
 msgstr ""
-"En redes de caminos, hay restricciones como vuelta a la izquierda o "
-"derecha, no vuelta en U."
+"En redes de caminos, hay restricciones como vuelta a la izquierda o derecha, "
+"no vuelta en U."
 
 #: ../../build/doc/TRSP-family.rst:115
 #, fuzzy
@@ -299,8 +297,8 @@ msgid ""
 "A restriction is a sequence of edges, called path and that path is to be "
 "avoided."
 msgstr ""
-"Una restricción es una secuencia de aristas, llamado **path** y ese "
-"**path** se debería evitar."
+"Una restricción es una secuencia de aristas, llamado **path** y ese **path** "
+"se debería evitar."
 
 #: ../../build/doc/TRSP-family.rst:123
 msgid "**Restrictions on the road network**"
@@ -312,9 +310,9 @@ msgstr "Éstas restricciones son representadas en la siguiente tabla:"
 
 #: ../../build/doc/TRSP-family.rst:131
 msgid ""
-"The table has an identifier, which maybe is needed for the administration"
-" of the restrictions, but the algorithms do not need that information. If"
-" given it will be ignored."
+"The table has an identifier, which maybe is needed for the administration of "
+"the restrictions, but the algorithms do not need that information. If given "
+"it will be ignored."
 msgstr ""
 "La tabla tiene un identificador, lo cual pueda ser necesaria para la "
 "administración de las restricciones, pero el algoritmo no necesita esa "
@@ -366,9 +364,9 @@ msgstr "Identificador del segundo vértice de la arista."
 msgid "``cost``"
 msgstr "``cost``"
 
-#: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:25
 #: ../../build/doc/pgRouting-concepts.rst:29
+#: ../../build/doc/pgRouting-concepts.rst:18
 msgid "**ANY-NUMERICAL**"
 msgstr "**FLOTANTES**"
 
@@ -390,23 +388,23 @@ msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
 msgid ""
-"When negative: edge (``target``, ``source``) does not exist, therefore "
-"it's not part of the graph."
+"When negative: edge (``target``, ``source``) does not exist, therefore it's "
+"not part of the graph."
 msgstr ""
-"Cuando negativo: la arista (``target``, ``source``) no existe, por lo "
-"tanto no es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
-#: ../../build/doc/pgRouting-concepts.rst:23
 #: ../../build/doc/pgRouting-concepts.rst:38
+#: ../../build/doc/pgRouting-concepts.rst:23
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``"
 msgstr "``SMALLINT``, ``INTEGER``, ``BIGINT``"
 
-#: ../../build/doc/pgRouting-concepts.rst
+#: ../../build/doc/pgRouting-concepts.rst:0
 msgid "ANY-NUMERICAL"
 msgstr "FLOTANTES"
 
-#: ../../build/doc/pgRouting-concepts.rst:24
 #: ../../build/doc/pgRouting-concepts.rst:39
+#: ../../build/doc/pgRouting-concepts.rst:24
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``, ``REAL``, ``FLOAT``"
 msgstr "``SMALLINT``, ``INTEGER``, ``BIGINT``, ``REAL``, ``FLOAT``"
 
@@ -421,12 +419,12 @@ msgstr "``path``"
 #: ../../build/doc/pgRouting-concepts.rst:13
 msgid ""
 "Sequence of edge identifiers that form a path that is not allowed to be "
-"taken. - Empty arrays or ``NULL`` arrays are ignored. - Arrays that have "
-"a ``NULL`` element will raise an exception."
+"taken. - Empty arrays or ``NULL`` arrays are ignored. - Arrays that have a "
+"``NULL`` element will raise an exception."
 msgstr ""
 "Secuencia de identificadores de aristas que forman un camino que no se "
-"permite tomar. - Arreglos vacios o ``NULL`` son ignorados. - Arreglos que"
-" tienen ``NULL`` arrojan una excepción."
+"permite tomar. - Arreglos vacios o ``NULL`` son ignorados. - Arreglos que "
+"tienen ``NULL`` arrojan una excepción."
 
 #: ../../build/doc/pgRouting-concepts.rst:17
 msgid "``Cost``"
@@ -451,4 +449,3 @@ msgstr ":ref:`genindex`"
 #: ../../build/doc/TRSP-family.rst:157
 msgid ":ref:`search`"
 msgstr ":ref:`search`"
-

--- a/locale/es/LC_MESSAGES/VRP-category.po
+++ b/locale/es/LC_MESSAGES/VRP-category.po
@@ -13,7 +13,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-07-04 15:45+0000\n"
+"PO-Revision-Date: 2022-09-11 04:55+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "vrp-category/es/>\n"
@@ -22,7 +22,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.13\n"
+"X-Generator: Weblate 4.13.1\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: ../../build/doc/VRP-category.rst:12
@@ -337,7 +337,6 @@ msgid "Description"
 msgstr "Descripción"
 
 #: ../../build/doc/VRP-category.rst:125 ../../build/doc/VRP-category.rst:146
-#, fuzzy
 msgid "`Orders SQL`_"
 msgstr "`Orders SQL`_"
 
@@ -352,7 +351,6 @@ msgid "`Orders SQL`_ as described below."
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:128 ../../build/doc/VRP-category.rst:149
-#, fuzzy
 msgid "`Vehicles SQL`_"
 msgstr "`Vehicles SQL`_"
 
@@ -365,9 +363,8 @@ msgid "Used in :doc:`pgr_pickDeliver`"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:152
-#, fuzzy
 msgid "`Matrix SQL`_"
-msgstr "`Matrix SQL`_"
+msgstr "`SQL matriz`_"
 
 #: ../../build/doc/VRP-category.rst:154
 msgid "`Matrix SQL`_ as described below."
@@ -417,9 +414,8 @@ msgid "Maximum number of cycles to perform on the optimization."
 msgstr "Número máximo de ciclos a realizar en la optimización."
 
 #: ../../build/doc/VRP-category.rst:180
-#, fuzzy
 msgid "``initial_sol``"
-msgstr "**initial_sol**"
+msgstr "``initial_sol``"
 
 #: ../../build/doc/VRP-category.rst:182
 msgid "4"
@@ -460,16 +456,14 @@ msgid "Inner Queries"
 msgstr "Consultas Internas"
 
 #: ../../build/doc/VRP-category.rst:200
-#, fuzzy
 msgid "Orders SQL"
 msgstr "Orders SQL"
 
 #: ../../build/doc/VRP-category.rst:202
-#, fuzzy
 msgid "Common columns for the orders SQL in both implementations:"
 msgstr ""
-"En general, las columnas para las órdenes SQL es la misma tanto en la "
-"implementación de recogida como de entrega:"
+"En general, las columnas de la consulta SQL de lass órdenes es la misma en "
+"ambas implementaciones:"
 
 #: ../../build/doc/VRP-category.rst:214 ../../build/doc/VRP-category.rst:329
 msgid "``id``"
@@ -486,9 +480,8 @@ msgid "Identifier of the pick-delivery order pair."
 msgstr "Identificador del par de órdenes recogida-entrega."
 
 #: ../../build/doc/VRP-category.rst:217
-#, fuzzy
 msgid "``demand``"
-msgstr "**demanda**"
+msgstr "``demand``"
 
 #: ../../build/doc/VRP-category.rst:218 ../../build/doc/VRP-category.rst:221
 #: ../../build/doc/VRP-category.rst:224 ../../build/doc/VRP-category.rst:227
@@ -510,27 +503,24 @@ msgid "Number of units in the order"
 msgstr "Número de unidades en la orden"
 
 #: ../../build/doc/VRP-category.rst:220
-#, fuzzy
 msgid "``p_open``"
-msgstr "`start_open`"
+msgstr "``p_open``"
 
 #: ../../build/doc/VRP-category.rst:222
 msgid "The time, relative to 0, when the pickup location opens."
 msgstr "La hora, en relación con 0, cuando se abre la ubicación de recogida."
 
 #: ../../build/doc/VRP-category.rst:223
-#, fuzzy
 msgid "``p_close``"
-msgstr "`start_close`"
+msgstr "``p_close``"
 
 #: ../../build/doc/VRP-category.rst:225
 msgid "The time, relative to 0, when the pickup location closes."
 msgstr "La hora, en relación con 0, cuando se cierra la ubicación de recogida."
 
 #: ../../build/doc/VRP-category.rst:226
-#, fuzzy
 msgid "[``p_service``]"
-msgstr "`start_service`"
+msgstr "[``p_service``]"
 
 #: ../../build/doc/VRP-category.rst:228
 msgid "The duration of the loading at the pickup location."
@@ -541,32 +531,28 @@ msgid "When missing: 0 time units are used"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:231
-#, fuzzy
 msgid "``d_open``"
-msgstr "`start_open`"
+msgstr "``d_open``"
 
 #: ../../build/doc/VRP-category.rst:233
 msgid "The time, relative to 0, when the delivery location opens."
 msgstr "La hora, en relación con 0, cuando se abre la ubicación de entrega."
 
 #: ../../build/doc/VRP-category.rst:234
-#, fuzzy
 msgid "``d_close``"
-msgstr "`start_close`"
+msgstr "``d_close``"
 
 #: ../../build/doc/VRP-category.rst:236
 msgid "The time, relative to 0, when the delivery location closes."
 msgstr "La hora, en relación con 0, cuando se cierra la ubicación de entrega."
 
 #: ../../build/doc/VRP-category.rst:237
-#, fuzzy
 msgid "[``d_service``]"
-msgstr "`start_service`"
+msgstr "[``d_service``]"
 
 #: ../../build/doc/VRP-category.rst:239
-#, fuzzy
 msgid "The duration of the unloading at the delivery location."
-msgstr "La duración de la carga en el lugar de entrega."
+msgstr "La duración de descargar en el lugar de entrega."
 
 #: ../../build/doc/VRP-category.rst:243 ../../build/doc/VRP-category.rst:272
 #: ../../build/doc/VRP-category.rst:304 ../../build/doc/VRP-category.rst:390
@@ -599,32 +585,28 @@ msgid ""
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:263
-#, fuzzy
 msgid "``p_node_id``"
-msgstr "`start_node_id`"
+msgstr "``p_node_id``"
 
 #: ../../build/doc/VRP-category.rst:265
-#, fuzzy
 msgid ""
 "The node identifier of the pickup, must match a vertex identifier in the "
 "`Matrix SQL`_."
 msgstr ""
-"El identificador de nodo de la recogida debe coincidir con un "
-"identificador de nodo en la `Matrix SQL`_."
+"El identificador de nodo de la recogida debe coincidir con un identificador "
+"de nodo en la `Matrix SQL`_."
 
 #: ../../build/doc/VRP-category.rst:267
-#, fuzzy
 msgid "``d_node_id``"
-msgstr "`start_node_id`"
+msgstr "``d_node_id``"
 
 #: ../../build/doc/VRP-category.rst:269
-#, fuzzy
 msgid ""
 "The node identifier of the delivery, must match a vertex identifier in "
 "the `Matrix SQL`_."
 msgstr ""
-"El identificador de nodo de la entrega debe coincidir con un "
-"identificador de nodo en la `Matrix SQL`_."
+"El identificador de nodo de la entrega debe coincidir con un identificador "
+"de nodo en la `Matrix SQL`_."
 
 #: ../../build/doc/VRP-category.rst:278 ../../build/doc/VRP-category.rst:396
 msgid ""
@@ -633,57 +615,50 @@ msgid ""
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:291
-#, fuzzy
 msgid "``p_x``"
-msgstr "``-1``"
+msgstr "``p_x``"
 
 #: ../../build/doc/VRP-category.rst:293
 msgid ":math:`x` value of the pick up location"
 msgstr ":math:`x` valor de la ubicación de recogida"
 
 #: ../../build/doc/VRP-category.rst:294
-#, fuzzy
 msgid "``p_y``"
-msgstr "``-1``"
+msgstr "``p_y``"
 
 #: ../../build/doc/VRP-category.rst:296
 msgid ":math:`y` value of the pick up location"
 msgstr ":math:`y` valor de la ubicación de recogida"
 
 #: ../../build/doc/VRP-category.rst:297
-#, fuzzy
 msgid "``d_x``"
-msgstr "``-1``"
+msgstr "``d_x``"
 
 #: ../../build/doc/VRP-category.rst:299
 msgid ":math:`x` value of the delivery location"
 msgstr "valor :math:`x` de la ubicación de entrega"
 
 #: ../../build/doc/VRP-category.rst:300
-#, fuzzy
 msgid "``d_y``"
-msgstr "``-1``"
+msgstr "``d_y``"
 
 #: ../../build/doc/VRP-category.rst:302
 msgid ":math:`y` value of the delivery location"
 msgstr "valor :math:`y` del lugar de entrega"
 
 #: ../../build/doc/VRP-category.rst:315
-#, fuzzy
 msgid "Vehicles SQL"
 msgstr "Vehicles SQL"
 
 #: ../../build/doc/VRP-category.rst:315
-#, fuzzy
 msgid "Common columns for the vehicles SQL in both implementations:"
 msgstr ""
-"En general, las columnas para vehicles_sql son las mismas tanto en la "
-"implementación de recogida como en la entrega:"
+"En general, las columnas para las consultas SQL de los vehículos son las "
+"mismas tanto en ambas imprementaciones:"
 
 #: ../../build/doc/VRP-category.rst:331
-#, fuzzy
 msgid "Identifier of the vehicle."
-msgstr "Velocidad media del vehículo."
+msgstr "Identificador del vehículo."
 
 #: ../../build/doc/VRP-category.rst:332
 msgid "``capacity``"
@@ -694,27 +669,24 @@ msgid "Maiximum capacity units"
 msgstr "Máxima capacidad"
 
 #: ../../build/doc/VRP-category.rst:335
-#, fuzzy
 msgid "``start_open``"
-msgstr "`start_open`"
+msgstr "``start_open``"
 
 #: ../../build/doc/VRP-category.rst:337
 msgid "The time, relative to 0, when the starting location opens."
 msgstr "La hora, en relación con 0, cuando se abre la ubicación inicial."
 
 #: ../../build/doc/VRP-category.rst:338
-#, fuzzy
 msgid "``start_close``"
-msgstr "`start_close`"
+msgstr "``start_close``"
 
 #: ../../build/doc/VRP-category.rst:340
 msgid "The time, relative to 0, when the starting location closes."
 msgstr "La hora, en relación con 0, cuando se cierra la ubicación inicial."
 
 #: ../../build/doc/VRP-category.rst:341
-#, fuzzy
 msgid "[``start_service``]"
-msgstr "`start_service`"
+msgstr "[``start_service``]"
 
 #: ../../build/doc/VRP-category.rst:343
 msgid "The duration of the loading at the starting location."
@@ -725,9 +697,8 @@ msgid "When missing: A duration of :math:`0` time units is used."
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:346
-#, fuzzy
 msgid "[``end_open``]"
-msgstr "**end_open**"
+msgstr "[``end_open``]"
 
 #: ../../build/doc/VRP-category.rst:348
 msgid "The time, relative to 0, when the ending location opens."
@@ -738,9 +709,8 @@ msgid "When missing: The value of ``start_open`` is used"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:351
-#, fuzzy
 msgid "[``end_close``]"
-msgstr "**end_close**"
+msgstr "[``end_close``]"
 
 #: ../../build/doc/VRP-category.rst:353
 msgid "The time, relative to 0, when the ending location closes."
@@ -751,9 +721,8 @@ msgid "When missing: The value of ``start_close`` is used"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:356
-#, fuzzy
 msgid "[``end_service``]"
-msgstr "**end_service**"
+msgstr "[``end_service``]"
 
 #: ../../build/doc/VRP-category.rst:358
 msgid "The duration of the loading at the ending location."
@@ -764,21 +733,18 @@ msgid "When missing: A duration in ``start_service`` is used."
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:366
-#, fuzzy
 msgid ""
 "For :doc:`pgr_pickDeliver` the starting and ending identifiers of the "
 "locations are needed:"
 msgstr ""
-"Para la implementación no euclidiana, se necesitan los identificadores "
-"inicial y final:"
+"Para :doc:`pgr_pickDeliver` los identificadores inicial y final de las "
+"ubicaciones son necesarias:"
 
 #: ../../build/doc/VRP-category.rst:379
-#, fuzzy
 msgid "``start_node_id``"
-msgstr "`start_node_id`"
+msgstr "``start_node_id``"
 
 #: ../../build/doc/VRP-category.rst:381
-#, fuzzy
 msgid ""
 "The node identifier of the start location, must match a vertex identifier"
 " in the `Matrix SQL`_."
@@ -787,12 +753,10 @@ msgstr ""
 "identificador de nodo en la `Matrix SQL`_."
 
 #: ../../build/doc/VRP-category.rst:383
-#, fuzzy
 msgid "[``end_node_id``]"
-msgstr "**end_node_id**"
+msgstr "[``end_node_id``]"
 
 #: ../../build/doc/VRP-category.rst:385
-#, fuzzy
 msgid ""
 "The node identifier of the end location, must match a vertex identifier "
 "in the `Matrix SQL`_."
@@ -805,31 +769,26 @@ msgid "When missing: ``end_node_id`` is used."
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:409
-#, fuzzy
 msgid "``start_x``"
-msgstr "`start_x`"
+msgstr "``start_x``"
 
 #: ../../build/doc/VRP-category.rst:411
-#, fuzzy
 msgid ":math:`x` value of the starting location"
-msgstr ":math:`x` valor de la ubicación de recogida"
+msgstr "valor :math:`x` de la ubicación de recogida"
 
 #: ../../build/doc/VRP-category.rst:412
-#, fuzzy
 msgid "``start_y``"
-msgstr "`start_y`"
+msgstr "``start_y``"
 
 #: ../../build/doc/VRP-category.rst:414
-#, fuzzy
 msgid ":math:`y` value of the starting location"
-msgstr ":math:`y` valor de la ubicación de recogida"
+msgstr "valor :math:`y` de la ubicación de recogida"
 
 #: ../../build/doc/VRP-category.rst:415
 msgid "[``end_x``]"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:417
-#, fuzzy
 msgid ":math:`x` value of the ending location"
 msgstr "valor :math:`x` de la ubicación de entrega"
 
@@ -842,7 +801,6 @@ msgid "[``end_y``]"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:422
-#, fuzzy
 msgid ":math:`y` value of the ending location"
 msgstr "valor :math:`y` del lugar de entrega"
 
@@ -851,7 +809,6 @@ msgid "When missing: ``start_y`` is used."
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:434
-#, fuzzy
 msgid "Matrix SQL"
 msgstr "Matrix SQL"
 
@@ -1122,9 +1079,8 @@ msgid "Summary Row"
 msgstr "Fila de Resumen"
 
 #: ../../build/doc/VRP-category.rst:562
-#, fuzzy
 msgid "Continues the sequence"
-msgstr "Continúa el valor Secuencial"
+msgstr "Continúa el valor secuencial"
 
 #: ../../build/doc/VRP-category.rst:568
 msgid "**total capacity violations**:"
@@ -1227,15 +1183,12 @@ msgstr ""
 "kg de plumas que se van a transportar (no embaladas en cajas)."
 
 #: ../../build/doc/VRP-category.rst:640
-#, fuzzy
 msgid ""
 "If the vehicle's **capacity** is measured in `boxes`, a conversion of `kg"
 " of feathers` to `number of boxes` is needed."
 msgstr ""
-"Si la `capacidad` del vehículo se mide mediante `cajas`, se necesita una "
-"conversión de `kg de plumas` a `número equivalente de cajas`. Si la "
-"`capacidad` del vehículo se mide por `kg`, se necesita una conversión de "
-"`caja de manzanas` a `número equivalente de kg`."
+"Si la **capacidad** del vehículo se mide mediante `cajas`, se necesita una "
+"conversión de `kg de plumas` a `cantidad equivalente de cajas`."
 
 #: ../../build/doc/VRP-category.rst:642
 msgid ""
@@ -1248,13 +1201,12 @@ msgid "Showing how the 2 possible conversions can be done"
 msgstr "Mostrar cómo se pueden hacer las 2 conversiones posibles"
 
 #: ../../build/doc/VRP-category.rst:647
-#, fuzzy
 msgid ""
 "Let: - :math:`f\\_boxes`: number of boxes needed for `1` kg of feathers. "
 "- :math:`a\\_weight`: weight of `1` box of apples."
 msgstr ""
-"Sea: - :math:`f_boxes`: el número de cajas que se utilizarían para `1` kg"
-" de plumas. - :math:`a_weight`: peso de `1` caja de manzanas."
+"Sea: - :math:`f_boxes`: el número de cajas que se utilizarían para `1` kg de "
+"plumas. - :math:`a_weight`: peso de `1` caja de manzanas."
 
 #: ../../build/doc/VRP-category.rst:652
 msgid "Capacity Units"
@@ -1420,9 +1372,8 @@ msgid ":math:`7.5*60 = 540`"
 msgstr ":math:`7.5*60 = 540`"
 
 #: ../../build/doc/VRP-category.rst:695
-#, fuzzy
 msgid "Factor handling"
-msgstr "Manejo de Factores"
+msgstr "Manejo del Factor"
 
 #: ../../build/doc/VRP-category.rst:697
 msgid ""
@@ -1536,16 +1487,14 @@ msgid ""
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:749
-#, fuzzy
 msgid "Units"
-msgstr "unidades de tiempo"
+msgstr "Unidades"
 
 #: ../../build/doc/VRP-category.rst:750
 msgid "velocity"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:753
-#, fuzzy
 msgid "Result"
 msgstr "Resultados"
 
@@ -1554,9 +1503,8 @@ msgid "seconds"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:755
-#, fuzzy
 msgid ":math:`10 m/s`"
-msgstr ":math:`9*60 = 54`"
+msgstr ":math:`10 m/s`"
 
 #: ../../build/doc/VRP-category.rst:756
 msgid ":math:`\\frac{1}{10m/s}`"
@@ -1571,9 +1519,8 @@ msgid ":math:`1000m * 0.1s/m = 100s`"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:760
-#, fuzzy
 msgid ":math:`600 m/min`"
-msgstr ":math:`9*60 = 54`"
+msgstr ":math:`600 m/min`"
 
 #: ../../build/doc/VRP-category.rst:761
 msgid ":math:`\\frac{1}{600m/min}`"
@@ -1588,14 +1535,12 @@ msgid ":math:`1000m * 0.0016min/m = 1.6min`"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:764
-#, fuzzy
 msgid "Hours"
-msgstr "horas"
+msgstr "Horas"
 
 #: ../../build/doc/VRP-category.rst:765
-#, fuzzy
 msgid ":math:`36 km/hr`"
-msgstr ":math:`9*60 = 54`"
+msgstr ":math:`36 km/hr`"
 
 #: ../../build/doc/VRP-category.rst:766
 msgid ":math:`\\frac{1}{36 km/hr}`"

--- a/locale/es/LC_MESSAGES/pgr_TSP.po
+++ b/locale/es/LC_MESSAGES/pgr_TSP.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-07-04 15:45+0000\n"
+"PO-Revision-Date: 2022-09-11 04:55+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/pgr_tsp/"
 "es/>\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.13\n"
+"X-Generator: Weblate 4.13.1\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: ../../build/doc/pgr_TSP.rst:12
@@ -432,7 +432,7 @@ msgstr "Consultas Internas"
 
 #: ../../build/doc/pgr_TSP.rst:166
 msgid "Matrix SQL"
-msgstr "SQL de matriz"
+msgstr "Matrix SQL"
 
 #: ../../src/common/matrixRows_input.c:6
 msgid "``start_vid``"

--- a/locale/es/LC_MESSAGES/pgr_maxCardinalityMatch.po
+++ b/locale/es/LC_MESSAGES/pgr_maxCardinalityMatch.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-07-07 10:07-0500\n"
-"PO-Revision-Date: 2022-06-28 01:20+0000\n"
+"PO-Revision-Date: 2022-09-11 04:55+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_maxcardinalitymatch/es/>\n"
@@ -205,7 +205,7 @@ msgstr ""
 
 #: ../../build/doc/pgr_maxCardinalityMatch.rst:107
 msgid "Parameters"
-msgstr ""
+msgstr "Parámetros"
 
 #: ../../build/doc/pgRouting-concepts.rst:8
 msgid "Parameter"
@@ -223,9 +223,8 @@ msgid "`Edges SQL`_"
 msgstr "``edge``"
 
 #: ../../build/doc/pgRouting-concepts.rst:12
-#, fuzzy
 msgid "``TEXT``"
-msgstr "``target``"
+msgstr "``TEXT``"
 
 #: ../../build/doc/pgRouting-concepts.rst:13
 msgid "`Edges SQL`_ as described below."

--- a/locale/es/LC_MESSAGES/pgr_pickDeliver.po
+++ b/locale/es/LC_MESSAGES/pgr_pickDeliver.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-07-04 15:45+0000\n"
+"PO-Revision-Date: 2022-09-11 04:55+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_pickdeliver/es/>\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.13\n"
+"X-Generator: Weblate 4.13.1\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: ../../build/doc/pgr_pickDeliver.rst:12
@@ -297,9 +297,8 @@ msgid "Description"
 msgstr "Descripción"
 
 #: ../../build/doc/VRP-category.rst:11
-#, fuzzy
 msgid "`Orders SQL`_"
-msgstr "**orders_sql**"
+msgstr "`Orders SQL`_"
 
 #: ../../build/doc/VRP-category.rst:12 ../../build/doc/VRP-category.rst:15
 #: ../../build/doc/VRP-category.rst:18
@@ -311,9 +310,8 @@ msgid "`Orders SQL`_ as described below."
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:14
-#, fuzzy
 msgid "`Vehicles SQL`_"
-msgstr "**vehicles_sql**"
+msgstr "`Vehicles SQL`_"
 
 #: ../../build/doc/VRP-category.rst:16
 msgid "`Vehicles SQL`_ as described below."
@@ -370,9 +368,8 @@ msgid "Maximum number of cycles to perform on the optimization."
 msgstr "Número máximo de ciclos a realizar en la optimización."
 
 #: ../../build/doc/VRP-category.rst:20
-#, fuzzy
 msgid "``initial_sol``"
-msgstr "**initial_sol**"
+msgstr "``initial_sol``"
 
 #: ../../build/doc/VRP-category.rst:22
 msgid "4"
@@ -409,9 +406,8 @@ msgid "``6`` Push front order that allows more orders to be inserted at the fron
 msgstr "``6`` Orden de avance que permite insertar más órdenes en la parte frontal"
 
 #: ../../build/doc/pgr_pickDeliver.rst:131
-#, fuzzy
 msgid "Orders SQL"
-msgstr "**orders_sql**"
+msgstr "Orders SQL"
 
 #: ../../build/doc/pgr_pickDeliver.rst:133
 #: ../../build/doc/pgr_pickDeliver.rst:155
@@ -436,9 +432,8 @@ msgid "Identifier of the pick-delivery order pair."
 msgstr "Identificador del par de órdenes recogida-entrega."
 
 #: ../../build/doc/VRP-category.rst:14
-#, fuzzy
 msgid "``demand``"
-msgstr "**demanda**"
+msgstr "``demand``"
 
 #: ../../build/doc/VRP-category.rst:12 ../../build/doc/VRP-category.rst:15
 #: ../../build/doc/VRP-category.rst:18 ../../build/doc/VRP-category.rst:21
@@ -453,27 +448,24 @@ msgid "Number of units in the order"
 msgstr "Número de unidades en la orden"
 
 #: ../../build/doc/VRP-category.rst:17
-#, fuzzy
 msgid "``p_open``"
-msgstr "`start_open`"
+msgstr "``p_open``"
 
 #: ../../build/doc/VRP-category.rst:19
 msgid "The time, relative to 0, when the pickup location opens."
 msgstr "La hora, en relación con 0, cuando se abre la ubicación de recogida."
 
 #: ../../build/doc/VRP-category.rst:20
-#, fuzzy
 msgid "``p_close``"
-msgstr "`start_close`"
+msgstr "``p_close``"
 
 #: ../../build/doc/VRP-category.rst:22
 msgid "The time, relative to 0, when the pickup location closes."
 msgstr "La hora, en relación con 0, cuando se cierra la ubicación de recogida."
 
 #: ../../build/doc/VRP-category.rst:23
-#, fuzzy
 msgid "[``p_service``]"
-msgstr "`start_service`"
+msgstr "[``p_service``]"
 
 #: ../../build/doc/VRP-category.rst:25
 msgid "The duration of the loading at the pickup location."
@@ -484,32 +476,28 @@ msgid "When missing: 0 time units are used"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:28
-#, fuzzy
 msgid "``d_open``"
-msgstr "`start_open`"
+msgstr "``d_open``"
 
 #: ../../build/doc/VRP-category.rst:30
 msgid "The time, relative to 0, when the delivery location opens."
 msgstr "La hora, en relación con 0, cuando se abre la ubicación de entrega."
 
 #: ../../build/doc/VRP-category.rst:31
-#, fuzzy
 msgid "``d_close``"
-msgstr "`start_close`"
+msgstr "``d_close``"
 
 #: ../../build/doc/VRP-category.rst:33
 msgid "The time, relative to 0, when the delivery location closes."
 msgstr "La hora, en relación con 0, cuando se cierra la ubicación de entrega."
 
 #: ../../build/doc/VRP-category.rst:34
-#, fuzzy
 msgid "[``d_service``]"
-msgstr "`start_service`"
+msgstr "[``d_service``]"
 
 #: ../../build/doc/VRP-category.rst:36
-#, fuzzy
 msgid "The duration of the unloading at the delivery location."
-msgstr "La duración de la carga en el lugar de entrega."
+msgstr "La duración de descargar en el lugar de entrega."
 
 #: ../../build/doc/VRP-category.rst:20 ../../build/doc/VRP-category.rst:22
 #: ../../build/doc/VRP-category.rst:40 ../../build/doc/pgRouting-concepts.rst:3
@@ -534,42 +522,36 @@ msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``, ``REAL``, ``FLOAT``"
 msgstr "``SMALLINT``, ``INTEGER``, ``BIGINT``, ``REAL``, ``FLOAT``"
 
 #: ../../build/doc/VRP-category.rst:11
-#, fuzzy
 msgid "``p_node_id``"
-msgstr "`start_node_id`"
+msgstr "``p_node_id``"
 
 #: ../../build/doc/VRP-category.rst:13
-#, fuzzy
 msgid ""
 "The node identifier of the pickup, must match a vertex identifier in the "
 "`Matrix SQL`_."
 msgstr ""
-"El identificador de nodo de la recogida debe coincidir con un "
-"identificador de nodo en la tabla de matriz."
+"El identificador de nodo de la recogida debe coincidir con un identificador "
+"de nodo en la `Matrix SQL`_."
 
 #: ../../build/doc/VRP-category.rst:15
-#, fuzzy
 msgid "``d_node_id``"
-msgstr "`start_node_id`"
+msgstr "``d_node_id``"
 
 #: ../../build/doc/VRP-category.rst:17
-#, fuzzy
 msgid ""
 "The node identifier of the delivery, must match a vertex identifier in "
 "the `Matrix SQL`_."
 msgstr ""
-"El identificador de nodo de la entrega debe coincidir con un "
-"identificador de nodo en la tabla de matriz."
+"El identificador de nodo de la entrega debe coincidir con un identificador "
+"de nodo en la `Matrix SQL`_."
 
 #: ../../build/doc/pgr_pickDeliver.rst:153
-#, fuzzy
 msgid "Vehicles SQL"
-msgstr "**vehicles_sql**"
+msgstr "Vehicles SQL"
 
 #: ../../build/doc/VRP-category.rst:13
-#, fuzzy
 msgid "Identifier of the vehicle."
-msgstr "Velocidad media del vehículo."
+msgstr "Identificador del vehículo."
 
 #: ../../build/doc/VRP-category.rst:14
 msgid "``capacity``"
@@ -580,27 +562,24 @@ msgid "Maiximum capacity units"
 msgstr "Máxima capacidad"
 
 #: ../../build/doc/VRP-category.rst:17
-#, fuzzy
 msgid "``start_open``"
-msgstr "`start_open`"
+msgstr "``start_open``"
 
 #: ../../build/doc/VRP-category.rst:19
 msgid "The time, relative to 0, when the starting location opens."
 msgstr "La hora, en relación con 0, cuando se abre la ubicación inicial."
 
 #: ../../build/doc/VRP-category.rst:20
-#, fuzzy
 msgid "``start_close``"
-msgstr "`start_close`"
+msgstr "``start_close``"
 
 #: ../../build/doc/VRP-category.rst:22
 msgid "The time, relative to 0, when the starting location closes."
 msgstr "La hora, en relación con 0, cuando se cierra la ubicación inicial."
 
 #: ../../build/doc/VRP-category.rst:23
-#, fuzzy
 msgid "[``start_service``]"
-msgstr "`start_service`"
+msgstr "[``start_service``]"
 
 #: ../../build/doc/VRP-category.rst:25
 msgid "The duration of the loading at the starting location."
@@ -611,9 +590,8 @@ msgid "When missing: A duration of :math:`0` time units is used."
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:28
-#, fuzzy
 msgid "[``end_open``]"
-msgstr "**end_open**"
+msgstr "[``end_open``]"
 
 #: ../../build/doc/VRP-category.rst:30
 msgid "The time, relative to 0, when the ending location opens."
@@ -624,9 +602,8 @@ msgid "When missing: The value of ``start_open`` is used"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:33
-#, fuzzy
 msgid "[``end_close``]"
-msgstr "**end_close**"
+msgstr "[``end_close``]"
 
 #: ../../build/doc/VRP-category.rst:35
 msgid "The time, relative to 0, when the ending location closes."
@@ -637,9 +614,8 @@ msgid "When missing: The value of ``start_close`` is used"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:38
-#, fuzzy
 msgid "[``end_service``]"
-msgstr "**end_service**"
+msgstr "[``end_service``]"
 
 #: ../../build/doc/VRP-category.rst:40
 msgid "The duration of the loading at the ending location."
@@ -650,32 +626,28 @@ msgid "When missing: A duration in ``start_service`` is used."
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:11
-#, fuzzy
 msgid "``start_node_id``"
-msgstr "`start_node_id`"
+msgstr "``start_node_id``"
 
 #: ../../build/doc/VRP-category.rst:13
-#, fuzzy
 msgid ""
 "The node identifier of the start location, must match a vertex identifier"
 " in the `Matrix SQL`_."
 msgstr ""
 "El identificador de nodo de la ubicación inicial debe coincidir con un "
-"identificador de nodo en la tabla de la matriz."
+"identificador de nodo en la `Matrix SQL`_."
 
 #: ../../build/doc/VRP-category.rst:15
-#, fuzzy
 msgid "[``end_node_id``]"
-msgstr "**end_node_id**"
+msgstr "[``end_node_id``]"
 
 #: ../../build/doc/VRP-category.rst:17
-#, fuzzy
 msgid ""
 "The node identifier of the end location, must match a vertex identifier "
 "in the `Matrix SQL`_."
 msgstr ""
 "El identificador de nodo de la ubicación final debe coincidir con un "
-"identificador de nodo en la tabla de matriz."
+"identificador de nodo en la `Matrix SQL`_."
 
 #: ../../build/doc/VRP-category.rst:20
 msgid "When missing: ``end_node_id`` is used."
@@ -683,7 +655,7 @@ msgstr ""
 
 #: ../../build/doc/pgr_pickDeliver.rst:175
 msgid "Matrix SQL"
-msgstr "SQL de matriz"
+msgstr "Matrix SQL"
 
 #: ../../build/doc/pgRouting-concepts.rst:5
 msgid "SMALLINT, INTEGER, BIGINT"

--- a/locale/es/LC_MESSAGES/pgr_pickDeliverEuclidean.po
+++ b/locale/es/LC_MESSAGES/pgr_pickDeliverEuclidean.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: pgRouting v3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-06-24 12:46-0500\n"
-"PO-Revision-Date: 2022-07-04 15:45+0000\n"
+"PO-Revision-Date: 2022-09-11 04:55+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgr_pickdelivereuclidean/es/>\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.13\n"
+"X-Generator: Weblate 4.13.1\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: ../../build/doc/pgr_pickDeliverEuclidean.rst:12
@@ -305,9 +305,8 @@ msgid "Description"
 msgstr "Descripción"
 
 #: ../../build/doc/VRP-category.rst:11
-#, fuzzy
 msgid "`Orders SQL`_"
-msgstr "**orders_sql**"
+msgstr "`Orders SQL`_"
 
 #: ../../build/doc/VRP-category.rst:12 ../../build/doc/VRP-category.rst:15
 msgid "``TEXT``"
@@ -318,9 +317,8 @@ msgid "`Orders SQL`_ as described below."
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:14
-#, fuzzy
 msgid "`Vehicles SQL`_"
-msgstr "**vehicles_sql**"
+msgstr "`Vehicles SQL`_"
 
 #: ../../build/doc/VRP-category.rst:16
 msgid "`Vehicles SQL`_ as described below."
@@ -369,9 +367,8 @@ msgid "Maximum number of cycles to perform on the optimization."
 msgstr "Número máximo de ciclos a realizar en la optimización."
 
 #: ../../build/doc/VRP-category.rst:20
-#, fuzzy
 msgid "``initial_sol``"
-msgstr "**initial_sol**"
+msgstr "``initial_sol``"
 
 #: ../../build/doc/VRP-category.rst:22
 msgid "4"
@@ -408,9 +405,8 @@ msgid "``6`` Push front order that allows more orders to be inserted at the fron
 msgstr "``6`` Orden de avance que permite insertar más órdenes en la parte frontal"
 
 #: ../../build/doc/pgr_pickDeliverEuclidean.rst:139
-#, fuzzy
 msgid "Orders SQL"
-msgstr "**orders_sql**"
+msgstr "Orders SQL"
 
 #: ../../build/doc/pgr_pickDeliverEuclidean.rst:141
 #: ../../build/doc/pgr_pickDeliverEuclidean.rst:163
@@ -436,9 +432,8 @@ msgid "Identifier of the pick-delivery order pair."
 msgstr "Identificador del par de órdenes recogida-entrega."
 
 #: ../../build/doc/VRP-category.rst:14
-#, fuzzy
 msgid "``demand``"
-msgstr "**demanda**"
+msgstr "``demand``"
 
 #: ../../build/doc/VRP-category.rst:12 ../../build/doc/VRP-category.rst:15
 #: ../../build/doc/VRP-category.rst:18 ../../build/doc/VRP-category.rst:21
@@ -454,27 +449,24 @@ msgid "Number of units in the order"
 msgstr "Número de unidades en la orden"
 
 #: ../../build/doc/VRP-category.rst:17
-#, fuzzy
 msgid "``p_open``"
-msgstr "`start_open`"
+msgstr "``p_open``"
 
 #: ../../build/doc/VRP-category.rst:19
 msgid "The time, relative to 0, when the pickup location opens."
 msgstr "La hora, en relación con 0, cuando se abre la ubicación de recogida."
 
 #: ../../build/doc/VRP-category.rst:20
-#, fuzzy
 msgid "``p_close``"
-msgstr "`start_close`"
+msgstr "``p_close``"
 
 #: ../../build/doc/VRP-category.rst:22
 msgid "The time, relative to 0, when the pickup location closes."
 msgstr "La hora, en relación con 0, cuando se cierra la ubicación de recogida."
 
 #: ../../build/doc/VRP-category.rst:23
-#, fuzzy
 msgid "[``p_service``]"
-msgstr "`start_service`"
+msgstr "[``p_service``]"
 
 #: ../../build/doc/VRP-category.rst:25
 msgid "The duration of the loading at the pickup location."
@@ -485,32 +477,28 @@ msgid "When missing: 0 time units are used"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:28
-#, fuzzy
 msgid "``d_open``"
-msgstr "`start_open`"
+msgstr "``d_open``"
 
 #: ../../build/doc/VRP-category.rst:30
 msgid "The time, relative to 0, when the delivery location opens."
 msgstr "La hora, en relación con 0, cuando se abre la ubicación de entrega."
 
 #: ../../build/doc/VRP-category.rst:31
-#, fuzzy
 msgid "``d_close``"
-msgstr "`start_close`"
+msgstr "``d_close``"
 
 #: ../../build/doc/VRP-category.rst:33
 msgid "The time, relative to 0, when the delivery location closes."
 msgstr "La hora, en relación con 0, cuando se cierra la ubicación de entrega."
 
 #: ../../build/doc/VRP-category.rst:34
-#, fuzzy
 msgid "[``d_service``]"
-msgstr "`start_service`"
+msgstr "[``d_service``]"
 
 #: ../../build/doc/VRP-category.rst:36
-#, fuzzy
 msgid "The duration of the unloading at the delivery location."
-msgstr "La duración de la carga en el lugar de entrega."
+msgstr "La duración de descargar en el lugar de entrega."
 
 #: ../../build/doc/VRP-category.rst
 msgid "ANY-INTEGER"
@@ -530,54 +518,48 @@ msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``, ``REAL``, ``FLOAT``"
 msgstr "``SMALLINT``, ``INTEGER``, ``BIGINT``, ``REAL``, ``FLOAT``"
 
 #: ../../build/doc/VRP-category.rst:11
-#, fuzzy
 msgid "``p_x``"
-msgstr "``-1``"
+msgstr "``p_x``"
 
 #: ../../build/doc/VRP-category.rst:13
 msgid ":math:`x` value of the pick up location"
 msgstr ":math:`x` valor de la ubicación de recogida"
 
 #: ../../build/doc/VRP-category.rst:14
-#, fuzzy
 msgid "``p_y``"
-msgstr "``-1``"
+msgstr "``p_y``"
 
 #: ../../build/doc/VRP-category.rst:16
 msgid ":math:`y` value of the pick up location"
 msgstr ":math:`y` valor de la ubicación de recogida"
 
 #: ../../build/doc/VRP-category.rst:17
-#, fuzzy
 msgid "``d_x``"
-msgstr "``-1``"
+msgstr "``d_x``"
 
 #: ../../build/doc/VRP-category.rst:19
 msgid ":math:`x` value of the delivery location"
 msgstr "valor :math:`x` de la ubicación de entrega"
 
 #: ../../build/doc/VRP-category.rst:20
-#, fuzzy
 msgid "``d_y``"
-msgstr "``-1``"
+msgstr "``d_y``"
 
 #: ../../build/doc/VRP-category.rst:22
 msgid ":math:`y` value of the delivery location"
 msgstr "valor :math:`y` del lugar de entrega"
 
 #: ../../build/doc/pgr_pickDeliverEuclidean.rst:161
-#, fuzzy
 msgid "Vehicles SQL"
-msgstr "**vehicles_sql**"
+msgstr "Vehicles SQL"
 
 #: ../../build/doc/pgr_pickDeliverEuclidean.rst:171
 msgid "where:"
 msgstr "Donde:"
 
 #: ../../build/doc/VRP-category.rst:13
-#, fuzzy
 msgid "Identifier of the vehicle."
-msgstr "Velocidad media del vehículo."
+msgstr "Identificador del vehículo."
 
 #: ../../build/doc/VRP-category.rst:14
 msgid "``capacity``"
@@ -588,27 +570,24 @@ msgid "Maiximum capacity units"
 msgstr "Máxima capacidad"
 
 #: ../../build/doc/VRP-category.rst:17
-#, fuzzy
 msgid "``start_open``"
-msgstr "`start_open`"
+msgstr "``start_open``"
 
 #: ../../build/doc/VRP-category.rst:19
 msgid "The time, relative to 0, when the starting location opens."
 msgstr "La hora, en relación con 0, cuando se abre la ubicación inicial."
 
 #: ../../build/doc/VRP-category.rst:20
-#, fuzzy
 msgid "``start_close``"
-msgstr "`start_close`"
+msgstr "``start_close``"
 
 #: ../../build/doc/VRP-category.rst:22
 msgid "The time, relative to 0, when the starting location closes."
 msgstr "La hora, en relación con 0, cuando se cierra la ubicación inicial."
 
 #: ../../build/doc/VRP-category.rst:23
-#, fuzzy
 msgid "[``start_service``]"
-msgstr "`start_service`"
+msgstr "[``start_service``]"
 
 #: ../../build/doc/VRP-category.rst:25
 msgid "The duration of the loading at the starting location."
@@ -619,9 +598,8 @@ msgid "When missing: A duration of :math:`0` time units is used."
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:28
-#, fuzzy
 msgid "[``end_open``]"
-msgstr "**end_open**"
+msgstr "[``end_open``]"
 
 #: ../../build/doc/VRP-category.rst:30
 msgid "The time, relative to 0, when the ending location opens."
@@ -632,9 +610,8 @@ msgid "When missing: The value of ``start_open`` is used"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:33
-#, fuzzy
 msgid "[``end_close``]"
-msgstr "**end_close**"
+msgstr "[``end_close``]"
 
 #: ../../build/doc/VRP-category.rst:35
 msgid "The time, relative to 0, when the ending location closes."
@@ -645,9 +622,8 @@ msgid "When missing: The value of ``start_close`` is used"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:38
-#, fuzzy
 msgid "[``end_service``]"
-msgstr "**end_service**"
+msgstr "[``end_service``]"
 
 #: ../../build/doc/VRP-category.rst:40
 msgid "The duration of the loading at the ending location."
@@ -658,31 +634,26 @@ msgid "When missing: A duration in ``start_service`` is used."
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:11
-#, fuzzy
 msgid "``start_x``"
-msgstr "`start_x`"
+msgstr "``start_x``"
 
 #: ../../build/doc/VRP-category.rst:13
-#, fuzzy
 msgid ":math:`x` value of the starting location"
-msgstr ":math:`x` valor de la ubicación de recogida"
+msgstr "valor :math:`x` de la ubicación de recogida"
 
 #: ../../build/doc/VRP-category.rst:14
-#, fuzzy
 msgid "``start_y``"
-msgstr "`start_y`"
+msgstr "``start_y``"
 
 #: ../../build/doc/VRP-category.rst:16
-#, fuzzy
 msgid ":math:`y` value of the starting location"
-msgstr ":math:`y` valor de la ubicación de recogida"
+msgstr "valor :math:`y` de la ubicación de recogida"
 
 #: ../../build/doc/VRP-category.rst:17
 msgid "[``end_x``]"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:19
-#, fuzzy
 msgid ":math:`x` value of the ending location"
 msgstr "valor :math:`x` de la ubicación de entrega"
 
@@ -695,7 +666,6 @@ msgid "[``end_y``]"
 msgstr ""
 
 #: ../../build/doc/VRP-category.rst:24
-#, fuzzy
 msgid ":math:`y` value of the ending location"
 msgstr "valor :math:`y` del lugar de entrega"
 

--- a/locale/es/LC_MESSAGES/pgr_trspVia.po
+++ b/locale/es/LC_MESSAGES/pgr_trspVia.po
@@ -10,20 +10,20 @@ msgstr ""
 "POT-Creation-Date: 2022-07-11 18:25-0500\n"
 "PO-Revision-Date: 2022-07-06 23:33+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
+"Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
+"pgr_trspvia/es/>\n"
 "Language: es\n"
-"Language-Team: Spanish "
-"<https://weblate.osgeo.org/projects/pgrouting/pgr_trspvia/es/>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: ../../build/doc/pgr_trspVia.rst:12
 msgid ""
-"**Supported versions:** `Latest "
-"<https://docs.pgrouting.org/latest/en/pgr_trspVia.html>`__ (`3.4 "
-"<https://docs.pgrouting.org/3.4/en/pgr_trspVia.html>`__)"
+"**Supported versions:** `Latest <https://docs.pgrouting.org/latest/en/"
+"pgr_trspVia.html>`__ (`3.4 <https://docs.pgrouting.org/3.4/en/pgr_trspVia."
+"html>`__)"
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia.rst:17
@@ -32,8 +32,7 @@ msgstr ""
 
 #: ../../build/doc/pgr_trspVia.rst:19
 msgid ""
-"``pgr_trspVia`` Route that goes through a list of vertices with "
-"restrictions."
+"``pgr_trspVia`` Route that goes through a list of vertices with restrictions."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia.rst:24
@@ -92,19 +91,19 @@ msgstr ""
 msgid "``pgr_trspVia`` (`One Via`_)"
 msgstr ""
 
-#: ../../build/doc/TRSP-family.rst:10 ../../build/doc/dijkstra-family.rst:11
+#: ../../build/doc/pgr_trspVia.rst:39 ../../build/doc/TRSP-family.rst:10
+#: ../../build/doc/dijkstra-family.rst:11 ../../build/doc/via-category.rst:11
+#: ../../build/doc/pgRouting-concepts.rst:11
 #: ../../build/doc/pgRouting-concepts.rst:10
-#: ../../build/doc/pgRouting-concepts.rst:11 ../../build/doc/pgr_trspVia.rst:39
-#: ../../build/doc/via-category.rst:10 ../../build/doc/via-category.rst:11
+#: ../../build/doc/via-category.rst:10
 msgid "Description"
 msgstr "Descripción"
 
 #: ../../build/doc/pgr_trspVia.rst:41
 msgid ""
-"Given a list of vertices and a graph, this function is equivalent to "
-"finding the shortest path between :math:`vertex_i` and "
-":math:`vertex_{i+1}` for all :math:`i < size\\_of(via\\;vertices)` trying"
-" not to use restricted paths."
+"Given a list of vertices and a graph, this function is equivalent to finding "
+"the shortest path between :math:`vertex_i` and :math:`vertex_{i+1}` for all :"
+"math:`i < size\\_of(via\\;vertices)` trying not to use restricted paths."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia.rst:45
@@ -121,8 +120,7 @@ msgstr ""
 
 #: ../../build/doc/pgr_trspVia.rst:50
 msgid ""
-"For the set of sub paths of the solution that pass through a restriction "
-"then"
+"For the set of sub paths of the solution that pass through a restriction then"
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia.rst:52
@@ -147,11 +145,10 @@ msgstr ""
 
 #: ../../build/doc/pgr_trspVia.rst:68
 msgid ""
-"pgr_trspVia(`Edges SQL`_, `Restrictions SQL`_, **via vertices**, "
-"[options])"
+"pgr_trspVia(`Edges SQL`_, `Restrictions SQL`_, **via vertices**, [options])"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst
+#: ../../build/doc/pgr_trspVia.rst:0
 msgid "[options]"
 msgstr ""
 
@@ -163,15 +160,15 @@ msgstr ""
 msgid "RETURNS SET OF |via-result| OR EMPTY SET"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst
+#: ../../build/doc/pgr_trspVia.rst:0
 msgid "Example"
 msgstr "Ejemplo"
 
 #: ../../build/doc/pgr_trspVia.rst:75
 #, fuzzy
 msgid ""
-"Find the route that visits the vertices :math:`\\{ 5, 1, 8\\}` in that "
-"order on an directed graph."
+"Find the route that visits the vertices :math:`\\{ 5, 1, 8\\}` in that order "
+"on an directed graph."
 msgstr ""
 "Encontrar la ruta que visita los vértices :math:`\\{ 5, 1, 8\\}` en ese "
 "orden, en un grafo **dirigido**."
@@ -185,7 +182,7 @@ msgid "Parameter"
 msgstr "Parámetro"
 
 #: ../../build/doc/TRSP-family.rst:9 ../../build/doc/dijkstra-family.rst:9
-#: ../../build/doc/pgRouting-concepts.rst:9 ../../build/doc/via-category.rst:9
+#: ../../build/doc/via-category.rst:9 ../../build/doc/pgRouting-concepts.rst:9
 msgid "Type"
 msgstr "Tipo"
 
@@ -221,12 +218,12 @@ msgstr "``ARRAY[`` **ANY-INTEGER** ``]``"
 msgid "Array of ordered vertices identifiers that are going to be visited."
 msgstr "Arreglo ordenado de identificadores de vértices que serán visitados."
 
-#: ../../build/doc/TRSP-family.rst:21 ../../build/doc/pgRouting-concepts.rst:21
-#: ../../build/doc/pgRouting-concepts.rst:36
+#: ../../build/doc/TRSP-family.rst:21 ../../build/doc/pgRouting-concepts.rst:36
+#: ../../build/doc/pgRouting-concepts.rst:21
 msgid "Where:"
 msgstr "Donde:"
 
-#: ../../build/doc/TRSP-family.rst ../../build/doc/pgRouting-concepts.rst
+#: ../../build/doc/TRSP-family.rst:0 ../../build/doc/pgRouting-concepts.rst:0
 msgid "ANY-INTEGER"
 msgstr "ENTEROS"
 
@@ -243,9 +240,8 @@ msgstr "Parámetros opcionales"
 msgid "Column"
 msgstr "Columna"
 
-#: ../../build/doc/dijkstra-family.rst:10
+#: ../../build/doc/dijkstra-family.rst:10 ../../build/doc/via-category.rst:10
 #: ../../build/doc/pgRouting-concepts.rst:10
-#: ../../build/doc/via-category.rst:10
 msgid "Default"
 msgstr "x Defecto"
 
@@ -298,7 +294,8 @@ msgstr "``U_turn_on_edge``"
 
 #: ../../build/doc/via-category.rst:20
 msgid "When ``true`` departing from a visited vertex will not try to avoid"
-msgstr "Cuando ``true`` saliendo desde un vértice visitado no intentara esquivarlo"
+msgstr ""
+"Cuando ``true`` saliendo desde un vértice visitado no intentara esquivarlo"
 
 #: ../../build/doc/pgr_trspVia.rst:104
 msgid "Inner Queries"
@@ -343,9 +340,9 @@ msgstr "Identificador del segundo vértice de la arista."
 msgid "``cost``"
 msgstr "``cost``"
 
-#: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:25
 #: ../../build/doc/pgRouting-concepts.rst:29
+#: ../../build/doc/pgRouting-concepts.rst:18
 msgid "**ANY-NUMERICAL**"
 msgstr "**FLOTANTES**"
 
@@ -367,23 +364,23 @@ msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
 msgid ""
-"When negative: edge (``target``, ``source``) does not exist, therefore "
-"it's not part of the graph."
+"When negative: edge (``target``, ``source``) does not exist, therefore it's "
+"not part of the graph."
 msgstr ""
-"Cuando negativo: la arista (``target``, ``source``) no existe, por lo "
-"tanto no es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
-#: ../../build/doc/pgRouting-concepts.rst:23
 #: ../../build/doc/pgRouting-concepts.rst:38
+#: ../../build/doc/pgRouting-concepts.rst:23
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``"
 msgstr "``SMALLINT``, ``INTEGER``, ``BIGINT``"
 
-#: ../../build/doc/pgRouting-concepts.rst
+#: ../../build/doc/pgRouting-concepts.rst:0
 msgid "ANY-NUMERICAL"
 msgstr "FLOTANTES"
 
-#: ../../build/doc/pgRouting-concepts.rst:24
 #: ../../build/doc/pgRouting-concepts.rst:39
+#: ../../build/doc/pgRouting-concepts.rst:24
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``, ``REAL``, ``FLOAT``"
 msgstr "``SMALLINT``, ``INTEGER``, ``BIGINT``, ``REAL``, ``FLOAT``"
 
@@ -398,12 +395,12 @@ msgstr "``path``"
 #: ../../build/doc/pgRouting-concepts.rst:13
 msgid ""
 "Sequence of edge identifiers that form a path that is not allowed to be "
-"taken. - Empty arrays or ``NULL`` arrays are ignored. - Arrays that have "
-"a ``NULL`` element will raise an exception."
+"taken. - Empty arrays or ``NULL`` arrays are ignored. - Arrays that have a "
+"``NULL`` element will raise an exception."
 msgstr ""
 "Secuencia de identificadores de aristas que forman un camino que no se "
-"permite tomar. - Arreglos vacios o ``NULL`` son ignorados. - Arreglos que"
-" tienen ``NULL`` arrojan una excepción."
+"permite tomar. - Arreglos vacios o ``NULL`` son ignorados. - Arreglos que "
+"tienen ``NULL`` arrojan una excepción."
 
 #: ../../build/doc/pgRouting-concepts.rst:17
 msgid "``Cost``"
@@ -444,8 +441,7 @@ msgstr "``path_seq``"
 
 #: ../../build/doc/via-category.rst:19
 msgid ""
-"Relative position in the path. Has value **1** for the beginning of a "
-"path."
+"Relative position in the path. Has value **1** for the beginning of a path."
 msgstr ""
 "Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
 "ruta."
@@ -485,11 +481,11 @@ msgstr "``edge``"
 
 #: ../../build/doc/via-category.rst:32
 msgid ""
-"Identifier of the edge used to go from ``node`` to the next node in the "
-"path sequence."
+"Identifier of the edge used to go from ``node`` to the next node in the path "
+"sequence."
 msgstr ""
-"Identificador de la arsita utilizada para ir del ``node`` al siguiente "
-"nodo de la secuencia de ruta."
+"Identificador de la arsita utilizada para ir del ``node`` al siguiente nodo "
+"de la secuencia de ruta."
 
 #: ../../build/doc/via-category.rst:35
 msgid "-1 for the last node of the path."
@@ -506,11 +502,11 @@ msgstr "``FLOAT``"
 
 #: ../../build/doc/via-category.rst:39
 msgid ""
-"Cost to traverse from ``node`` using ``edge`` to the next node in the "
-"path sequence."
+"Cost to traverse from ``node`` using ``edge`` to the next node in the path "
+"sequence."
 msgstr ""
-"Costo para atravesar desde ``node`` usando ``edge`` hasta el siguiente "
-"nodo en la secuencia de la ruta."
+"Costo para atravesar desde ``node`` usando ``edge`` hasta el siguiente nodo "
+"en la secuencia de la ruta."
 
 #: ../../build/doc/via-category.rst:41
 msgid "``agg_cost``"
@@ -526,11 +522,11 @@ msgstr "``route_agg_cost``"
 
 #: ../../build/doc/via-category.rst:46
 msgid ""
-"Total cost from ``start_vid`` of ``seq = 1`` to ``end_vid`` of the "
-"current ``seq``."
+"Total cost from ``start_vid`` of ``seq = 1`` to ``end_vid`` of the current "
+"``seq``."
 msgstr ""
-"Costo total desde ``start_vid`` en ``seq = 1`` hasta ``end_vid`` del "
-"``seq`` actual."
+"Costo total desde ``start_vid`` en ``seq = 1`` hasta ``end_vid`` del ``seq`` "
+"actual."
 
 #: ../../build/doc/pgr_trspVia.rst:128
 msgid "Additional Examples"
@@ -539,11 +535,11 @@ msgstr "Ejemplos Adicionales"
 #: ../../build/doc/pgr_trspVia.rst:133
 #, fuzzy
 msgid ""
-"All this examples are about the route that visits the vertices "
-":math:`\\{5, 7, 1, 8, 15\\}` in that order on a directed graph."
+"All this examples are about the route that visits the vertices :math:`\\{5, "
+"7, 1, 8, 15\\}` in that order on a directed graph."
 msgstr ""
-"Todos estos ejemplos son sobre la ruta que visita los vértices "
-":math:`\\{5, 7, 1, 8, 15\\}` en ese orden, en un grafo **dirigido**."
+"Todos estos ejemplos son sobre la ruta que visita los vértices :math:`\\{5, "
+"7, 1, 8, 15\\}` en ese orden, en un grafo **dirigido**."
 
 #: ../../build/doc/pgr_trspVia.rst:137
 msgid "The main query"
@@ -580,8 +576,8 @@ msgstr ""
 
 #: ../../build/doc/pgr_trspVia.rst:187
 msgid ""
-"Detects which of the sub paths pass through a restriction in this case is"
-" for the ``path_id = 5`` from ``6`` to ``3`` because the path :math:`15 "
+"Detects which of the sub paths pass through a restriction in this case is "
+"for the ``path_id = 5`` from ``6`` to ``3`` because the path :math:`15 "
 "\\rightarrow 1` is restricted."
 msgstr ""
 
@@ -591,16 +587,15 @@ msgstr ""
 
 #: ../../build/doc/pgr_trspVia.rst:197
 msgid ""
-"From the :doc:`pgr_dijkstraVia` result it removes the conflicting paths "
-"and builds the solution with the results of the :doc:`pgr_trsp` "
-"algorithm:"
+"From the :doc:`pgr_dijkstraVia` result it removes the conflicting paths and "
+"builds the solution with the results of the :doc:`pgr_trsp` algorithm:"
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia.rst:204
 msgid "Getting the same result as ``pgr_trspVia``:"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst
+#: ../../build/doc/pgr_trspVia.rst:0
 msgid "Example 8"
 msgstr "Ejemplo 8"
 
@@ -610,15 +605,15 @@ msgstr ""
 
 #: ../../build/doc/pgr_trspVia.rst:213
 msgid ""
-"The first step, doing a :doc:`pgr_dijkstraVia` does consider not making a"
-" U turn on the same edge. But the path :math:`16 \\rightarrow 13` (Rows 4"
-" and 5) is restricted and the result is using it."
+"The first step, doing a :doc:`pgr_dijkstraVia` does consider not making a U "
+"turn on the same edge. But the path :math:`16 \\rightarrow 13` (Rows 4 and "
+"5) is restricted and the result is using it."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia.rst:221
 msgid ""
-"When executing the :doc:`pgr_trsp` algorithm for the conflicting path, "
-"there is no ``U_turn_on_edge`` flag."
+"When executing the :doc:`pgr_trsp` algorithm for the conflicting path, there "
+"is no ``U_turn_on_edge`` flag."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia.rst:228
@@ -650,4 +645,3 @@ msgstr ":ref:`genindex`"
 #: ../../build/doc/pgr_trspVia.rst:243
 msgid ":ref:`search`"
 msgstr ":ref:`search`"
-

--- a/locale/es/LC_MESSAGES/pgr_trspVia_withPoints.po
+++ b/locale/es/LC_MESSAGES/pgr_trspVia_withPoints.po
@@ -10,21 +10,20 @@ msgstr ""
 "POT-Creation-Date: 2022-07-11 18:25-0500\n"
 "PO-Revision-Date: 2022-07-04 16:00+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
+"Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
+"pgr_trspvia_withpoints/es/>\n"
 "Language: es\n"
-"Language-Team: Spanish "
-"<https://weblate.osgeo.org/projects/pgrouting/pgr_trspvia_withpoints/es/>"
-"\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:12
 msgid ""
-"**Supported versions:** `Latest "
-"<https://docs.pgrouting.org/latest/en/pgr_trspVia_withPoints.html>`__ "
-"(`3.4 <https://docs.pgrouting.org/3.4/en/pgr_trspVia_withPoints.html>`__)"
+"**Supported versions:** `Latest <https://docs.pgrouting.org/latest/en/"
+"pgr_trspVia_withPoints.html>`__ (`3.4 <https://docs.pgrouting.org/3.4/en/"
+"pgr_trspVia_withPoints.html>`__)"
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:17
@@ -33,8 +32,8 @@ msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:19
 msgid ""
-"``pgr_trspVia_withPoints`` - Route that goes through a list of vertices "
-"and/or points with restrictions."
+"``pgr_trspVia_withPoints`` - Route that goes through a list of vertices and/"
+"or points with restrictions."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:25
@@ -93,27 +92,26 @@ msgstr ""
 msgid "``pgr_trspVia_withPoints`` (`One Via`_)"
 msgstr ""
 
-#: ../../build/doc/dijkstra-family.rst:11
-#: ../../build/doc/pgRouting-concepts.rst:10
-#: ../../build/doc/pgRouting-concepts.rst:11
 #: ../../build/doc/pgr_trspVia_withPoints.rst:40
+#: ../../build/doc/via-category.rst:11 ../../build/doc/dijkstra-family.rst:11
 #: ../../build/doc/pgr_trsp_withPoints.rst:11
-#: ../../build/doc/via-category.rst:10 ../../build/doc/via-category.rst:11
+#: ../../build/doc/pgRouting-concepts.rst:11
+#: ../../build/doc/pgRouting-concepts.rst:10
 #: ../../build/doc/withPoints-category.rst:11
+#: ../../build/doc/via-category.rst:10
 msgid "Description"
 msgstr "Descripción"
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:42
 msgid ""
-"Given a graph, a set of restriction on the graph edges, a set of points "
-"on the graphs edges and a list of vertices, this function is equivalent "
-"to finding the shortest path between :math:`vertex_i` and "
-":math:`vertex_{i+1}` (where :math:`vertex` can be a vertex or a point on "
-"the graph) for all :math:`i < size\\_of(via\\;vertices)` trying not to "
-"use restricted paths."
+"Given a graph, a set of restriction on the graph edges, a set of points on "
+"the graphs edges and a list of vertices, this function is equivalent to "
+"finding the shortest path between :math:`vertex_i` and :math:`vertex_{i+1}` "
+"(where :math:`vertex` can be a vertex or a point on the graph) for all :math:"
+"`i < size\\_of(via\\;vertices)` trying not to use restricted paths."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst
+#: ../../build/doc/pgr_trspVia_withPoints.rst:0
 msgid "Route"
 msgstr ""
 
@@ -121,7 +119,7 @@ msgstr ""
 msgid "is a sequence of paths"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst
+#: ../../build/doc/pgr_trspVia_withPoints.rst:0
 msgid "Path"
 msgstr ""
 
@@ -150,7 +148,8 @@ msgid "Execute a :doc:`pgr_withPointsVia`."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:59
-msgid "For the set of paths of the solution that pass through a restriction then"
+msgid ""
+"For the set of paths of the solution that pass through a restriction then"
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:61
@@ -183,7 +182,7 @@ msgid ""
 "vertices**, [options])"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst
+#: ../../build/doc/pgr_trspVia_withPoints.rst:0
 msgid "[options]"
 msgstr ""
 
@@ -195,7 +194,7 @@ msgstr ""
 msgid "RETURNS SET OF |via-result| OR EMPTY SET"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst
+#: ../../build/doc/pgr_trspVia_withPoints.rst:0
 msgid "Example"
 msgstr "Ejemplo"
 
@@ -209,22 +208,21 @@ msgstr ""
 msgid "Parameters"
 msgstr "Parámetros"
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:8 ../../build/doc/via-category.rst:8
+#: ../../build/doc/via-category.rst:8 ../../build/doc/pgr_trsp_withPoints.rst:8
 #: ../../build/doc/withPoints-category.rst:8
 msgid "Parameter"
 msgstr "Parámetro"
 
-#: ../../build/doc/dijkstra-family.rst:9
+#: ../../build/doc/via-category.rst:9 ../../build/doc/dijkstra-family.rst:9
+#: ../../build/doc/pgr_trsp_withPoints.rst:9
 #: ../../build/doc/pgRouting-concepts.rst:9
-#: ../../build/doc/pgr_trsp_withPoints.rst:9 ../../build/doc/via-category.rst:9
 #: ../../build/doc/withPoints-category.rst:9
 msgid "Type"
 msgstr "Tipo"
 
-#: ../../build/doc/dijkstra-family.rst:10
-#: ../../build/doc/pgRouting-concepts.rst:10
+#: ../../build/doc/via-category.rst:10 ../../build/doc/dijkstra-family.rst:10
 #: ../../build/doc/pgr_trsp_withPoints.rst:10
-#: ../../build/doc/via-category.rst:10
+#: ../../build/doc/pgRouting-concepts.rst:10
 #: ../../build/doc/withPoints-category.rst:10
 msgid "Default"
 msgstr "x Defecto"
@@ -249,8 +247,8 @@ msgstr "`SQL puntos`_"
 msgid "**via vertices**"
 msgstr "**vía vértices**"
 
-#: ../../build/doc/pgRouting-concepts.rst:12
 #: ../../build/doc/via-category.rst:21
+#: ../../build/doc/pgRouting-concepts.rst:12
 msgid "``ARRAY[`` **ANY-INTEGER** ``]``"
 msgstr "``ARRAY[`` **ANY-INTEGER** ``]``"
 
@@ -266,15 +264,15 @@ msgstr "Cuando sea positivo se considera como un identificador de vértice"
 msgid "When negative it is considered a point identifier"
 msgstr "Cuando sea negativo se considera como un identificador de punto"
 
-#: ../../build/doc/pgRouting-concepts.rst:21
-#: ../../build/doc/pgRouting-concepts.rst:36
 #: ../../build/doc/via-category.rst:28
+#: ../../build/doc/pgRouting-concepts.rst:36
+#: ../../build/doc/pgRouting-concepts.rst:21
 #: ../../build/doc/withPoints-category.rst:40
 msgid "Where:"
 msgstr "Donde:"
 
-#: ../../build/doc/pgRouting-concepts.rst ../../build/doc/via-category.rst
-#: ../../build/doc/withPoints-category.rst
+#: ../../build/doc/via-category.rst:0 ../../build/doc/pgRouting-concepts.rst:0
+#: ../../build/doc/withPoints-category.rst:0
 msgid "ANY-INTEGER"
 msgstr "ENTEROS"
 
@@ -282,8 +280,8 @@ msgstr "ENTEROS"
 msgid "SMALLINT, INTEGER, BIGINT"
 msgstr "``SMALLINT, INTEGER, BIGINT``"
 
-#: ../../build/doc/pgRouting-concepts.rst ../../build/doc/via-category.rst
-#: ../../build/doc/withPoints-category.rst
+#: ../../build/doc/via-category.rst:0 ../../build/doc/pgRouting-concepts.rst:0
+#: ../../build/doc/withPoints-category.rst:0
 msgid "ANY-NUMERICAL"
 msgstr "FLOTANTES"
 
@@ -304,9 +302,9 @@ msgstr "Columna"
 msgid "``directed``"
 msgstr "``directed``"
 
-#: ../../build/doc/dijkstra-family.rst:13
+#: ../../build/doc/dijkstra-family.rst:13 ../../build/doc/via-category.rst:13
+#: ../../build/doc/via-category.rst:18
 #: ../../build/doc/pgr_trsp_withPoints.rst:21
-#: ../../build/doc/via-category.rst:13 ../../build/doc/via-category.rst:18
 msgid "``BOOLEAN``"
 msgstr "``BOOLEAN``"
 
@@ -330,8 +328,8 @@ msgstr "Parámetros opcionales Vía"
 msgid "``strict``"
 msgstr "``strict``"
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:22
 #: ../../build/doc/via-category.rst:14
+#: ../../build/doc/pgr_trsp_withPoints.rst:22
 msgid "``false``"
 msgstr "``false``"
 
@@ -351,7 +349,8 @@ msgstr "``U_turn_on_edge``"
 
 #: ../../build/doc/via-category.rst:20
 msgid "When ``true`` departing from a visited vertex will not try to avoid"
-msgstr "Cuando ``true`` saliendo desde un vértice visitado no intentara esquivarlo"
+msgstr ""
+"Cuando ``true`` saliendo desde un vértice visitado no intentara esquivarlo"
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:115
 msgid "With points optional parameters"
@@ -392,12 +391,12 @@ msgstr "``details``"
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:23
 msgid "When ``true`` the results will include the points that are in the path."
-msgstr "Cuando ``true`` los resultados incluyen los puntos que están en el camino."
+msgstr ""
+"Cuando ``true`` los resultados incluyen los puntos que están en el camino."
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:24
 msgid ""
-"When ``false`` the results will not include the points that are in the "
-"path."
+"When ``false`` the results will not include the points that are in the path."
 msgstr ""
 "Cuando ``false`` los resultados no incluyen los puntos que están en el "
 "camino."
@@ -447,9 +446,9 @@ msgstr "Identificador del segundo vértice de la arista."
 msgid "``cost``"
 msgstr "``cost``"
 
-#: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:25
 #: ../../build/doc/pgRouting-concepts.rst:29
+#: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/withPoints-category.rst:27
 msgid "**ANY-NUMERICAL**"
 msgstr "**FLOTANTES**"
@@ -472,20 +471,20 @@ msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
 msgid ""
-"When negative: edge (``target``, ``source``) does not exist, therefore "
-"it's not part of the graph."
+"When negative: edge (``target``, ``source``) does not exist, therefore it's "
+"not part of the graph."
 msgstr ""
-"Cuando negativo: la arista (``target``, ``source``) no existe, por lo "
-"tanto no es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
-#: ../../build/doc/pgRouting-concepts.rst:23
 #: ../../build/doc/pgRouting-concepts.rst:38
+#: ../../build/doc/pgRouting-concepts.rst:23
 #: ../../build/doc/withPoints-category.rst:42
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``"
 msgstr "``SMALLINT``, ``INTEGER``, ``BIGINT``"
 
-#: ../../build/doc/pgRouting-concepts.rst:24
 #: ../../build/doc/pgRouting-concepts.rst:39
+#: ../../build/doc/pgRouting-concepts.rst:24
 #: ../../build/doc/withPoints-category.rst:43
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``, ``REAL``, ``FLOAT``"
 msgstr "``SMALLINT``, ``INTEGER``, ``BIGINT``, ``REAL``, ``FLOAT``"
@@ -501,12 +500,12 @@ msgstr "``path``"
 #: ../../build/doc/pgRouting-concepts.rst:13
 msgid ""
 "Sequence of edge identifiers that form a path that is not allowed to be "
-"taken. - Empty arrays or ``NULL`` arrays are ignored. - Arrays that have "
-"a ``NULL`` element will raise an exception."
+"taken. - Empty arrays or ``NULL`` arrays are ignored. - Arrays that have a "
+"``NULL`` element will raise an exception."
 msgstr ""
 "Secuencia de identificadores de aristas que forman un camino que no se "
-"permite tomar. - Arreglos vacios o ``NULL`` son ignorados. - Arreglos que"
-" tienen ``NULL`` arrojan una excepción."
+"permite tomar. - Arreglos vacios o ``NULL`` son ignorados. - Arreglos que "
+"tienen ``NULL`` arrojan una excepción."
 
 #: ../../build/doc/pgRouting-concepts.rst:17
 msgid "``Cost``"
@@ -533,10 +532,11 @@ msgid "Identifier of the point."
 msgstr "Identificador del punto."
 
 #: ../../build/doc/withPoints-category.rst:17
-msgid "Use with positive value, as internally will be converted to negative value"
+msgid ""
+"Use with positive value, as internally will be converted to negative value"
 msgstr ""
-"Use con un valor positivo, dado que internamente se convertirá a un valor"
-" negativo"
+"Use con un valor positivo, dado que internamente se convertirá a un valor "
+"negativo"
 
 #: ../../build/doc/withPoints-category.rst:19
 msgid "If column is present, it can not be NULL."
@@ -547,8 +547,8 @@ msgid ""
 "If column is not present, a sequential negative **value** will be given "
 "automatically."
 msgstr ""
-"Si columna no esta presente, un **valor** secuencial negativo se otorgará"
-" automáticamente."
+"Si columna no esta presente, un **valor** secuencial negativo se otorgará "
+"automáticamente."
 
 #: ../../build/doc/withPoints-category.rst:22
 msgid "``edge_id``"
@@ -567,8 +567,8 @@ msgid ""
 "Value in <0,1> that indicates the relative postition from the first end "
 "point of the edge."
 msgstr ""
-"El valor en <0,1> que indica la posición relativa desde el primer punto "
-"de la arista."
+"El valor en <0,1> que indica la posición relativa desde el primer punto de "
+"la arista."
 
 #: ../../build/doc/withPoints-category.rst:31
 msgid "``side``"
@@ -625,8 +625,7 @@ msgstr "``path_seq``"
 
 #: ../../build/doc/via-category.rst:19
 msgid ""
-"Relative position in the path. Has value **1** for the beginning of a "
-"path."
+"Relative position in the path. Has value **1** for the beginning of a path."
 msgstr ""
 "Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
 "ruta."
@@ -666,11 +665,11 @@ msgstr "``edge``"
 
 #: ../../build/doc/via-category.rst:32
 msgid ""
-"Identifier of the edge used to go from ``node`` to the next node in the "
-"path sequence."
+"Identifier of the edge used to go from ``node`` to the next node in the path "
+"sequence."
 msgstr ""
-"Identificador de la arsita utilizada para ir del ``node`` al siguiente "
-"nodo de la secuencia de ruta."
+"Identificador de la arsita utilizada para ir del ``node`` al siguiente nodo "
+"de la secuencia de ruta."
 
 #: ../../build/doc/via-category.rst:35
 msgid "-1 for the last node of the path."
@@ -687,11 +686,11 @@ msgstr "``FLOAT``"
 
 #: ../../build/doc/via-category.rst:39
 msgid ""
-"Cost to traverse from ``node`` using ``edge`` to the next node in the "
-"path sequence."
+"Cost to traverse from ``node`` using ``edge`` to the next node in the path "
+"sequence."
 msgstr ""
-"Costo para atravesar desde ``node`` usando ``edge`` hasta el siguiente "
-"nodo en la secuencia de la ruta."
+"Costo para atravesar desde ``node`` usando ``edge`` hasta el siguiente nodo "
+"en la secuencia de la ruta."
 
 #: ../../build/doc/via-category.rst:41
 msgid "``agg_cost``"
@@ -707,16 +706,16 @@ msgstr "``route_agg_cost``"
 
 #: ../../build/doc/via-category.rst:46
 msgid ""
-"Total cost from ``start_vid`` of ``seq = 1`` to ``end_vid`` of the "
-"current ``seq``."
+"Total cost from ``start_vid`` of ``seq = 1`` to ``end_vid`` of the current "
+"``seq``."
 msgstr ""
-"Costo total desde ``start_vid`` en ``seq = 1`` hasta ``end_vid`` del "
-"``seq`` actual."
+"Costo total desde ``start_vid`` en ``seq = 1`` hasta ``end_vid`` del ``seq`` "
+"actual."
 
 #: ../../build/doc/via-category.rst:4
 msgid ""
-"When ``start_vid``, ``end_vid`` and ``node`` columns have negative "
-"values, the identifier is for a Point."
+"When ``start_vid``, ``end_vid`` and ``node`` columns have negative values, "
+"the identifier is for a Point."
 msgstr ""
 "Cuando las columnas ``start_vid``, ``end_vid`` y``node`` tengan valores "
 "negativos, el identificador es para un Punto."
@@ -741,23 +740,22 @@ msgid ""
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:174
-msgid "Point :math:`-1` corresponds to the closest edge from point `(2.9,1.8)`."
+msgid ""
+"Point :math:`-1` corresponds to the closest edge from point `(2.9,1.8)`."
 msgstr ""
-"Punto :math:`-1` corresponde a la arista más cercana al punto `(2.9, "
-"1.8)`."
+"Punto :math:`-1` corresponde a la arista más cercana al punto `(2.9, 1.8)`."
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:175
 msgid ""
-"Point :math:`-2` corresponds to the next close edge from point "
-"`(2.9,1.8)`."
+"Point :math:`-2` corresponds to the next close edge from point `(2.9,1.8)`."
 msgstr ""
-"Punto :math:`-2` corresponde a la segunda arista más cercana al punto "
-"`(2.9, 1.8)`."
+"Punto :math:`-2` corresponde a la segunda arista más cercana al punto `(2.9, "
+"1.8)`."
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:176
 msgid ""
-"Point :math:`-2` is visited on the route to from vertex :math:`1` to "
-"Point :math:`-1` (See row where :math:`seq = 4`)."
+"Point :math:`-2` is visited on the route to from vertex :math:`1` to Point :"
+"math:`-1` (See row where :math:`seq = 4`)."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:180
@@ -766,8 +764,8 @@ msgstr "Variaciones de uso"
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:182
 msgid ""
-"All this examples are about the route that visits the vertices "
-":math:`\\{-6, 7, -4, 8, -2\\}` in that order on a directed graph."
+"All this examples are about the route that visits the vertices :math:`\\{-6, "
+"7, -4, 8, -2\\}` in that order on a directed graph."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:190
@@ -801,27 +799,27 @@ msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:233
 msgid ""
-"Detects which of the paths pass through a restriction in this case is for"
-" the ``path_id = 1`` from ``-6`` to ``15`` because the path :math:`9 "
+"Detects which of the paths pass through a restriction in this case is for "
+"the ``path_id = 1`` from ``-6`` to ``15`` because the path :math:`9 "
 "\\rightarrow 16` is restricted."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:237
-msgid "Executes the :ref:`TRSP-family:TRSP algorithm` for the conflicting paths."
+msgid ""
+"Executes the :ref:`TRSP-family:TRSP algorithm` for the conflicting paths."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:243
 msgid ""
-"From the :doc:`pgr_withPointsVia` result it removes the conflicting paths"
-" and builds the solution with the results of the :doc:`pgr_trsp` "
-"algorithm:"
+"From the :doc:`pgr_withPointsVia` result it removes the conflicting paths "
+"and builds the solution with the results of the :doc:`pgr_trsp` algorithm:"
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:250
 msgid "Getting the same result as ``pgr_trspVia_withPoints``:"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst
+#: ../../build/doc/pgr_trspVia_withPoints.rst:0
 msgid "Example 8"
 msgstr "Ejemplo 8"
 
@@ -831,24 +829,23 @@ msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:259
 msgid ""
-"The first step, doing a :doc:`pgr_withPointsVia` does consider not making"
-" a U turn on the same edge. But the path :math:`9 \\rightarrow 16` (Rows "
-"4 and 5) is restricted and the result is using it."
+"The first step, doing a :doc:`pgr_withPointsVia` does consider not making a "
+"U turn on the same edge. But the path :math:`9 \\rightarrow 16` (Rows 4 and "
+"5) is restricted and the result is using it."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:267
 msgid ""
-"When executing the :doc:`pgr_trsp_withPoints` algorithm for the "
-"conflicting path, there is no ``U_turn_on_edge`` flag."
+"When executing the :doc:`pgr_trsp_withPoints` algorithm for the conflicting "
+"path, there is no ``U_turn_on_edge`` flag."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:274
 msgid ""
 "Therefore the result ignores the ``U_turn_on_edge`` flag when set to "
 "``false``. From the :doc:`pgr_withPointsVia` result it removes the "
-"conflicting paths and builds the solution with the results of the "
-":doc:`pgr_trsp` algorithm. In this case a U turn is been done using the "
-"same edge."
+"conflicting paths and builds the solution with the results of the :doc:"
+"`pgr_trsp` algorithm. In this case a U turn is been done using the same edge."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:284
@@ -882,4 +879,3 @@ msgstr ":ref:`genindex`"
 #: ../../build/doc/pgr_trspVia_withPoints.rst:294
 msgid ":ref:`search`"
 msgstr ":ref:`search`"
-

--- a/locale/es/LC_MESSAGES/pgr_trsp_withPoints.po
+++ b/locale/es/LC_MESSAGES/pgr_trsp_withPoints.po
@@ -10,20 +10,20 @@ msgstr ""
 "POT-Creation-Date: 2022-07-11 18:25-0500\n"
 "PO-Revision-Date: 2022-07-07 16:25+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@georepublic.de>\n"
+"Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
+"pgr_trsp_withpoints/es/>\n"
 "Language: es\n"
-"Language-Team: Spanish "
-"<https://weblate.osgeo.org/projects/pgrouting/pgr_trsp_withpoints/es/>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:12
 msgid ""
-"**Supported versions:** `Latest "
-"<https://docs.pgrouting.org/latest/en/pgr_trsp_withPoints.html>`__ (`3.4 "
-"<https://docs.pgrouting.org/3.4/en/pgr_trsp_withPoints.html>`__)"
+"**Supported versions:** `Latest <https://docs.pgrouting.org/latest/en/"
+"pgr_trsp_withPoints.html>`__ (`3.4 <https://docs.pgrouting.org/3.4/en/"
+"pgr_trsp_withPoints.html>`__)"
 msgstr ""
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:17
@@ -106,13 +106,13 @@ msgstr ""
 msgid "``pgr_trsp_withPoints`` (`Combinations`_)"
 msgstr ""
 
-#: ../../build/doc/dijkstra-family.rst:11
-#: ../../build/doc/pgRouting-concepts.rst:10
-#: ../../build/doc/pgRouting-concepts.rst:11
-#: ../../build/doc/pgRouting-concepts.rst:13
 #: ../../build/doc/pgr_trsp_withPoints.rst:43
+#: ../../build/doc/pgRouting-concepts.rst:10
+#: ../../build/doc/dijkstra-family.rst:11
 #: ../../build/doc/pgr_trsp_withPoints.rst:230
+#: ../../build/doc/pgRouting-concepts.rst:11
 #: ../../build/doc/withPoints-category.rst:11
+#: ../../build/doc/pgRouting-concepts.rst:13
 msgid "Description"
 msgstr "Descripción"
 
@@ -121,8 +121,8 @@ msgid ""
 "Modify the graph to include points defined by points_sql. Using Dijkstra "
 "algorithm, find the shortest path(s)"
 msgstr ""
-"Modificar el grafo para incluir puntos definidos por points_sql. Usando "
-"el algoritmo Dijkstra, busar la o las rutas más cortas"
+"Modificar el grafo para incluir puntos definidos por points_sql. Usando el "
+"algoritmo Dijkstra, busar la o las rutas más cortas"
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:48
 #, fuzzy
@@ -150,8 +150,10 @@ msgid "Values are returned when there is a path."
 msgstr "Los valores se devuelven cuando hay una ruta."
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:58
-msgid "When the starting vertex and ending vertex are the same, there is no path."
-msgstr "Cuando el vértice inicial y el vértice final son iguales, no hay camino."
+msgid ""
+"When the starting vertex and ending vertex are the same, there is no path."
+msgstr ""
+"Cuando el vértice inicial y el vértice final son iguales, no hay camino."
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:60
 msgid "The agg_cost the non included values (v, v) is 0"
@@ -159,8 +161,8 @@ msgstr ""
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:62
 msgid ""
-"When the starting vertex and ending vertex are the different and there is"
-" no path:"
+"When the starting vertex and ending vertex are the different and there is no "
+"path:"
 msgstr ""
 "Cuando el vértice de salida y el vértice destino son diferentes y no hay "
 "ninguna ruta:"
@@ -174,14 +176,14 @@ msgid ""
 "For optimization purposes, any duplicated value in the start_vids or "
 "end_vids are ignored."
 msgstr ""
-"Para fines de optimización, se omite cualquier valor duplicado en "
-"start_vids o end_vids."
+"Para fines de optimización, se omite cualquier valor duplicado en start_vids "
+"o end_vids."
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:69
-msgid "The returned values are ordered: - start_vid ascending - end_vid ascending"
+msgid ""
+"The returned values are ordered: - start_vid ascending - end_vid ascending"
 msgstr ""
-"Los valores devueltos se ordenan: - start_vid ascendente - end_vid "
-"ascendente"
+"Los valores devueltos se ordenan: - start_vid ascendente - end_vid ascendente"
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:73
 msgid "Running time: :math:`O(|start\\_vids|\\times(V \\log V + E))`"
@@ -204,37 +206,37 @@ msgstr "Resumen"
 msgid "\\ \\"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
 msgid ""
 "pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Points SQL`_, "
 "**start vid**, **end vid**, [options])"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
 msgid ""
 "pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Points SQL`_, "
 "**start vid**, **end vids**, [options])"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
 msgid ""
 "pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Points SQL`_, "
 "**start vids**, **end vid**, [options])"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
 msgid ""
 "pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Points SQL`_, "
 "**start vids**, **end vids**, [options])"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
 msgid ""
-"pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Combinations "
-"SQL`_, `Points SQL`_, [options])"
+"pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Combinations SQL`_, "
+"`Points SQL`_, [options])"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
 msgid "[options]"
 msgstr ""
 
@@ -242,11 +244,11 @@ msgstr ""
 msgid "[directed, driving_side [details]"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
 msgid "RETURNS SET OF |generic-result|"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
 msgid "OR EMPTY SET"
 msgstr ""
 
@@ -260,7 +262,7 @@ msgid ""
 "**start vid**, **end vid**, [directed, driving_side, details])"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
 msgid "Example"
 msgstr "Ejemplo"
 
@@ -274,8 +276,8 @@ msgid ""
 "side configuration on a directed graph with details."
 msgstr ""
 "Desde el punto :math:`1` al vértice :math:`3` con detalles en una "
-"configuración de manejo por la **izquierda** en un grafo **dirigido** con"
-" **detalles**."
+"configuración de manejo por la **izquierda** en un grafo **dirigido** con "
+"**detalles**."
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:120
 msgid "One to Many"
@@ -323,8 +325,8 @@ msgstr ""
 #: ../../build/doc/pgr_trsp_withPoints.rst:173
 #, fuzzy
 msgid ""
-"From point :math:`1` and vertex :math:`6` to point :math:`3` and vertex "
-":math:`1`."
+"From point :math:`1` and vertex :math:`6` to point :math:`3` and vertex :"
+"math:`1`."
 msgstr "Desde el punto :math:`1` al punto :math:`3` y vértice :math:`5`."
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:184
@@ -333,8 +335,8 @@ msgstr "Combinaciones"
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:189
 msgid ""
-"pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Combinations "
-"SQL`_, `Points SQL`_, [directed, driving_side, details])"
+"pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Combinations SQL`_, "
+"`Points SQL`_, [directed, driving_side, details])"
 msgstr ""
 
 # | msgid "From point :math:`1` and vertex :math:`2` to point :math:`3`."
@@ -349,17 +351,17 @@ msgstr "Desde el punto :math:`1` y vértice :math:`2` al punto :math:`3`."
 msgid "Parameters"
 msgstr "Parámetros"
 
-#: ../../build/doc/dijkstra-family.rst:8
 #: ../../build/doc/pgRouting-concepts.rst:8
+#: ../../build/doc/dijkstra-family.rst:8
 #: ../../build/doc/pgRouting-concepts.rst:11
 msgid "Column"
 msgstr "Columna"
 
-#: ../../build/doc/dijkstra-family.rst:9
 #: ../../build/doc/pgRouting-concepts.rst:9
-#: ../../build/doc/pgRouting-concepts.rst:12
+#: ../../build/doc/dijkstra-family.rst:9
 #: ../../build/doc/pgr_trsp_withPoints.rst:228
 #: ../../build/doc/withPoints-category.rst:9
+#: ../../build/doc/pgRouting-concepts.rst:12
 msgid "Type"
 msgstr "Tipo"
 
@@ -394,20 +396,20 @@ msgstr "`SQL Combinaciones`_ como se describe a abajo"
 msgid "**start vid**"
 msgstr "**vid de salida**"
 
-#: ../../build/doc/pgRouting-concepts.rst:12
-#: ../../build/doc/pgRouting-concepts.rst:13
-#: ../../build/doc/pgRouting-concepts.rst:15
-#: ../../build/doc/pgRouting-concepts.rst:17
 #: ../../build/doc/pgRouting-concepts.rst:21
 #: ../../build/doc/pgRouting-concepts.rst:27
+#: ../../build/doc/pgRouting-concepts.rst:13
+#: ../../build/doc/pgRouting-concepts.rst:17
 #: ../../build/doc/withPoints-category.rst:13
 #: ../../build/doc/withPoints-category.rst:23
+#: ../../build/doc/pgRouting-concepts.rst:12
+#: ../../build/doc/pgRouting-concepts.rst:15
 msgid "**ANY-INTEGER**"
 msgstr "**ENTEROS**"
 
-#: ../../build/doc/pgRouting-concepts.rst:13
 #: ../../build/doc/pgRouting-concepts.rst:22
 #: ../../build/doc/pgRouting-concepts.rst:28
+#: ../../build/doc/pgRouting-concepts.rst:13
 msgid "Identifier of the departure vertex."
 msgstr "Identificador del vértice de salida."
 
@@ -415,9 +417,9 @@ msgstr "Identificador del vértice de salida."
 msgid "**start vids**"
 msgstr "**vid salidas**"
 
-#: ../../build/doc/pgRouting-concepts.rst:12
 #: ../../build/doc/pgRouting-concepts.rst:24
 #: ../../build/doc/pgRouting-concepts.rst:30
+#: ../../build/doc/pgRouting-concepts.rst:12
 msgid "``ARRAY[`` **ANY-INTEGER** ``]``"
 msgstr "``ARRAY[`` **ANY-INTEGER** ``]``"
 
@@ -434,24 +436,24 @@ msgstr "**vid destino**"
 msgid "**end vids**"
 msgstr "**vids destinos**"
 
-#: ../../build/doc/pgRouting-concepts.rst:18
-#: ../../build/doc/pgRouting-concepts.rst:21
 #: ../../build/doc/pgRouting-concepts.rst:33
 #: ../../build/doc/pgRouting-concepts.rst:36
+#: ../../build/doc/pgRouting-concepts.rst:21
 #: ../../build/doc/withPoints-category.rst:40
+#: ../../build/doc/pgRouting-concepts.rst:18
 msgid "Where:"
 msgstr "Donde:"
 
-#: ../../build/doc/pgRouting-concepts.rst
-#: ../../build/doc/withPoints-category.rst
+#: ../../build/doc/pgRouting-concepts.rst:0
+#: ../../build/doc/withPoints-category.rst:0
 msgid "ANY-INTEGER"
 msgstr "ENTEROS"
 
-#: ../../build/doc/pgRouting-concepts.rst:20
-#: ../../build/doc/pgRouting-concepts.rst:23
 #: ../../build/doc/pgRouting-concepts.rst:35
 #: ../../build/doc/pgRouting-concepts.rst:38
+#: ../../build/doc/pgRouting-concepts.rst:23
 #: ../../build/doc/withPoints-category.rst:42
+#: ../../build/doc/pgRouting-concepts.rst:20
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``"
 msgstr "``SMALLINT``, ``INTEGER``, ``BIGINT``"
 
@@ -460,8 +462,8 @@ msgid "Optional parameters"
 msgstr "Parámetros opcionales"
 
 #: ../../build/doc/dijkstra-family.rst:10
-#: ../../build/doc/pgRouting-concepts.rst:10
 #: ../../build/doc/pgr_trsp_withPoints.rst:229
+#: ../../build/doc/pgRouting-concepts.rst:10
 #: ../../build/doc/withPoints-category.rst:10
 msgid "Default"
 msgstr "x Defecto"
@@ -491,9 +493,9 @@ msgstr "Cuando ``false`` el gráfo se considera `No Dirigido`."
 msgid "With points optional parameters"
 msgstr "Parámetros opcionales para Con puntos"
 
-#: ../../build/doc/pgRouting-concepts.rst:8
 #: ../../build/doc/pgr_trsp_withPoints.rst:227
 #: ../../build/doc/withPoints-category.rst:8
+#: ../../build/doc/pgRouting-concepts.rst:8
 msgid "Parameter"
 msgstr "Parámetro"
 
@@ -536,12 +538,12 @@ msgstr "``false``"
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:242
 msgid "When ``true`` the results will include the points that are in the path."
-msgstr "Cuando ``true`` los resultados incluyen los puntos que están en el camino."
+msgstr ""
+"Cuando ``true`` los resultados incluyen los puntos que están en el camino."
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:243
 msgid ""
-"When ``false`` the results will not include the points that are in the "
-"path."
+"When ``false`` the results will not include the points that are in the path."
 msgstr ""
 "Cuando ``false`` los resultados no incluyen los puntos que están en el "
 "camino."
@@ -562,8 +564,8 @@ msgstr "``id``"
 msgid "Identifier of the edge."
 msgstr "Identificador de la arista."
 
-#: ../../build/doc/pgRouting-concepts.rst:11
 #: ../../build/doc/pgRouting-concepts.rst:16
+#: ../../build/doc/pgRouting-concepts.rst:11
 msgid "``source``"
 msgstr "``source``"
 
@@ -571,8 +573,8 @@ msgstr "``source``"
 msgid "Identifier of the first end point vertex of the edge."
 msgstr "Identificador del primer vértice de la arista."
 
-#: ../../build/doc/pgRouting-concepts.rst:14
 #: ../../build/doc/pgRouting-concepts.rst:20
+#: ../../build/doc/pgRouting-concepts.rst:14
 msgid "``target``"
 msgstr "``target``"
 
@@ -585,9 +587,9 @@ msgstr "Identificador del segundo vértice de la arista."
 msgid "``cost``"
 msgstr "``cost``"
 
-#: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/pgRouting-concepts.rst:25
 #: ../../build/doc/pgRouting-concepts.rst:29
+#: ../../build/doc/pgRouting-concepts.rst:18
 #: ../../build/doc/withPoints-category.rst:27
 msgid "**ANY-NUMERICAL**"
 msgstr "**FLOTANTES**"
@@ -610,19 +612,19 @@ msgstr "Peso de la arista (``target``, ``source``)"
 
 #: ../../build/doc/pgRouting-concepts.rst:33
 msgid ""
-"When negative: edge (``target``, ``source``) does not exist, therefore "
-"it's not part of the graph."
+"When negative: edge (``target``, ``source``) does not exist, therefore it's "
+"not part of the graph."
 msgstr ""
-"Cuando negativo: la arista (``target``, ``source``) no existe, por lo "
-"tanto no es parte del grafo."
+"Cuando negativo: la arista (``target``, ``source``) no existe, por lo tanto "
+"no es parte del grafo."
 
-#: ../../build/doc/pgRouting-concepts.rst
-#: ../../build/doc/withPoints-category.rst
+#: ../../build/doc/pgRouting-concepts.rst:0
+#: ../../build/doc/withPoints-category.rst:0
 msgid "ANY-NUMERICAL"
 msgstr "FLOTANTES"
 
-#: ../../build/doc/pgRouting-concepts.rst:24
 #: ../../build/doc/pgRouting-concepts.rst:39
+#: ../../build/doc/pgRouting-concepts.rst:24
 #: ../../build/doc/withPoints-category.rst:43
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``, ``REAL``, ``FLOAT``"
 msgstr "``SMALLINT``, ``INTEGER``, ``BIGINT``, ``REAL``, ``FLOAT``"
@@ -638,12 +640,12 @@ msgstr "``path``"
 #: ../../build/doc/pgRouting-concepts.rst:13
 msgid ""
 "Sequence of edge identifiers that form a path that is not allowed to be "
-"taken. - Empty arrays or ``NULL`` arrays are ignored. - Arrays that have "
-"a ``NULL`` element will raise an exception."
+"taken. - Empty arrays or ``NULL`` arrays are ignored. - Arrays that have a "
+"``NULL`` element will raise an exception."
 msgstr ""
 "Secuencia de identificadores de aristas que forman un camino que no se "
-"permite tomar. - Arreglos vacios o ``NULL`` son ignorados. - Arreglos que"
-" tienen ``NULL`` arrojan una excepción."
+"permite tomar. - Arreglos vacios o ``NULL`` son ignorados. - Arreglos que "
+"tienen ``NULL`` arrojan una excepción."
 
 #: ../../build/doc/pgRouting-concepts.rst:17
 msgid "``Cost``"
@@ -670,10 +672,11 @@ msgid "Identifier of the point."
 msgstr "Identificador del punto."
 
 #: ../../build/doc/withPoints-category.rst:17
-msgid "Use with positive value, as internally will be converted to negative value"
+msgid ""
+"Use with positive value, as internally will be converted to negative value"
 msgstr ""
-"Use con un valor positivo, dado que internamente se convertirá a un valor"
-" negativo"
+"Use con un valor positivo, dado que internamente se convertirá a un valor "
+"negativo"
 
 #: ../../build/doc/withPoints-category.rst:19
 msgid "If column is present, it can not be NULL."
@@ -684,8 +687,8 @@ msgid ""
 "If column is not present, a sequential negative **value** will be given "
 "automatically."
 msgstr ""
-"Si columna no esta presente, un **valor** secuencial negativo se otorgará"
-" automáticamente."
+"Si columna no esta presente, un **valor** secuencial negativo se otorgará "
+"automáticamente."
 
 #: ../../build/doc/withPoints-category.rst:22
 msgid "``edge_id``"
@@ -704,8 +707,8 @@ msgid ""
 "Value in <0,1> that indicates the relative postition from the first end "
 "point of the edge."
 msgstr ""
-"El valor en <0,1> que indica la posición relativa desde el primer punto "
-"de la arista."
+"El valor en <0,1> que indica la posición relativa desde el primer punto de "
+"la arista."
 
 #: ../../build/doc/withPoints-category.rst:31
 msgid "``side``"
@@ -745,8 +748,8 @@ msgstr "Columnas de Resultados"
 
 #: ../../build/doc/pgRouting-concepts.rst:3
 msgid ""
-"Returns set of ``(seq, path_id, path_seq, start_vid, end_vid, node, edge,"
-" cost, agg_cost)``"
+"Returns set of ``(seq, path_id, path_seq, start_vid, end_vid, node, edge, "
+"cost, agg_cost)``"
 msgstr ""
 
 #: ../../build/doc/pgRouting-concepts.rst:14
@@ -774,7 +777,8 @@ msgstr ""
 
 #: ../../build/doc/pgRouting-concepts.rst:21
 #, fuzzy
-msgid "Has value **1** for the first of a path from ``start_vid`` to ``end_vid``."
+msgid ""
+"Has value **1** for the first of a path from ``start_vid`` to ``end_vid``."
 msgstr "Identificador del nodo en la ruta de ``start_vid`` a ``end_vid``."
 
 #: ../../build/doc/pgRouting-concepts.rst:23
@@ -783,8 +787,7 @@ msgstr "``path_seq``"
 
 #: ../../build/doc/pgRouting-concepts.rst:25
 msgid ""
-"Relative position in the path. Has value **1** for the beginning of a "
-"path."
+"Relative position in the path. Has value **1** for the beginning of a path."
 msgstr ""
 "Posición relativa en la ruta. Tiene el valor **1** para el inicio de una "
 "ruta."
@@ -829,11 +832,11 @@ msgstr "``edge``"
 #: ../../build/doc/pgRouting-concepts.rst:38
 #, fuzzy
 msgid ""
-"Identifier of the edge used to go from ``node`` to the next node in the "
-"path sequence. **-1** for the last node of the path."
+"Identifier of the edge used to go from ``node`` to the next node in the path "
+"sequence. **-1** for the last node of the path."
 msgstr ""
-"Identificador de la arsita utilizada para ir del ``node`` al siguiente "
-"nodo de la secuencia de ruta."
+"Identificador de la arsita utilizada para ir del ``node`` al siguiente nodo "
+"de la secuencia de ruta."
 
 #: ../../build/doc/pgRouting-concepts.rst:41
 #: ../../build/doc/pgRouting-concepts.rst:45
@@ -842,11 +845,11 @@ msgstr "``FLOAT``"
 
 #: ../../build/doc/pgRouting-concepts.rst:42
 msgid ""
-"Cost to traverse from ``node`` using ``edge`` to the next node in the "
-"path sequence."
+"Cost to traverse from ``node`` using ``edge`` to the next node in the path "
+"sequence."
 msgstr ""
-"Costo para atravesar desde ``node`` usando ``edge`` hasta el siguiente "
-"nodo en la secuencia de la ruta."
+"Costo para atravesar desde ``node`` usando ``edge`` hasta el siguiente nodo "
+"en la secuencia de la ruta."
 
 #: ../../build/doc/pgRouting-concepts.rst:44
 msgid "``agg_cost``"
@@ -871,27 +874,26 @@ msgstr "Usa :doc:`pgr_findCloseEdges` en el `SQL puntos`_."
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:297
 msgid ""
-"Find the routes from vertex :math:`1` to the two closest locations on the"
-" graph of point `(2.9, 1.8)`."
+"Find the routes from vertex :math:`1` to the two closest locations on the "
+"graph of point `(2.9, 1.8)`."
 msgstr ""
 "Wncontrar las rutas desde el vértice :math:`1` a las dos ubicaciones más "
 "cercanas en el grafo al punto`(2.9, 1.8)`."
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:304
 #, fuzzy
-msgid "Point :math:`-1` corresponds to the closest edge from point `(2.9, 1.8)`."
+msgid ""
+"Point :math:`-1` corresponds to the closest edge from point `(2.9, 1.8)`."
 msgstr ""
-"Punto :math:`-1` corresponde a la arista más cercana al punto `(2.9, "
-"1.8)`."
+"Punto :math:`-1` corresponde a la arista más cercana al punto `(2.9, 1.8)`."
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:305
 #, fuzzy
 msgid ""
-"Point :math:`-2` corresponds to the next close edge from point `(2.9, "
-"1.8)`."
+"Point :math:`-2` corresponds to the next close edge from point `(2.9, 1.8)`."
 msgstr ""
-"Punto :math:`-2` corresponde a la segunda arista más cercana al punto "
-"`(2.9, 1.8)`."
+"Punto :math:`-2` corresponde a la segunda arista más cercana al punto `(2.9, "
+"1.8)`."
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:308
 msgid "Pass in front or visits."
@@ -899,8 +901,8 @@ msgstr ""
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:310
 msgid ""
-"Which path (if any) passes in front of point :math:`6` or vertex "
-":math:`11` with right side driving topology."
+"Which path (if any) passes in front of point :math:`6` or vertex :math:`11` "
+"with right side driving topology."
 msgstr ""
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:318
@@ -913,12 +915,12 @@ msgstr ""
 #: ../../build/doc/pgr_trsp_withPoints.rst:320
 #, fuzzy
 msgid ""
-"From point :math:`1` and vertex :math:`6` to point :math:`3` to vertex "
-":math:`1` on an undirected graph, with details."
+"From point :math:`1` and vertex :math:`6` to point :math:`3` to vertex :math:"
+"`1` on an undirected graph, with details."
 msgstr ""
 "Desde el punto :math:`1` al vértice :math:`3` con detalles en una "
-"configuración de manejo por la **izquierda** en un grafo **dirigido** con"
-" **detalles**."
+"configuración de manejo por la **izquierda** en un grafo **dirigido** con "
+"**detalles**."
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:328
 msgid "See Also"
@@ -947,4 +949,3 @@ msgstr ":ref:`genindex`"
 #: ../../build/doc/pgr_trsp_withPoints.rst:337
 msgid ":ref:`search`"
 msgstr ":ref:`search`"
-

--- a/locale/zh_Hans/LC_MESSAGES/TRSP-family.po
+++ b/locale/zh_Hans/LC_MESSAGES/TRSP-family.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-25 12:55-0500\n"
+"POT-Creation-Date: 2022-07-11 18:25-0500\n"
 "PO-Revision-Date: 2022-03-28 21:21+0000\n"
 "Last-Translator: Chen <onsummer@foxmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://weblate.osgeo.org/projects/"
@@ -182,7 +182,7 @@ msgid ""
 "Road restrictions are a sequence of road segments that can not be taken in a "
 "sequential manner. Some restrictions are implicit on a directed graph, for "
 "example, one way roads where the wrong way edge is not even inserted on the "
-"graph. But normally on turns like **left turn** or **right turn**, hence the "
+"graph. But normally on turns like no left turn or no right turn, hence the "
 "name turn restrictions, there are sometimes restrictions."
 msgstr ""
 
@@ -273,8 +273,8 @@ msgstr ""
 
 #: ../../build/doc/TRSP-family.rst:115
 msgid ""
-"A restriction is a sequence of edges, called **path** and that **path** is "
-"to be avoided."
+"A restriction is a sequence of edges, called path and that path is to be "
+"avoided."
 msgstr ""
 
 #: ../../build/doc/TRSP-family.rst:123

--- a/locale/zh_Hans/LC_MESSAGES/pgr_trspVia.po
+++ b/locale/zh_Hans/LC_MESSAGES/pgr_trspVia.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-25 12:55-0500\n"
+"POT-Creation-Date: 2022-07-11 18:25-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -30,6 +30,10 @@ msgstr ""
 #: ../../build/doc/pgr_trspVia.rst:19
 msgid ""
 "``pgr_trspVia`` Route that goes through a list of vertices with restrictions."
+msgstr ""
+
+#: ../../build/doc/pgr_trspVia.rst:24
+msgid "Boost Graph Inside"
 msgstr ""
 
 #: ../../build/doc/proposed.rst:3
@@ -68,10 +72,6 @@ msgstr ""
 msgid "Documentation might need refinement."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:28
-msgid "Boost Graph Inside"
-msgstr ""
-
 #: ../../build/doc/pgr_trspVia.rst:31
 msgid "Availability"
 msgstr ""
@@ -81,10 +81,14 @@ msgid "Version 3.4.0"
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia.rst:34
-msgid "New **proposed** function ``pgr_trspVia`` (`One Via`_)"
+msgid "New proposed function:"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:37 ../../build/doc/TRSP-family.rst:10
+#: ../../build/doc/pgr_trspVia.rst:36
+msgid "``pgr_trspVia`` (`One Via`_)"
+msgstr ""
+
+#: ../../build/doc/pgr_trspVia.rst:39 ../../build/doc/TRSP-family.rst:10
 #: ../../build/doc/dijkstra-family.rst:11 ../../build/doc/via-category.rst:11
 #: ../../build/doc/pgRouting-concepts.rst:11
 #: ../../build/doc/pgRouting-concepts.rst:10
@@ -92,57 +96,78 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:39
+#: ../../build/doc/pgr_trspVia.rst:41
 msgid ""
 "Given a list of vertices and a graph, this function is equivalent to finding "
 "the shortest path between :math:`vertex_i` and :math:`vertex_{i+1}` for all :"
 "math:`i < size\\_of(via\\;vertices)` trying not to use restricted paths."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:43
+#: ../../build/doc/pgr_trspVia.rst:45
 msgid "The paths represents the sections of the route."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:45
+#: ../../build/doc/pgr_trspVia.rst:47
 msgid "The general algorithm is as follows:"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:47
+#: ../../build/doc/pgr_trspVia.rst:49
 msgid "Execute a :doc:`pgr_dijkstraVia`."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:48
+#: ../../build/doc/pgr_trspVia.rst:50
 msgid ""
 "For the set of sub paths of the solution that pass through a restriction then"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:50
+#: ../../build/doc/pgr_trspVia.rst:52
 msgid "Execute the **TRSP** algorithm with restrictions for the paths."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:51
+#: ../../build/doc/pgr_trspVia.rst:53
 msgid "**NOTE** when this is done, ``U_turn_on_edge`` flag is ignored."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:55
+#: ../../build/doc/pgr_trspVia.rst:57
 msgid "Signatures"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:61
+#: ../../build/doc/pgr_trspVia.rst:63
 msgid "One Via"
+msgstr ""
+
+#: ../../build/doc/pgr_trspVia.rst:65
+msgid "\\ \\"
+msgstr ""
+
+#: ../../build/doc/pgr_trspVia.rst:68
+msgid ""
+"pgr_trspVia(`Edges SQL`_, `Restrictions SQL`_, **via vertices**, [options])"
+msgstr ""
+
+#: ../../build/doc/pgr_trspVia.rst:0
+msgid "[options]"
+msgstr ""
+
+#: ../../build/doc/pgr_trspVia.rst:70
+msgid "[directed, strict, U_turn_on_edge]"
+msgstr ""
+
+#: ../../build/doc/pgr_trspVia.rst:72
+msgid "RETURNS SET OF |via-result| OR EMPTY SET"
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia.rst:0
 msgid "Example"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:71
+#: ../../build/doc/pgr_trspVia.rst:75
 msgid ""
 "Find the route that visits the vertices :math:`\\{ 5, 1, 8\\}` in that order "
-"on an **directed** graph."
+"on an directed graph."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:79
+#: ../../build/doc/pgr_trspVia.rst:83
 msgid "Parameters"
 msgstr ""
 
@@ -200,7 +225,7 @@ msgstr ""
 msgid "SMALLINT, INTEGER, BIGINT"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:86
+#: ../../build/doc/pgr_trspVia.rst:90
 msgid "Optional parameters"
 msgstr ""
 
@@ -235,7 +260,7 @@ msgstr ""
 msgid "When ``false`` the graph is considered as `Undirected`."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:93
+#: ../../build/doc/pgr_trspVia.rst:97
 msgid "Via optional parameters"
 msgstr ""
 
@@ -263,11 +288,11 @@ msgstr ""
 msgid "When ``true`` departing from a visited vertex will not try to avoid"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:100
+#: ../../build/doc/pgr_trspVia.rst:104
 msgid "Inner Queries"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:103
+#: ../../build/doc/pgr_trspVia.rst:107
 msgid "Edges SQL"
 msgstr ""
 
@@ -348,7 +373,7 @@ msgstr ""
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``, ``REAL``, ``FLOAT``"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:110
+#: ../../build/doc/pgr_trspVia.rst:114
 msgid "Restrictions SQL"
 msgstr ""
 
@@ -371,7 +396,7 @@ msgstr ""
 msgid "Cost of taking the forbidden path."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:117
+#: ../../build/doc/pgr_trspVia.rst:121
 msgid "Result Columns"
 msgstr ""
 
@@ -481,66 +506,66 @@ msgid ""
 "``seq``."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:124
+#: ../../build/doc/pgr_trspVia.rst:128
 msgid "Additional Examples"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:129
+#: ../../build/doc/pgr_trspVia.rst:133
 msgid ""
 "All this examples are about the route that visits the vertices :math:`\\{5, "
-"7, 1, 8, 15\\}` in that order on a **directed** graph."
+"7, 1, 8, 15\\}` in that order on a directed graph."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:133
+#: ../../build/doc/pgr_trspVia.rst:137
 msgid "The main query"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:140
+#: ../../build/doc/pgr_trspVia.rst:144
 msgid "Aggregate cost of the third path."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:147
+#: ../../build/doc/pgr_trspVia.rst:151
 msgid "Route's aggregate cost of the route at the end of the third path."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:154
+#: ../../build/doc/pgr_trspVia.rst:158
 msgid "Nodes visited in the route."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:161
+#: ../../build/doc/pgr_trspVia.rst:165
 msgid "The aggregate costs of the route when the visited vertices are reached."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:168
+#: ../../build/doc/pgr_trspVia.rst:172
 msgid "Status of \"passes in front\" or \"visits\" of the nodes."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:175
-msgid "Simulation of how algorithm works"
+#: ../../build/doc/pgr_trspVia.rst:179
+msgid "Simulation of how algorithm works."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:177
+#: ../../build/doc/pgr_trspVia.rst:181
 msgid "The algorithm performs a :doc:`pgr_dijkstraVia`"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:183
+#: ../../build/doc/pgr_trspVia.rst:187
 msgid ""
 "Detects which of the sub paths pass through a restriction in this case is "
 "for the ``path_id = 5`` from ``6`` to ``3`` because the path :math:`15 "
 "\\rightarrow 1` is restricted."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:187
+#: ../../build/doc/pgr_trspVia.rst:191
 msgid "Executes the :doc:`pgr_trsp` algorithm for the conflicting paths."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:193
+#: ../../build/doc/pgr_trspVia.rst:197
 msgid ""
 "From the :doc:`pgr_dijkstraVia` result it removes the conflicting paths and "
 "builds the solution with the results of the :doc:`pgr_trsp` algorithm:"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:200
+#: ../../build/doc/pgr_trspVia.rst:204
 msgid "Getting the same result as ``pgr_trspVia``:"
 msgstr ""
 
@@ -548,49 +573,49 @@ msgstr ""
 msgid "Example 8"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:206
+#: ../../build/doc/pgr_trspVia.rst:210
 msgid "Sometimes ``U_turn_on_edge`` flag is ignored when is set to ``false``."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:209
+#: ../../build/doc/pgr_trspVia.rst:213
 msgid ""
 "The first step, doing a :doc:`pgr_dijkstraVia` does consider not making a U "
 "turn on the same edge. But the path :math:`16 \\rightarrow 13` (Rows 4 and "
 "5) is restricted and the result is using it."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:217
+#: ../../build/doc/pgr_trspVia.rst:221
 msgid ""
 "When executing the :doc:`pgr_trsp` algorithm for the conflicting path, there "
 "is no ``U_turn_on_edge`` flag."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:224
+#: ../../build/doc/pgr_trspVia.rst:228
 msgid ""
 "Therefore the result ignores the ``U_turn_on_edge`` flag when set to "
 "``false``."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:231
+#: ../../build/doc/pgr_trspVia.rst:235
 msgid "See Also"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:233
+#: ../../build/doc/pgr_trspVia.rst:237
 msgid ":doc:`via-category`"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:234
+#: ../../build/doc/pgr_trspVia.rst:238
 msgid ":doc:`sampledata` network."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:237
+#: ../../build/doc/pgr_trspVia.rst:241
 msgid "Indices and tables"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:238
+#: ../../build/doc/pgr_trspVia.rst:242
 msgid ":ref:`genindex`"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia.rst:239
+#: ../../build/doc/pgr_trspVia.rst:243
 msgid ":ref:`search`"
 msgstr ""

--- a/locale/zh_Hans/LC_MESSAGES/pgr_trspVia_withPoints.po
+++ b/locale/zh_Hans/LC_MESSAGES/pgr_trspVia_withPoints.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-25 12:55-0500\n"
+"POT-Creation-Date: 2022-07-11 18:25-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -31,6 +31,10 @@ msgstr ""
 msgid ""
 "``pgr_trspVia_withPoints`` - Route that goes through a list of vertices and/"
 "or points with restrictions."
+msgstr ""
+
+#: ../../build/doc/pgr_trspVia_withPoints.rst:25
+msgid "Boost Graph Inside"
 msgstr ""
 
 #: ../../build/doc/proposed.rst:3
@@ -69,10 +73,6 @@ msgstr ""
 msgid "Documentation might need refinement."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:29
-msgid "Boost Graph Inside"
-msgstr ""
-
 #: ../../build/doc/pgr_trspVia_withPoints.rst:32
 msgid "Availability"
 msgstr ""
@@ -82,10 +82,14 @@ msgid "Version 3.4.0"
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:35
-msgid "New **proposed** function ``pgr_trspVia_withPoints`` (`One Via`_)"
+msgid "New proposed function:"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:38
+#: ../../build/doc/pgr_trspVia_withPoints.rst:37
+msgid "``pgr_trspVia_withPoints`` (`One Via`_)"
+msgstr ""
+
+#: ../../build/doc/pgr_trspVia_withPoints.rst:40
 #: ../../build/doc/via-category.rst:11 ../../build/doc/dijkstra-family.rst:11
 #: ../../build/doc/pgr_trsp_withPoints.rst:11
 #: ../../build/doc/pgRouting-concepts.rst:11
@@ -95,7 +99,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:40
+#: ../../build/doc/pgr_trspVia_withPoints.rst:42
 msgid ""
 "Given a graph, a set of restriction on the graph edges, a set of points on "
 "the graphs edges and a list of vertices, this function is equivalent to "
@@ -108,7 +112,7 @@ msgstr ""
 msgid "Route"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:46
+#: ../../build/doc/pgr_trspVia_withPoints.rst:48
 msgid "is a sequence of paths"
 msgstr ""
 
@@ -116,66 +120,88 @@ msgstr ""
 msgid "Path"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:47
+#: ../../build/doc/pgr_trspVia_withPoints.rst:49
 msgid "is a section of the route."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:49
+#: ../../build/doc/pgr_trspVia_withPoints.rst:51
 msgid "The general algorithm is as follows:"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:51
+#: ../../build/doc/pgr_trspVia_withPoints.rst:53
 msgid "Build the Graph with the new points."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:53
+#: ../../build/doc/pgr_trspVia_withPoints.rst:55
 msgid "The points identifiers will be converted to negative values."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:54
+#: ../../build/doc/pgr_trspVia_withPoints.rst:56
 msgid "The vertices identifiers will remain positive."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:56
+#: ../../build/doc/pgr_trspVia_withPoints.rst:58
 msgid "Execute a :doc:`pgr_withPointsVia`."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:57
+#: ../../build/doc/pgr_trspVia_withPoints.rst:59
 msgid ""
 "For the set of paths of the solution that pass through a restriction then"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:59
+#: ../../build/doc/pgr_trspVia_withPoints.rst:61
 msgid "Execute the **TRSP** algorithm with restrictions for the path."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:60
+#: ../../build/doc/pgr_trspVia_withPoints.rst:62
 msgid "**NOTE** when this is done, ``U_turn_on_edge`` flag is ignored."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:62
+#: ../../build/doc/pgr_trspVia_withPoints.rst:64
 msgid "Do not use negative values on identifiers of the inner queries."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:65
+#: ../../build/doc/pgr_trspVia_withPoints.rst:67
 msgid "Signatures"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:71
+#: ../../build/doc/pgr_trspVia_withPoints.rst:73
 msgid "One Via"
+msgstr ""
+
+#: ../../build/doc/pgr_trspVia_withPoints.rst:75
+msgid "\\ \\"
+msgstr ""
+
+#: ../../build/doc/pgr_trspVia_withPoints.rst:78
+msgid ""
+"pgr_trspVia(`Edges SQL`_, `Restrictions SQL`_, `Points SQL`_, **via "
+"vertices**, [options])"
+msgstr ""
+
+#: ../../build/doc/pgr_trspVia_withPoints.rst:0
+msgid "[options]"
+msgstr ""
+
+#: ../../build/doc/pgr_trspVia_withPoints.rst:81
+msgid "[directed, strict, U_turn_on_edge]"
+msgstr ""
+
+#: ../../build/doc/pgr_trspVia_withPoints.rst:83
+msgid "RETURNS SET OF |via-result| OR EMPTY SET"
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:0
 msgid "Example"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:81
+#: ../../build/doc/pgr_trspVia_withPoints.rst:86
 msgid ""
 "Find the route that visits the vertices :math:`\\{-6, 15, -5\\}` in that "
-"order on an **directed** graph."
+"order on an directed graph."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:89
+#: ../../build/doc/pgr_trspVia_withPoints.rst:94
 msgid "Parameters"
 msgstr ""
 
@@ -260,7 +286,7 @@ msgstr ""
 msgid "SMALLINT, INTEGER, BIGINT, REAL, FLOAT"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:96
+#: ../../build/doc/pgr_trspVia_withPoints.rst:101
 msgid "Optional parameters"
 msgstr ""
 
@@ -291,7 +317,7 @@ msgstr ""
 msgid "When ``false`` the graph is considered as `Undirected`."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:103
+#: ../../build/doc/pgr_trspVia_withPoints.rst:108
 msgid "Via optional parameters"
 msgstr ""
 
@@ -320,7 +346,7 @@ msgstr ""
 msgid "When ``true`` departing from a visited vertex will not try to avoid"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:110
+#: ../../build/doc/pgr_trspVia_withPoints.rst:115
 msgid "With points optional parameters"
 msgstr ""
 
@@ -366,11 +392,11 @@ msgid ""
 "When ``false`` the results will not include the points that are in the path."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:117
+#: ../../build/doc/pgr_trspVia_withPoints.rst:122
 msgid "Inner Queries"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:120
+#: ../../build/doc/pgr_trspVia_withPoints.rst:125
 msgid "Edges SQL"
 msgstr ""
 
@@ -452,7 +478,7 @@ msgstr ""
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``, ``REAL``, ``FLOAT``"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:127
+#: ../../build/doc/pgr_trspVia_withPoints.rst:132
 msgid "Restrictions SQL"
 msgstr ""
 
@@ -475,7 +501,7 @@ msgstr ""
 msgid "Cost of taking the forbidden path."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:134
+#: ../../build/doc/pgr_trspVia_withPoints.rst:139
 msgid "Points SQL"
 msgstr ""
 
@@ -548,7 +574,7 @@ msgstr ""
 msgid "In both sides ``b``, ``NULL``"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:141
+#: ../../build/doc/pgr_trspVia_withPoints.rst:146
 msgid "Result Columns"
 msgstr ""
 
@@ -664,93 +690,97 @@ msgid ""
 "the identifier is for a Point."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:152
+#: ../../build/doc/pgr_trspVia_withPoints.rst:157
 msgid "Additional Examples"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:158
-msgid "Use :doc:`pgr_findCloseEdges` in the `Points SQL`_."
+#: ../../build/doc/pgr_trspVia_withPoints.rst:163
+msgid "Use ``pgr_findCloseEdges`` for points on the fly"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:160
+#: ../../build/doc/pgr_trspVia_withPoints.rst:165
+msgid "Using :doc:`pgr_findCloseEdges`:"
+msgstr ""
+
+#: ../../build/doc/pgr_trspVia_withPoints.rst:167
 msgid ""
 "Visit from vertex :math:`1` to the two locations on the graph of point "
 "`(2.9, 1.8)` in order of closeness to the graph."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:167
+#: ../../build/doc/pgr_trspVia_withPoints.rst:174
 msgid ""
 "Point :math:`-1` corresponds to the closest edge from point `(2.9,1.8)`."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:168
+#: ../../build/doc/pgr_trspVia_withPoints.rst:175
 msgid ""
 "Point :math:`-2` corresponds to the next close edge from point `(2.9,1.8)`."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:169
+#: ../../build/doc/pgr_trspVia_withPoints.rst:176
 msgid ""
 "Point :math:`-2` is visited on the route to from vertex :math:`1` to Point :"
 "math:`-1` (See row where :math:`seq = 4`)."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:173
+#: ../../build/doc/pgr_trspVia_withPoints.rst:180
 msgid "Usage variations"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:175
+#: ../../build/doc/pgr_trspVia_withPoints.rst:182
 msgid ""
 "All this examples are about the route that visits the vertices :math:`\\{-6, "
-"7, -4, 8, -2\\}` in that order on a **directed** graph."
-msgstr ""
-
-#: ../../build/doc/pgr_trspVia_withPoints.rst:183
-msgid "Aggregate cost of the third path."
+"7, -4, 8, -2\\}` in that order on a directed graph."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:190
-msgid "Route's aggregate cost of the route at the end of the third path."
+msgid "Aggregate cost of the third path."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:197
-msgid "Nodes visited in the route."
+msgid "Route's aggregate cost of the route at the end of the third path."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:204
-msgid "The aggregate costs of the route when the visited vertices are reached."
+msgid "Nodes visited in the route."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:211
-msgid "Status of \"passes in front\" or \"visits\" of the nodes and points."
+msgid "The aggregate costs of the route when the visited vertices are reached."
 msgstr ""
 
 #: ../../build/doc/pgr_trspVia_withPoints.rst:218
-msgid "Simulation of how algorithm works"
+msgid "Status of \"passes in front\" or \"visits\" of the nodes and points."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:220
+#: ../../build/doc/pgr_trspVia_withPoints.rst:225
+msgid "Simulation of how algorithm works."
+msgstr ""
+
+#: ../../build/doc/pgr_trspVia_withPoints.rst:227
 msgid "The algorithm performs a :doc:`pgr_withPointsVia`"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:226
+#: ../../build/doc/pgr_trspVia_withPoints.rst:233
 msgid ""
 "Detects which of the paths pass through a restriction in this case is for "
 "the ``path_id = 1`` from ``-6`` to ``15`` because the path :math:`9 "
 "\\rightarrow 16` is restricted."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:230
+#: ../../build/doc/pgr_trspVia_withPoints.rst:237
 msgid ""
 "Executes the :ref:`TRSP-family:TRSP algorithm` for the conflicting paths."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:236
+#: ../../build/doc/pgr_trspVia_withPoints.rst:243
 msgid ""
 "From the :doc:`pgr_withPointsVia` result it removes the conflicting paths "
 "and builds the solution with the results of the :doc:`pgr_trsp` algorithm:"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:243
+#: ../../build/doc/pgr_trspVia_withPoints.rst:250
 msgid "Getting the same result as ``pgr_trspVia_withPoints``:"
 msgstr ""
 
@@ -758,24 +788,24 @@ msgstr ""
 msgid "Example 8"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:249
+#: ../../build/doc/pgr_trspVia_withPoints.rst:256
 msgid "Sometimes ``U_turn_on_edge`` flag is ignored when is set to ``false``."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:252
+#: ../../build/doc/pgr_trspVia_withPoints.rst:259
 msgid ""
 "The first step, doing a :doc:`pgr_withPointsVia` does consider not making a "
 "U turn on the same edge. But the path :math:`9 \\rightarrow 16` (Rows 4 and "
 "5) is restricted and the result is using it."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:260
+#: ../../build/doc/pgr_trspVia_withPoints.rst:267
 msgid ""
 "When executing the :doc:`pgr_trsp_withPoints` algorithm for the conflicting "
 "path, there is no ``U_turn_on_edge`` flag."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:267
+#: ../../build/doc/pgr_trspVia_withPoints.rst:274
 msgid ""
 "Therefore the result ignores the ``U_turn_on_edge`` flag when set to "
 "``false``. From the :doc:`pgr_withPointsVia` result it removes the "
@@ -783,34 +813,34 @@ msgid ""
 "`pgr_trsp` algorithm. In this case a U turn is been done using the same edge."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:277
+#: ../../build/doc/pgr_trspVia_withPoints.rst:284
 msgid "See Also"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:279
+#: ../../build/doc/pgr_trspVia_withPoints.rst:286
 msgid ":doc:`TRSP-family`"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:280
+#: ../../build/doc/pgr_trspVia_withPoints.rst:287
 msgid ":doc:`via-category`"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:281
+#: ../../build/doc/pgr_trspVia_withPoints.rst:288
 msgid ":doc:`withPoints-category`"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:282
+#: ../../build/doc/pgr_trspVia_withPoints.rst:289
 msgid ":doc:`sampledata` network."
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:285
+#: ../../build/doc/pgr_trspVia_withPoints.rst:292
 msgid "Indices and tables"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:286
+#: ../../build/doc/pgr_trspVia_withPoints.rst:293
 msgid ":ref:`genindex`"
 msgstr ""
 
-#: ../../build/doc/pgr_trspVia_withPoints.rst:287
+#: ../../build/doc/pgr_trspVia_withPoints.rst:294
 msgid ":ref:`search`"
 msgstr ""

--- a/locale/zh_Hans/LC_MESSAGES/pgr_trsp_withPoints.po
+++ b/locale/zh_Hans/LC_MESSAGES/pgr_trsp_withPoints.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-25 12:55-0500\n"
+"POT-Creation-Date: 2022-07-11 18:25-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -29,6 +29,10 @@ msgstr ""
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:19
 msgid "``pgr_trsp_withPoints`` Routing Vertex/Point with restrictions."
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:24
+msgid "Boost Graph Inside"
 msgstr ""
 
 #: ../../build/doc/proposed.rst:3
@@ -67,10 +71,6 @@ msgstr ""
 msgid "Documentation might need refinement."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:28
-msgid "Boost Graph Inside"
-msgstr ""
-
 #: ../../build/doc/pgr_trsp_withPoints.rst:31
 msgid "Availability"
 msgstr ""
@@ -80,7 +80,7 @@ msgid "Version 3.4.0"
 msgstr ""
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:34
-msgid "New **Proposed** signatures"
+msgid "New proposed signatures:"
 msgstr ""
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:36
@@ -106,10 +106,10 @@ msgstr ""
 #: ../../build/doc/pgr_trsp_withPoints.rst:43
 #: ../../build/doc/pgRouting-concepts.rst:10
 #: ../../build/doc/dijkstra-family.rst:11
-#: ../../build/doc/pgr_trsp_withPoints.rst:221
+#: ../../build/doc/pgr_trsp_withPoints.rst:230
 #: ../../build/doc/pgRouting-concepts.rst:11
 #: ../../build/doc/withPoints-category.rst:11
-#: ../../build/doc/pgr_trsp_withPoints.rst:282
+#: ../../build/doc/pgRouting-concepts.rst:13
 msgid "Description"
 msgstr ""
 
@@ -120,77 +120,134 @@ msgid ""
 msgstr ""
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:48
-msgid "**The main characteristics are:**"
+msgid "Characteristics:"
 msgstr ""
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:50
-msgid "Process is done only on edges with positive costs."
-msgstr ""
-
-#: ../../build/doc/pgr_trsp_withPoints.rst:51
-msgid "Driving side can not be `b` (**both**)"
-msgstr ""
-
-#: ../../build/doc/pgr_trsp_withPoints.rst:52
 msgid "Vertices of the graph are:"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:54
+#: ../../build/doc/pgr_trsp_withPoints.rst:52
 msgid "**positive** when it belongs to the `Edges SQL`_"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:55
+#: ../../build/doc/pgr_trsp_withPoints.rst:53
 msgid "**negative** when it belongs to the `Points SQL`_"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:57
+#: ../../build/doc/pgr_trsp_withPoints.rst:55
+msgid "Driving side can not be ``b``"
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:56
 msgid "Values are returned when there is a path."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:59
+#: ../../build/doc/pgr_trsp_withPoints.rst:58
 msgid ""
 "When the starting vertex and ending vertex are the same, there is no path."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:61
+#: ../../build/doc/pgr_trsp_withPoints.rst:60
 msgid "The agg_cost the non included values (v, v) is 0"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:63
+#: ../../build/doc/pgr_trsp_withPoints.rst:62
 msgid ""
 "When the starting vertex and ending vertex are the different and there is no "
 "path:"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:66
+#: ../../build/doc/pgr_trsp_withPoints.rst:65
 msgid "The agg_cost the non included values (u, v) is ∞"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:68
+#: ../../build/doc/pgr_trsp_withPoints.rst:67
 msgid ""
 "For optimization purposes, any duplicated value in the start_vids or "
 "end_vids are ignored."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:70
+#: ../../build/doc/pgr_trsp_withPoints.rst:69
 msgid ""
 "The returned values are ordered: - start_vid ascending - end_vid ascending"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:74
+#: ../../build/doc/pgr_trsp_withPoints.rst:73
 msgid "Running time: :math:`O(|start\\_vids|\\times(V \\log V + E))`"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:77
+#: ../../build/doc/pgr_trsp_withPoints.rst:76
 msgid "Signatures"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:80
+#: ../../build/doc/pgr_trsp_withPoints.rst:79
 msgid "Summary"
 msgstr ""
 
+#: ../../build/doc/pgr_trsp_withPoints.rst:80
 #: ../../build/doc/pgr_trsp_withPoints.rst:100
+#: ../../build/doc/pgr_trsp_withPoints.rst:122
+#: ../../build/doc/pgr_trsp_withPoints.rst:143
+#: ../../build/doc/pgr_trsp_withPoints.rst:164
+#: ../../build/doc/pgr_trsp_withPoints.rst:186
+msgid "\\ \\"
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
+msgid ""
+"pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Points SQL`_, "
+"**start vid**, **end vid**, [options])"
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
+msgid ""
+"pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Points SQL`_, "
+"**start vid**, **end vids**, [options])"
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
+msgid ""
+"pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Points SQL`_, "
+"**start vids**, **end vid**, [options])"
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
+msgid ""
+"pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Points SQL`_, "
+"**start vids**, **end vids**, [options])"
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
+msgid ""
+"pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Combinations SQL`_, "
+"`Points SQL`_, [options])"
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
+msgid "[options]"
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:89
+msgid "[directed, driving_side [details]"
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
+msgid "RETURNS SET OF |generic-result|"
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:0
+msgid "OR EMPTY SET"
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:98
 msgid "One to One"
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:103
+msgid ""
+"pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Points SQL`_, "
+"**start vid**, **end vid**, [directed, driving_side, details])"
 msgstr ""
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:0
@@ -199,61 +256,85 @@ msgstr ""
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:109
 msgid ""
-"From point :math:`1` to vertex :math:`10` with details on a **left** driving "
-"side configuration on a **directed** graph with **details**."
+"From point :math:`1` to vertex :math:`10` with details on a left driving "
+"side configuration on a directed graph with details."
 msgstr ""
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:120
 msgid "One to Many"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:129
+#: ../../build/doc/pgr_trsp_withPoints.rst:125
+msgid ""
+"pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Points SQL`_, "
+"**start vid**, **end vids** [directed, driving_side, details])"
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:131
 msgid "From point :math:`1` to point :math:`3` and vertex :math:`7`."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:139
+#: ../../build/doc/pgr_trsp_withPoints.rst:141
 msgid "Many to One"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:148
+#: ../../build/doc/pgr_trsp_withPoints.rst:146
+msgid ""
+"pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Points SQL`_, "
+"**start vids**, **end vid** [directed, driving_side, details])"
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:152
 msgid "From point :math:`1` and vertex :math:`6` to point :math:`3`."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:158
+#: ../../build/doc/pgr_trsp_withPoints.rst:162
 msgid "Many to Many"
 msgstr ""
 
 #: ../../build/doc/pgr_trsp_withPoints.rst:167
 msgid ""
-"From point :math:`1` and vertex :math:`6`  to point :math:`3` and vertex :"
+"pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Points SQL`_, "
+"**start vids**, **end vids** [directed, driving_side, details])"
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:173
+msgid ""
+"From point :math:`1` and vertex :math:`6` to point :math:`3` and vertex :"
 "math:`1`."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:178
+#: ../../build/doc/pgr_trsp_withPoints.rst:184
 msgid "Combinations"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:186
+#: ../../build/doc/pgr_trsp_withPoints.rst:189
 msgid ""
-"From point :math:`1` to vertex :math:`10` and from vertex :math:`6` to "
-"point :math:`3` with **right** side driving configuration."
+"pgr_trsp_withPoints(`Edges SQL`_, `Restrictions SQL`_, `Combinations SQL`_, "
+"`Points SQL`_, [directed, driving_side, details])"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:194
+#: ../../build/doc/pgr_trsp_withPoints.rst:195
+msgid ""
+"From point :math:`1` to vertex :math:`10` and from vertex :math:`6` to "
+"point :math:`3` with right side driving configuration."
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:203
 msgid "Parameters"
 msgstr ""
 
 #: ../../build/doc/pgRouting-concepts.rst:8
 #: ../../build/doc/dijkstra-family.rst:8
-#: ../../build/doc/pgr_trsp_withPoints.rst:280
+#: ../../build/doc/pgRouting-concepts.rst:11
 msgid "Column"
 msgstr ""
 
 #: ../../build/doc/pgRouting-concepts.rst:9
 #: ../../build/doc/dijkstra-family.rst:9
-#: ../../build/doc/pgr_trsp_withPoints.rst:219
+#: ../../build/doc/pgr_trsp_withPoints.rst:228
 #: ../../build/doc/withPoints-category.rst:9
-#: ../../build/doc/pgr_trsp_withPoints.rst:281
+#: ../../build/doc/pgRouting-concepts.rst:12
 msgid "Type"
 msgstr ""
 
@@ -349,12 +430,12 @@ msgstr ""
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:202
+#: ../../build/doc/pgr_trsp_withPoints.rst:211
 msgid "Optional parameters"
 msgstr ""
 
 #: ../../build/doc/dijkstra-family.rst:10
-#: ../../build/doc/pgr_trsp_withPoints.rst:220
+#: ../../build/doc/pgr_trsp_withPoints.rst:229
 #: ../../build/doc/pgRouting-concepts.rst:10
 #: ../../build/doc/withPoints-category.rst:10
 msgid "Default"
@@ -365,7 +446,7 @@ msgid "``directed``"
 msgstr ""
 
 #: ../../build/doc/dijkstra-family.rst:13
-#: ../../build/doc/pgr_trsp_withPoints.rst:231
+#: ../../build/doc/pgr_trsp_withPoints.rst:240
 msgid "``BOOLEAN``"
 msgstr ""
 
@@ -381,67 +462,67 @@ msgstr ""
 msgid "When ``false`` the graph is considered as `Undirected`."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:209
+#: ../../build/doc/pgr_trsp_withPoints.rst:218
 msgid "With points optional parameters"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:218
+#: ../../build/doc/pgr_trsp_withPoints.rst:227
 #: ../../build/doc/withPoints-category.rst:8
 #: ../../build/doc/pgRouting-concepts.rst:8
 msgid "Parameter"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:222
+#: ../../build/doc/pgr_trsp_withPoints.rst:231
 msgid "``driving_side``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:223
+#: ../../build/doc/pgr_trsp_withPoints.rst:232
 #: ../../build/doc/withPoints-category.rst:32
 msgid "``CHAR``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:224
+#: ../../build/doc/pgr_trsp_withPoints.rst:233
 msgid "``r``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:225
+#: ../../build/doc/pgr_trsp_withPoints.rst:234
 msgid "Value in [``r``, ``l``] indicating if the driving side is:"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:227
+#: ../../build/doc/pgr_trsp_withPoints.rst:236
 msgid "``r`` for right driving side"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:228
+#: ../../build/doc/pgr_trsp_withPoints.rst:237
 msgid "``l`` for left driving side"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:229
+#: ../../build/doc/pgr_trsp_withPoints.rst:238
 msgid "Any other value will be considered as ``r``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:230
+#: ../../build/doc/pgr_trsp_withPoints.rst:239
 msgid "``details``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:232
+#: ../../build/doc/pgr_trsp_withPoints.rst:241
 msgid "``false``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:233
+#: ../../build/doc/pgr_trsp_withPoints.rst:242
 msgid "When ``true`` the results will include the points that are in the path."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:234
+#: ../../build/doc/pgr_trsp_withPoints.rst:243
 msgid ""
 "When ``false`` the results will not include the points that are in the path."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:242
+#: ../../build/doc/pgr_trsp_withPoints.rst:249
 msgid "Inner Queries"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:245
+#: ../../build/doc/pgr_trsp_withPoints.rst:252
 msgid "Edges SQL"
 msgstr ""
 
@@ -472,7 +553,7 @@ msgid "Identifier of the second end point vertex of the edge."
 msgstr ""
 
 #: ../../build/doc/pgRouting-concepts.rst:24
-#: ../../build/doc/pgr_trsp_withPoints.rst:305
+#: ../../build/doc/pgRouting-concepts.rst:40
 msgid "``cost``"
 msgstr ""
 
@@ -516,7 +597,7 @@ msgstr ""
 msgid "``SMALLINT``, ``INTEGER``, ``BIGINT``, ``REAL``, ``FLOAT``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:252
+#: ../../build/doc/pgr_trsp_withPoints.rst:259
 msgid "Restrictions SQL"
 msgstr ""
 
@@ -539,7 +620,7 @@ msgstr ""
 msgid "Cost of taking the forbidden path."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:259
+#: ../../build/doc/pgr_trsp_withPoints.rst:266
 msgid "Points SQL"
 msgstr ""
 
@@ -612,7 +693,7 @@ msgstr ""
 msgid "In both sides ``b``, ``NULL``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:266
+#: ../../build/doc/pgr_trsp_withPoints.rst:273
 msgid "Combinations SQL"
 msgstr ""
 
@@ -620,172 +701,184 @@ msgstr ""
 msgid "Identifier of the arrival vertex."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:273
+#: ../../build/doc/pgr_trsp_withPoints.rst:280
 msgid "Result Columns"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:283
+#: ../../build/doc/pgRouting-concepts.rst:3
+msgid ""
+"Returns set of ``(seq, path_id, path_seq, start_vid, end_vid, node, edge, "
+"cost, agg_cost)``"
+msgstr ""
+
+#: ../../build/doc/pgRouting-concepts.rst:14
 msgid "``seq``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:284
-#: ../../build/doc/pgr_trsp_withPoints.rst:287
+#: ../../build/doc/pgRouting-concepts.rst:15
+#: ../../build/doc/pgRouting-concepts.rst:18
+#: ../../build/doc/pgRouting-concepts.rst:24
 msgid "``INTEGER``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:285
+#: ../../build/doc/pgRouting-concepts.rst:16
 msgid "Sequential value starting from **1**."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:286
+#: ../../build/doc/pgRouting-concepts.rst:17
+msgid "``path_id``"
+msgstr ""
+
+#: ../../build/doc/pgRouting-concepts.rst:19
+msgid "Path identifier."
+msgstr ""
+
+#: ../../build/doc/pgRouting-concepts.rst:21
+msgid ""
+"Has value **1** for the first of a path from ``start_vid`` to ``end_vid``."
+msgstr ""
+
+#: ../../build/doc/pgRouting-concepts.rst:23
 msgid "``path_seq``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:288
+#: ../../build/doc/pgRouting-concepts.rst:25
 msgid ""
 "Relative position in the path. Has value **1** for the beginning of a path."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:290
+#: ../../build/doc/pgRouting-concepts.rst:27
 msgid "``start_vid``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:291
-#: ../../build/doc/pgr_trsp_withPoints.rst:294
-#: ../../build/doc/pgr_trsp_withPoints.rst:297
-#: ../../build/doc/pgr_trsp_withPoints.rst:300
+#: ../../build/doc/pgRouting-concepts.rst:28
+#: ../../build/doc/pgRouting-concepts.rst:31
+#: ../../build/doc/pgRouting-concepts.rst:34
+#: ../../build/doc/pgRouting-concepts.rst:37
 msgid "``BIGINT``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:292
-msgid "Identifier of the starting vertex of the path."
+#: ../../build/doc/pgRouting-concepts.rst:29
+msgid "Identifier of the starting vertex."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:293
+#: ../../build/doc/pgRouting-concepts.rst:30
 msgid "``end_vid``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:295
-msgid "Identifier of the ending vertex of the path."
+#: ../../build/doc/pgRouting-concepts.rst:32
+msgid "Identifier of the ending vertex."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:296
+#: ../../build/doc/pgRouting-concepts.rst:33
 msgid "``node``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:298
+#: ../../build/doc/pgRouting-concepts.rst:35
 msgid "Identifier of the node in the path from ``start_vid`` to ``end_vid``."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:299
+#: ../../build/doc/pgRouting-concepts.rst:36
 msgid "``edge``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:301
+#: ../../build/doc/pgRouting-concepts.rst:38
 msgid ""
 "Identifier of the edge used to go from ``node`` to the next node in the path "
-"sequence."
+"sequence. **-1** for the last node of the path."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:304
-msgid "-1 for the last node of the path."
-msgstr ""
-
-#: ../../build/doc/pgr_trsp_withPoints.rst:306
-#: ../../build/doc/pgr_trsp_withPoints.rst:312
+#: ../../build/doc/pgRouting-concepts.rst:41
+#: ../../build/doc/pgRouting-concepts.rst:45
 msgid "``FLOAT``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:307
+#: ../../build/doc/pgRouting-concepts.rst:42
 msgid ""
 "Cost to traverse from ``node`` using ``edge`` to the next node in the path "
 "sequence."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:310
-msgid "``0`` for the last row in the path sequence."
-msgstr ""
-
-#: ../../build/doc/pgr_trsp_withPoints.rst:311
+#: ../../build/doc/pgRouting-concepts.rst:44
 msgid "``agg_cost``"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:313
+#: ../../build/doc/pgRouting-concepts.rst:46
 msgid "Aggregate cost from ``start_vid`` to ``node``."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:315
-msgid "``0`` for the first row in the path sequence."
-msgstr ""
-
-#: ../../build/doc/pgr_trsp_withPoints.rst:320
+#: ../../build/doc/pgr_trsp_withPoints.rst:287
 msgid "Additional Examples"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:326
-msgid "Use :doc:`pgr_findCloseEdges` in the `Points SQL`_."
+#: ../../build/doc/pgr_trsp_withPoints.rst:293
+msgid "Use ``pgr_findCloseEdges`` for points on the fly"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:328
+#: ../../build/doc/pgr_trsp_withPoints.rst:295
+msgid "Using :doc:`pgr_findCloseEdges`:"
+msgstr ""
+
+#: ../../build/doc/pgr_trsp_withPoints.rst:297
 msgid ""
 "Find the routes from vertex :math:`1` to the two closest locations on the "
 "graph of point `(2.9, 1.8)`."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:335
+#: ../../build/doc/pgr_trsp_withPoints.rst:304
 msgid ""
-"Point :math:`-1` corresponds to the closest edge from point `(2.9,1.8)`."
+"Point :math:`-1` corresponds to the closest edge from point `(2.9, 1.8)`."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:336
+#: ../../build/doc/pgr_trsp_withPoints.rst:305
 msgid ""
-"Point :math:`-2` corresponds to the next close edge from point `(2.9,1.8)`."
+"Point :math:`-2` corresponds to the next close edge from point `(2.9, 1.8)`."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:339
-msgid "Pass in front or visits"
+#: ../../build/doc/pgr_trsp_withPoints.rst:308
+msgid "Pass in front or visits."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:341
+#: ../../build/doc/pgr_trsp_withPoints.rst:310
 msgid ""
 "Which path (if any) passes in front of point :math:`6` or vertex :math:`11` "
-"with **right** side driving topology."
+"with right side driving topology."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:349
-msgid "Show details on undirected graph"
+#: ../../build/doc/pgr_trsp_withPoints.rst:318
+msgid "Show details on undirected graph."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:351
+#: ../../build/doc/pgr_trsp_withPoints.rst:320
 msgid ""
 "From point :math:`1` and vertex :math:`6` to point :math:`3` to vertex :math:"
-"`1` on an **undirected** graph, with details."
+"`1` on an undirected graph, with details."
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:359
+#: ../../build/doc/pgr_trsp_withPoints.rst:328
 msgid "See Also"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:361
+#: ../../build/doc/pgr_trsp_withPoints.rst:330
 msgid ":doc:`TRSP-family`"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:362
+#: ../../build/doc/pgr_trsp_withPoints.rst:331
 msgid ":doc:`withPoints-category`"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:363
+#: ../../build/doc/pgr_trsp_withPoints.rst:332
 msgid ":doc:`sampledata`"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:366
+#: ../../build/doc/pgr_trsp_withPoints.rst:335
 msgid "Indices and tables"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:367
+#: ../../build/doc/pgr_trsp_withPoints.rst:336
 msgid ":ref:`genindex`"
 msgstr ""
 
-#: ../../build/doc/pgr_trsp_withPoints.rst:368
+#: ../../build/doc/pgr_trsp_withPoints.rst:337
 msgid ":ref:`search`"
 msgstr ""


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [pgRouting/index](https://weblate.osgeo.org/projects/pgrouting/index/).


It also includes following components:

* [pgRouting/pgr_nodeNetwork](https://weblate.osgeo.org/projects/pgrouting/pgr_nodenetwork/)

* [pgRouting/pgRouting-concepts](https://weblate.osgeo.org/projects/pgrouting/pgrouting-concepts/)

* [pgRouting/pgr_johnson](https://weblate.osgeo.org/projects/pgrouting/pgr_johnson/)

* [pgRouting/allpairs-family](https://weblate.osgeo.org/projects/pgrouting/allpairs-family/)

* [pgRouting/pgr_maxCardinalityMatch](https://weblate.osgeo.org/projects/pgrouting/pgr_maxcardinalitymatch/)

* [pgRouting/BFS-category](https://weblate.osgeo.org/projects/pgrouting/bfs-category/)

* [pgRouting/costMatrix-category](https://weblate.osgeo.org/projects/pgrouting/costmatrix-category/)

* [pgRouting/pgr_isPlanar](https://weblate.osgeo.org/projects/pgrouting/pgr_isplanar/)

* [pgRouting/pgr_trspVia_withPoints](https://weblate.osgeo.org/projects/pgrouting/pgr_trspvia_withpoints/)

* [pgRouting/pgr_withPointsKSP](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointsksp/)

* [pgRouting/pgr_transitiveClosure](https://weblate.osgeo.org/projects/pgrouting/pgr_transitiveclosure/)

* [pgRouting/bdAstar-family](https://weblate.osgeo.org/projects/pgrouting/bdastar-family/)

* [pgRouting/pgRouting-introduction](https://weblate.osgeo.org/projects/pgrouting/pgrouting-introduction/)

* [pgRouting/pgr_version](https://weblate.osgeo.org/projects/pgrouting/pgr_version/)

* [pgRouting/pgr_pickDeliver](https://weblate.osgeo.org/projects/pgrouting/pgr_pickdeliver/)

* [pgRouting/bdDijkstra-family](https://weblate.osgeo.org/projects/pgrouting/bddijkstra-family/)

* [pgRouting/pgr_aStarCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_astarcostmatrix/)

* [pgRouting/pgr_TSPeuclidean](https://weblate.osgeo.org/projects/pgrouting/pgr_tspeuclidean/)

* [pgRouting/release_notes](https://weblate.osgeo.org/projects/pgrouting/release_notes/)

* [pgRouting/pgr_analyzeGraph](https://weblate.osgeo.org/projects/pgrouting/pgr_analyzegraph/)

* [pgRouting/pgr_full_version](https://weblate.osgeo.org/projects/pgrouting/pgr_full_version/)

* [pgRouting/migration](https://weblate.osgeo.org/projects/pgrouting/migration/)

* [pgRouting/contraction-family](https://weblate.osgeo.org/projects/pgrouting/contraction-family/)

* [pgRouting/support](https://weblate.osgeo.org/projects/pgrouting/support/)

* [pgRouting/pgr_depthFirstSearch](https://weblate.osgeo.org/projects/pgrouting/pgr_depthfirstsearch/)

* [pgRouting/spanningTree-family](https://weblate.osgeo.org/projects/pgrouting/spanningtree-family/)

* [pgRouting/pgr_boykovKolmogorov](https://weblate.osgeo.org/projects/pgrouting/pgr_boykovkolmogorov/)

* [pgRouting/pgr_extractVertices](https://weblate.osgeo.org/projects/pgrouting/pgr_extractvertices/)

* [pgRouting/reference](https://weblate.osgeo.org/projects/pgrouting/reference/)

* [pgRouting/pgr_createVerticesTable](https://weblate.osgeo.org/projects/pgrouting/pgr_createverticestable/)

* [pgRouting/pgr_vrpOneDepot](https://weblate.osgeo.org/projects/pgrouting/pgr_vrponedepot/)

* [pgRouting/cost-category](https://weblate.osgeo.org/projects/pgrouting/cost-category/)

* [pgRouting/topology-functions](https://weblate.osgeo.org/projects/pgrouting/topology-functions/)

* [pgRouting/pgr_edwardMoore](https://weblate.osgeo.org/projects/pgrouting/pgr_edwardmoore/)

* [pgRouting/proposed](https://weblate.osgeo.org/projects/pgrouting/proposed/)

* [pgRouting/KSP-category](https://weblate.osgeo.org/projects/pgrouting/ksp-category/)

* [pgRouting/pgr_trsp](https://weblate.osgeo.org/projects/pgrouting/pgr_trsp/)

* [pgRouting/pgRouting-installation](https://weblate.osgeo.org/projects/pgrouting/pgrouting-installation/)

* [pgRouting/pgr_bellmanFord](https://weblate.osgeo.org/projects/pgrouting/pgr_bellmanford/)

* [pgRouting/transformation-family](https://weblate.osgeo.org/projects/pgrouting/transformation-family/)

* [pgRouting/traversal-family](https://weblate.osgeo.org/projects/pgrouting/traversal-family/)

* [pgRouting/pgr_kruskalBFS](https://weblate.osgeo.org/projects/pgrouting/pgr_kruskalbfs/)

* [pgRouting/components-family](https://weblate.osgeo.org/projects/pgrouting/components-family/)

* [pgRouting/pgr_chinesePostmanCost](https://weblate.osgeo.org/projects/pgrouting/pgr_chinesepostmancost/)

* [pgRouting/pgr_aStarCost](https://weblate.osgeo.org/projects/pgrouting/pgr_astarcost/)

* [pgRouting/pgr_strongComponents](https://weblate.osgeo.org/projects/pgrouting/pgr_strongcomponents/)

* [pgRouting/coloring-family](https://weblate.osgeo.org/projects/pgrouting/coloring-family/)

* [pgRouting/pgr_drivingDistance](https://weblate.osgeo.org/projects/pgrouting/pgr_drivingdistance/)

* [pgRouting/pgr_sequentialVertexColoring](https://weblate.osgeo.org/projects/pgrouting/pgr_sequentialvertexcoloring/)

* [pgRouting/pgr_createTopology](https://weblate.osgeo.org/projects/pgrouting/pgr_createtopology/)

* [pgRouting/pgr_turnRestrictedPath](https://weblate.osgeo.org/projects/pgrouting/pgr_turnrestrictedpath/)

* [pgRouting/aStar-family](https://weblate.osgeo.org/projects/pgrouting/astar-family/)

* [pgRouting/pgr_breadthFirstSearch](https://weblate.osgeo.org/projects/pgrouting/pgr_breadthfirstsearch/)

* [pgRouting/VRP-category](https://weblate.osgeo.org/projects/pgrouting/vrp-category/)

* [pgRouting/routingFunctions](https://weblate.osgeo.org/projects/pgrouting/routingfunctions/)

* [pgRouting/pgr_maxFlowMinCost_Cost](https://weblate.osgeo.org/projects/pgrouting/pgr_maxflowmincost_cost/)

* [pgRouting/pgr_dijkstraNearCost](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstranearcost/)

* [pgRouting/pgr_dagShortestPath](https://weblate.osgeo.org/projects/pgrouting/pgr_dagshortestpath/)

* [pgRouting/DFS-category](https://weblate.osgeo.org/projects/pgrouting/dfs-category/)

* [pgRouting/pgr_makeConnected](https://weblate.osgeo.org/projects/pgrouting/pgr_makeconnected/)

* [pgRouting/pgr_topologicalSort](https://weblate.osgeo.org/projects/pgrouting/pgr_topologicalsort/)

* [pgRouting/pgr_edgeColoring](https://weblate.osgeo.org/projects/pgrouting/pgr_edgecoloring/)

* [pgRouting/pgr_primDD](https://weblate.osgeo.org/projects/pgrouting/pgr_primdd/)

* [pgRouting/pgr_biconnectedComponents](https://weblate.osgeo.org/projects/pgrouting/pgr_biconnectedcomponents/)

* [pgRouting/pgr_lineGraph](https://weblate.osgeo.org/projects/pgrouting/pgr_linegraph/)

* [pgRouting/withPoints-family](https://weblate.osgeo.org/projects/pgrouting/withpoints-family/)

* [pgRouting/kruskal-family](https://weblate.osgeo.org/projects/pgrouting/kruskal-family/)

* [pgRouting/pgr_prim](https://weblate.osgeo.org/projects/pgrouting/pgr_prim/)

* [pgRouting/pgr_withPointsCost](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointscost/)

* [pgRouting/pgr_bipartite](https://weblate.osgeo.org/projects/pgrouting/pgr_bipartite/)

* [pgRouting/pgr_dijkstraCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstracostmatrix/)

* [pgRouting/pgr_withPoints](https://weblate.osgeo.org/projects/pgrouting/pgr_withpoints/)

* [pgRouting/pgr_bridges](https://weblate.osgeo.org/projects/pgrouting/pgr_bridges/)

* [pgRouting/pgr_chinesePostman](https://weblate.osgeo.org/projects/pgrouting/pgr_chinesepostman/)

* [pgRouting/pgr_dijkstraVia](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstravia/)

* [pgRouting/chinesePostmanProblem-family](https://weblate.osgeo.org/projects/pgrouting/chinesepostmanproblem-family/)

* [pgRouting/via-category](https://weblate.osgeo.org/projects/pgrouting/via-category/)

* [pgRouting/prim-family](https://weblate.osgeo.org/projects/pgrouting/prim-family/)

* [pgRouting/pgr_stoerWagner](https://weblate.osgeo.org/projects/pgrouting/pgr_stoerwagner/)

* [pgRouting/dijkstra-family](https://weblate.osgeo.org/projects/pgrouting/dijkstra-family/)

* [pgRouting/pgr_analyzeOneWay](https://weblate.osgeo.org/projects/pgrouting/pgr_analyzeoneway/)

* [pgRouting/sampledata](https://weblate.osgeo.org/projects/pgrouting/sampledata/)

* [pgRouting/pgr_bdAstar](https://weblate.osgeo.org/projects/pgrouting/pgr_bdastar/)

* [pgRouting/pgr_kruskalDD](https://weblate.osgeo.org/projects/pgrouting/pgr_kruskaldd/)

* [pgRouting/pgr_connectedComponents](https://weblate.osgeo.org/projects/pgrouting/pgr_connectedcomponents/)

* [pgRouting/pgr_withPointsCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointscostmatrix/)

* [pgRouting/TSP-family](https://weblate.osgeo.org/projects/pgrouting/tsp-family/)

* [pgRouting/pgr_dijkstraCost](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstracost/)

* [pgRouting/pgr_articulationPoints](https://weblate.osgeo.org/projects/pgrouting/pgr_articulationpoints/)

* [pgRouting/pgr_floydWarshall](https://weblate.osgeo.org/projects/pgrouting/pgr_floydwarshall/)

* [pgRouting/pgr_withPointsDD](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointsdd/)

* [pgRouting/flow-family](https://weblate.osgeo.org/projects/pgrouting/flow-family/)

* [pgRouting/TRSP-family](https://weblate.osgeo.org/projects/pgrouting/trsp-family/)

* [pgRouting/pgr_trsp_withPoints](https://weblate.osgeo.org/projects/pgrouting/pgr_trsp_withpoints/)

* [pgRouting/pgr_trspVia](https://weblate.osgeo.org/projects/pgrouting/pgr_trspvia/)

* [pgRouting/pgr_withPointsVia](https://weblate.osgeo.org/projects/pgrouting/pgr_withpointsvia/)

* [pgRouting/withPoints-category](https://weblate.osgeo.org/projects/pgrouting/withpoints-category/)

* [pgRouting/pgr_degree](https://weblate.osgeo.org/projects/pgrouting/pgr_degree/)

* [pgRouting/pgr_findCloseEdges](https://weblate.osgeo.org/projects/pgrouting/pgr_findcloseedges/)

* [pgRouting/pgr_maxFlow](https://weblate.osgeo.org/projects/pgrouting/pgr_maxflow/)

* [pgRouting/pgr_KSP](https://weblate.osgeo.org/projects/pgrouting/pgr_ksp/)

* [pgRouting/pgr_dijkstraNear](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstranear/)

* [pgRouting/experimental](https://weblate.osgeo.org/projects/pgrouting/experimental/)

* [pgRouting/pgr_TSP](https://weblate.osgeo.org/projects/pgrouting/pgr_tsp/)

* [pgRouting/drivingDistance-category](https://weblate.osgeo.org/projects/pgrouting/drivingdistance-category/)

* [pgRouting/pgr_primBFS](https://weblate.osgeo.org/projects/pgrouting/pgr_primbfs/)

* [pgRouting/pgr_lineGraphFull](https://weblate.osgeo.org/projects/pgrouting/pgr_linegraphfull/)

* [pgRouting/pgr_alphaShape](https://weblate.osgeo.org/projects/pgrouting/pgr_alphashape/)

* [pgRouting/pgr_kruskal](https://weblate.osgeo.org/projects/pgrouting/pgr_kruskal/)

* [pgRouting/pgr_bdAstarCost](https://weblate.osgeo.org/projects/pgrouting/pgr_bdastarcost/)

* [pgRouting/pgr_contraction](https://weblate.osgeo.org/projects/pgrouting/pgr_contraction/)

* [pgRouting/pgr_binaryBreadthFirstSearch](https://weblate.osgeo.org/projects/pgrouting/pgr_binarybreadthfirstsearch/)

* [pgRouting/pgr_pushRelabel](https://weblate.osgeo.org/projects/pgrouting/pgr_pushrelabel/)

* [pgRouting/pgr_primDFS](https://weblate.osgeo.org/projects/pgrouting/pgr_primdfs/)

* [pgRouting/pgr_edmondsKarp](https://weblate.osgeo.org/projects/pgrouting/pgr_edmondskarp/)

* [pgRouting/pgr_dijkstra](https://weblate.osgeo.org/projects/pgrouting/pgr_dijkstra/)

* [pgRouting/pgr_bdDijkstra](https://weblate.osgeo.org/projects/pgrouting/pgr_bddijkstra/)

* [pgRouting/pgr_lengauerTarjanDominatorTree](https://weblate.osgeo.org/projects/pgrouting/pgr_lengauertarjandominatortree/)

* [pgRouting/pgr_bdAstarCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_bdastarcostmatrix/)

* [pgRouting/pgr_bdDijkstraCostMatrix](https://weblate.osgeo.org/projects/pgrouting/pgr_bddijkstracostmatrix/)

* [pgRouting/pgr_aStar](https://weblate.osgeo.org/projects/pgrouting/pgr_astar/)

* [pgRouting/pgr_edgeDisjointPaths](https://weblate.osgeo.org/projects/pgrouting/pgr_edgedisjointpaths/)

* [pgRouting/pgr_kruskalDFS](https://weblate.osgeo.org/projects/pgrouting/pgr_kruskaldfs/)

* [pgRouting/pgr_bdDijkstraCost](https://weblate.osgeo.org/projects/pgrouting/pgr_bddijkstracost/)

* [pgRouting/pgr_pickDeliverEuclidean](https://weblate.osgeo.org/projects/pgrouting/pgr_pickdelivereuclidean/)

* [pgRouting/pgr_maxFlowMinCost](https://weblate.osgeo.org/projects/pgrouting/pgr_maxflowmincost/)



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widgets/pgrouting/-/index/horizontal-auto.svg)