### PR TITLE
Fix for pg16. Closes #2525

### DIFF
--- a/src/alpha_shape/alphaShape.c
+++ b/src/alpha_shape/alphaShape.c
@@ -161,7 +161,7 @@ Datum _pgr_alphashape(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int64GetDatum(call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)call_cntr + 1);
         values[1] = CStringGetTextDatum(result_tuples[call_cntr].geom);
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);

--- a/src/astar/astar.c
+++ b/src/astar/astar.c
@@ -233,7 +233,7 @@ _pgr_astar(PG_FUNCTION_ARGS) {
         }
 
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[funcctx->call_cntr].seq);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].end_id);

--- a/src/bdAstar/bdAstar.c
+++ b/src/bdAstar/bdAstar.c
@@ -222,7 +222,7 @@ _pgr_bdastar(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[call_cntr].seq);
         values[2] = Int64GetDatum(result_tuples[call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[call_cntr].end_id);

--- a/src/bdDijkstra/bdDijkstra.c
+++ b/src/bdDijkstra/bdDijkstra.c
@@ -232,7 +232,7 @@ PGDLLEXPORT Datum _pgr_bddijkstra(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[call_cntr].seq);
         values[2] = Int64GetDatum(result_tuples[call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[call_cntr].end_id);

--- a/src/bellman_ford/bellman_ford.c
+++ b/src/bellman_ford/bellman_ford.c
@@ -238,7 +238,7 @@ PGDLLEXPORT Datum _pgr_bellmanford(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[funcctx->call_cntr].seq);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].end_id);

--- a/src/bellman_ford/bellman_ford_neg.c
+++ b/src/bellman_ford/bellman_ford_neg.c
@@ -257,7 +257,7 @@ PGDLLEXPORT Datum _pgr_bellmanfordneg(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[funcctx->call_cntr].seq);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].end_id);

--- a/src/bellman_ford/edwardMoore.c
+++ b/src/bellman_ford/edwardMoore.c
@@ -239,7 +239,7 @@ PGDLLEXPORT Datum _pgr_edwardmoore(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[funcctx->call_cntr].seq);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].end_id);

--- a/src/breadthFirstSearch/binaryBreadthFirstSearch.c
+++ b/src/breadthFirstSearch/binaryBreadthFirstSearch.c
@@ -248,7 +248,7 @@ PGDLLEXPORT Datum _pgr_binarybreadthfirstsearch(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[funcctx->call_cntr].seq);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].end_id);

--- a/src/breadthFirstSearch/breadthFirstSearch.c
+++ b/src/breadthFirstSearch/breadthFirstSearch.c
@@ -203,7 +203,7 @@ PGDLLEXPORT Datum _pgr_breadthfirstsearch(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].depth);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].from_v);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].node);

--- a/src/chinese/chinesePostman.c
+++ b/src/chinese/chinesePostman.c
@@ -171,7 +171,7 @@ PGDLLEXPORT Datum _pgr_chinesepostman(PG_FUNCTION_ARGS) {
         for (i = 0; i < numb; ++i) {
             nulls[i] = false;
         }
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[call_cntr].node);
         values[2] = Int64GetDatum(result_tuples[call_cntr].edge);
         values[3] = Float8GetDatum(result_tuples[call_cntr].cost);

--- a/src/circuits/hawickCircuits.c
+++ b/src/circuits/hawickCircuits.c
@@ -175,7 +175,7 @@ PGDLLEXPORT Datum _pgr_hawickcircuits(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[call_cntr].circuit_id);
         values[2] = Int32GetDatum(result_tuples[call_cntr].circuit_path_seq);
         values[3] = Int64GetDatum(result_tuples[call_cntr].start_vid);

--- a/src/components/articulationPoints.c
+++ b/src/components/articulationPoints.c
@@ -150,7 +150,7 @@ PGDLLEXPORT Datum _pgr_articulationpoints(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr]);
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);

--- a/src/components/biconnectedComponents.c
+++ b/src/components/biconnectedComponents.c
@@ -150,7 +150,7 @@ PGDLLEXPORT Datum _pgr_biconnectedcomponents(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int64GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2.value);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].d1.id);
 

--- a/src/components/bridges.c
+++ b/src/components/bridges.c
@@ -149,7 +149,7 @@ PGDLLEXPORT Datum _pgr_bridges(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr]);
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);

--- a/src/components/connectedComponents.c
+++ b/src/components/connectedComponents.c
@@ -151,7 +151,7 @@ PGDLLEXPORT Datum _pgr_connectedcomponents(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int64GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2.value);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].d1.id);
 

