### PR TITLE
fix 2394 : don't store heuristic cost into cost vector

### DIFF
--- a/include/bdAstar/pgr_bdAstar.hpp
+++ b/include/bdAstar/pgr_bdAstar.hpp
@@ -106,6 +106,7 @@ class Pgr_bdAstar : public Pgr_bidirectional<G> {
 
         auto current_cost = node.first;
         auto current_node = node.second;
+        auto current_node_cost = forward_cost[current_node];
 
         for (boost::tie(out, out_end) = out_edges(current_node, graph.graph);
                 out != out_end; ++out) {
@@ -114,8 +115,8 @@ class Pgr_bdAstar : public Pgr_bidirectional<G> {
 
             if (forward_finished[next_node]) continue;
 
-            if (edge_cost + current_cost < forward_cost[next_node]) {
-                forward_cost[next_node] = edge_cost + current_cost;
+            if (edge_cost + current_node_cost < forward_cost[next_node]) {
+                forward_cost[next_node] = edge_cost + current_node_cost;
                 forward_predecessor[next_node] = current_node;
                 forward_edge[next_node] = graph[*out].id;
                 forward_queue.push({


### PR DESCRIPTION
Fixes #3294 .

Changes proposed in this pull request:
- No longer store heuristic code into node cost vector and use it only to best candidate selection
-
-

@pgRouting/admins
