### PR TITLE
Centos 7 runner config fix 2

### DIFF
--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           export PGPORT=5432
           export PG_RUNNER_USER=`whoami`
-          sudo -u postgres sh -c "cd ~/" psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
+          sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS \"${PG_RUNNER_USER}\";"
           sudo -u postgres psql -p ${PGPORT} -c "DROP ROLE IF EXISTS \"${PG_RUNNER_USER}\";"
           sudo -u postgres psql -p ${PGPORT} -c "CREATE ROLE \"${PG_RUNNER_USER}\" WITH LOGIN SUPERUSER;"


### PR DESCRIPTION
Fixes #2452

Changes proposed in this pull request:
- Get rid of the cd ~, seems to be preventing the second command to drop from working


@pgRouting/admins
