### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/locale/ja/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/ja/LC_MESSAGES/pgrouting_doc_strings.po
@@ -17667,5 +17667,3 @@ msgstr ""
 
 msgid "Advanced Documentation"
 msgstr ""
-
-#, fuzzy

--- a/locale/ko/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/ko/LC_MESSAGES/pgrouting_doc_strings.po
@@ -17587,5 +17587,3 @@ msgstr ""
 
 msgid "Advanced Documentation"
 msgstr ""
-
-#, fuzzy


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [pgRouting/pgRouting](https://weblate.osgeo.org/projects/pgrouting/pgrouting-develop/).


It also includes following components:

* [pgRouting/index](https://weblate.osgeo.org/projects/pgrouting/index/)



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widgets/pgrouting/-/pgrouting-develop/horizontal-auto.svg)

**Reminder**: Do not squash, do a rebase