### PR TITLE
Bump MarkusJx/install-boost from 2.3.0 to 2.4.0

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install boost
-        uses: MarkusJx/install-boost@v2.3.0
+        uses: MarkusJx/install-boost@v2.4.0
         id: install-boost
         with:
           # REQUIRED: Specify the required boost version


### PR DESCRIPTION
Ports from #2361

Bumps [MarkusJx/install-boost](https://github.com/MarkusJx/install-boost) from 2.3.0 to 2.4.0.
- [Release notes](https://github.com/MarkusJx/install-boost/releases)
- [Commits](https://github.com/MarkusJx/install-boost/compare/v2.3.0...v2.4.0)

---
updated-dependencies:
- dependency-name: MarkusJx/install-boost dependency-type: direct:production update-type: version-update:semver-minor ...

Signed-off-by: dependabot[bot] <support@github.com>



@pgRouting/admins
