### PR TITLE
[lint] removing trailing spaces

### DIFF
--- a/include/c_common/get_check_data.h
+++ b/include/c_common/get_check_data.h
@@ -43,13 +43,7 @@ bool column_found(int colNumber);
 /*!
  * @brief Function tells expected type of each column and then check the correspondence type of each column.
  *
- * @param[in] info[]     contain one or more column information.
- * @param[in] info_size  number of columns.
- * 
  * @throw ERROR Unknown type of column.
- *
- * @return NULL is always returned.
- *
  */
 void pgr_fetch_column_info(
         Column_info_t info[],
@@ -59,11 +53,11 @@ void pgr_fetch_column_info(
  * @brief The function check whether column type is ANY-INTEGER or not.
  *       Where ANY-INTEGER is SQL type:
  *           SMALLINT, INTEGER, BIGINT
- * 
+ *
  * @param[in] info contain column information.
- * 
+ *
  * @throw ERROR Unexpected Column type. Expected column type is ANY-INTEGER.
- * 
+ *
  */
 void pgr_check_any_integer_type(Column_info_t info);
 
@@ -71,11 +65,11 @@ void pgr_check_any_integer_type(Column_info_t info);
  * @brief The function check whether column type is ANY-NUMERICAL.
  *        Where ANY-NUMERICAL is SQL type:
  *             SMALLINT, INTEGER, BIGINT, REAL, FLOAT
- * 
+ *
  * @param[in] info contain column information.
- * 
+ *
  * @throw ERROR Unexpected Column type. Expected column type is ANY-NUMERICAL.
- * 
+ *
  */
 void pgr_check_any_numerical_type(Column_info_t info);
 
@@ -83,9 +77,9 @@ void pgr_check_any_numerical_type(Column_info_t info);
  * @brief The function check whether column type is CHAR or not.
  *        Where CHAR is SQL type:
  *             CHARACTER
- * 
+ *
  * @param[in] info contain column information.
- * 
+ *
  * @throw ERROR Unexpected Column type. Expected column type is CHAR.
  *
  */
@@ -95,11 +89,11 @@ void pgr_check_char_type(Column_info_t info);
  * @brief The function check whether column type is TEXT or not.
  *       Where TEXT is SQL type:
  *             TEXT
- * 
+ *
  * @param[in] info contain column information.
- * 
+ *
  * @throw ERROR Unexpected Column type. Expected column type is TEXT.
- * 
+ *
  */
 void pgr_check_text_type(Column_info_t info);
 void pgr_check_boolean_type(Column_info_t info);
@@ -108,29 +102,29 @@ void pgr_check_boolean_type(Column_info_t info);
  * @brief The function check whether column type is ANY-INTEGER-ARRAY or not.
  *        Where ANY-INTEGER-ARRAY is SQL type:
  *             SMALLINT[], INTEGER[], BIGINT[]
- * 
+ *
  * @param[in] info contain column information.
- * 
+ *
  * @throw ERROR Unexpected Column type. Expected ANY-INTEGER-ARRAY.
- * 
+ *
  */
 
 void pgr_check_any_integerarray_type(Column_info_t info);
 
 /*!
  * @brief Function return the value of specified column in char type.
- * 
+ *
  * @param[in]  tuple         input row to be examined.
  * @param[in]  tupdesc       input row description.
  * @param[in]  info          contain column information.
  * @param[in]  strict        boolean value of strict.
  * @param[in]  default_value returned when column contain NULL value.
- * 
+ *
  * @throw ERROR Unexpected Column type. Expected column type is CHAR.
  * @throw ERROR When value of column is NULL.
- * 
+ *
  * @return Char type of column value is returned.
- * 
+ *
  */
 char pgr_SPI_getChar(
         HeapTuple *tuple,
@@ -141,18 +135,18 @@ char pgr_SPI_getChar(
 
 /*!
  * @brief Function returns the values of specified columns in array.
- * 
+ *
  * @param[in]  tuple    input row to be examined.
  * @param[in]  tupdesc  input row description.
  * @param[in]  info     contain column information.
  * @param[out] the_size number of element in array.
- * 
+ *
  * @throw ERROR No elements found in ARRAY.
  * @throw ERROR Unexpected Column type. Expected column type is ANY-INTEGER-ARRAY.
  * @throw ERROR NULL value found in Array.
- * 
+ *
  * @return Array of columns value is returned.
- * 
+ *
  */
 
 int64_t*
@@ -164,16 +158,16 @@ pgr_SPI_getBigIntArr(
 
 /*!
  * @brief Function returns the value of specified column in integer type.
- * 
+ *
  * @param[in]  tuple   input row to be examined.
  * @param[in]  tupdesc input row description.
  * @param[in]  info    contain column information.
- * 
+ *
  * @throw ERROR Unexpected Column type. Expected column type is ANY-INTEGER.
  * @throw ERROR When value of column is NULL.
- * 
+ *
  * @return Integer type of column value is returned.
- * 
+ *
  */
 
 int64_t pgr_SPI_getBigInt(
@@ -183,16 +177,16 @@ int64_t pgr_SPI_getBigInt(
 
 /*!
  * @brief Function returns the value of specified column in double type.
- * 
+ *
  * @param[in] tuple   input row to be examined.
  * @param[in] tupdesc input row description.
  * @param[in] info    contain column information.
- * 
+ *
  * @throw ERROR Unexpected Column type. Expected column type is ANY-NUMERICAL.
  * @throw ERROR When value of column is NULL.
- * 
+ *
  * @return Double type of column value is returned.
- * 
+ *
  */
 
 double  pgr_SPI_getFloat8(
@@ -201,13 +195,9 @@ double  pgr_SPI_getFloat8(
         Column_info_t info);
 /*!
  * @brief Function returns the string representation of the value of specified column.
- * 
- * @param[in]  tuple   input row to be examined.
- * @param[in]  tupdesc input row description.
- * @param[in]  info    contain column information.cd cd 
- * 
+ *
  * @return Pointer of string is returned.
- * 
+ *
  */
 
 char* pgr_SPI_getText(

--- a/src/common/get_check_data.c
+++ b/src/common/get_check_data.c
@@ -52,12 +52,11 @@ column_found(int colNumber) {
 /*!
  * @brief Function tells expected type of each column and then check the correspondence type of each column.
  *
- * @param[in] info[]     contain one or more column information.
- * @param[in] info_size  number of columns.
- * 
+ * @param[in] info     contain one or more column information.
+ *
  * @throw column not found.
  * @throw ERROR Unknown type of column.
- *  
+ *
  *
  * @return @b TRUE when column exist.
  *        @b FALSE when column was not found.
@@ -101,12 +100,10 @@ fetch_column_info(
 /*!
  * @brief Function tells expected type of each column and then check the correspondence type of each column.
  *
- * @param[in] info[]     contain one or more column information.
+ * @param[in] info     contain one or more column information.
  * @param[in] info_size  number of columns.
- * 
- * @throw ERROR Unknown type of column.
  *
- * @return NULL is always returned.
+ * @throw ERROR Unknown type of column.
  *
  */
 
@@ -148,9 +145,9 @@ void pgr_fetch_column_info(
  * @brief The function check whether column type is CHAR or not.
  *        Where CHAR is SQL type:
  *             CHARACTER
- * 
+ *
  * @param[in] info contain column information.
- * 
+ *
  * @throw ERROR Unexpected Column type. Expected column type is CHAR.
  *
  */
@@ -165,11 +162,11 @@ pgr_check_char_type(Column_info_t info) {
  * @brief The function check whether column type is TEXT or not.
  *       Where TEXT is SQL type:
  *             TEXT
- * 
+ *
  * @param[in] info contain column information.
- * 
+ *
  * @throw ERROR Unexpected Column type. Expected column type is TEXT.
- * 
+ *
  */
 
 void
@@ -183,11 +180,11 @@ pgr_check_text_type(Column_info_t info) {
  * @brief The function check whether column type is ANY-INTEGER or not.
  *       Where ANY-INTEGER is SQL type:
  *           SMALLINT, INTEGER, BIGINT
- * 
+ *
  * @param[in] info contain column information.
- * 
+ *
  * @throw ERROR Unexpected Column type. Expected column type is ANY-INTEGER.
- * 
+ *
  */
 
 void
@@ -204,11 +201,11 @@ pgr_check_any_integer_type(Column_info_t info) {
  * @brief The function check whether column type is ANY-INTEGER-ARRAY or not.
  *        Where ANY-INTEGER-ARRAY is SQL type:
  *             SMALLINT[], INTEGER[], BIGINT[]
- * 
+ *
  * @param[in] info contain column information.
- * 
+ *
  * @throw ERROR Unexpected Column type. Expected ANY-INTEGER-ARRAY.
- * 
+ *
  */
 void
 pgr_check_any_integerarray_type(Column_info_t info) {
@@ -225,11 +222,11 @@ pgr_check_any_integerarray_type(Column_info_t info) {
  * @brief The function check whether column type is ANY-NUMERICAL.
  *        Where ANY-NUMERICAL is SQL type:
  *             SMALLINT, INTEGER, BIGINT, REAL, FLOAT
- * 
+ *
  * @param[in] info contain column information.
- * 
+ *
  * @throw ERROR Unexpected Column type. Expected column type is ANY-NUMERICAL.
- * 
+ *
  */
 
 void pgr_check_any_numerical_type(Column_info_t info) {
@@ -255,18 +252,18 @@ void pgr_check_any_numerical_type(Column_info_t info) {
 
 /*!
  * @brief Function return the value of specified column in char type.
- * 
+ *
  * @param[in]  tuple         input row to be examined.
  * @param[in]  tupdesc       input row description.
  * @param[in]  info          contain column information.
  * @param[in]  strict        boolean value of strict.
  * @param[in]  default_value returned when column contain NULL value.
- * 
+ *
  * @throw ERROR Unexpected Column type. Expected column type is CHAR.
  * @throw ERROR When value of column is NULL.
- * 
+ *
  * @return Char type of column value is returned.
- * 
+ *
  */
 
 char
@@ -294,18 +291,18 @@ pgr_SPI_getChar(
 
 /*!
  * @brief Function returns the values of specified columns in array.
- * 
+ *
  * @param[in]  tuple    input row to be examined.
  * @param[in]  tupdesc  input row description.
  * @param[in]  info     contain column information.
  * @param[out] the_size number of element in array.
- * 
+ *
  * @throw ERROR No elements found in ARRAY.
  * @throw ERROR Unexpected Column type. Expected column type is ANY-INTEGER-ARRAY.
  * @throw ERROR NULL value found in Array.
- * 
+ *
  * @return Array of columns value is returned.
- * 
+ *
  */
 
 int64_t*
@@ -331,16 +328,16 @@ pgr_SPI_getBigIntArr(
 
 /*!
  * @brief Function returns the value of specified column in integer type.
- * 
+ *
  * @param[in]  tuple   input row to be examined.
  * @param[in]  tupdesc input row description.
  * @param[in]  info    contain column information.
- * 
+ *
  * @throw ERROR Unexpected Column type. Expected column type is ANY-INTEGER.
  * @throw ERROR When value of column is NULL.
- * 
+ *
  * @return Integer type of column value is returned.
- * 
+ *
  */
 
 int64_t
@@ -375,17 +372,17 @@ pgr_SPI_getBigInt(HeapTuple *tuple, TupleDesc *tupdesc, Column_info_t info) {
 
 /*!
  * @brief Function returns the value of specified column in double type.
- * 
+ *
  * @param[in] tuple   input row to be examined.
  * @param[in] tupdesc input row description.
  * @param[in] info    contain column information.
- * 
+ *
  * @throw ERROR Unexpected Column type. Expected column type is ANY-NUMERICAL.
  * @throw ERROR When value of column is NULL.
- * 
+ *
  * @return Double type of column value is returned.
- * 
- */ 
+ *
+ */
 
 double
 pgr_SPI_getFloat8(HeapTuple *tuple, TupleDesc *tupdesc, Column_info_t info) {
@@ -437,13 +434,13 @@ pgr_SPI_getFloat8(HeapTuple *tuple, TupleDesc *tupdesc, Column_info_t info) {
 
 /*!
  * @brief Function returns the string representation of the value of specified column.
- * 
+ *
  * @param[in]  tuple   input row to be examined.
  * @param[in]  tupdesc input row description.
  * @param[in]  info    contain column information.
- * 
+ *
  * @return Pointer of string is returned.
- * 
+ *
  */
 
 char*


### PR DESCRIPTION
Fixes trailing spaces generated by contributor and some errors found when using Doxygen on files:
`src/common/get_check_data.c` 
`include/c_common/get_check_data.h`


@pgRouting/admins