--- a/src/components/makeConnected.c
+++ b/src/components/makeConnected.c
@@ -174,7 +174,7 @@ PGDLLEXPORT Datum _pgr_makeconnected(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d1.start_vid);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2.end_vid);
 

--- a/src/components/strongComponents.c
+++ b/src/components/strongComponents.c
@@ -150,7 +150,7 @@ PGDLLEXPORT Datum _pgr_strongcomponents(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int64GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2.value);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].d1.id);
 

--- a/src/cpp_common/get_check_data.cpp
+++ b/src/cpp_common/get_check_data.cpp
@@ -443,7 +443,11 @@ double getFloat8(
 }
 
 /*!
- * [DatumGetCString](https://doxygen.postgresql.org/postgres_8h.html#ae401c8476d1a12b420e3061823a206a7)
+ * [SPI_getvalue](https://doxygen.postgresql.org/spi_8c.html#ae53c12ff90592f67e4e40ad0af24205b
+ which calls OidOutputFunctionCall, which calls
+ OutputFunctionCall - https://doxygen.postgresql.org/fmgr_8c.html#ae19cff34818e4a6c90523e8bb02c3420
+ which returns pointer to CString
+  )
  * @note under development Not used, not tested
  * @param[in] tuple   input row to be examined.
  * @param[in]  tupdesc  tuple descriptor
@@ -452,7 +456,7 @@ double getFloat8(
  */
 
 char* getText(const HeapTuple tuple, const TupleDesc &tupdesc,  const pgrouting::Column_info_t &info) {
-    return DatumGetCString(SPI_getvalue(tuple, tupdesc, info.colNumber));
+    return SPI_getvalue(tuple, tupdesc, info.colNumber);
 }
 
 }  // namespace pgrouting

--- a/src/dagShortestPath/dagShortestPath.c
+++ b/src/dagShortestPath/dagShortestPath.c
@@ -229,7 +229,7 @@ PGDLLEXPORT Datum _pgr_dagshortestpath(PG_FUNCTION_ARGS) {
         }
 
         // postgres starts counting from 1
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[funcctx->call_cntr].seq);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].node);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].edge);

--- a/src/dijkstra/dijkstra.c
+++ b/src/dijkstra/dijkstra.c
@@ -274,7 +274,7 @@ _pgr_dijkstra(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[call_cntr].seq);
         values[2] = Int64GetDatum(result_tuples[call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[call_cntr].end_id);

--- a/src/dijkstra/dijkstraVia.c
+++ b/src/dijkstra/dijkstraVia.c
@@ -182,7 +182,7 @@ _pgr_dijkstravia(PG_FUNCTION_ARGS) {
         }
 
         // postgres starts counting from 1
-        values[0] = Int32GetDatum(call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[call_cntr].path_id);
         values[2] = Int32GetDatum(result_tuples[call_cntr].path_seq + 1);
         values[3] = Int64GetDatum(result_tuples[call_cntr].start_vid);

--- a/src/dominator/lengauerTarjanDominatorTree.c
+++ b/src/dominator/lengauerTarjanDominatorTree.c
@@ -148,7 +148,7 @@ _pgr_lengauertarjandominatortree(PG_FUNCTION_ARGS) {
         for (i = 0; i < numb; ++i) {
             nulls[i] = false;
         }
-            values[0] = Int32GetDatum(call_cntr + 1);
+            values[0] = Int64GetDatum((int64_t)call_cntr + 1);
             values[1] = Int64GetDatum(result_tuples[call_cntr].d1.id);
             values[2] = Int64GetDatum(result_tuples[call_cntr].d2.value);
             tuple = heap_form_tuple(tuple_desc, values, nulls);

--- a/src/driving_distance/many_to_dist_driving_distance.c
+++ b/src/driving_distance/many_to_dist_driving_distance.c
@@ -163,7 +163,7 @@ _pgr_drivingdistance(PG_FUNCTION_ARGS) {
         for (i = 0; i < numb; ++i) {
             nulls[i] = false;
         }
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].start_id);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].node);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].edge);

--- a/src/driving_distance/many_to_dist_withPointsDD.c
+++ b/src/driving_distance/many_to_dist_withPointsDD.c
@@ -223,7 +223,7 @@ _pgr_withpointsdd(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].start_id);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].node);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].edge);

