### PR TITLE
[docqueries][tsp] do not use deprecated tsp on examples of cost matrix

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -19,11 +19,8 @@ jobs:
         fail-fast: false
         matrix:
           psql: [10,11,12,13,14]
-          postgis: [2.5,3]
+          postgis: [3]
           os: [ubuntu-latest, ubuntu-18.04]
-          exclude:
-            - postgis: 2.5
-              psql: 14
 
     steps:
       - uses: actions/checkout@v3

--- a/docqueries/astar/doc-aStarCostMatrix.result
+++ b/docqueries/astar/doc-aStarCostMatrix.result
@@ -30,9 +30,7 @@ SELECT * FROM pgr_TSP(
     'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2 FROM edges',
     (SELECT array_agg(id) FROM vertices WHERE id IN (5, 6, 10, 15)),
     directed=> false, heuristic => 2)
-  $$,
-  randomize => false
-);
+  $$);
 NOTICE:  pgr_TSP no longer solving with simulated annaeling
 HINT:  Ignoring annaeling parameters
  seq | node | cost | agg_cost

--- a/docqueries/astar/doc-aStarCostMatrix.test.sql
+++ b/docqueries/astar/doc-aStarCostMatrix.test.sql
@@ -12,7 +12,5 @@ SELECT * FROM pgr_TSP(
     'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2 FROM edges',
     (SELECT array_agg(id) FROM vertices WHERE id IN (5, 6, 10, 15)),
     directed=> false, heuristic => 2)
-  $$,
-  randomize => false
-);
+  $$);
 /* -- q4 */

--- a/docqueries/bdAstar/doc-pgr_bdAstarCostMatrix.result
+++ b/docqueries/bdAstar/doc-pgr_bdAstarCostMatrix.result
@@ -32,8 +32,7 @@ SELECT * FROM pgr_TSP(
     (SELECT array_agg(id) FROM vertices WHERE id IN (5, 6, 10, 15)),
     directed=> false, heuristic => 2
   )
-  $$,
-  randomize => false
+  $$
 );
 NOTICE:  pgr_TSP no longer solving with simulated annaeling
 HINT:  Ignoring annaeling parameters

--- a/docqueries/bdAstar/doc-pgr_bdAstarCostMatrix.test.sql
+++ b/docqueries/bdAstar/doc-pgr_bdAstarCostMatrix.test.sql
@@ -14,7 +14,6 @@ SELECT * FROM pgr_TSP(
     (SELECT array_agg(id) FROM vertices WHERE id IN (5, 6, 10, 15)),
     directed=> false, heuristic => 2
   )
-  $$,
-  randomize => false
+  $$
 );
 /* -- q4 */


### PR DESCRIPTION
Changes proposed in this pull request:
- do not use deprecated signature of tsp on examples of cost matrix

@pgRouting/admins
