### PR TITLE
Pgsql 15 and no 18.04 tests

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -31,7 +31,7 @@ jobs:
         matrix:
           psql: [11,12,13,14,15]
           postgis: [3]
-          os: [ubuntu-latest, ubuntu-20.04, ubuntu-18.04]
+          os: [ubuntu-latest, ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          psql: [11,12,13,14]
+          psql: [11,12,13,14,15]
           postgis: [3]
           os: [ubuntu-latest, ubuntu-20.04, ubuntu-18.04]
 


### PR DESCRIPTION
Cherry pick from #2460 and removing 18.04 no longer supported fro pgsql 15

@pgRouting/admins
