### PR TITLE
Centos 7 self hosted runner - fix permission issue on tests

### DIFF
--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -41,7 +41,7 @@ jobs:
           export PGPORT=5432
           export PG_RUNNER_USER=`whoami`
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
-          sudo -u postgres psql -p ${PGPORT} -c "CREATE ROLE ${PG_RUNNER_USER} WITH LOGIN SUPERUSER;"
+          sudo -u postgres psql -p ${PGPORT} -c "CREATE ROLE ""${PG_RUNNER_USER}"" WITH LOGIN SUPERUSER;"
           psql -c "CREATE DATABASE ___pgr___test___;"
           bash ./tools/testers/pg_prove_tests.sh postgres ${PGPORT}  Release
           psql -c "DROP DATABASE IF EXISTS ___pgr___test___;"

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Test
         run: |
           export PGPORT=5432
+          sudo chmod 777 -R ./tools/testers/
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
           sudo -u postgres createdb -p ${PGPORT}  ___pgr___test___
           sudo -u postgres bash ./tools/testers/pg_prove_tests.sh postgres ${PGPORT}  Release

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -40,8 +40,10 @@ jobs:
         run: |
           export PGPORT=5432
           export PG_RUNNER_USER=`whoami`
-          sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;DROP DATABASE IF EXISTS \"${PG_RUNNER_USER}\";"
-          sudo -u postgres psql -p ${PGPORT} -c "CREATE ROLE \"${PG_RUNNER_USER}\" WITH LOGIN SUPERUSER;CREATE DATABASE IF NOT EXISTS \"${PG_RUNNER_USER}\";"
+          sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
+          sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS \"${PG_RUNNER_USER}\";"
+          sudo -u postgres psql -p ${PGPORT} -c "CREATE ROLE \"${PG_RUNNER_USER}\" WITH LOGIN SUPERUSER;"
+          sudo -u postgres psql -p ${PGPORT} -c "CREATE DATABASE IF NOT EXISTS \"${PG_RUNNER_USER}\";"
           psql -c "CREATE DATABASE ___pgr___test___;"
           bash ./tools/testers/pg_prove_tests.sh ${PG_RUNNER_USER} ${PGPORT}  Release
           psql -c "DROP DATABASE IF EXISTS ___pgr___test___;"

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -41,7 +41,7 @@ jobs:
           export PGPORT=5432
           export PG_RUNNER_USER=`whoami`
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
-          sudo -u postgres psql -p ${PGPORT} -c 'CREATE ROLE "${PG_RUNNER_USER}" WITH LOGIN SUPERUSER;''
+          sudo -u postgres psql -p ${PGPORT} -c 'CREATE ROLE "${PG_RUNNER_USER}" WITH LOGIN SUPERUSER;'
           psql -c "CREATE DATABASE ___pgr___test___;"
           bash ./tools/testers/pg_prove_tests.sh postgres ${PGPORT}  Release
           psql -c "DROP DATABASE IF EXISTS ___pgr___test___;"

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -40,8 +40,8 @@ jobs:
         run: |
           export PGPORT=5432
           export PG_RUNNER_USER=`whoami`
-          sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
-          sudo -u postgres psql -p ${PGPORT} -c "CREATE ROLE \"${PG_RUNNER_USER}\" WITH LOGIN SUPERUSER;"
-          psql -d postgres -c "CREATE DATABASE ___pgr___test___;"
+          sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;DROP DATABASE IF EXISTS \"${PG_RUNNER_USER}\";"
+          sudo -u postgres psql -p ${PGPORT} -c "CREATE ROLE \"${PG_RUNNER_USER}\" WITH LOGIN SUPERUSER;CREATE DATABASE IF NOT EXISTS \"${PG_RUNNER_USER}\";"
+          psql -c "CREATE DATABASE ___pgr___test___;"
           bash ./tools/testers/pg_prove_tests.sh ${PG_RUNNER_USER} ${PGPORT}  Release
           psql -c "DROP DATABASE IF EXISTS ___pgr___test___;"

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -41,7 +41,7 @@ jobs:
           export PGPORT=5432
           export PG_RUNNER_USER=`whoami`
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
-          sudo -u postgres psql -p ${PGPORT} -c 'CREATE ROLE "${PG_RUNNER_USER}" WITH LOGIN SUPERUSER;'
+          sudo -u postgres psql -p ${PGPORT} -c "CREATE ROLE \"${PG_RUNNER_USER}\" WITH LOGIN SUPERUSER;"
           psql -c "CREATE DATABASE ___pgr___test___;"
           bash ./tools/testers/pg_prove_tests.sh postgres ${PGPORT}  Release
           psql -c "DROP DATABASE IF EXISTS ___pgr___test___;"

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -41,7 +41,7 @@ jobs:
           export PGPORT=5432
           export PG_RUNNER_USER=`whoami`
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
-          sudo -u postgres psql -p ${PGPORT} -c "CREATE ROLE ""${PG_RUNNER_USER}"" WITH LOGIN SUPERUSER;"
+          sudo -u postgres psql -p ${PGPORT} -c 'CREATE ROLE "${PG_RUNNER_USER}" WITH LOGIN SUPERUSER;''
           psql -c "CREATE DATABASE ___pgr___test___;"
           bash ./tools/testers/pg_prove_tests.sh postgres ${PGPORT}  Release
           psql -c "DROP DATABASE IF EXISTS ___pgr___test___;"

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -42,6 +42,7 @@ jobs:
           export PG_RUNNER_USER=`whoami`
           sudo -u postgres sh -c "cd ~/" psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS \"${PG_RUNNER_USER}\";"
