### PR TITLE
Centos 7 self hosted runner

### DIFF
--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -30,7 +30,10 @@ jobs:
         run: |
           cd build
           make -j 4
-          sudo make
+
+      - name: Install
+        run: |
+          sudo make install
 
       - name: Test
         run: |

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -34,6 +34,6 @@ jobs:
 
       - name: Test
         run: |
-          sudo service postgresql start
+          export PGPORT=5432
           sudo -u postgres createdb -p ${PGPORT}  ___pgr___test___
           sudo -u postgres bash ./tools/testers/pg_prove_tests.sh postgres ${PGPORT}  Release

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -4,8 +4,7 @@ name: Build for Centos
 # - 5 * 2 * 2 = 20 jobs are triggered
 # - So many jobs take too much time
 
-on:
-  workflow_dispatch:
+on: [push]
 
 permissions:
   contents: read

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Install
         run: |
+          cd build
           sudo make install
 
       - name: Test

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build:
-    name: psql
+    name: centos-7-gcc-4.8.5
     runs-on:
       - self-hosted
       - centos-7 gcc-4.8.5
@@ -30,4 +30,10 @@ jobs:
         run: |
           cd build
           make -j 4
-          sudo make install
+          sudo make
+
+      - name: Test
+        run: |
+          sudo service postgresql start
+          sudo -u postgres createdb -p ${PGPORT}  ___pgr___test___
+          sudo -u postgres bash ./tools/testers/pg_prove_tests.sh postgres ${PGPORT}  Release

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -1,0 +1,33 @@
+name: Build for Centos
+
+# manually triggered workflow
+# - 5 * 2 * 2 = 20 jobs are triggered
+# - So many jobs take too much time
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: psql
+    runs-on:
+      - self-hosted
+      - centos-7 gcc-4.8.5
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure for gcc
+        run: |
+          mkdir build
+          cd build
+          export PATH=${PATH}:/usr/pgsql-15/bin
+          cmake3 -DCMAKE_BUILD_TYPE=Release -DBOOST_ROOT:PATH="/opt/boost" ..
+
+      - name: Build
+        run: |
+          cd build
+          make -j 4

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -31,3 +31,4 @@ jobs:
         run: |
           cd build
           make -j 4
+          sudo make install

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -39,5 +39,6 @@ jobs:
       - name: Test
         run: |
           export PGPORT=5432
+          sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
           sudo -u postgres createdb -p ${PGPORT}  ___pgr___test___
           sudo -u postgres bash ./tools/testers/pg_prove_tests.sh postgres ${PGPORT}  Release


### PR DESCRIPTION
Fixes #2452

This allows for running a self-hosted centos runner.
I have one on osgeo8 server, and tested on mine.  Seems to be stuck on some sort of permission issue in testing.  But I think it's something specific to my repo since the ubuntu ones have the same failure (but are okay on pgrouting org).

In order to use, we'll need to setup the runner configs as I have detailed here:

https://github.com/robe2/pgrouting/wiki/centtie-7-pgrouting-lxd-container#setup-as-a-runner

I gave @cvvergara  root rights to ssh root@osgeo8-centtie-7-pgrouting

@pgRouting/admins
