### PR TITLE
Update README.md - master to main correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Branches
 
-* The *master* branch has the development of the next micro release
+* The *main* branch has the development of the next micro release
 * The *develop* branch has the development of the next minor/major release
 
 For the complete list of releases go to:


### PR DESCRIPTION
master branch was renamed to main a while ago, but README still talking about master branch

