### PR TITLE
Revert "To cpp arrays input"

### DIFF
--- a/include/c_common/arrays_input.h
+++ b/include/c_common/arrays_input.h
@@ -1,9 +1,8 @@
 /*PGR-GNU*****************************************************************
 File: arrays_input.h
 
-Copyright (c) 2023 Celia Virginia Vergara Castillo
 Copyright (c) 2015 Celia Virginia Vergara Castillo
-mail: vicky at erosion.dev
+vicky_vergara@hotmail.com
 
 ------
 
@@ -27,21 +26,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #define INCLUDE_C_COMMON_ARRAYS_INPUT_H_
 #pragma once
 
-#include <stddef.h>
+
 #include <stdint.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <postgres.h>
 #include <utils/array.h>
 
 /** @brief Enforces the input array to be @b NOT empty */
-int64_t* pgr_get_bigIntArray(size_t*, ArrayType*, bool);
+int64_t* pgr_get_bigIntArray(size_t *arrlen, ArrayType *input);
 
-#ifdef __cplusplus
-}
-#endif
+/** @brief Allows the input array to be empty */
+int64_t* pgr_get_bigIntArray_allowEmpty(size_t *arrlen, ArrayType *input);
 
 #endif  // INCLUDE_C_COMMON_ARRAYS_INPUT_H_

--- a/src/astar/astar.c
+++ b/src/astar/astar.c
@@ -102,18 +102,18 @@ process(char* edges_sql,
         pgr_get_edges_xy(edges_sql, &edges, &total_edges, true);
         if (starts && ends) {
             start_vidsArr = (int64_t*)
-                pgr_get_bigIntArray(&size_start_vidsArr, starts, false);
+                pgr_get_bigIntArray(&size_start_vidsArr, starts);
             end_vidsArr = (int64_t*)
-                pgr_get_bigIntArray(&size_end_vidsArr, ends, false);
+                pgr_get_bigIntArray(&size_end_vidsArr, ends);
         } else if (combinations_sql) {
             pgr_get_combinations(combinations_sql, &combinations, &total_combinations);
         }
     } else {
         pgr_get_edges_xy(edges_sql, &edges, &total_edges, false);
         end_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_end_vidsArr, starts, false);
+            pgr_get_bigIntArray(&size_end_vidsArr, starts);
         start_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_start_vidsArr, ends, false);
+            pgr_get_bigIntArray(&size_start_vidsArr, ends);
     }
 
     if (total_edges == 0) {

--- a/src/bdAstar/bdAstar.c
+++ b/src/bdAstar/bdAstar.c
@@ -77,9 +77,9 @@ process(char* edges_sql,
 
     if (starts && ends) {
         start_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_start_vidsArr, starts, false);
+            pgr_get_bigIntArray(&size_start_vidsArr, starts);
         end_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_end_vidsArr, ends, false);
+            pgr_get_bigIntArray(&size_end_vidsArr, ends);
     } else if (combinations_sql) {
         pgr_get_combinations(combinations_sql, &combinations, &total_combinations);
     }

--- a/src/bdDijkstra/bdDijkstra.c
+++ b/src/bdDijkstra/bdDijkstra.c
@@ -75,9 +75,9 @@ process(
 
     if (starts && ends) {
         start_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_start_vidsArr, starts, false);
+            pgr_get_bigIntArray(&size_start_vidsArr, starts);
         end_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_end_vidsArr, ends, false);
+            pgr_get_bigIntArray(&size_end_vidsArr, ends);
     } else if (combinations_sql) {
         pgr_get_combinations(combinations_sql, &combinations, &total_combinations);
     }

--- a/src/bellman_ford/bellman_ford.c
+++ b/src/bellman_ford/bellman_ford.c
@@ -72,9 +72,9 @@ process(
 
     if (starts && ends) {
         start_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_start_vidsArr, starts, false);
+            pgr_get_bigIntArray(&size_start_vidsArr, starts);
         end_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_end_vidsArr, ends, false);
