### PR TITLE
[pgr_drivingdistance]Signature Changes in doc

### DIFF
--- a/doc/driving_distance/pgr_drivingDistance.rst
+++ b/doc/driving_distance/pgr_drivingDistance.rst
@@ -49,7 +49,7 @@ Signatures
    | pgr_drivingDistance(`Edges SQL`_, **Root vids**, **distance**, [**options**])
    | **options:** [directed, equicost]
 
-   | RETURNS SET OF |result-dij-dd|
+   | RETURNS SET OF |result-dij-dd-m|
 
 .. index::
    single: drivingDistance(Single vertex)
@@ -62,7 +62,7 @@ Single Vertex
 
    | pgr_drivingDistance(`Edges SQL`_, **Root vid**,  **distance**, [``directed``])
 
-   | RETURNS SET OF |result-1-1|
+   | RETURNS SET OF |result-1-1-no-seq|
 
 :Example: From vertex :math:`11` for a distance of :math:`3.0`
 

--- a/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-16 12:56-0600\n"
+"POT-Creation-Date: 2023-03-28 05:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10629,7 +10629,7 @@ msgstr ""
 msgid "**options:** [directed, equicost]"
 msgstr ""
 
-msgid "RETURNS SET OF |result-dij-dd|"
+msgid "RETURNS SET OF |result-dij-dd-m|"
 msgstr ""
 
 msgid "Single Vertex"
@@ -10639,9 +10639,6 @@ msgid "From vertex :math:`11` for a distance of :math:`3.0`"
 msgstr ""
 
 msgid "Multiple Vertices"
-msgstr ""
-
-msgid "RETURNS SET OF |result-dij-dd-m|"
 msgstr ""
 
 msgid ""

--- a/locale/pot/pgrouting_doc_strings.pot
+++ b/locale/pot/pgrouting_doc_strings.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.5.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-16 12:56-0600\n"
+"POT-Creation-Date: 2023-03-28 05:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -9181,7 +9181,7 @@ msgstr ""
 msgid "**options:** [directed, equicost]"
 msgstr ""
 
-msgid "RETURNS SET OF |result-dij-dd|"
+msgid "RETURNS SET OF |result-dij-dd-m|"
 msgstr ""
 
 msgid "Single Vertex"
@@ -9191,9 +9191,6 @@ msgid "From vertex :math:`11` for a distance of :math:`3.0`"
 msgstr ""
 
 msgid "Multiple Vertices"
-msgstr ""
-
-msgid "RETURNS SET OF |result-dij-dd-m|"
 msgstr ""
 
 msgid "From vertices :math:`\\{11, 16\\}` for a distance of :math:`3.0` with equi-cost on a directed graph"


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
### THE OVERALL SIGNATURE
![image](https://user-images.githubusercontent.com/65810122/228135495-c783f2c9-c947-4caa-86cb-9285dcd9744e.png)
to 
![image](https://user-images.githubusercontent.com/65810122/228135536-f98ad726-553c-46bd-9e73-b2cb7b4056ee.png)
AND
### SINGLE VERTEX SIGNATURE
![image](https://user-images.githubusercontent.com/65810122/228135993-9134b0b9-d35a-4585-b909-ce0173dc9d0a.png)
to 
![image](https://user-images.githubusercontent.com/65810122/228136027-ba006cb6-6862-4469-8170-d3981d922dfe.png)


@pgRouting/admins