+          sudo -u postgres psql -p ${PGPORT} -c "DROP ROLE IF EXISTS \"${PG_RUNNER_USER}\";"
           sudo -u postgres psql -p ${PGPORT} -c "CREATE ROLE \"${PG_RUNNER_USER}\" WITH LOGIN SUPERUSER;"
           sudo -u postgres psql -p ${PGPORT} -c "CREATE DATABASE IF NOT EXISTS \"${PG_RUNNER_USER}\";"
           psql -c "CREATE DATABASE ___pgr___test___;"

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -42,6 +42,6 @@ jobs:
           export PG_RUNNER_USER=`whoami`
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
           sudo -u postgres psql -p ${PGPORT} -c "CREATE ROLE \"${PG_RUNNER_USER}\" WITH LOGIN SUPERUSER;"
-          psql -c "CREATE DATABASE ___pgr___test___;"
-          bash ./tools/testers/pg_prove_tests.sh postgres ${PGPORT}  Release
+          psql -d postgres -c "CREATE DATABASE ___pgr___test___;"
+          bash ./tools/testers/pg_prove_tests.sh ${PG_RUNNER_USER} ${PGPORT}  Release
           psql -c "DROP DATABASE IF EXISTS ___pgr___test___;"

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Test
         run: |
           export PGPORT=5432
-          sudo chmod 777 -R ./tools/testers/
+          export PG_RUNNER_USER=`whoami`
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
-          sudo -u postgres createdb -p ${PGPORT}  ___pgr___test___
-          sudo -u postgres bash ./tools/testers/pg_prove_tests.sh postgres ${PGPORT}  Release
+          sudo -u postgres psql -p ${PGPORT} -c "CREATE ROLE ${PG_RUNNER_USER} WITH LOGIN SUPERUSER;"
+          psql -c "CREATE DATABASE ___pgr___test___;"
+          bash ./tools/testers/pg_prove_tests.sh postgres ${PGPORT}  Release
+          psql -c "DROP DATABASE IF EXISTS ___pgr___test___;"

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -44,7 +44,7 @@ jobs:
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS \"${PG_RUNNER_USER}\";"
           sudo -u postgres psql -p ${PGPORT} -c "DROP ROLE IF EXISTS \"${PG_RUNNER_USER}\";"
           sudo -u postgres psql -p ${PGPORT} -c "CREATE ROLE \"${PG_RUNNER_USER}\" WITH LOGIN SUPERUSER;"
-          sudo -u postgres psql -p ${PGPORT} -c "CREATE DATABASE IF NOT EXISTS \"${PG_RUNNER_USER}\";"
+          sudo -u postgres psql -p ${PGPORT} -c "CREATE DATABASE \"${PG_RUNNER_USER}\";"
           psql -c "CREATE DATABASE ___pgr___test___;"
           bash ./tools/testers/pg_prove_tests.sh ${PG_RUNNER_USER} ${PGPORT}  Release
           psql -c "DROP DATABASE IF EXISTS ___pgr___test___;"

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           export PGPORT=5432
           export PG_RUNNER_USER=`whoami`
-          sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
+          sudo -u postgres sh -c "cd ~/" psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS \"${PG_RUNNER_USER}\";"
           sudo -u postgres psql -p ${PGPORT} -c "CREATE ROLE \"${PG_RUNNER_USER}\" WITH LOGIN SUPERUSER;"
           sudo -u postgres psql -p ${PGPORT} -c "CREATE DATABASE IF NOT EXISTS \"${PG_RUNNER_USER}\";"


### PR DESCRIPTION
Fixes #2452

Changes proposed in this pull request:
We do sudo switch to postgres account, but unfortunately postgres doesn't have rights to the working directory of the runner.

The proposed fix here is to create a postgres database user account for the logged in runner, and then do the tests under then runner account instead of postgres.

Things additional I had to do:

1) Create database with same name as runner, cause by default psql will try to connect to the same named database unless a database is explicitly specified.  This was easier than changing all non-test db commands to use postgres database

2) I chose a very bad name for the runner account gha-pgrouting-runner, so had to escape user name in psql commands when creating user and db.

Tests run now but some are failing.  I think they are just failing because they really fail on centos 

@pgRouting/admins