--- a/src/ksp/ksp.c
+++ b/src/ksp/ksp.c
@@ -189,8 +189,8 @@ _pgr_ksp(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
-        values[1] = Int32GetDatum(path[funcctx->call_cntr].start_id + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
+        values[1] = Int32GetDatum((int32_t)path[funcctx->call_cntr].start_id + 1);
         values[2] = Int32GetDatum(path[funcctx->call_cntr].seq);
         values[3] = Int64GetDatum(path[funcctx->call_cntr].node);
         values[4] = Int64GetDatum(path[funcctx->call_cntr].edge);

--- a/src/ksp/turnRestrictedPath.c
+++ b/src/ksp/turnRestrictedPath.c
@@ -232,8 +232,8 @@ _pgr_turnrestrictedpath(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
-        values[1] = Int32GetDatum(path[funcctx->call_cntr].start_id + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
+        values[1] = Int32GetDatum((int32_t)path[funcctx->call_cntr].start_id + 1);
         values[2] = Int32GetDatum(path[funcctx->call_cntr].seq);
         values[3] = Int64GetDatum(path[funcctx->call_cntr].node);
         values[4] = Int64GetDatum(path[funcctx->call_cntr].edge);

--- a/src/ksp/withPoints_ksp.c
+++ b/src/ksp/withPoints_ksp.c
@@ -246,7 +246,7 @@ PGDLLEXPORT Datum _pgr_withpointsksp(PG_FUNCTION_ARGS) {
 
 
         // postgres starts counting from 1
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int32GetDatum((int)
                 (result_tuples[funcctx->call_cntr].start_id + 1));
         values[2] = Int32GetDatum(result_tuples[funcctx->call_cntr].seq);

--- a/src/lineGraph/lineGraph.c
+++ b/src/lineGraph/lineGraph.c
@@ -199,7 +199,7 @@ PGDLLEXPORT Datum _pgr_linegraph(PG_FUNCTION_ARGS) {
         }
 
         // postgres starts counting from 1
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].source);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].target);
         values[3] = Float8GetDatum(result_tuples[funcctx->call_cntr].cost);

--- a/src/lineGraph/lineGraphFull.c
+++ b/src/lineGraph/lineGraphFull.c
@@ -152,7 +152,7 @@ PGDLLEXPORT Datum _pgr_linegraphfull(PG_FUNCTION_ARGS) {
 
         size_t c_cntr = funcctx->call_cntr;
 
-        values[0] = Int32GetDatum(c_cntr + 1);
+        values[0] = Int32GetDatum((int32_t)c_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[c_cntr].source);
         values[2] = Int64GetDatum(result_tuples[c_cntr].target);
         values[3] = Float8GetDatum(result_tuples[c_cntr].cost);

--- a/src/max_flow/edge_disjoint_paths.c
+++ b/src/max_flow/edge_disjoint_paths.c
@@ -221,9 +221,9 @@ _pgr_edgedisjointpaths(PG_FUNCTION_ARGS) {
             }
         }
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
-        values[1] = Int32GetDatum(path_id);
-        values[2] = Int32GetDatum(seq);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
+        values[1] = Int32GetDatum((int32_t)path_id);
+        values[2] = Int32GetDatum((int32_t)seq);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].start_id);
         values[4] = Int64GetDatum(result_tuples[funcctx->call_cntr].end_id);
         values[5] = Int64GetDatum(result_tuples[funcctx->call_cntr].node);

--- a/src/max_flow/max_flow.c
+++ b/src/max_flow/max_flow.c
@@ -242,7 +242,7 @@ _pgr_maxflow(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[call_cntr].edge);
         values[2] = Int64GetDatum(result_tuples[call_cntr].source);
         values[3] = Int64GetDatum(result_tuples[call_cntr].target);

--- a/src/max_flow/maximum_cardinality_matching.c
+++ b/src/max_flow/maximum_cardinality_matching.c
@@ -162,7 +162,7 @@ _pgr_maxcardinalitymatch(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].edge_id);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].source);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].target);

--- a/src/max_flow/minCostMaxFlow.c
+++ b/src/max_flow/minCostMaxFlow.c
@@ -268,7 +268,7 @@ PGDLLEXPORT Datum _pgr_maxflowmincost(PG_FUNCTION_ARGS) {
         }
 
         // postgres starts counting from 1
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].edge);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].source);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].target);

--- a/src/mincut/stoerWagner.c
+++ b/src/mincut/stoerWagner.c
@@ -168,7 +168,7 @@ PGDLLEXPORT Datum _pgr_stoerwagner(PG_FUNCTION_ARGS) {
         }
 
         // postgres starts counting from 1
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].edge);
         values[2] = Float8GetDatum(result_tuples[funcctx->call_cntr].cost);
         values[3] = Float8GetDatum(result_tuples[funcctx->call_cntr].mincut);

