### PR TITLE
Centos 7 self hosted test fix 3 (for Develop)

### DIFF
--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -8,6 +8,11 @@ on:
   push:
     paths:
       - '.github/workflows/centos.yml'
+      - 'src/**'
+      - 'include/**'
+      - 'pgtap/**'
+      - 'tools/testers/**'
+      - './CMakeLists.txt'
 
     branches-ignore:
       - 'gh-pages'
@@ -62,5 +67,5 @@ jobs:
           sudo -u postgres psql -p ${PGPORT} -c "CREATE ROLE \"${PG_RUNNER_USER}\" WITH LOGIN SUPERUSER;"
           sudo -u postgres psql -p ${PGPORT} -c "CREATE DATABASE \"${PG_RUNNER_USER}\";"
           psql -c "CREATE DATABASE ___pgr___test___;"
-          bash ./tools/testers/pg_prove_tests.sh ${PG_RUNNER_USER} ${PGPORT}  Release
+          ./tools/testers/pg_prove_tests.sh ${PG_RUNNER_USER} ${PGPORT} Release
           psql -c "DROP DATABASE IF EXISTS ___pgr___test___;"

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Test
         run: |
           sudo systemctl restart postgresql-15
+          export PGPORT=5432
           export PG_RUNNER_USER=`whoami`
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS \"${PG_RUNNER_USER}\";"

--- a/pgtap/dijkstra/dijkstra/edge_cases/oneToOne_equiv_manyToMany.pg
+++ b/pgtap/dijkstra/dijkstra/edge_cases/oneToOne_equiv_manyToMany.pg
@@ -47,7 +47,7 @@ BEGIN
                 sql_OneToOne := sql_OneToOne ||' UNION ALL';
             END IF;
             sql_OneToOne := sql_OneToOne ||
-            '( SELECT seq, ' || i || 'as start_vid, ' || j || 'as end_vid, node, edge, cost, agg_cost  FROM pgr_dijkstra(
+            '( SELECT seq, ' || i || ' AS start_vid, ' || j || ' AS end_vid, node, edge, cost, agg_cost  FROM pgr_dijkstra(
                     ''SELECT id, source, target, cost, reverse_cost FROM edge_table'', '
                     || i || ', ' || j ||
                     ') )';

--- a/pgtap/dijkstra/dijkstra/edge_cases/oneToOne_equiv_manyToOne.pg
+++ b/pgtap/dijkstra/dijkstra/edge_cases/oneToOne_equiv_manyToOne.pg
@@ -44,14 +44,14 @@ BEGIN
                 sql_Many := sql_Many ||', ';
     END IF;
     sql_OneToOne := sql_OneToOne ||
-    '( SELECT seq, ' || j || 'as start_vid, ' || i || 'as end_vid, node, edge, round(cost::numeric,8) AS cost, round(agg_cost::numeric,8) AS agg_cost   FROM pgr_dijkstra(
+    '( SELECT seq, ' || j || ' AS start_vid, ' || i || ' AS end_vid, node, edge, round(cost::numeric,8) AS cost, round(agg_cost::numeric,8) AS agg_cost   FROM pgr_dijkstra(
             ''SELECT id, source, target, cost, reverse_cost FROM edge_table'', '
             || j || ', ' || i ||
             ') )';
     sql_Many := sql_Many || j ;
 END LOOP;
 sql_Many :=
-' SELECT path_seq, start_vid, ' || i || ' as end_vid, node, edge, round(cost::numeric,8) AS cost, round(agg_cost::numeric,8) AS agg_cost  FROM pgr_dijkstra(
+' SELECT path_seq, start_vid, ' || i || ' AS end_vid, node, edge, round(cost::numeric,8) AS cost, round(agg_cost::numeric,8) AS agg_cost  FROM pgr_dijkstra(
     ''SELECT id, source, target, cost, reverse_cost FROM edge_table'', '
     ' ARRAY[' || sql_Many || '], ' || i ||
     ' ) ';

--- a/tools/testers/setup_db.sh
+++ b/tools/testers/setup_db.sh
@@ -25,7 +25,7 @@
 
 set -e
 
-DIR="$(git rev-parse --show-toplevel)/tools/testers"
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 psql -p "$1" -U "$3"  -d "$2" -X -q --set client_min_messages=WARNING --set ON_ERROR_STOP=1 --pset pager=off \
     -c "CREATE EXTENSION IF NOT EXISTS pgtap; CREATE EXTENSION IF NOT EXISTS pgrouting WITH VERSION '${4}' CASCADE;"


### PR DESCRIPTION
Fixes #2452

Changes proposed in this pull request:
-  Test whenever any code changes
-  I added the port back PGPORT, it is possible to have multiple versions of PostgreSQL installed on Centos, so if we ever do that, we'd have different versions running on different ports and will need this.
-  Change setup_db.sh to not rely on folder being part of a git repo (this is the part that was causing it to fail) maybe GHA does an export instead of a git clone.  Doing 
`git status`  within the centos 7, gives the same error in the pgrouting folder.
Anyway not good to rely on it being a git repo, cause I thing when apt packagers test, the way they export and import into theirs it might not be testing against a git repo

- Fix syntax errors in edge_cases tests


@pgRouting/admins
