### PR TITLE
Directory should not rely on folder being part of a git repository (against main)

### DIFF
--- a/tools/testers/setup_db.sh
+++ b/tools/testers/setup_db.sh
@@ -25,7 +25,7 @@
 
 set -e
 
-DIR="$(git rev-parse --show-toplevel)/tools/testers"
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 psql -p "$1" -U "$3"  -d "$2" -X -q --set client_min_messages=WARNING --set ON_ERROR_STOP=1 --pset pager=off \
     -c "CREATE EXTENSION IF NOT EXISTS pgtap; CREATE EXTENSION IF NOT EXISTS pgrouting WITH VERSION '${4}' CASCADE;"


### PR DESCRIPTION

Fixes #2452

Changes proposed in this pull request:
- The recent change to setup_db.sh assumed testing will be done against a git repository.  
- In the case of self-hosted runner, this is not the case
- I suspect many packagers will also not be testing against a git repository, and may be using a tar ball instead. As such relying on this folder being part of a git repo will fail for them.

Note that this fix is a subset of #2469.  Those additional changes I don't think are needed to make it work for CentOS so don't need to be backported to main.

@pgRouting/admins