--- a/src/ordering/cuthillMckeeOrdering.c
+++ b/src/ordering/cuthillMckeeOrdering.c
@@ -188,7 +188,7 @@ _pgr_cuthillmckeeordering(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int64GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2.value);
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);

--- a/src/pickDeliver/pickDeliver.c
+++ b/src/pickDeliver/pickDeliver.c
@@ -301,7 +301,7 @@ _pgr_pickdeliver(PG_FUNCTION_ARGS) {
         }
 
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[call_cntr].vehicle_seq);
         values[2] = Int64GetDatum(result_tuples[call_cntr].vehicle_id);
         values[3] = Int32GetDatum(result_tuples[call_cntr].stop_seq);

--- a/src/pickDeliver/pickDeliverEuclidean.c
+++ b/src/pickDeliver/pickDeliverEuclidean.c
@@ -285,7 +285,7 @@ _pgr_pickdelivereuclidean(PG_FUNCTION_ARGS) {
 
 
         // postgres starts counting from 1
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[call_cntr].vehicle_seq);
         values[2] = Int64GetDatum(result_tuples[call_cntr].vehicle_id);
         values[3] = Int32GetDatum(result_tuples[call_cntr].stop_seq);

--- a/src/planar/boyerMyrvold.c
+++ b/src/planar/boyerMyrvold.c
@@ -175,7 +175,7 @@ PGDLLEXPORT Datum _pgr_boyermyrvold(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].source);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].target);
         values[3] = Float8GetDatum(result_tuples[funcctx->call_cntr].cost);

--- a/src/spanningTree/kruskal.c
+++ b/src/spanningTree/kruskal.c
@@ -166,7 +166,7 @@ PGDLLEXPORT Datum _pgr_kruskal(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int64GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].depth);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].from_v);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].node);

--- a/src/spanningTree/prim.c
+++ b/src/spanningTree/prim.c
@@ -170,7 +170,7 @@ PGDLLEXPORT Datum _pgr_prim(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int64GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].depth);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].from_v);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].node);

--- a/src/spanningTree/randomSpanningTree.c
+++ b/src/spanningTree/randomSpanningTree.c
@@ -159,7 +159,7 @@ PGDLLEXPORT Datum randomSpanningTree(PG_FUNCTION_ARGS) {
         }
 
         // postgres starts counting from 1
-        values[0] = Int64GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] =
             Int64GetDatum(result_tuples[funcctx->call_cntr].root_vertex);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].edge);

--- a/src/topologicalSort/topologicalSort.c
+++ b/src/topologicalSort/topologicalSort.c
@@ -154,7 +154,7 @@ _pgr_topologicalsort(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[call_cntr].id);
         /**********************************************************************/
 

--- a/src/transitiveClosure/transitiveClosure.c
+++ b/src/transitiveClosure/transitiveClosure.c
@@ -201,7 +201,7 @@ _pgr_transitiveclosure(PG_FUNCTION_ARGS) {
         TupleDescInitEntry(tuple_desc, (AttrNumber) 3, "target_array",
                 INT8ARRAYOID, -1, 0);
 
-        values[0] = Int32GetDatum(call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[call_cntr].vid);
         values[2] = PointerGetDatum(arrayType);
 

--- a/src/traversal/depthFirstSearch.c
+++ b/src/traversal/depthFirstSearch.c
@@ -214,7 +214,7 @@ PGDLLEXPORT Datum _pgr_depthfirstsearch(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int64GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].depth);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].from_v);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].node);