+            pgr_get_bigIntArray(&size_end_vidsArr, ends);
     } else if (combinations_sql) {
         pgr_get_combinations(combinations_sql, &combinations, &total_combinations);
         if (total_combinations == 0) {

--- a/src/bellman_ford/bellman_ford_neg.c
+++ b/src/bellman_ford/bellman_ford_neg.c
@@ -72,9 +72,9 @@ process(
 
     if (starts && ends) {
         start_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_start_vidsArr, starts, false);
+            pgr_get_bigIntArray(&size_start_vidsArr, starts);
         end_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_end_vidsArr, ends, false);
+            pgr_get_bigIntArray(&size_end_vidsArr, ends);
     } else if (combinations_sql) {
         pgr_get_combinations(combinations_sql, &combinations, &total_combinations);
         if (total_combinations == 0) {

--- a/src/bellman_ford/edwardMoore.c
+++ b/src/bellman_ford/edwardMoore.c
@@ -70,9 +70,9 @@ process(
 
     if (starts && ends) {
         start_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_start_vidsArr, starts, false);
+            pgr_get_bigIntArray(&size_start_vidsArr, starts);
         end_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_end_vidsArr, ends, false);
+            pgr_get_bigIntArray(&size_end_vidsArr, ends);
     } else if (combinations_sql) {
         pgr_get_combinations(combinations_sql, &combinations, &total_combinations);
         if (total_combinations == 0) {

--- a/src/breadthFirstSearch/binaryBreadthFirstSearch.c
+++ b/src/breadthFirstSearch/binaryBreadthFirstSearch.c
@@ -70,9 +70,9 @@ process(
 
     if (starts && ends) {
         start_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_start_vidsArr, starts, false);
+            pgr_get_bigIntArray(&size_start_vidsArr, starts);
         end_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_end_vidsArr, ends, false);
+            pgr_get_bigIntArray(&size_end_vidsArr, ends);
     } else if (combinations_sql) {
         pgr_get_combinations(combinations_sql, &combinations, &total_combinations);
         if (total_combinations == 0) {

--- a/src/breadthFirstSearch/breadthFirstSearch.c
+++ b/src/breadthFirstSearch/breadthFirstSearch.c
@@ -61,7 +61,7 @@ process(
 
     size_t size_start_vidsArr = 0;
     int64_t *start_vidsArr = (int64_t *)
-        pgr_get_bigIntArray(&size_start_vidsArr, starts, false);
+        pgr_get_bigIntArray(&size_start_vidsArr, starts);
     PGR_DBG("start_vidsArr size %ld ", size_start_vidsArr);
 
 

--- a/src/circuits/hawickCircuits.c
+++ b/src/circuits/hawickCircuits.c
@@ -54,6 +54,8 @@ PG_FUNCTION_INFO_V1(_pgr_hawickcircuits);
  * @param edges_sql      the edges of the SQL query
  * @param result_tuples  the rows in the result
  * @param result_count   the count of rows in the result
+ *
+ * @returns void
  */
 
 static void

--- a/src/coloring/edgeColoring.c
+++ b/src/coloring/edgeColoring.c
@@ -57,6 +57,8 @@ PG_FUNCTION_INFO_V1(_pgr_edgecoloring);
  * @param edges_sql      the edges of the SQL query
  * @param result_tuples  the rows in the result
  * @param result_count   the count of rows in the result
+ *
+ * @returns void
  */
 
 static

--- a/src/coloring/sequentialVertexColoring.c
+++ b/src/coloring/sequentialVertexColoring.c
@@ -59,6 +59,8 @@ PG_FUNCTION_INFO_V1(_pgr_sequentialvertexcoloring);
  * @param edges_sql      the edges of the SQL query
  * @param result_tuples  the rows in the result
  * @param result_count   the count of rows in the result
+ *
+ * @returns void
  */
 static
 void

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -16,6 +16,7 @@ ADD_LIBRARY(common OBJECT
     restrictions_input.c
 
     coordinates_input.c
+    arrays_input.c
     delauny_input.c
 
     check_parameters.c

--- a/src/common/arrays_input.c
+++ b/src/common/arrays_input.c
@@ -1,9 +1,8 @@
 /*PGR-GNU*****************************************************************
-File: arrays_input.cpp
+File: arrays_input.c
 
-Copyright (c) 2023 Celia Virginia Vergara Castillo
 Copyright (c) 2015 Celia Virginia Vergara Castillo
-mail: vicky at erosion.dev
+vicky_vergara@hotmail.com
 
 ------
 
@@ -25,17 +24,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "c_common/arrays_input.h"
 
-extern "C" {
+#include <assert.h>
 #include <utils/lsyscache.h>
 #include <catalog/pg_type.h>
-}
 
-#include "cpp_common/pgr_alloc.hpp"
-
-namespace {
-
-/** @brief get the array contents from postgres
- *
+#include "c_common/time_msg.h"
+#include "c_common/debug_macro.h"
+/**
+ * Function for array input
  * @details This function generates the array inputs according to their type
  * received through @a ArrayType *v parameter and store them in @a c_array. It
  * can be empty also if received @a allow_empty true. The cases of failure are:-
@@ -46,42 +42,46 @@ namespace {
  * 5. When null value is found in the array.
  *
  * All these failures are represented as error through @a elog.
- * @param[in] v Pointer to the postgres C array
- * @param[out] arrlen size of the C array
- * @param[in] allow_empty flag to allow empty arrays
- *
- * @pre the array has to be one dimension
- * @pre Must have elements (when allow_empty is false)
- *
- * @returns The resultant array
+ * @param[in] v The type of element to be processed.
+ * @param[out] arrlen The length of the array (To be determined in this function).
+ * @param[in] allow_empty Bool type parameter that tells us whether to consider empty
+ *                    array or not.
+ * @pre The initial value of @a *arrlen should be zero.
+ * @returns The resultant array i.e. @a c_array.
  */
+static
 int64_t*
-get_bigIntArr(ArrayType *v, size_t *arrlen, bool allow_empty) {
-    int64_t *c_array = nullptr;
+pgr_get_bigIntArr(ArrayType *v, size_t *arrlen, bool allow_empty) {
+    clock_t start_t = clock();
+    int64_t *c_array = NULL;
 
-    auto    element_type = ARR_ELEMTYPE(v);
-    auto    dim = ARR_DIMS(v);
-    auto    ndim = ARR_NDIM(v);
-    auto    nitems = ArrayGetNItems(ndim, dim);
-    Datum  *elements = nullptr;
-    bool   *nulls = nullptr;
+    Oid     element_type = ARR_ELEMTYPE(v);
+    int    *dim = ARR_DIMS(v);
+    int     ndim = ARR_NDIM(v);
+    int     nitems = ArrayGetNItems(ndim, dim);
+    Datum  *elements;
+    bool   *nulls;
     int16   typlen;
     bool    typbyval;
     char    typalign;
 
+    assert((*arrlen) == 0);
+
 
     if (allow_empty && (ndim == 0 || nitems <= 0)) {
-        return nullptr;
+        PGR_DBG("ndim %d nitems %d", ndim, nitems);
+        return (int64_t*)NULL;
     }
+    /* the array is not empty*/
 
     if (ndim != 1) {
         elog(ERROR, "One dimension expected");
-        return nullptr;
+        return (int64_t*)NULL;
     }
 
     if (nitems <= 0) {
         elog(ERROR, "No elements found");
-        return nullptr;
+        return (int64_t*)NULL;
     }
 
     get_typlenbyvalalign(element_type,
@@ -95,7 +95,7 @@ get_bigIntArr(ArrayType *v, size_t *arrlen, bool allow_empty) {
             break;
         default:
             elog(ERROR, "Expected array of ANY-INTEGER");
-            return nullptr;
+            return (int64_t*)NULL;
             break;
     }
 
@@ -103,23 +103,24 @@ get_bigIntArr(ArrayType *v, size_t *arrlen, bool allow_empty) {
             typalign, &elements, &nulls,
             &nitems);
 
-    c_array = pgr_alloc(static_cast<size_t>(nitems), (c_array));
+    c_array = (int64_t *) palloc(sizeof(int64_t) * (size_t)nitems);
     if (!c_array) {
         elog(ERROR, "Out of memory!");
     }
 
 
-    for (int i = 0; i < nitems; i++) {
+    int i;
+    for (i = 0; i < nitems; i++) {
         if (nulls[i]) {
             pfree(c_array);
             elog(ERROR, "NULL value found in Array!");
         } else {
             switch (element_type) {
                 case INT2OID:
-                    c_array[i] = static_cast<int64_t>(DatumGetInt16(elements[i]));
+                    c_array[i] = (int64_t) DatumGetInt16(elements[i]);
                     break;
                 case INT4OID:
-                    c_array[i] = static_cast<int64_t>(DatumGetInt32(elements[i]));
+                    c_array[i] = (int64_t) DatumGetInt32(elements[i]);
                     break;
                 case INT8OID:
                     c_array[i] = DatumGetInt64(elements[i]);
@@ -127,22 +128,31 @@ get_bigIntArr(ArrayType *v, size_t *arrlen, bool allow_empty) {
             }
         }
     }
-    (*arrlen) = static_cast<size_t>(nitems);
+    (*arrlen) = (size_t)nitems;
 
     pfree(elements);
     pfree(nulls);
+    PGR_DBG("Array size %ld", (*arrlen));
+    time_msg("reading Array", start_t, clock());
     return c_array;
 }
 
-}  // namespace
+/**
+ * @param[out] arrlen Length of the array
+ * @param[in] input Input type of the array
+ * @returns Returns the output of @a pgr_get_bitIntArray when @a allow_empty is set to false.
+ */
+
+int64_t* pgr_get_bigIntArray(size_t *arrlen, ArrayType *input) {
+    return pgr_get_bigIntArr(input, arrlen, false);
+}
 
 /**
  * @param[out] arrlen Length of the array
- * @param[in] input the postgres array
- * @param[in] allow_empty when true, empty arrays are accepted.
- * @returns Returns a C array of integers
+ * @param[in] input Input type of the array
+ * @returns Returns the output of @a pgr_get_bitIntArray when @a allow_empty is set to true.
  */
 
-int64_t* pgr_get_bigIntArray(size_t *arrlen, ArrayType *input, bool allow_empty) {
-    return get_bigIntArr(input, arrlen, allow_empty);
+int64_t* pgr_get_bigIntArray_allowEmpty(size_t *arrlen, ArrayType *input) {
+    return pgr_get_bigIntArr(input, arrlen, true);
 }

--- a/src/common/get_check_data.c
+++ b/src/common/get_check_data.c
@@ -323,7 +323,7 @@ pgr_SPI_getBigIntArr(
     */
     ArrayType *pg_array = DatumGetArrayTypeP(raw_array);
 
-    return pgr_get_bigIntArray((size_t*)the_size, pg_array, true);
+    return pgr_get_bigIntArray_allowEmpty((size_t*)the_size, pg_array);
 }
 
 /*!

--- a/src/contraction/contractGraph.c
+++ b/src/contraction/contractGraph.c
@@ -68,11 +68,17 @@ process(char* edges_sql,
     pgr_SPI_connect();
 
     size_t size_forbidden_vertices = 0;
-    int64_t* forbidden_vertices = pgr_get_bigIntArray(&size_forbidden_vertices, forbidden, true);
+    int64_t* forbidden_vertices =
+        pgr_get_bigIntArray_allowEmpty(
+                &size_forbidden_vertices,
+                forbidden);
     PGR_DBG("size_forbidden_vertices %ld", size_forbidden_vertices);
 
     size_t size_contraction_order = 0;
-    int64_t* contraction_order = pgr_get_bigIntArray(&size_contraction_order, order, false);
+    int64_t* contraction_order =
+        pgr_get_bigIntArray(
+                &size_contraction_order,
+                order);
     PGR_DBG("size_contraction_order %ld ", size_contraction_order);
 
 

--- a/src/cpp_common/CMakeLists.txt
+++ b/src/cpp_common/CMakeLists.txt
@@ -5,5 +5,4 @@ ADD_LIBRARY(cpp_common OBJECT
     bpoint.cpp
     pgr_messages.cpp
     combinations.cpp
-    arrays_input.cpp
     )

--- a/src/dagShortestPath/dagShortestPath.c
+++ b/src/dagShortestPath/dagShortestPath.c
@@ -75,9 +75,9 @@ process(
 
     if (starts && ends) {
         start_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_start_vidsArr, starts, false);
+            pgr_get_bigIntArray(&size_start_vidsArr, starts);
         end_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_end_vidsArr, ends, false);
+            pgr_get_bigIntArray(&size_end_vidsArr, ends);
     } else if (combinations_sql) {
         pgr_get_combinations(combinations_sql, &combinations, &total_combinations);
         if (total_combinations == 0) {

--- a/src/dijkstra/dijkstra.c
+++ b/src/dijkstra/dijkstra.c
@@ -77,15 +77,15 @@ process(
     if (normal) {
         pgr_get_edges(edges_sql, &edges, &total_edges, true, false);
         start_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_start_vidsArr, starts, false);
+            pgr_get_bigIntArray(&size_start_vidsArr, starts);
         end_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_end_vidsArr, ends, false);
+            pgr_get_bigIntArray(&size_end_vidsArr, ends);
     } else {
         pgr_get_edges(edges_sql, &edges, &total_edges, false, false);
         end_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_end_vidsArr, starts, false);
+            pgr_get_bigIntArray(&size_end_vidsArr, starts);
         start_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_start_vidsArr, ends, false);
+            pgr_get_bigIntArray(&size_start_vidsArr, ends);
     }
 
     if (total_edges == 0) {

--- a/src/dijkstra/dijkstraVia.c
+++ b/src/dijkstra/dijkstraVia.c
@@ -51,7 +51,7 @@ process(char* edges_sql,
     pgr_SPI_connect();
 
     size_t size_via_vidsArr = 0;
-    int64_t* via_vidsArr = (int64_t*) pgr_get_bigIntArray(&size_via_vidsArr, vias, false);
+    int64_t* via_vidsArr = (int64_t*) pgr_get_bigIntArray(&size_via_vidsArr, vias);
 
     Edge_t* edges = NULL;
     size_t total_edges = 0;

--- a/src/driving_distance/many_to_dist_driving_distance.c
+++ b/src/driving_distance/many_to_dist_driving_distance.c
@@ -52,7 +52,7 @@ void process(
     pgr_SPI_connect();
 
     size_t size_start_vidsArr = 0;
-    int64_t* start_vidsArr = pgr_get_bigIntArray(&size_start_vidsArr, starts, false);
+    int64_t* start_vidsArr = pgr_get_bigIntArray(&size_start_vidsArr, starts);
 
     Edge_t *edges = NULL;
     size_t total_tuples = 0;

--- a/src/driving_distance/many_to_dist_withPointsDD.c
+++ b/src/driving_distance/many_to_dist_withPointsDD.c
@@ -61,7 +61,7 @@ void process(
     pgr_SPI_connect();
 
     size_t total_starts = 0;
-    int64_t* start_pidsArr = pgr_get_bigIntArray(&total_starts, starts, false);
+    int64_t* start_pidsArr = pgr_get_bigIntArray(&total_starts, starts);
     PGR_DBG("sourcesArr size %ld ", total_starts);
 
     Point_on_edge_t *points = NULL;

--- a/src/max_flow/edge_disjoint_paths.c
+++ b/src/max_flow/edge_disjoint_paths.c
@@ -71,9 +71,9 @@ process(
 
     if (starts && ends) {
         source_vertices = (int64_t*)
-            pgr_get_bigIntArray(&size_source_verticesArr, starts, false);
+            pgr_get_bigIntArray(&size_source_verticesArr, starts);
         sink_vertices = (int64_t*)
-            pgr_get_bigIntArray(&size_sink_verticesArr, ends, false);
+            pgr_get_bigIntArray(&size_sink_verticesArr, ends);
     } else if (combinations_sql) {
         pgr_get_combinations(combinations_sql, &combinations, &total_combinations);
         if (total_combinations == 0) {

--- a/src/max_flow/max_flow.c
+++ b/src/max_flow/max_flow.c
@@ -76,9 +76,9 @@ process(
 
     if (starts && ends) {
         source_vertices = (int64_t*)
-            pgr_get_bigIntArray(&size_source_verticesArr, starts, false);
+            pgr_get_bigIntArray(&size_source_verticesArr, starts);
         sink_vertices = (int64_t*)
-            pgr_get_bigIntArray(&size_sink_verticesArr, ends, false);
+            pgr_get_bigIntArray(&size_sink_verticesArr, ends);
     } else if (combinations_sql) {
         pgr_get_combinations(combinations_sql, &combinations, &total_combinations);
         if (total_combinations == 0) {

--- a/src/max_flow/minCostMaxFlow.c
+++ b/src/max_flow/minCostMaxFlow.c
@@ -94,9 +94,9 @@ process(
 
     if (starts && ends) {
         sourceVertices = (int64_t*)
-            pgr_get_bigIntArray(&sizeSourceVerticesArr, starts, false);
+            pgr_get_bigIntArray(&sizeSourceVerticesArr, starts);
         sinkVertices = (int64_t*)
-            pgr_get_bigIntArray(&sizeSinkVerticesArr, ends, false);
+            pgr_get_bigIntArray(&sizeSinkVerticesArr, ends);
     } else if (combinations_sql) {
         pgr_get_combinations(combinations_sql, &combinations, &total_combinations);
         if (total_combinations == 0) {

--- a/src/ordering/cuthillMckeeOrdering.c
+++ b/src/ordering/cuthillMckeeOrdering.c
@@ -57,6 +57,8 @@ PG_FUNCTION_INFO_V1(_pgr_cuthillmckeeordering);
  * @param edges_sql      the edges of the SQL query
  * @param result_tuples  the rows in the result
  * @param result_count   the count of rows in the result
+ *
+ * @returns void
  */
 
 static

--- a/src/spanningTree/kruskal.c
+++ b/src/spanningTree/kruskal.c
@@ -69,7 +69,7 @@ process(
     }
 
     size_t size_rootsArr = 0;
-    int64_t* rootsArr = (int64_t*) pgr_get_bigIntArray(&size_rootsArr, roots, false);
+    int64_t* rootsArr = (int64_t*) pgr_get_bigIntArray(&size_rootsArr, roots);
 
     (*result_tuples) = NULL;
     (*result_count) = 0;

--- a/src/spanningTree/prim.c
+++ b/src/spanningTree/prim.c
@@ -68,7 +68,7 @@ process(
     }
 
     size_t size_rootsArr = 0;
-    int64_t* rootsArr = (int64_t*) pgr_get_bigIntArray(&size_rootsArr, roots, false);
+    int64_t* rootsArr = (int64_t*) pgr_get_bigIntArray(&size_rootsArr, roots);
 
     (*result_tuples) = NULL;
     (*result_count) = 0;

--- a/src/traversal/depthFirstSearch.c
+++ b/src/traversal/depthFirstSearch.c
@@ -63,6 +63,8 @@ PG_FUNCTION_INFO_V1(_pgr_depthfirstsearch);
  * @param max_depth      the maximum depth of traversal
  * @param result_tuples  the rows in the result
  * @param result_count   the count of rows in the result
+ *
+ * @returns void
  */
 static
 void
@@ -78,7 +80,7 @@ process(
 
     size_t size_rootsArr = 0;
 
-    int64_t* rootsArr = (int64_t*) pgr_get_bigIntArray(&size_rootsArr, roots, false);
+    int64_t* rootsArr = (int64_t*) pgr_get_bigIntArray(&size_rootsArr, roots);
 
     (*result_tuples) = NULL;
     (*result_count) = 0;

--- a/src/trsp/new_trsp.c
+++ b/src/trsp/new_trsp.c
@@ -91,9 +91,9 @@ void process(
 
     if (starts && ends) {
         start_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_start_vidsArr, starts, false);
+            pgr_get_bigIntArray(&size_start_vidsArr, starts);
         end_vidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_end_vidsArr, ends, false);
+            pgr_get_bigIntArray(&size_end_vidsArr, ends);
     } else if (combinations_sql) {
         pgr_get_combinations(combinations_sql, &combinations, &total_combinations);
     }

--- a/src/trsp/trspVia.c
+++ b/src/trsp/trspVia.c
@@ -50,7 +50,7 @@ process(
     pgr_SPI_connect();
 
     size_t size_via = 0;
-    int64_t* via = (int64_t*) pgr_get_bigIntArray(&size_via, via_arr, false);
+    int64_t* via = (int64_t*) pgr_get_bigIntArray(&size_via, via_arr);
 
     Edge_t* edges = NULL;
     size_t size_edges = 0;

--- a/src/trsp/trspVia_withPoints.c
+++ b/src/trsp/trspVia_withPoints.c
@@ -60,7 +60,7 @@ process(
      * Processing Via
      */
     size_t size_via = 0;
-    int64_t* via = (int64_t*) pgr_get_bigIntArray(&size_via, viasArr, false);
+    int64_t* via = (int64_t*) pgr_get_bigIntArray(&size_via, viasArr);
 
     // TODO(vicky) figure out what happens when one point or 0 points are given
 

--- a/src/trsp/trsp_withPoints.c
+++ b/src/trsp/trsp_withPoints.c
@@ -111,8 +111,8 @@ process(
 
     /* Managing departure & destination */
     if (starts && ends) {
-        start_pidsArr = (int64_t*) pgr_get_bigIntArray(&size_start_pidsArr, starts, false);
-        end_pidsArr = (int64_t*) pgr_get_bigIntArray(&size_end_pidsArr, ends, false);
+        start_pidsArr = (int64_t*) pgr_get_bigIntArray(&size_start_pidsArr, starts);
+        end_pidsArr = (int64_t*) pgr_get_bigIntArray(&size_end_pidsArr, ends);
     } else if (combinations_sql) {
         pgr_get_combinations(combinations_sql, &combinations, &total_combinations);
     }

--- a/src/withPoints/withPoints.c
+++ b/src/withPoints/withPoints.c
@@ -107,9 +107,9 @@ process(
 
         if (starts && ends) {
             start_pidsArr = (int64_t*)
-                pgr_get_bigIntArray(&size_start_pidsArr, starts, false);
+                pgr_get_bigIntArray(&size_start_pidsArr, starts);
             end_pidsArr = (int64_t*)
-                pgr_get_bigIntArray(&size_end_pidsArr, ends, false);
+                pgr_get_bigIntArray(&size_end_pidsArr, ends);
         } else if (combinations_sql) {
             pgr_get_combinations(combinations_sql, &combinations, &total_combinations);
         }
@@ -118,9 +118,9 @@ process(
         pgr_get_edges(edges_no_points_query, &edges, &total_edges, false, false);
 
         end_pidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_end_pidsArr, starts, false);
+            pgr_get_bigIntArray(&size_end_pidsArr, starts);
         start_pidsArr = (int64_t*)
-            pgr_get_bigIntArray(&size_start_pidsArr, ends, false);
+            pgr_get_bigIntArray(&size_start_pidsArr, ends);
     }
 
 

--- a/src/withPoints/withPointsVia.c
+++ b/src/withPoints/withPointsVia.c
@@ -58,7 +58,7 @@ process(
      * Processing Via
      */
     size_t size_vias = 0;
-    int64_t* vias = (int64_t*) pgr_get_bigIntArray(&size_vias, viasArr, false);
+    int64_t* vias = (int64_t*) pgr_get_bigIntArray(&size_vias, viasArr);
 
     // TODO(vicky) figure out what happens when one point or 0 points are given
 


### PR DESCRIPTION
Reverts pgRouting/pgrouting#2497

Based on the conversation we had, where no big changes happen during a micro.
moving code from C to C++ is a big change, so I am reverting the PR where get_arrays_input is changed from C to C++