--- a/src/trsp/new_trsp.c
+++ b/src/trsp/new_trsp.c
@@ -210,7 +210,7 @@ _v4trsp(PG_FUNCTION_ARGS) {
         int path_id = call_cntr == 0? 0 : result_tuples[call_cntr - 1].seq;
         path_id += result_tuples[call_cntr].seq == 1? 1 : 0;
 
-        values[0] = Int32GetDatum(call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[call_cntr].seq);
         values[2] = Int64GetDatum(result_tuples[call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[call_cntr].end_id);
@@ -293,7 +293,7 @@ _trsp(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[call_cntr].seq);
         values[2] = Int64GetDatum(result_tuples[call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[call_cntr].end_id);

--- a/src/trsp/trsp.c
+++ b/src/trsp/trsp.c
@@ -115,8 +115,7 @@ fetch_restrict(HeapTuple *tuple, TupleDesc *tupdesc,
   if (isnull)
     elog(ERROR, "to_cost contains a null value");
   rest->to_cost = DatumGetFloat8(binval);
-  char *str = DatumGetCString(SPI_getvalue(*tuple, *tupdesc,
-       restrict_columns->via_path));
+  char *str = SPI_getvalue(*tuple, *tupdesc, restrict_columns->via_path);
 
   // PGR_DBG("restriction: %f, %i, %s", rest->to_cost, rest->target_id, str);
 
@@ -430,11 +429,11 @@ _pgr_trsp(PG_FUNCTION_ARGS) {
       values = palloc(4 * sizeof(Datum));
       nulls = palloc(4 * sizeof(char));
 
-      values[0] = Int32GetDatum(funcctx->call_cntr);
+      values[0] = Int64GetDatum((int64_t)funcctx->call_cntr);
       nulls[0] = false;
-      values[1] = Int32GetDatum(path[funcctx->call_cntr].vertex_id);
+      values[1] = Int32GetDatum((int32_t)path[funcctx->call_cntr].vertex_id);
       nulls[1] = false;
-      values[2] = Int32GetDatum(path[funcctx->call_cntr].edge_id);
+      values[2] = Int32GetDatum((int32_t)path[funcctx->call_cntr].edge_id);
       nulls[2] = false;
       values[3] = Float8GetDatum(path[funcctx->call_cntr].cost);
       nulls[3] = false;

--- a/src/trsp/trspVia.c
+++ b/src/trsp/trspVia.c
@@ -188,7 +188,7 @@ _pgr_trspvia(PG_FUNCTION_ARGS) {
         }
 
         // postgres starts counting from 1
-        values[0] = Int32GetDatum(call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[call_cntr].path_id);
         values[2] = Int32GetDatum(result_tuples[call_cntr].path_seq + 1);
         values[3] = Int64GetDatum(result_tuples[call_cntr].start_vid);

--- a/src/trsp/trspVia_withPoints.c
+++ b/src/trsp/trspVia_withPoints.c
@@ -220,7 +220,7 @@ _pgr_trspvia_withpoints(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[call_cntr].path_id);
         values[2] = Int32GetDatum(result_tuples[call_cntr].path_seq + 1);
         values[3] = Int64GetDatum(result_tuples[call_cntr].start_vid);

--- a/src/trsp/trsp_withPoints.c
+++ b/src/trsp/trsp_withPoints.c
@@ -272,7 +272,7 @@ _pgr_trsp_withpoints(PG_FUNCTION_ARGS) {
         int path_id = call_cntr == 0? 0 : result_tuples[call_cntr - 1].seq;
         path_id += result_tuples[call_cntr].seq == 1? 1 : 0;
 
-        values[0] = Int32GetDatum(call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[call_cntr].seq);
         values[2] = Int64GetDatum(result_tuples[call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[call_cntr].end_id);

--- a/src/tsp/TSP.c
+++ b/src/tsp/TSP.c
@@ -172,7 +172,7 @@ _pgr_tsp(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].node);
         values[2] = Float8GetDatum(result_tuples[funcctx->call_cntr].cost);
         values[3] = Float8GetDatum(result_tuples[funcctx->call_cntr].agg_cost);

--- a/src/tsp/euclideanTSP.c
+++ b/src/tsp/euclideanTSP.c
@@ -173,7 +173,7 @@ _pgr_tspeuclidean(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].node);
         values[2] = Float8GetDatum(result_tuples[funcctx->call_cntr].cost);
         values[3] = Float8GetDatum(result_tuples[funcctx->call_cntr].agg_cost);

--- a/src/withPoints/withPoints.c
+++ b/src/withPoints/withPoints.c
@@ -293,7 +293,7 @@ _pgr_withpoints(PG_FUNCTION_ARGS) {
         }
 
 
-        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[funcctx->call_cntr].seq);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].end_id);

--- a/src/withPoints/withPointsVia.c
+++ b/src/withPoints/withPointsVia.c
@@ -204,7 +204,7 @@ _pgr_withpointsvia(PG_FUNCTION_ARGS) {
         }
 
         // postgres starts counting from 1
-        values[0] = Int32GetDatum(call_cntr + 1);
+        values[0] = Int64GetDatum((int64_t)call_cntr + 1);
         values[1] = Int32GetDatum(result_tuples[call_cntr].path_id);
         values[2] = Int32GetDatum(result_tuples[call_cntr].path_seq + 1);
         values[3] = Int64GetDatum(result_tuples[call_cntr].start_vid);


### PR DESCRIPTION
Fixes #2525 

Changes proposed in this pull request:
-  Use SPI_getvalue directly as it already calls DatumGetCString.  DatumGetCString expects a Datum so can not be used here.
-  Note this is a new function in develop and note says it's not used, so hard to tell if this change fixed anything, aside from pg16 now being able to compile.


@pgRouting/admins
