### PR TITLE
Fix documentation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 pgRouting 3.6.0 Release Notes
 -------------------------------------------------------------------------------
 
+To see all issues & pull requests closed by this release see the `Git closed
+milestone for 3.6.0
+<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.6.0%22>`_
+
 **Official functions changes**
 
 * [#2516](https://github.com/pgRouting/pgrouting/pull/2516) Standarize output
@@ -17,87 +21,94 @@ pgRouting 3.6.0 Release Notes
 
   * Standarizing output columns to |short-generic-result|
 
-    * ``pgr_bdAstar`` (`One to One`) added ``start_vid`` and ``end_vid`` columns.
+    * ``pgr_bdAstar`` (`One to One`) added ``start_vid`` and ``end_vid``
+      columns.
     * ``pgr_bdAstar`` (`One to Many`) added ``end_vid`` column.
     * ``pgr_bdAstar`` (`Many to One`) added ``start_vid`` column.
 
-**Proposed functions changes**
+* [#2547](https://github.com/pgRouting/pgrouting/pull/2547) Standarize output
+  and modifying signature pgr_KSP
 
-* [#2544](https://github.com/pgRouting/pgrouting/pull/2544) Standarize output and modifying signature
-  pgr_withPointsDD
+  
+  * Return columns standarized to: |nksp-result|
+  * ``pgr_ksp`` (One to One)
+  
+    * Added ``start_vid`` and ``end_vid`` result columns.
+  
+  * New overload functions:
+  
+    * ``pgr_ksp`` (One to Many)
+    * ``pgr_ksp`` (Many to One)
+    * ``pgr_ksp`` (Many to Many)
+    * ``pgr_ksp`` (Combinations)
+  
 
-  * New proposed signatures: ``driving side`` parameter changed from optional to compulsory
-
-    * ``pgr_withPointsDD`` (`Single vertex`)
-    * ``pgr_withPointsDD`` (`Multiple vertices`)
-
-  * Deprecated signatures:
-
-    * ``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)``
-    * ``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,boolean,boolean)``
-
-  * Standarizing output columns to |result-bfs|
-
-    * ``pgr_withPointsDD`` (`Single vertex`) added ``depth`` and ``start_vid`` column.
-    * ``pgr_withPointsDD`` (`Multiple vertices`) added ``depth`` column.
-
-* [#2546](https://github.com/pgRouting/pgrouting/pull/2546) Standarize output and modifying signature
-  pgr_withPointsKSP
-
-  * New proposed functions:
-    * ``pgr_withPointsKSP`` (`One to Many`)
-    * ``pgr_withPointsKSP`` (`Many to One`)
-    * ``pgr_withPointsKSP`` (`Many to Many`)
-    * ``pgr_withPointsKSP`` (`Combinations`)
-
-  * New proposed signatures: ``driving side`` parameter changed from optional to compulsory
-
-    * ``pgr_withPointsKSP`` (`One to One`)
-
-  * Deprecated signatures:
-
-    * ``pgr_withpointsksp(text, text, bigint, bigint, integer, boolean, boolean, char, boolean)``
-
-  * Standarizing output columns to |nksp-result|
-
-    * ``pgr_withPointsKSP`` (`One To One`) added ``start_vid`` and ``end_vid`` column.
-
-
-* [#2547](https://github.com/pgRouting/pgrouting/pull/2547) Standarize output and modifying signature
-  pgr_KSP
-
-  * New proposed functions:
-    * ``pgr_KSP`` (`One to Many`)
-    * ``pgr_KSP`` (`Many to One`)
-    * ``pgr_KSP`` (`Many to Many`)
-    * ``pgr_KSP`` (`Combinations`)
-
-  * Deprecated signatures:
-
-    * ``pgr_ksp(text, bigint, bigint, integer, boolean, boolean)``
-
-  * Standarizing output columns to |nksp-result|
-
-    * ``pgr_KSP`` (`One To One`) added ``start_vid`` and ``end_vid`` column.
-
-
-* [#2548](https://github.com/pgRouting/pgrouting/pull/2548) Standarize output and modifying signature
+* [#2548](https://github.com/pgRouting/pgrouting/pull/2548) Standarize output
   pgr_drivingdistance
 
-  * New proposed functions:
-    * ``pgr_drivingdistance`` (`Single vertex`)
-    * ``pgr_drivingdistance`` (`Multiple vertices`)
-
-  * Deprecated signatures:
-
-    * ``pgr_drivingdistance(text,anyarray,double precision,boolean,boolean)``
-    * ``pgr_drivingdistance(text,bigint,double precision,boolean,boolean)``
-
+  
   * Standarizing output columns to |result-bfs|
+  
+    * ``pgr_drivingdistance`` (Single vertex)
+  
+      * Added ``depth`` and ``start_vid`` result columns.
+  
+    * ``pgr_drivingdistance`` (Multiple vertices)
+  
+      * Result column name change: ``from_v`` to ``start_vid``.
+      * Added ``depth`` result column.
+  
 
-    * ``pgr_drivingdistance`` (`Single vertex`) added ``depth`` and ``start_vid`` column.
-    * ``pgr_drivindistance`` (`Multiple vertices`) added ``depth`` column.
+**Proposed functions changes**
 
+* [#2544](https://github.com/pgRouting/pgrouting/pull/2544) Standarize output
+  and modifying signature pgr_withPointsDD
+
+  
+  * Signature change: ``driving_side`` parameter changed from named optional to
+    unnamed compulsory **driving side**.
+  
+    * ``pgr_withPointsDD`` (`Single vertex`)
+    * ``pgr_withPointsDD`` (`Multiple vertices`)
+  
+  * Standarizing output columns to |result-bfs|
+  
+    * ``pgr_withPointsDD`` (`Single vertex`)
+  
+      * Added ``depth`` and ``start_vid`` column.
+  
+    * ``pgr_withPointsDD`` (`Multiple vertices`)
+  
+      * Added ``depth`` column.
+  
+  * Deprecated signatures:
+  
+    * ``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)``
+    * ``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,boolean,boolean)``
+  
+
+* [#2546](https://github.com/pgRouting/pgrouting/pull/2546) Standarize output
+  and modifying signature pgr_withPointsKSP
+
+  
+  * Standarizing output columns to |nksp-result|
+  * ``pgr_withPointsKSP`` (One to One)
+  
+    * Signature change: ``driving_side`` parameter changed from named optional to
+      unnamed compulsory **driving side**.
+    * Added ``start_vid`` and ``end_vid`` result columns.
+  
+  * New overload functions:
+  
+    * ``pgr_withPointsKSP`` (One to Many)
+    * ``pgr_withPointsKSP`` (Many to One)
+    * ``pgr_withPointsKSP`` (Many to Many)
+    * ``pgr_withPointsKSP`` (Combinations)
+  
+  * Deprecated signature:
+  
+    * ``pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,boolean)``
+  
 
 **C/C++ code enhancements**
 

--- a/doc/driving_distance/pgr_drivingDistance.rst
+++ b/doc/driving_distance/pgr_drivingDistance.rst
@@ -21,22 +21,28 @@
    Boost Graph Inside
 
 .. rubric:: Availability
-   
-* Version 3.6.0
 
-  * Standarizing output columns to |result-bfs|
+:Version 3.6.0:
 
-    * ``pgr_drivingdistance`` (`Single vertex`_) added ``depth`` and ``start_vid`` column.
-    * ``pgr_drivingdistance`` (`Multiple vertices`_) added ``depth`` column.
+* Standarizing output columns to |result-bfs|
 
-* Version 2.1.0:
+  * ``pgr_drivingdistance`` (Single vertex)
 
-  * Signature change pgr_drivingDistance(single vertex)
-  * New **Official** pgr_drivingDistance(multiple vertices)
+    * Added ``depth`` and ``start_vid`` result columns.
 
-* Version 2.0.0:
+  * ``pgr_drivingdistance`` (Multiple vertices)
 
-  * **Official** pgr_drivingDistance(single vertex)
+    * Result column name change: ``from_v`` to ``start_vid``.
+    * Added ``depth`` result column.
+
+:Version 2.1.0:
+
+* Signature change pgr_drivingDistance(single vertex)
+* New **Official** pgr_drivingDistance(multiple vertices)
+
+:Version 2.0.0:
+
+* Official:: pgr_drivingDistance(single vertex)
 
 
 Description
@@ -130,9 +136,9 @@ Driving distance optional parameters
      - ``BOOLEAN``
      - ``true``
      - * When ``true`` the node will only appear in the closest ``start_vid``
-         list.
-       * When ``false`` which resembles several calls using the single starting
-         point signatures. Tie brakes are arbitrary.
+         list. Tie brakes are arbitrary.
+       * When ``false`` which resembles several calls using the single vertex
+         signature.
 
 .. equicost_end
 

--- a/doc/ksp/pgr_KSP.rst
+++ b/doc/ksp/pgr_KSP.rst
@@ -23,26 +23,29 @@ pgr_KSP
 
 .. rubric:: Availability
 
-* Version 3.6.0
+.. rubric:: Version 3.6.0
 
-  * ``pgr_ksp`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns.
+* Return columns standarized to: |nksp-result|
+* ``pgr_ksp`` (One to One)
 
-  * New **overloades** functions:
+  * Added ``start_vid`` and ``end_vid`` result columns.
 
-    * ``pgr_ksp`` (`One to Many`_)
-    * ``pgr_ksp`` (`Many to One`_)
-    * ``pgr_ksp`` (`Many to Many`_)
-    * ``pgr_ksp`` (`Combinations`_)
+* New overload functions:
 
-* Version 2.1.0
+  * ``pgr_ksp`` (One to Many)
+  * ``pgr_ksp`` (Many to One)
+  * ``pgr_ksp`` (Many to Many)
+  * ``pgr_ksp`` (Combinations)
 
-  * Signature change
+.. rubric:: Version 2.1.0
 
-    * Old signature no longer supported
+* Signature change
 
-* Version 2.0.0
+  * Old signature no longer supported
 
-  * **Official** function
+.. rubric:: Version 2.0.0
+
+* **Official** function
 
 
 Description
@@ -79,6 +82,7 @@ One to One
    :class: signatures
 
    | pgr_KSP(`Edges SQL`_, **start vid**, **end vid**, **K**, [**options**])
+   | **options:** ``[directed, heap_paths]``
 
    | RETURNS SET OF |nksp-result|
    | OR EMPTY SET
@@ -99,6 +103,7 @@ One to Many
    :class: signatures
 
    | pgr_KSP(`Edges SQL`_, **start vid**, **end vids**, **K**, [**options**])
+   | **options:** ``[directed, heap_paths]``
 
    | RETURNS SET OF |nksp-result|
    | OR EMPTY SET
@@ -106,8 +111,8 @@ One to Many
 :Example: Get 2 paths from vertex :math:`6` to vertices :math:`\{10, 17\}` on a directed graph.
 
 .. literalinclude:: doc-ksp.queries
-    :start-after: --q3
-    :end-before: --q4
+    :start-after: --q2
+    :end-before: --q3
 
 .. index::
     single: ksp(Many to One)
@@ -119,6 +124,7 @@ Many to One
    :class: signatures
 
    | pgr_KSP(`Edges SQL`_, **start vids**, **end vid**, **K**, [**options**])
+   | **options:** ``[directed, heap_paths]``
 
    | RETURNS SET OF |nksp-result|
    | OR EMPTY SET
@@ -126,8 +132,8 @@ Many to One
 :Example: Get 2 paths from vertices :math:`\{6, 1\}` to vertex :math:`17` on a directed graph.
 
 .. literalinclude:: doc-ksp.queries
-    :start-after: --q4
-    :end-before: --q5
+    :start-after: --q3
+    :end-before: --q4
 
 .. index::
     single: ksp(Many to Many)
@@ -139,6 +145,7 @@ Many to Many
    :class: signatures
 
    | pgr_KSP(`Edges SQL`_, **start vids**, **end vids**, **K**, [**options**])
+   | **options:** ``[directed, heap_paths]``
 
    | RETURNS SET OF |nksp-result|
    | OR EMPTY SET
@@ -146,8 +153,8 @@ Many to Many
 :Example: Get 2 paths vertices :math:`\{6, 1\}` to vertices :math:`\{10, 17\}` on a directed graph.
 
 .. literalinclude:: doc-ksp.queries
-    :start-after: --q5
-    :end-before: --q6
+    :start-after: --q4
+    :end-before: --q5
 
 .. index::
    single: ksp(Combinations)
@@ -159,6 +166,7 @@ Combinations
    :class: signatures
 
    | pgr_KSP(`Edges SQL`_, `Combinations SQL`_, **K**, [**options**])
+   | **options:** ``[directed, heap_paths]``
 
    | RETURNS SET OF |nksp-result|
    | OR EMPTY SET
@@ -174,8 +182,8 @@ The combinations table:
 The query:
 
 .. literalinclude:: doc-ksp.queries
-    :start-after: --q6
-    :end-before: --q7
+    :start-after: --q5
+    :end-before: --q6
 
 
 Parameters
@@ -202,7 +210,7 @@ Parameters
      - Identifier of the destination vertex.
    * - **K**
      - **ANY-INTEGER**
-     - Number of required paths
+     - Number of required paths.
 
 Where:
 
@@ -234,7 +242,7 @@ KSP Optional parameters
    * - ``heap_paths``
      - ``BOOLEAN``
      - ``false``
-     - * When ``false`` Returns at most K paths
+     - * When ``false`` Returns at most K paths.
        * When ``true`` all the calculated paths while processing are returned.
        * Roughly, when the shortest path has ``N`` edges, the heap will contain
          about than ``N * K`` paths for small value of ``K`` and ``K > 5``.
@@ -281,15 +289,15 @@ Returns set of |nksp-result|
      - ``INTEGER``
      - Path identifier.
 
-       * Has value **1** for the first of a path from **start vid** to
-         **end vid**
+       * Has value **1** for the first of a path from ``start_vid`` to
+         ``end_vid``
    * - ``path_seq``
      - ``INTEGER``
      - Relative position in the path. Has value **1** for the beginning of a
        path.
    * - ``node``
      - ``BIGINT``
-     - Identifier of the node in the path from **start vid** to **end vid**
+     - Identifier of the node in the path from ``start_vid`` to ``end_vid``
    * - ``edge``
      - ``BIGINT``
      - Identifier of the edge used to go from ``node`` to the next node in the
@@ -315,10 +323,10 @@ Additional Examples
 Also get the paths in the heap.
 
 .. literalinclude:: doc-ksp.queries
-    :start-after: --q2
-    :end-before: --q3
+    :start-after: --q6
+    :end-before: --q7
 
-:Example: Get 2 paths using combinations table on an undirecte graph
+:Example: Get 2 paths using combinations table on an undirected graph
 
 Also get the paths in the heap.
 

--- a/doc/src/migration.rst
+++ b/doc/src/migration.rst
@@ -18,127 +18,17 @@ replaced by new functions.
 
 Results can be different because of the changes.
 
-Migrating functions:
-
-:doc:`pgr_drivingDistance` signatures have changed, with the addition of new columns
-in the new signatures.
-
-:doc:`pgr_KSP` signatures have been changed, with the addition of new columns start_vid & end_vid
-in the new signatures. one to many, many to one, many to many, and combinations overloads have been added.
-
-:doc:`pgr_maxCardinalityMatch` works only for undirected graphs, therefore the
-``directed`` flag has been removed.
-
-:doc:`pgr_trsp` signatures have changed and many issues have been fixed in the new
-signatures. This section will show how to migrate from the old signatures to the
-new replacement functions. This also affects the restrictions.
-
-:doc:`pgr_withPointsDD` signatures have changed, with the addition of new columns
-in the new signatures. It works mainly for driving cases, therefore the ``driving side``
-parameter changed from optional to compulsory, and its valid values differ for
-directed and undirected graphs.
-
-:doc:`pgr_withPointsKSP` signature have changed, with the addition of new columns
-in the new signature. It works mainly for driving cases, therefore the ``driving side``
-parameter changed from optional to compulsory, and its valid values differ for
-directed and undirected graphs.
-
 .. warning::
    All deprecated functions will be removed on next mayor version 4.0.0
 
 .. contents:: Contents
 
-Migration of functions that add new columns
+Migration of functions
 *******************************************************************************
 
-.. contents:: Contents
+.. contents:: Migrating functions
    :local:
 
-Migration of ``pgr_drivingdistance``
--------------------------------------------------------------------------------
-
-Starting from `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__
-
-Signatures to be migrated:
-
-* ``pgr_drivingdistance`` (`Single vertex`)
-* ``pgr_drivingdistance`` (`Multiple vertices`)
-
-:Before Migration:
-
-* Output columns were |result-dij-dd-m|
-
-  * Depending on the vertices, the column ``start_vid`` might be missing and the depth column is not in any one of them:
-
-    * ``pgr_drivingdistance`` (`Single vertex`) does not have ``start_vid`` and ``depth``.
-    * ``pgr_drivingdistance`` (`Multiple vertices`) does not have ``depth``.
-
-:Migration:
-
-* Be aware of the existance of the additional columns.
-
-* In ``pgr_drivingdistance`` (`Single vertex`)
-
-  * ``start_vid`` contains the **start vid** parameter value.
-  * ``depth`` contains the **depth** parameter value.
-
-.. literalinclude:: migration.queries
-   :start-after: --drivingdistance1
-   :end-before: --drivingdistance2
-
-* In ``pgr_drivingdistance`` (`Multiple vertices`)
-
-  * ``depth`` contains the **depth** parameter value.
-
-.. literalinclude:: migration.queries
-   :start-after: --drivingdistance2
-   :end-before: --drivingdistance3
-
-* If needed filter out the added columns, for example:
-
-.. literalinclude:: migration.queries
-   :start-after: --drivingdistance3
-   :end-before: --drivingdistance4
-
-Migration of ``pgr_KSP``
--------------------------------------------------------------------------------
-
-Starting from `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__
-
-Signatures to be migrated:
-
-* ``pgr_KSP`` (`One to One`)
-
-:Before Migration:
-
-* Output columns were |ksp-result|
-
-  * the columns ``start_vid`` and ``end_vid`` will be missing:
-
-    * ``pgr_KSP`` (`One to One`) does not have ``start_vid`` and ``end_vid``.
-    * ``pgr_KSP`` did not have (`One to Many`), (`Many to One`), (`Many to Many`) and (`Combinations`) overloads.
-
-:Migration:
-
-* Be aware of the existance of the additional columns.
-
-* In ``pgr_KSP`` (`One to One`)
-* In ``pgr_KSP`` (`One to Many`)
-* In ``pgr_KSP`` (`Many to One`)
-* In ``pgr_KSP`` (`Many to Many`)
-
-  * ``start_vid`` contains the **start vid** parameter value.
-  * ``end_vid`` contains the **end vid** parameter value.
-
-.. literalinclude:: migration.queries
-   :start-after: --ksp1
-   :end-before: --ksp2
-
-* If needed filter out the added columns, for example:
-
-.. literalinclude:: migration.queries
-   :start-after: --ksp2
-   :end-before: --ksp3
 
 Migration of ``pgr_aStar``
 -------------------------------------------------------------------------------
@@ -201,9 +91,11 @@ Signatures to be migrated:
   ``pgr_dijkstra`` is used, and the function had to be modified to be able to
   return the new columns:
 
-  * In `v3.0 <https://docs.pgrouting.org/3.0/en/contraction-family.html#case-1-both-source-and-target-belong-to-the-contracted-graph>`__
+  * In `v3.0
+    <https://docs.pgrouting.org/3.0/en/contraction-family.html#case-1-both-source-and-target-belong-to-the-contracted-graph>`__
     the function ``my_dijkstra`` uses ``pgr_dijkstra``.
-  * Starting from `v3.5 <https://docs.pgrouting.org/3.5/en/contraction-family.html#case-1-both-source-and-target-belong-to-the-contracted-graph>`__
+  * Starting from `v3.5
+    <https://docs.pgrouting.org/3.5/en/contraction-family.html#case-1-both-source-and-target-belong-to-the-contracted-graph>`__
     the function ``my_dijkstra`` returns the new additional columns of
     ``pgr_dijkstra``.
 
@@ -341,84 +233,130 @@ Signatures to be migrated:
     the function ``my_dijkstra`` returns the new additional columns of
     ``pgr_dijkstra``.
 
-Migration of ``pgr_withPointsDD``
+Migration of ``pgr_drivingdistance``
 -------------------------------------------------------------------------------
 
 Starting from `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__
+:doc:`pgr_drivingDistance` result columns are being standarized.
+
+:from: |result-dij-dd|
+:to: |result-bfs|
 
 Signatures to be migrated:
 
-* ``pgr_withPointsDD`` (`Single vertex`)
-* ``pgr_withPointsDD`` (`Multiple vertices`)
+* ``pgr_drivingdistance`` (Single vertex)
+* ``pgr_drivingdistance`` (Multiple vertices)
 
 :Before Migration:
 
-.. literalinclude:: migration.queries
-   :start-after: --withpointsdd1
-   :end-before: --withpointsdd2
+Output columns were |result-dij-dd|
 
-* ``driving_side`` parameter is optional.
-* Output columns were |result-generic-no-seq|
+* ``pgr_drivingdistance`` (Single vertex)
 
-  * Depending on the overload used, the columns ``start_vid`` might be missing:
+  * Does not have ``start_vid`` and ``depth`` result columns.
 
-    * ``pgr_withPointsDD`` (`Single vertex`) does not have ``start_vid``
+* ``pgr_drivingdistance`` (Multiple vertices)
+
+  * Has ``from_v`` instead of ``start_vid`` result column.
+  * does not have ``depth`` result column.
 
 :Migration:
 
-* ``driving side`` parameter is compulsory, and valid values differ for directed
-  and undirected graphs.
+* Be aware of the existance and name change of the result columns.
 
-  * Does not have a default value.
+``pgr_drivingdistance`` (Single vertex)
+...............................................................................
 
-  * In directed graph, valid values are [``r``, ``R``, ``l``, ``L``]
+Using `this
+<https://docs.pgrouting.org/3.5/en/pgr_drivingDistance.html#single-vertex>`__
+example.
 
-  * In undirected graph, valid values are [``b``, ``B``]
+* ``start_vid`` contains the **start vid** parameter value.
+* ``depth`` contains the depth of the ``node``.
 
+  .. literalinclude:: migration.queries
+     :start-after: --drivingdistance1
+     :end-before: --drivingdistance2
+
+If needed filter out the added columns, for example, to return the original columns
+
+.. literalinclude:: migration.queries
+   :start-after: --drivingdistance2
+   :end-before: --drivingdistance3
+
+``pgr_drivingdistance`` (Multiple vertices)
+...............................................................................
+
+Using `this
+<https://docs.pgrouting.org/3.5/en/pgr_drivingDistance.html#multiple-vertices>`__
+example.
+
+* The ``from_v`` result column name changes to ``start_vid``.
+* ``depth`` contains the depth of the ``node``.
+
+  .. literalinclude:: migration.queries
+     :start-after: --drivingdistance3
+     :end-before: --drivingdistance4
+
+If needed filter out and rename colums, for example, to return the original
+columns:
+
+.. literalinclude:: migration.queries
+   :start-after: --drivingdistance4
+   :end-before: --drivingdistance5
+
+
+Migration of ``pgr_KSP``
+-------------------------------------------------------------------------------
+
+Starting from `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__
+:doc:`pgr_KSP` result columns are being standarized.
+
+:from: |ksp-result|
+:from: |nksp-result|
+
+Signatures to be migrated:
+
+* ``pgr_KSP`` (One to One)
+
+:Before Migration:
+
+* Output columns were |ksp-result|
+
+  * the columns ``start_vid`` and ``end_vid`` do not exist.
+
+    * ``pgr_KSP`` (One to One) does not have ``start_vid`` and ``end_vid``.
+
+:Migration:
 
 * Be aware of the existance of the additional columns.
 
-* In ``pgr_withPointsDD`` (`Single vertex`)
+``pgr_KSP`` (One to One)
+...............................................................................
 
-  * ``start_vid`` contains the **start vid** parameter value.
-  * ``depth`` contains the **depth** parameter value.
+Using
+`this <https://docs.pgrouting.org/3.5/en/pgr_KSP.html#signatures>`__
+example.
 
-.. literalinclude:: migration.queries
-   :start-after: --withpointsdd2
-   :end-before: --withpointsdd3
-
-* In ``pgr_withPointsDD`` (`Multiple vertices`)
-
-  * ``depth`` contains the **depth** parameter value.
+* ``start_vid`` contains the **start vid** parameter value.
+* ``end_vid`` contains the **end vid** parameter value.
 
 .. literalinclude:: migration.queries
-   :start-after: --withpointsdd3
-   :end-before: --withpointsdd4
+   :start-after: --ksp1
+   :end-before: --ksp2
 
-* If needed filter out the added columns, for example:
+If needed filter out the added columns, for example, to return the original
+columns:
 
 .. literalinclude:: migration.queries
-   :start-after: --withpointsdd4
-   :end-before: --withpointsdd5
-
-* If needed add the new columns, similar to the following example where
-  ``pgr_dijkstra`` is used, and the function had to be modified to be able to
-  return the new columns:
-
-  * In `v3.0 <https://docs.pgrouting.org/3.0/en/contraction-family.html#case-1-both-source-and-target-belong-to-the-contracted-graph>`__
-    the function ``my_dijkstra`` uses ``pgr_dijkstra``.
-  * Starting from `v3.5 <https://docs.pgrouting.org/3.5/en/contraction-family.html#case-1-both-source-and-target-belong-to-the-contracted-graph>`__
-    the function ``my_dijkstra`` returns the new additional columns of
-    ``pgr_dijkstra``.
-
-Migration of functions that change inner query columns names
-*******************************************************************************
-
-.. contents:: Contents
-   :local:
+   :start-after: --ksp2
+   :end-before: --ksp3
 
 Migration of ``pgr_maxCardinalityMatch``
 -------------------------------------------------------------------------------
+
+:doc:`pgr_maxCardinalityMatch` works only for undirected graphs, therefore the
+``directed`` flag has been removed.
 
 Starting from `v3.4.0 <https://docs.pgrouting.org/3.4/en/migration.html>`__
 
@@ -465,6 +403,175 @@ Migration is needed, because:
 .. literalinclude:: migration.queries
    :start-after: --maxcard2
    :end-before: --maxcard3
+
+Migration of ``pgr_withPointsDD``
+-------------------------------------------------------------------------------
+
+Starting from `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__
+:doc:`pgr_withPointsDD` result columns are being standarized.
+
+:from: |result-generic-no-seq|
+:to: |result-bfs|
+
+And ``driving side`` parameter changed from named optional to unnamed compulsory
+**driving side** and its validity differ for directed and undirected graphs.
+
+Signatures to be migrated:
+
+* ``pgr_withPointsDD`` (Single vertex)
+* ``pgr_withPointsDD`` (Multiple vertices)
+
+:Before Migration:
+
+* ``pgr_withPointsDD`` (Single vertex)
+
+  * Output columns were |result-1-1-no-seq|
+  * Does not have ``start_vid`` and ``depth`` result columns.
+  * ``driving_side`` parameter was named optional.
+
+* ``pgr_withPointsDD`` (`Multiple vertices`)
+
+  * Output columns were |result-m-1-no-seq|
+  * Does not have ``depth`` result column.
+  * ``driving_side`` parameter was named optional.
+
+.. rubric:: Driving side was optional
+
+.. literalinclude:: migration.queries
+   :start-after: --withpointsdd1
+   :end-before: --withpointsdd2
+
+.. rubric:: Driving side was named optional
+
+.. literalinclude:: migration.queries
+   :start-after: --withpointsdd2
+   :end-before: --withpointsdd3
+
+.. rubric:: On directed graph ``b`` could be used as **driving side**
+
+.. literalinclude:: migration.queries
+   :start-after: --withpointsdd3
+   :end-before: --withpointsdd4
+
+.. rubric:: On undirected graph ``r`` could be used as **driving side**
+
+.. literalinclude:: migration.queries
+   :start-after: --withpointsdd3
+   :end-before: --withpointsdd4
+
+:After Migration:
+
+* Be aware of the existance of the additional return columns.
+* New output columns are |result-bfs|
+* **driving side** parameter is unnamed compulsory, and valid values differ for
+  directed and undirected graphs.
+
+  * Does not have a default value.
+  * In directed graph: valid values are [``r``, ``R``, ``l``, ``L``]
+  * In undirected graph: valid values are [``b``, ``B``]
+  * Using an invalid value throws an ``ERROR``.
+
+``pgr_withPointsDD`` (Single vertex)
+...............................................................................
+
+Using
+`this <https://docs.pgrouting.org/3.5/en/pgr_withPointsDD.html#single-vertex>`__
+example.
+
+* |result-bfs|
+* ``start_vid`` contains the **start vid** parameter value.
+* ``depth`` contains the **depth** parameter value.
+
+
+To migrate, use an unnamed valid value for **driving side** after the
+**distance** parameter:
+
+.. literalinclude:: migration.queries
+   :start-after: --withpointsdd4
+   :end-before: --withpointsdd5
+
+If needed filter out the additional columns, for example, to return the original columns:
+
+.. literalinclude:: migration.queries
+   :start-after: --withpointsdd5
+   :end-before: --withpointsdd6
+
+``pgr_withPointsDD`` (Multiple vertices)
+...............................................................................
+
+Using
+`this <https://docs.pgrouting.org/3.5/en/pgr_withPointsDD.html#multiple-vertices>`__
+example.
+
+* |result-bfs|
+* ``depth`` contains the **depth** parameter value.
+
+.. literalinclude:: migration.queries
+   :start-after: --withpointsdd6
+   :end-before: --withpointsdd7
+
+If needed filter out the additional columns, for example, to return the original
+columns:
+
+.. literalinclude:: migration.queries
+   :start-after: --withpointsdd7
+   :end-before: --withpointsdd8
+
+Migration of ``pgr_withPointsKSP``
+-------------------------------------------------------------------------------
+
+Starting from `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__
+:doc:`pgr_withPointsKSP` result columns are being standarized.
+
+:from: |ksp-result|
+:from: |nksp-result|
+
+And ``driving side`` parameter changed from named optional to unnamed compulsory
+**driving side** and its validity differ for directed and undirected graphs.
+
+Signatures to be migrated:
+
+* ``pgr_withPointsKSP`` (`One to One`)
+
+:Before Migration:
+
+* Output columns were |old-pid-result|
+
+  * the columns ``start_vid`` and ``end_vid`` do not exist.
+
+
+:Migration:
+
+* Be aware of the existance of the additional return columns.
+* New output columns are |nksp-result|
+* **driving side** parameter is unnamed compulsory, and valid values differ for
+  directed and undirected graphs.
+
+  * Does not have a default value.
+  * In directed graph: valid values are [``r``, ``R``, ``l``, ``L``]
+  * In undirected graph: valid values are [``b``, ``B``]
+  * Using an invalid value throws an ``ERROR``.
+
+``pgr_withPointsKSP`` (`One to One`)
+...............................................................................
+
+Using
+`this <https://docs.pgrouting.org/3.5/en/pgr_withPointsKSP.html#signatures>`__
+example.
+
+* ``start_vid`` contains the **start vid** parameter value.
+* ``end_vid`` contains the **end vid** parameter value.
+
+.. literalinclude:: migration.queries
+   :start-after: --withPointsKSP1
+   :end-before: --withPointsKSP2
+
+If needed filter out the additional columns, for example, to return the original
+columns:
+
+.. literalinclude:: migration.queries
+   :start-after: --withPointsKSP2
+   :end-before: --withPointsKSP3
 
 Migration of turn restrictions
 *******************************************************************************
@@ -588,6 +695,10 @@ The migrated table contents:
 
 Migration of ``pgr_trsp`` (Vertices)
 -------------------------------------------------------------------------------
+
+:doc:`pgr_trsp` signatures have changed and many issues have been fixed in the
+new signatures. This section will show how to migrate from the old signatures to
+the new replacement functions. This also affects the restrictions.
 
 Starting from `v3.4.0 <https://docs.pgrouting.org/3.4/en/migration.html>`__
 
@@ -1122,42 +1233,6 @@ values of the function been migrated then:
 * ``id2`` is the node
 * ``id3`` is the edge
 
-Migration of ``pgr_withPointsKSP``
--------------------------------------------------------------------------------
-
-Starting from `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__
-
-Signatures to be migrated:
-
-* ``pgr_withPointsKSP`` (`One to One`)
-
-:Before Migration:
-
-* Output columns were |old-pid-result|
-
-  * Depending on the overload used, the columns ``start_vid`` and ``end_vid``
-    might be missing:
-
-    * ``pgr_withPointsKSP`` (`One to One`) does not have ``start_vid`` and ``end_vid``.
-
-:Migration:
-
-* Be aware of the existance of the additional columns.
-
-* In ``pgr_withPointsKSP`` (`One to One`)
-
-  * ``start_vid`` contains the **start vid** parameter value.
-  * ``end_vid`` contains the **end vid** parameter value.
-
-.. literalinclude:: migration.queries
-   :start-after: --withPointsKSP1
-   :end-before: --withPointsKSP2
-
-* If needed filter out the added columns, for example:
-
-.. literalinclude:: migration.queries
-   :start-after: --withPointsKSP2
-   :end-before: --withPointsKSP3
 
 See Also
 -------------------------------------------------------------------------------

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -22,6 +22,10 @@ To see the full list of changes check the list of `Git commits
 pgRouting 3.6.0 Release Notes
 -------------------------------------------------------------------------------
 
+To see all issues & pull requests closed by this release see the `Git closed
+milestone for 3.6.0
+<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.6.0%22>`_
+
 .. rubric:: Official functions changes
 
 * `#2516 <https://github.com/pgRouting/pgrouting/pull/2516>`__ Standarize output
@@ -38,87 +42,40 @@ pgRouting 3.6.0 Release Notes
 
   * Standarizing output columns to |short-generic-result|
 
-    * ``pgr_bdAstar`` (`One to One`) added ``start_vid`` and ``end_vid`` columns.
+    * ``pgr_bdAstar`` (`One to One`) added ``start_vid`` and ``end_vid``
+      columns.
     * ``pgr_bdAstar`` (`One to Many`) added ``end_vid`` column.
     * ``pgr_bdAstar`` (`Many to One`) added ``start_vid`` column.
 
-.. rubric:: Proposed functions changes
+* `#2547 <https://github.com/pgRouting/pgrouting/pull/2547>`__ Standarize output
+  and modifying signature pgr_KSP
 
-* `#2544 <https://github.com/pgRouting/pgrouting/pull/2544>`__ Standarize output and modifying signature
-  pgr_withPointsDD
+  .. include:: pgr_KSP.rst
+     :start-after: Version 3.6.0
+     :end-before: .. rubric
 
-  * New proposed signatures: ``driving side`` parameter changed from optional to compulsory
-
-    * ``pgr_withPointsDD`` (`Single vertex`)
-    * ``pgr_withPointsDD`` (`Multiple vertices`)
-
-  * Deprecated signatures:
-
-    * ``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)``
-    * ``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,boolean,boolean)``
-
-  * Standarizing output columns to |result-bfs|
-
-    * ``pgr_withPointsDD`` (`Single vertex`) added ``depth`` and ``start_vid`` column.
-    * ``pgr_withPointsDD`` (`Multiple vertices`) added ``depth`` column.
-
-* `#2546 <https://github.com/pgRouting/pgrouting/pull/2546>`__ Standarize output and modifying signature
-  pgr_withPointsKSP
-
-  * New proposed functions:
-    * ``pgr_withPointsKSP`` (`One to Many`)
-    * ``pgr_withPointsKSP`` (`Many to One`)
-    * ``pgr_withPointsKSP`` (`Many to Many`)
-    * ``pgr_withPointsKSP`` (`Combinations`)
-
-  * New proposed signatures: ``driving side`` parameter changed from optional to compulsory
-
-    * ``pgr_withPointsKSP`` (`One to One`)
-
-  * Deprecated signatures:
-
-    * ``pgr_withpointsksp(text, text, bigint, bigint, integer, boolean, boolean, char, boolean)``
-
-  * Standarizing output columns to |nksp-result|
-
-    * ``pgr_withPointsKSP`` (`One To One`) added ``start_vid`` and ``end_vid`` column.
-
-
-* [#2547](https://github.com/pgRouting/pgrouting/pull/2547) Standarize output and modifying signature
-  pgr_KSP
-
-  * New proposed functions:
-    * ``pgr_KSP`` (`One to Many`)
-    * ``pgr_KSP`` (`Many to One`)
-    * ``pgr_KSP`` (`Many to Many`)
-    * ``pgr_KSP`` (`Combinations`)
-
-  * Deprecated signatures:
-
-    * ``pgr_ksp(text, bigint, bigint, integer, boolean, boolean)``
-
-  * Standarizing output columns to |nksp-result|
-
-    * ``pgr_KSP`` (`One To One`) added ``start_vid`` and ``end_vid`` column.
-
-
-* [#2548](https://github.com/pgRouting/pgrouting/pull/2548) Standarize output and modifying signature
+* `#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ Standarize output
   pgr_drivingdistance
 
-  * New proposed functions:
-    * ``pgr_drivingdistance`` (`Single vertex`)
-    * ``pgr_drivingdistance`` (`Multiple vertices`)
+  .. include:: pgr_drivingDistance.rst
+     :start-after: Version 3.6.0:
+     :end-before: :Version
 
-  * Deprecated signatures:
+.. rubric:: Proposed functions changes
 
-    * ``pgr_drivingdistance(text,anyarray,double precision,boolean,boolean)``
-    * ``pgr_drivingdistance(text,bigint,double precision,boolean,boolean)``
+* `#2544 <https://github.com/pgRouting/pgrouting/pull/2544>`__ Standarize output
+  and modifying signature pgr_withPointsDD
 
-  * Standarizing output columns to |result-bfs|
+  .. include:: pgr_withPointsDD.rst
+     :start-after: Version 3.6.0
+     :end-before: .. rubric
 
-    * ``pgr_drivingdistance`` (`Single vertex`) added ``depth`` and ``start_vid`` column.
-    * ``pgr_drivindistance`` (`Multiple vertices`) added ``depth`` column.
+* `#2546 <https://github.com/pgRouting/pgrouting/pull/2546>`__ Standarize output
+  and modifying signature pgr_withPointsKSP
 
+  .. include:: pgr_withPointsKSP.rst
+     :start-after: Version 3.6.0
+     :end-before: .. rubric
 
 .. rubric:: C/C++ code enhancements
 

--- a/doc/withPoints/pgr_withPointsDD.rst
+++ b/doc/withPoints/pgr_withPointsDD.rst
@@ -24,29 +24,35 @@
 
    Boost Graph Inside
 
+
 .. rubric:: Availability
 
-* Version 3.6.0
+.. rubric:: Version 3.6.0
 
-  * New proposed signatures:
+* Signature change: ``driving_side`` parameter changed from named optional to
+  unnamed compulsory **driving side**.
 
-    * ``pgr_withPointsDD`` (`Single vertex`_)
-    * ``pgr_withPointsDD`` (`Multiple vertices`_)
+  * ``pgr_withPointsDD`` (`Single vertex`)
+  * ``pgr_withPointsDD`` (`Multiple vertices`)
 
-  * Deprecated signatures:
+* Standarizing output columns to |result-bfs|
 
-    * ``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)``
-    * ``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,boolean,boolean)``
+  * ``pgr_withPointsDD`` (`Single vertex`)
 
-  * Standarizing output columns to |result-bfs|
+    * Added ``depth`` and ``start_vid`` column.
 
-    * ``pgr_withPointsDD`` (`Single vertex`_) added ``depth`` and ``start_vid`` column.
-    * ``pgr_withPointsDD`` (`Multiple vertices`_) added ``depth`` column.
+  * ``pgr_withPointsDD`` (`Multiple vertices`)
 
+    * Added ``depth`` column.
 
-* Version 2.2.0
+* Deprecated signatures:
 
-  * New **proposed** function
+  * ``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)``
+  * ``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,boolean,boolean)``
+
+.. rubric:: Version 2.2.0
+
+* New **proposed** function
 
 
 Description

--- a/doc/withPoints/pgr_withPointsKSP.rst
+++ b/doc/withPoints/pgr_withPointsKSP.rst
@@ -26,25 +26,29 @@ pgr_withPointsKSP - Proposed
 
 .. rubric:: Availability
 
-* Version 3.6.0
+.. rubric:: Version 3.6.0
 
-  * New **proposed** function:
+* Standarizing output columns to |nksp-result|
+* ``pgr_withPointsKSP`` (One to One)
 
-    * ``pgr_withPointsKSP`` (`One to Many`_)
-    * ``pgr_withPointsKSP`` (`Many to One`_)
-    * ``pgr_withPointsKSP`` (`Many to Many`_)
-    * ``pgr_withPointsKSP`` (`Combinations`_)
+  * Signature change: ``driving_side`` parameter changed from named optional to
+    unnamed compulsory **driving side**.
+  * Added ``start_vid`` and ``end_vid`` result columns.
 
-  * Standarizing output columns to |nksp-result|
+* New overload functions:
 
-    * ``pgr_withPointsKSP`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns.
+  * ``pgr_withPointsKSP`` (One to Many)
+  * ``pgr_withPointsKSP`` (Many to One)
+  * ``pgr_withPointsKSP`` (Many to Many)
+  * ``pgr_withPointsKSP`` (Combinations)
 
-  * Signature change on ``pgr_withPointsKSP`` (`One to One`_)
+* Deprecated signature:
 
+  * ``pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,boolean)``
 
-* Version 2.2.0
+.. rubric:: Version 2.2.0
 
-  * New **proposed** function
+* New **proposed** function
 
 
 Description

--- a/docqueries/driving_distance/test.conf
+++ b/docqueries/driving_distance/test.conf
@@ -10,9 +10,6 @@
             )],
         'documentation' => [qw(
             pgr_drivingDistance
-            dijksraDD-issue729
-            )],
-        'nottested' => [qw(
             )]
     },
 #    'vpg-vpgis' => {}, # for version specific tests

--- a/docqueries/ksp/doc-ksp.result
+++ b/docqueries/ksp/doc-ksp.result
@@ -22,37 +22,7 @@ SELECT * FROM pgr_KSP(
 
 /* --q2 */
 SELECT * FROM pgr_KSP(
-  'SELECT id, source, target, cost, reverse_cost FROM edges',
-  6, 17, 2,
-  directed => false, heap_paths => true
-);
- seq | path_id | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
------+---------+----------+-----------+---------+------+------+------+----------
-   1 |       1 |        1 |         6 |      17 |    6 |    4 |    1 |        0
-   2 |       1 |        2 |         6 |      17 |    7 |   10 |    1 |        1
-   3 |       1 |        3 |         6 |      17 |    8 |   12 |    1 |        2
-   4 |       1 |        4 |         6 |      17 |   12 |   13 |    1 |        3
-   5 |       1 |        5 |         6 |      17 |   17 |   -1 |    0 |        4
-   6 |       2 |        1 |         6 |      17 |    6 |    4 |    1 |        0
-   7 |       2 |        2 |         6 |      17 |    7 |    8 |    1 |        1
-   8 |       2 |        3 |         6 |      17 |   11 |   11 |    1 |        2
-   9 |       2 |        4 |         6 |      17 |   12 |   13 |    1 |        3
-  10 |       2 |        5 |         6 |      17 |   17 |   -1 |    0 |        4
-  11 |       3 |        1 |         6 |      17 |    6 |    4 |    1 |        0
-  12 |       3 |        2 |         6 |      17 |    7 |    8 |    1 |        1
-  13 |       3 |        3 |         6 |      17 |   11 |    9 |    1 |        2
-  14 |       3 |        4 |         6 |      17 |   16 |   15 |    1 |        3
-  15 |       3 |        5 |         6 |      17 |   17 |   -1 |    0 |        4
-  16 |       4 |        1 |         6 |      17 |    6 |    2 |    1 |        0
-  17 |       4 |        2 |         6 |      17 |   10 |    5 |    1 |        1
-  18 |       4 |        3 |         6 |      17 |   11 |    9 |    1 |        2
-  19 |       4 |        4 |         6 |      17 |   16 |   15 |    1 |        3
-  20 |       4 |        5 |         6 |      17 |   17 |   -1 |    0 |        4
-(20 rows)
-
-/* --q3 */
-SELECT * FROM pgr_KSP(
-  'select id, source, target, cost, reverse_cost from edges', 
+  'select id, source, target, cost, reverse_cost from edges',
   6, ARRAY[10, 17], 2);
  seq | path_id | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
 -----+---------+----------+-----------+---------+------+------+------+----------
@@ -82,9 +52,9 @@ SELECT * FROM pgr_KSP(
   24 |       4 |        5 |         6 |      17 |   17 |   -1 |    0 |        4
 (24 rows)
 
-/* --q4 */
+/* --q3 */
 SELECT * FROM pgr_KSP(
-  'select id, source, target, cost, reverse_cost from edges', 
+  'select id, source, target, cost, reverse_cost from edges',
   ARRAY[6, 1], 17, 2);
  seq | path_id | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
 -----+---------+----------+-----------+---------+------+------+------+----------
@@ -112,7 +82,7 @@ SELECT * FROM pgr_KSP(
   22 |       4 |        5 |         6 |      17 |   17 |   -1 |    0 |        4
 (22 rows)
 
-/* --q5 */
+/* --q4 */
 SELECT * FROM pgr_KSP(
   'select id, source, target, cost, reverse_cost from edges',
   ARRAY[6, 1], ARRAY[10, 17], 2);
@@ -172,7 +142,7 @@ SELECT * FROM pgr_KSP(
   52 |       8 |        5 |         6 |      17 |   17 |   -1 |    0 |        4
 (52 rows)
 
-/* --q6 */
+/* --q5 */
 SELECT * FROM pgr_KSP(
   'SELECT id, source, target, cost, reverse_cost FROM edges',
   'SELECT source, target FROM combinations', 2);
@@ -212,9 +182,39 @@ SELECT * FROM pgr_KSP(
   32 |       6 |        7 |         6 |      15 |   15 |   -1 |    0 |        6
 (32 rows)
 
+/* --q6 */
+SELECT * FROM pgr_KSP(
+  'SELECT id, source, target, cost, reverse_cost FROM edges',
+  6, 17, 2,
+  directed => false, heap_paths => true
+);
+ seq | path_id | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
+-----+---------+----------+-----------+---------+------+------+------+----------
+   1 |       1 |        1 |         6 |      17 |    6 |    4 |    1 |        0
+   2 |       1 |        2 |         6 |      17 |    7 |   10 |    1 |        1
+   3 |       1 |        3 |         6 |      17 |    8 |   12 |    1 |        2
+   4 |       1 |        4 |         6 |      17 |   12 |   13 |    1 |        3
+   5 |       1 |        5 |         6 |      17 |   17 |   -1 |    0 |        4
+   6 |       2 |        1 |         6 |      17 |    6 |    4 |    1 |        0
+   7 |       2 |        2 |         6 |      17 |    7 |    8 |    1 |        1
+   8 |       2 |        3 |         6 |      17 |   11 |   11 |    1 |        2
+   9 |       2 |        4 |         6 |      17 |   12 |   13 |    1 |        3
+  10 |       2 |        5 |         6 |      17 |   17 |   -1 |    0 |        4
+  11 |       3 |        1 |         6 |      17 |    6 |    4 |    1 |        0
+  12 |       3 |        2 |         6 |      17 |    7 |    8 |    1 |        1
+  13 |       3 |        3 |         6 |      17 |   11 |    9 |    1 |        2
+  14 |       3 |        4 |         6 |      17 |   16 |   15 |    1 |        3
+  15 |       3 |        5 |         6 |      17 |   17 |   -1 |    0 |        4
+  16 |       4 |        1 |         6 |      17 |    6 |    2 |    1 |        0
+  17 |       4 |        2 |         6 |      17 |   10 |    5 |    1 |        1
+  18 |       4 |        3 |         6 |      17 |   11 |    9 |    1 |        2
+  19 |       4 |        4 |         6 |      17 |   16 |   15 |    1 |        3
+  20 |       4 |        5 |         6 |      17 |   17 |   -1 |    0 |        4
+(20 rows)
+
 /* --q7 */
 SELECT * FROM pgr_KSP(
-  'SELECT id, source, target, cost, reverse_cost FROM edges', 
+  'SELECT id, source, target, cost, reverse_cost FROM edges',
   'SELECT source, target FROM combinations', 2, directed => false, heap_paths => true);
  seq | path_id | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
 -----+---------+----------+-----------+---------+------+------+------+----------
@@ -247,7 +247,7 @@ SELECT * FROM pgr_KSP(
 
 /* --q8 */
 SELECT * FROM pgr_KSP(
-  'select id, source, target, cost, reverse_cost from edges', 
+  'select id, source, target, cost, reverse_cost from edges',
   ARRAY[6, 1], 17, 2, directed => false);
  seq | path_id | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
 -----+---------+----------+-----------+---------+------+------+------+----------

--- a/docqueries/ksp/doc-ksp.test.sql
+++ b/docqueries/ksp/doc-ksp.test.sql
@@ -6,33 +6,33 @@ SELECT * FROM pgr_KSP(
   6, 17, 2);
 /* --q2 */
 SELECT * FROM pgr_KSP(
+  'select id, source, target, cost, reverse_cost from edges',
+  6, ARRAY[10, 17], 2);
+/* --q3 */
+SELECT * FROM pgr_KSP(
+  'select id, source, target, cost, reverse_cost from edges',
+  ARRAY[6, 1], 17, 2);
+/* --q4 */
+SELECT * FROM pgr_KSP(
+  'select id, source, target, cost, reverse_cost from edges',
+  ARRAY[6, 1], ARRAY[10, 17], 2);
+/* --q5 */
+SELECT * FROM pgr_KSP(
+  'SELECT id, source, target, cost, reverse_cost FROM edges',
+  'SELECT source, target FROM combinations', 2);
+/* --q6 */
+SELECT * FROM pgr_KSP(
   'SELECT id, source, target, cost, reverse_cost FROM edges',
   6, 17, 2,
   directed => false, heap_paths => true
 );
-/* --q3 */
-SELECT * FROM pgr_KSP(
-  'select id, source, target, cost, reverse_cost from edges', 
-  6, ARRAY[10, 17], 2);
-/* --q4 */
-SELECT * FROM pgr_KSP(
-  'select id, source, target, cost, reverse_cost from edges', 
-  ARRAY[6, 1], 17, 2);
-/* --q5 */
-SELECT * FROM pgr_KSP(
-  'select id, source, target, cost, reverse_cost from edges',
-  ARRAY[6, 1], ARRAY[10, 17], 2);
-/* --q6 */
-SELECT * FROM pgr_KSP(
-  'SELECT id, source, target, cost, reverse_cost FROM edges', 
-  'SELECT source, target FROM combinations', 2);
 /* --q7 */
 SELECT * FROM pgr_KSP(
-  'SELECT id, source, target, cost, reverse_cost FROM edges', 
+  'SELECT id, source, target, cost, reverse_cost FROM edges',
   'SELECT source, target FROM combinations', 2, directed => false, heap_paths => true);
 /* --q8 */
 SELECT * FROM pgr_KSP(
-  'select id, source, target, cost, reverse_cost from edges', 
+  'select id, source, target, cost, reverse_cost from edges',
   ARRAY[6, 1], 17, 2, directed => false);
 /* --q9 */
 SELECT * FROM pgr_KSP(

--- a/docqueries/src/migration.result
+++ b/docqueries/src/migration.result
@@ -789,119 +789,168 @@ SELECT seq, path_seq, node, edge, cost, agg_cost FROM pgr_bdAstar(
 SELECT * FROM pgr_withPointsDD(
   $$SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id$$,
   $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
-  -5, 2.3,
-  driving_side => 'r');
+  -1, 3.3);
 WARNING:  pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean) is been deprecated
  seq | node | edge | cost | agg_cost
 -----+------+------+------+----------
-   1 |   -5 |   -1 |    0 |        0
-   2 |   11 |    5 |  0.2 |      0.2
-   3 |    7 |    8 |    1 |      1.2
-   4 |   12 |   11 |    1 |      1.2
-   5 |   16 |    9 |    1 |      1.2
-   6 |    3 |    7 |    1 |      2.2
-   7 |    6 |    4 |    1 |      2.2
-   8 |    8 |   10 |    1 |      2.2
-   9 |   15 |   16 |    1 |      2.2
-  10 |   17 |   13 |    1 |      2.2
-(10 rows)
+   1 |   -1 |   -1 |    0 |        0
+   2 |    5 |    1 |  0.4 |      0.4
+   3 |    6 |    1 |    1 |      1.4
+   4 |    7 |    4 |    1 |      2.4
+(4 rows)
 
 /* --withpointsdd2 */
 SELECT * FROM pgr_withPointsDD(
   $$SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id$$,
   $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
-  -5, 2.3, 'r');
- seq | depth | start_vid | node | edge | cost | agg_cost
------+-------+-----------+------+------+------+----------
-   1 |     0 |        -5 |   -5 |   -1 |    0 |        0
-   2 |     1 |        -5 |   11 |    5 |  0.2 |      0.2
-   3 |     2 |        -5 |    7 |    8 |    1 |      1.2
-   4 |     2 |        -5 |   12 |   11 |    1 |      1.2
-   5 |     2 |        -5 |   16 |    9 |    1 |      1.2
-   6 |     3 |        -5 |    3 |    7 |    1 |      2.2
-   7 |     3 |        -5 |    6 |    4 |    1 |      2.2
-   8 |     3 |        -5 |    8 |   10 |    1 |      2.2
-   9 |     3 |        -5 |   15 |   16 |    1 |      2.2
-  10 |     3 |        -5 |   17 |   13 |    1 |      2.2
-(10 rows)
+  -1, 3.3, driving_side => 'r');
+WARNING:  pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean) is been deprecated
+ seq | node | edge | cost | agg_cost
+-----+------+------+------+----------
+   1 |   -1 |   -1 |    0 |        0
+   2 |    5 |    1 |  0.4 |      0.4
+   3 |    6 |    1 |    1 |      1.4
+   4 |    7 |    4 |    1 |      2.4
+(4 rows)
 
 /* --withpointsdd3 */
 SELECT * FROM pgr_withPointsDD(
   $$SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id$$,
   $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
-  ARRAY[-3, 16], 3.3, 'r');
- seq | depth | start_vid | node | edge | cost | agg_cost
------+-------+-----------+------+------+------+----------
-   1 |     0 |        -3 |   -3 |   -1 |    0 |        0
-   2 |     1 |        -3 |   12 |   12 |  0.4 |      0.4
-   3 |     2 |        -3 |   17 |   13 |    1 |      1.4
-   4 |     3 |        -3 |   16 |   15 |    1 |      2.4
-   5 |     0 |        16 |   16 |   -1 |    0 |        0
-   6 |     1 |        16 |   11 |    9 |    1 |        1
-   7 |     1 |        16 |   15 |   16 |    1 |        1
-   8 |     1 |        16 |   17 |   15 |    1 |        1
-   9 |     2 |        16 |    7 |    8 |    1 |        2
-  10 |     2 |        16 |   10 |    3 |    1 |        2
-  11 |     2 |        16 |   12 |   11 |    1 |        2
-  12 |     3 |        16 |    3 |    7 |    1 |        3
-  13 |     3 |        16 |    6 |    2 |    1 |        3
-  14 |     3 |        16 |    8 |   10 |    1 |        3
-(14 rows)
+  -1, 3.3, directed => false, driving_side => 'r');
+WARNING:  pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean) is been deprecated
+ seq | node | edge | cost | agg_cost
+-----+------+------+------+----------
+   1 |   -1 |   -1 |    0 |        0
+   2 |    5 |    1 |  0.4 |      0.4
+   3 |    6 |    1 |  0.6 |      0.6
+   4 |    7 |    4 |    1 |      1.6
+   5 |   10 |    2 |    1 |      1.6
+   6 |    3 |    7 |    1 |      2.6
+   7 |    8 |   10 |    1 |      2.6
+   8 |   11 |    8 |    1 |      2.6
+   9 |   15 |    3 |    1 |      2.6
+(9 rows)
 
 /* --withpointsdd4 */
+SELECT * FROM pgr_withPointsDD(
+  $$SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id$$,
+  $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
+  -1, 3.3, 'r', details => true);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |        -1 |   -1 |   -1 |    0 |        0
+   2 |     1 |        -1 |    5 |    1 |  0.4 |      0.4
+   3 |     2 |        -1 |    6 |    1 |    1 |      1.4
+   4 |     3 |        -1 |   -6 |    4 |  0.7 |      2.1
+   5 |     4 |        -1 |    7 |    4 |  0.3 |      2.4
+(5 rows)
+
+/* --withpointsdd5 */
 SELECT seq, node, edge, cost, agg_cost FROM pgr_withPointsDD(
   $$SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id$$,
   $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
-  -5, 2.3, 'r');
+  -1, 3.3, 'r', details => true);
  seq | node | edge | cost | agg_cost
 -----+------+------+------+----------
-   1 |   -5 |   -1 |    0 |        0
-   2 |   11 |    5 |  0.2 |      0.2
-   3 |    7 |    8 |    1 |      1.2
-   4 |   12 |   11 |    1 |      1.2
-   5 |   16 |    9 |    1 |      1.2
-   6 |    3 |    7 |    1 |      2.2
-   7 |    6 |    4 |    1 |      2.2
-   8 |    8 |   10 |    1 |      2.2
-   9 |   15 |   16 |    1 |      2.2
-  10 |   17 |   13 |    1 |      2.2
-(10 rows)
+   1 |   -1 |   -1 |    0 |        0
+   2 |    5 |    1 |  0.4 |      0.4
+   3 |    6 |    1 |    1 |      1.4
+   4 |   -6 |    4 |  0.7 |      2.1
+   5 |    7 |    4 |  0.3 |      2.4
+(5 rows)
 
-/* --withpointsdd5 */
+/* --withpointsdd6 */
+SELECT * FROM pgr_withPointsDD(
+  $$SELECT * FROM edges ORDER BY id$$,
+  $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
+  ARRAY[-1, 16], 3.3, 'l', equicost => true);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |        -1 |   -1 |   -1 |    0 |        0
+   2 |     1 |        -1 |    6 |    1 |  0.6 |      0.6
+   3 |     2 |        -1 |    7 |    4 |    1 |      1.6
+   4 |     2 |        -1 |    5 |    1 |    1 |      1.6
+   5 |     3 |        -1 |    3 |    7 |    1 |      2.6
+   6 |     3 |        -1 |    8 |   10 |    1 |      2.6
+   7 |     0 |        16 |   16 |   -1 |    0 |        0
+   8 |     1 |        16 |   11 |    9 |    1 |        1
+   9 |     1 |        16 |   15 |   16 |    1 |        1
+  10 |     1 |        16 |   17 |   15 |    1 |        1
+  11 |     2 |        16 |   10 |    3 |    1 |        2
+  12 |     2 |        16 |   12 |   11 |    1 |        2
+(12 rows)
+
+/* --withpointsdd7 */
+SELECT seq, start_vid, node, edge, cost, agg_cost FROM pgr_withPointsDD(
+  $$SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id$$,
+  $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
+  ARRAY[-1, 16], 3.3, 'l', equicost => true);
+ seq | start_vid | node | edge | cost | agg_cost
+-----+-----------+------+------+------+----------
+   1 |        -1 |   -1 |   -1 |    0 |        0
+   2 |        -1 |    6 |    1 |  0.6 |      0.6
+   3 |        -1 |    7 |    4 |    1 |      1.6
+   4 |        -1 |    5 |    1 |    1 |      1.6
+   5 |        -1 |    3 |    7 |    1 |      2.6
+   6 |        -1 |    8 |   10 |    1 |      2.6
+   7 |        16 |   16 |   -1 |    0 |        0
+   8 |        16 |   11 |    9 |    1 |        1
+   9 |        16 |   15 |   16 |    1 |        1
+  10 |        16 |   17 |   15 |    1 |        1
+  11 |        16 |   10 |    3 |    1 |        2
+  12 |        16 |   12 |   11 |    1 |        2
+(12 rows)
+
+/* --withpointsdd8 */
 /* --withPointsKSP1 */
 SELECT * FROM pgr_withPointsKSP(
   $$SELECT id, source, target, cost, reverse_cost FROM edges$$,
   $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
-  6, 10, 1,'r');
+  -1, -2, 2, 'l');
  seq | path_id | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
 -----+---------+----------+-----------+---------+------+------+------+----------
-   1 |       1 |        1 |         6 |      10 |    6 |    4 |    1 |        0
-   2 |       1 |        2 |         6 |      10 |    7 |    8 |    1 |        1
-   3 |       1 |        3 |         6 |      10 |   11 |    9 |    1 |        2
-   4 |       1 |        4 |         6 |      10 |   16 |   16 |    1 |        3
-   5 |       1 |        5 |         6 |      10 |   15 |    3 |    1 |        4
-   6 |       1 |        6 |         6 |      10 |   10 |   -1 |    0 |        5
-(6 rows)
+   1 |       1 |        1 |        -1 |      -2 |   -1 |    1 |  0.6 |        0
+   2 |       1 |        2 |        -1 |      -2 |    6 |    4 |    1 |      0.6
+   3 |       1 |        3 |        -1 |      -2 |    7 |    8 |    1 |      1.6
+   4 |       1 |        4 |        -1 |      -2 |   11 |   11 |    1 |      2.6
+   5 |       1 |        5 |        -1 |      -2 |   12 |   13 |    1 |      3.6
+   6 |       1 |        6 |        -1 |      -2 |   17 |   15 |  0.6 |      4.6
+   7 |       1 |        7 |        -1 |      -2 |   -2 |   -1 |    0 |      5.2
+   8 |       2 |        1 |        -1 |      -2 |   -1 |    1 |  0.6 |        0
+   9 |       2 |        2 |        -1 |      -2 |    6 |    4 |    1 |      0.6
+  10 |       2 |        3 |        -1 |      -2 |    7 |    8 |    1 |      1.6
+  11 |       2 |        4 |        -1 |      -2 |   11 |    9 |    1 |      2.6
+  12 |       2 |        5 |        -1 |      -2 |   16 |   15 |  1.6 |      3.6
+  13 |       2 |        6 |        -1 |      -2 |   -2 |   -1 |    0 |      5.2
+(13 rows)
 
 /* --withPointsKSP2 */
-SELECT seq, path_seq, node, edge, cost, agg_cost FROM pgr_withPointsKSP(
+SELECT seq, path_id, path_seq, node, edge, cost, agg_cost FROM pgr_withPointsKSP(
   $$SELECT id, source, target, cost, reverse_cost FROM edges$$,
   $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
-  6, 10, 1,'r');
- seq | path_seq | node | edge | cost | agg_cost
------+----------+------+------+------+----------
-   1 |        1 |    6 |    4 |    1 |        0
-   2 |        2 |    7 |    8 |    1 |        1
-   3 |        3 |   11 |    9 |    1 |        2
-   4 |        4 |   16 |   16 |    1 |        3
-   5 |        5 |   15 |    3 |    1 |        4
-   6 |        6 |   10 |   -1 |    0 |        5
-(6 rows)
+  -1, -2, 2, 'l');
+ seq | path_id | path_seq | node | edge | cost | agg_cost
+-----+---------+----------+------+------+------+----------
+   1 |       1 |        1 |   -1 |    1 |  0.6 |        0
+   2 |       1 |        2 |    6 |    4 |    1 |      0.6
+   3 |       1 |        3 |    7 |    8 |    1 |      1.6
+   4 |       1 |        4 |   11 |   11 |    1 |      2.6
+   5 |       1 |        5 |   12 |   13 |    1 |      3.6
+   6 |       1 |        6 |   17 |   15 |  0.6 |      4.6
+   7 |       1 |        7 |   -2 |   -1 |    0 |      5.2
+   8 |       2 |        1 |   -1 |    1 |  0.6 |        0
+   9 |       2 |        2 |    6 |    4 |    1 |      0.6
+  10 |       2 |        3 |    7 |    8 |    1 |      1.6
+  11 |       2 |        4 |   11 |    9 |    1 |      2.6
+  12 |       2 |        5 |   16 |   15 |  1.6 |      3.6
+  13 |       2 |        6 |   -2 |   -1 |    0 |      5.2
+(13 rows)
 
 /* --withPointsKSP3 */
 /* --ksp1 */
 SELECT * FROM pgr_KSP(
-  'SELECT id, source, target, cost, reverse_cost FROM edges',
+  $$SELECT id, source, target, cost, reverse_cost FROM edges$$,
   6, 17, 2);
  seq | path_id | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
 -----+---------+----------+-----------+---------+------+------+------+----------
@@ -919,7 +968,7 @@ SELECT * FROM pgr_KSP(
 
 /* --ksp2 */
 SELECT seq, path_id, path_seq, node, edge, cost, agg_cost FROM pgr_KSP(
-  'SELECT id, source, target, cost, reverse_cost FROM edges',
+  $$SELECT id, source, target, cost, reverse_cost FROM edges$$,
   6, 17, 2);
  seq | path_id | path_seq | node | edge | cost | agg_cost
 -----+---------+----------+------+------+------+----------
@@ -939,73 +988,90 @@ SELECT seq, path_id, path_seq, node, edge, cost, agg_cost FROM pgr_KSP(
 /* --drivingdistance1 */
 SELECT * FROM pgr_drivingDistance(
   $$SELECT id, source, target, cost, reverse_cost FROM edges$$,
-  7, 2.0);
+  11, 3.0);
  seq | depth | start_vid | node | edge | cost | agg_cost
 -----+-------+-----------+------+------+------+----------
-   1 |     0 |         7 |    7 |   -1 |    0 |        0
-   2 |     1 |         7 |    3 |    7 |    1 |        1
-   3 |     1 |         7 |    6 |    4 |    1 |        1
-   4 |     1 |         7 |    8 |   10 |    1 |        1
-   5 |     1 |         7 |   11 |    8 |    1 |        1
-   6 |     2 |         7 |    1 |    6 |    1 |        2
-   7 |     2 |         7 |    5 |    1 |    1 |        2
-   8 |     2 |         7 |    9 |   14 |    1 |        2
-   9 |     2 |         7 |   12 |   12 |    1 |        2
-  10 |     2 |         7 |   16 |    9 |    1 |        2
-(10 rows)
+   1 |     0 |        11 |   11 |   -1 |    0 |        0
+   2 |     1 |        11 |    7 |    8 |    1 |        1
+   3 |     1 |        11 |   12 |   11 |    1 |        1
+   4 |     1 |        11 |   16 |    9 |    1 |        1
+   5 |     2 |        11 |    3 |    7 |    1 |        2
+   6 |     2 |        11 |    6 |    4 |    1 |        2
+   7 |     2 |        11 |    8 |   10 |    1 |        2
+   8 |     2 |        11 |   15 |   16 |    1 |        2
+   9 |     2 |        11 |   17 |   15 |    1 |        2
+  10 |     3 |        11 |    1 |    6 |    1 |        3
+  11 |     3 |        11 |    5 |    1 |    1 |        3
+  12 |     3 |        11 |    9 |   14 |    1 |        3
+  13 |     3 |        11 |   10 |    3 |    1 |        3
+(13 rows)
 
 /* --drivingdistance2 */
-SELECT * FROM pgr_drivingDistance(
+SELECT seq, node, edge, cost, agg_cost
+FROM pgr_drivingDistance(
   $$SELECT id, source, target, cost, reverse_cost FROM edges$$,
-  array[7, 16], 2.0, directed => false);
- seq | depth | start_vid | node | edge | cost | agg_cost
------+-------+-----------+------+------+------+----------
-   1 |     0 |         7 |    7 |   -1 |    0 |        0
-   2 |     1 |         7 |    3 |    7 |    1 |        1
-   3 |     1 |         7 |    6 |    4 |    1 |        1
-   4 |     1 |         7 |    8 |   10 |    1 |        1
-   5 |     1 |         7 |   11 |    8 |    1 |        1
-   6 |     2 |         7 |    1 |    6 |    1 |        2
-   7 |     2 |         7 |    5 |    1 |    1 |        2
-   8 |     2 |         7 |    9 |   14 |    1 |        2
-   9 |     2 |         7 |   10 |    2 |    1 |        2
-  10 |     2 |         7 |   12 |   12 |    1 |        2
-  11 |     2 |         7 |   16 |    9 |    1 |        2
-  12 |     0 |        16 |   16 |   -1 |    0 |        0
-  13 |     1 |        16 |   11 |    9 |    1 |        1
-  14 |     1 |        16 |   15 |   16 |    1 |        1
-  15 |     1 |        16 |   17 |   15 |    1 |        1
-  16 |     2 |        16 |    7 |    8 |    1 |        2
-  17 |     2 |        16 |   10 |    5 |    1 |        2
-  18 |     2 |        16 |   12 |   13 |    1 |        2
-(18 rows)
+  11, 3.0);
+ seq | node | edge | cost | agg_cost
+-----+------+------+------+----------
+   1 |   11 |   -1 |    0 |        0
+   2 |    7 |    8 |    1 |        1
+   3 |   12 |   11 |    1 |        1
+   4 |   16 |    9 |    1 |        1
+   5 |    3 |    7 |    1 |        2
+   6 |    6 |    4 |    1 |        2
+   7 |    8 |   10 |    1 |        2
+   8 |   15 |   16 |    1 |        2
+   9 |   17 |   15 |    1 |        2
+  10 |    1 |    6 |    1 |        3
+  11 |    5 |    1 |    1 |        3
+  12 |    9 |   14 |    1 |        3
+  13 |   10 |    3 |    1 |        3
+(13 rows)
 
 /* --drivingdistance3 */
-SELECT seq, start_vid, node, edge, cost, agg_cost FROM pgr_drivingDistance(
+SELECT *
+FROM pgr_drivingDistance(
   $$SELECT id, source, target, cost, reverse_cost FROM edges$$,
-  array[7, 16], 2.0, directed => false);
- seq | start_vid | node | edge | cost | agg_cost
------+-----------+------+------+------+----------
-   1 |         7 |    7 |   -1 |    0 |        0
-   2 |         7 |    3 |    7 |    1 |        1
-   3 |         7 |    6 |    4 |    1 |        1
-   4 |         7 |    8 |   10 |    1 |        1
-   5 |         7 |   11 |    8 |    1 |        1
-   6 |         7 |    1 |    6 |    1 |        2
-   7 |         7 |    5 |    1 |    1 |        2
-   8 |         7 |    9 |   14 |    1 |        2
-   9 |         7 |   10 |    2 |    1 |        2
-  10 |         7 |   12 |   12 |    1 |        2
-  11 |         7 |   16 |    9 |    1 |        2
-  12 |        16 |   16 |   -1 |    0 |        0
-  13 |        16 |   11 |    9 |    1 |        1
-  14 |        16 |   15 |   16 |    1 |        1
-  15 |        16 |   17 |   15 |    1 |        1
-  16 |        16 |    7 |    8 |    1 |        2
-  17 |        16 |   10 |    5 |    1 |        2
-  18 |        16 |   12 |   13 |    1 |        2
-(18 rows)
+  ARRAY[11, 16], 3.0, equicost => true);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |        11 |   11 |   -1 |    0 |        0
+   2 |     1 |        11 |    7 |    8 |    1 |        1
+   3 |     1 |        11 |   12 |   11 |    1 |        1
+   4 |     2 |        11 |    3 |    7 |    1 |        2
+   5 |     2 |        11 |    6 |    4 |    1 |        2
+   6 |     2 |        11 |    8 |   10 |    1 |        2
+   7 |     3 |        11 |    1 |    6 |    1 |        3
+   8 |     3 |        11 |    5 |    1 |    1 |        3
+   9 |     3 |        11 |    9 |   14 |    1 |        3
+  10 |     0 |        16 |   16 |   -1 |    0 |        0
+  11 |     1 |        16 |   15 |   16 |    1 |        1
+  12 |     1 |        16 |   17 |   15 |    1 |        1
+  13 |     2 |        16 |   10 |    3 |    1 |        2
+(13 rows)
 
 /* --drivingdistance4 */
+SELECT seq, start_vid AS from_v, node, edge, cost, agg_cost
+FROM pgr_drivingDistance(
+  $$SELECT id, source, target, cost, reverse_cost FROM edges$$,
+  ARRAY[11, 16], 3.0, equicost => true);
+ seq | from_v | node | edge | cost | agg_cost
+-----+--------+------+------+------+----------
+   1 |     11 |   11 |   -1 |    0 |        0
+   2 |     11 |    7 |    8 |    1 |        1
+   3 |     11 |   12 |   11 |    1 |        1
+   4 |     11 |    3 |    7 |    1 |        2
+   5 |     11 |    6 |    4 |    1 |        2
+   6 |     11 |    8 |   10 |    1 |        2
+   7 |     11 |    1 |    6 |    1 |        3
+   8 |     11 |    5 |    1 |    1 |        3
+   9 |     11 |    9 |   14 |    1 |        3
+  10 |     16 |   16 |   -1 |    0 |        0
+  11 |     16 |   15 |   16 |    1 |        1
+  12 |     16 |   17 |   15 |    1 |        1
+  13 |     16 |   10 |    3 |    1 |        2
+(13 rows)
+
+/* --drivingdistance5 */
 ROLLBACK;
 ROLLBACK

--- a/docqueries/src/migration.test.sql
+++ b/docqueries/src/migration.test.sql
@@ -265,55 +265,76 @@ SELECT seq, path_seq, node, edge, cost, agg_cost FROM pgr_bdAstar(
 SELECT * FROM pgr_withPointsDD(
   $$SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id$$,
   $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
-  -5, 2.3,
-  driving_side => 'r');
+  -1, 3.3);
 /* --withpointsdd2 */
 SELECT * FROM pgr_withPointsDD(
   $$SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id$$,
   $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
-  -5, 2.3, 'r');
+  -1, 3.3, driving_side => 'r');
 /* --withpointsdd3 */
 SELECT * FROM pgr_withPointsDD(
   $$SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id$$,
   $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
-  ARRAY[-3, 16], 3.3, 'r');
+  -1, 3.3, directed => false, driving_side => 'r');
 /* --withpointsdd4 */
+SELECT * FROM pgr_withPointsDD(
+  $$SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id$$,
+  $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
+  -1, 3.3, 'r', details => true);
+/* --withpointsdd5 */
 SELECT seq, node, edge, cost, agg_cost FROM pgr_withPointsDD(
   $$SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id$$,
   $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
-  -5, 2.3, 'r');
-/* --withpointsdd5 */
+  -1, 3.3, 'r', details => true);
+/* --withpointsdd6 */
+SELECT * FROM pgr_withPointsDD(
+  $$SELECT * FROM edges ORDER BY id$$,
+  $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
+  ARRAY[-1, 16], 3.3, 'l', equicost => true);
+/* --withpointsdd7 */
+SELECT seq, start_vid, node, edge, cost, agg_cost FROM pgr_withPointsDD(
+  $$SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id$$,
+  $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
+  ARRAY[-1, 16], 3.3, 'l', equicost => true);
+/* --withpointsdd8 */
 /* --withPointsKSP1 */
 SELECT * FROM pgr_withPointsKSP(
   $$SELECT id, source, target, cost, reverse_cost FROM edges$$,
   $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
-  6, 10, 1,'r');
+  -1, -2, 2, 'l');
 /* --withPointsKSP2 */
-SELECT seq, path_seq, node, edge, cost, agg_cost FROM pgr_withPointsKSP(
+SELECT seq, path_id, path_seq, node, edge, cost, agg_cost FROM pgr_withPointsKSP(
   $$SELECT id, source, target, cost, reverse_cost FROM edges$$,
   $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
-  6, 10, 1,'r');
+  -1, -2, 2, 'l');
 /* --withPointsKSP3 */
 /* --ksp1 */
 SELECT * FROM pgr_KSP(
-  'SELECT id, source, target, cost, reverse_cost FROM edges',
+  $$SELECT id, source, target, cost, reverse_cost FROM edges$$,
   6, 17, 2);
 /* --ksp2 */
 SELECT seq, path_id, path_seq, node, edge, cost, agg_cost FROM pgr_KSP(
-  'SELECT id, source, target, cost, reverse_cost FROM edges',
+  $$SELECT id, source, target, cost, reverse_cost FROM edges$$,
   6, 17, 2);
 /* --ksp3 */
 /* --drivingdistance1 */
 SELECT * FROM pgr_drivingDistance(
   $$SELECT id, source, target, cost, reverse_cost FROM edges$$,
-  7, 2.0);
+  11, 3.0);
 /* --drivingdistance2 */
-SELECT * FROM pgr_drivingDistance(
+SELECT seq, node, edge, cost, agg_cost
+FROM pgr_drivingDistance(
   $$SELECT id, source, target, cost, reverse_cost FROM edges$$,
-  array[7, 16], 2.0, directed => false);
+  11, 3.0);
 /* --drivingdistance3 */
-SELECT seq, start_vid, node, edge, cost, agg_cost FROM pgr_drivingDistance(
+SELECT *
+FROM pgr_drivingDistance(
   $$SELECT id, source, target, cost, reverse_cost FROM edges$$,
-  array[7, 16], 2.0, directed => false);
+  ARRAY[11, 16], 3.0, equicost => true);
 /* --drivingdistance4 */
+SELECT seq, start_vid AS from_v, node, edge, cost, agg_cost
+FROM pgr_drivingDistance(
+  $$SELECT id, source, target, cost, reverse_cost FROM edges$$,
+  ARRAY[11, 16], 3.0, equicost => true);
+/* --drivingdistance5 */
 

--- a/docqueries/withPoints/doc-pgr_withPointsKSP.result
+++ b/docqueries/withPoints/doc-pgr_withPointsKSP.result
@@ -59,7 +59,7 @@ SELECT * FROM pgr_withPointsKSP(
 SELECT * FROM pgr_withPointsKSP(
   'SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id',
   'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-  ARRAY[-1, 6], -3, 1,'r', details:= true);
+  ARRAY[-1, 6], -3, 1, 'r', details=> true);
  seq | path_id | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
 -----+---------+----------+-----------+---------+------+------+------+----------
    1 |       1 |        1 |        -1 |      -3 |   -1 |    1 |  0.4 |        0
@@ -80,7 +80,7 @@ SELECT * FROM pgr_withPointsKSP(
 SELECT * FROM pgr_withPointsKSP(
   'SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id',
   'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-  ARRAY[-1, 6], ARRAY[-3, 1], 1, 'l', heap_paths:= true);
+  ARRAY[-1, 6], ARRAY[-3, 1], 1, 'l', heap_paths => true);
  seq | path_id | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
 -----+---------+----------+-----------+---------+------+------+------+----------
    1 |       1 |        1 |        -1 |      -3 |   -1 |    1 |  0.6 |        0
@@ -174,7 +174,7 @@ SELECT * FROM pgr_withPointsKSP(
 SELECT * FROM pgr_withPointsKSP(
     'SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id',
     'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    -1, -3, 2, 'l', details := true);
+    -1, -3, 2, 'l', details => true);
  seq | path_id | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
 -----+---------+----------+-----------+---------+------+------+------+----------
    1 |       1 |        1 |        -1 |      -3 |   -1 |    1 |  0.6 |        0
@@ -190,7 +190,7 @@ SELECT * FROM pgr_withPointsKSP(
     'SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id',
     'SELECT pid, edge_id, fraction, side from pointsOfInterest',
     -1, -2, 2, 'r',
-    heap_paths := true, details := true);
+    heap_paths => true, details => true);
  seq | path_id | path_seq | start_vid | end_vid | node | edge | cost | agg_cost
 -----+---------+----------+-----------+---------+------+------+------+----------
    1 |       1 |        1 |        -1 |      -2 |   -1 |    1 |  0.4 |        0

--- a/docqueries/withPoints/doc-pgr_withPointsKSP.test.sql
+++ b/docqueries/withPoints/doc-pgr_withPointsKSP.test.sql
@@ -16,12 +16,12 @@ SELECT * FROM pgr_withPointsKSP(
 SELECT * FROM pgr_withPointsKSP(
   'SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id',
   'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-  ARRAY[-1, 6], -3, 1,'r', details:= true);
+  ARRAY[-1, 6], -3, 1, 'r', details=> true);
 /* --q4 */
 SELECT * FROM pgr_withPointsKSP(
   'SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id',
   'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-  ARRAY[-1, 6], ARRAY[-3, 1], 1, 'l', heap_paths:= true);
+  ARRAY[-1, 6], ARRAY[-3, 1], 1, 'l', heap_paths => true);
 /* --q5 */
 SELECT * FROM pgr_withPointsKSP(
   'SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id',
@@ -42,11 +42,11 @@ SELECT * FROM pgr_withPointsKSP(
 SELECT * FROM pgr_withPointsKSP(
     'SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id',
     'SELECT pid, edge_id, fraction, side from pointsOfInterest',
-    -1, -3, 2, 'l', details := true);
+    -1, -3, 2, 'l', details => true);
 /* --q8 */
 SELECT * FROM pgr_withPointsKSP(
     'SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id',
     'SELECT pid, edge_id, fraction, side from pointsOfInterest',
     -1, -2, 2, 'r',
-    heap_paths := true, details := true);
+    heap_paths => true, details => true);
 /* --q9 */

--- a/include/dijkstra/drivingDist.hpp
+++ b/include/dijkstra/drivingDist.hpp
@@ -2,16 +2,19 @@
 
 file: drivingDist.hpp
 
-Generated with Template by:                                                                                             
-Copyright (c) 2023 pgRouting developers                                                                                 
-Mail: project AT pgrouting.org   
+Copyright (c) 2015 pgRouting developers
+Mail: project@pgrouting.org
 
-Copyright (c) 2023 Aryan Gupta
-guptaaryan1010 AT gmail.com
+Copyright (c) 2022 Celia Virginia Vergara Castillo
+Copyright (c) 2015 Celia Virginia Vergara Castillo
+vicky at erosion.dev
 
 Copyright (c) 2020 The combinations_sql signature is added by Mahmoud SAKR
 and Esteban ZIMANYI
 mail: m_attia_sakri at yahoo.com, estebanzimanyi at gmail.com
+
+Copyright (c) 2023 Aryan Gupta
+guptaaryan1010 AT gmail.com
 
 ------
 

--- a/include/drivers/driving_distance/drivedist_driver.h
+++ b/include/drivers/driving_distance/drivedist_driver.h
@@ -1,9 +1,8 @@
 /*PGR-GNU*****************************************************************
 File: drivedist_driver.h
 
-Generated with Template by:                                                                                             
-Copyright (c) 2023 pgRouting developers                                                                                 
-Mail: project AT pgrouting.org   
+Copyright (c) 2015 Celia Virginia Vergara Castillo
+vicky at erosion.dev
 
 Copyright (c) 2023 Aryan Gupta
 guptaaryan1010 AT gmail.com

--- a/include/yen/pgr_ksp.hpp
+++ b/include/yen/pgr_ksp.hpp
@@ -3,6 +3,7 @@ File: pgr_ksp.hpp
 
 Copyright (c) 2015 Celia Virginia Vergara Castillo
 Mail: vicky AT erosion.dev
+
 Copyright (c) 2023 Aniket Agarwal
 Mail: aniketgarg187 AT gmail.com
 
@@ -25,7 +26,6 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
-
 
 #ifndef INCLUDE_YEN_PGR_KSP_HPP_
 #define INCLUDE_YEN_PGR_KSP_HPP_
@@ -273,6 +273,5 @@ namespace algorithms {
 }  // namespace algorithms
 
 }  // namespace pgrouting
-
 
 #endif  // INCLUDE_YEN_PGR_KSP_HPP_

--- a/pgtap/dijkstra/driving_distance/edge_cases/issue_519.pg
+++ b/pgtap/dijkstra/driving_distance/edge_cases/issue_519.pg
@@ -27,32 +27,32 @@ BEGIN
     IF min_version('3.6.0') THEN
         PREPARE q1 AS
         SELECT 1 AS start_vid, node, edge, cost, agg_cost FROM pgr_drivingDistance('SELECT id, source, target, cost FROM edge_table', 1, 3.5);
-        
+
         PREPARE q2 AS
         SELECT 5 AS start_vid, node, edge, cost, agg_cost FROM pgr_drivingDistance('SELECT id, source, target, cost FROM edge_table', 5, 3.5);
-        
+
         PREPARE q3 AS
         SELECT 25 AS start_vid, node, edge, cost, agg_cost FROM pgr_drivingDistance('SELECT id, source, target, cost FROM edge_table', 25, 3.5);
-        
+
         PREPARE q4 AS
         SELECT start_vid, node, edge, cost, agg_cost FROM pgr_drivingDistance('SELECT id, source, target, cost FROM edge_table', ARRAY[1, 5, 25], 3.5);
-        
+
         RETURN QUERY SELECT bag_has('q4', 'q1', '1: DD from [1, 5, 25] should have results of DD from 1');
         RETURN QUERY SELECT bag_has('q4', 'q2', '2: DD from [1, 5, 25] should have results of DD from 5');
         RETURN QUERY SELECT bag_has('q4', 'q3', '3: DD from [1, 5, 25] should have results of DD from 25');
     ELSE
         PREPARE q1 AS
         SELECT 1 AS from_v, node, edge, cost, agg_cost FROM pgr_drivingDistance('SELECT id, source, target, cost FROM edge_table', 1, 3.5);
-        
+
         PREPARE q2 AS
         SELECT 5 AS from_v, node, edge, cost, agg_cost FROM pgr_drivingDistance('SELECT id, source, target, cost FROM edge_table', 5, 3.5);
-        
+
         PREPARE q3 AS
         SELECT 25 AS from_v, node, edge, cost, agg_cost FROM pgr_drivingDistance('SELECT id, source, target, cost FROM edge_table', 25, 3.5);
-        
+
         PREPARE q4 AS
         SELECT from_v, node, edge, cost, agg_cost FROM pgr_drivingDistance('SELECT id, source, target, cost FROM edge_table', ARRAY[1, 5, 25], 3.5);
-        
+
         RETURN QUERY SELECT bag_has('q4', 'q1', '1: DD from [1, 5, 25] should have results of DD from 1');
         RETURN QUERY SELECT bag_has('q4', 'q2', '2: DD from [1, 5, 25] should have results of DD from 5');
         RETURN QUERY SELECT bag_has('q4', 'q3', '3: DD from [1, 5, 25] should have results of DD from 25');

--- a/pgtap/ksp/ksp/types_check.pg
+++ b/pgtap/ksp/ksp/types_check.pg
@@ -1,4 +1,3 @@
-
 /*PGR-GNU*****************************************************************
 
 Copyright (c) 2018  pgRouting developers
@@ -44,7 +43,7 @@ BEGIN
     RETURN QUERY  SELECT function_returns('pgr_ksp',ARRAY['text','bigint','bigint','integer','boolean','boolean'],'setof record');
   END IF;
 
-  RETURN QUERY SELECT CASE WHEN min_version('3.6.0') THEN 
+  RETURN QUERY SELECT CASE WHEN min_version('3.6.0') THEN
     collect_tap(
       set_eq(
           $$SELECT  proargnames from pg_proc WHERE proname = 'pgr_ksp'$$,
@@ -63,7 +62,7 @@ BEGIN
         $$
       )
     )
-  ELSE 
+  ELSE
     collect_tap(
       set_eq(
         $$SELECT  proargnames from pg_proc WHERE proname = 'pgr_ksp'$$,

--- a/pgtap/ksp/withPointsKSP/no_crash_test.pg
+++ b/pgtap/ksp/withPointsKSP/no_crash_test.pg
@@ -1,4 +1,3 @@
-
 /*PGR-GNU*****************************************************************
 
 Copyright (c) 2018  pgRouting developers
@@ -107,7 +106,7 @@ IF min_version('3.6.0') THEN
     -- many to one
     params = ARRAY['$$edges$$',
     '$$SELECT pid, edge_id, fraction from pointsOfInterest$$',
-    'ARRAY[2,5]::BIGINT[]', 
+    'ARRAY[2,5]::BIGINT[]',
     '1',
     '2',
     '$$r$$'

--- a/pgtap/ksp/withPointsKSP/types_check.pg
+++ b/pgtap/ksp/withPointsKSP/types_check.pg
@@ -1,4 +1,3 @@
-
 /*PGR-GNU*****************************************************************
 
 Copyright (c) 2018  pgRouting developers
@@ -44,7 +43,7 @@ BEGIN
     THEN collect_tap(
       set_eq(
         $$SELECT proargnames from pg_proc WHERE proname = 'pgr_withpointsksp'$$,
-        $$VALUES 
+        $$VALUES
         ('{"","","","","","","directed","heap_paths","details","seq","path_id","path_seq","start_vid","end_vid","node","edge","cost","agg_cost"}'::TEXT[]),
         ('{"","","","","","directed","heap_paths","details","seq","path_id","path_seq","start_vid","end_vid","node","edge","cost","agg_cost"}'::TEXT[]),
         ('{"","","","","","directed","heap_paths","driving_side","details","seq","path_id","path_seq","node","edge","cost","agg_cost"}'::TEXT[])
@@ -57,8 +56,8 @@ BEGIN
         ('{25,25,2277,20,23,1042,16,16,16,23,23,23,20,20,20,20,701,701}'::OID[]),
         ('{25,25,2277,2277,23,1042,16,16,16,23,23,23,20,20,20,20,701,701}'::OID[]),
         ('{25,25,25,23,1042,16,16,16,23,23,23,20,20,20,20,701,701}'::OID[]),
-        ('{25,25,20,20,23,16,16,1042,16,23,23,23,20,20,701,701}'::OID[]) 
-        $$) 
+        ('{25,25,20,20,23,16,16,1042,16,23,23,23,20,20,701,701}'::OID[])
+        $$)
     )
     ELSE collect_tap(
       set_eq(

--- a/pgtap/withPoints/withPointsDD/edge_cases/issue_979.pg
+++ b/pgtap/withPoints/withPointsDD/edge_cases/issue_979.pg
@@ -1,4 +1,3 @@
-
 /*PGR-GNU*****************************************************************
 
 Copyright (c) 2018  pgRouting developers
@@ -35,7 +34,7 @@ SELECT node, edge, round(cost::numeric, 12) AS cost, round(agg_cost::numeric, 12
 ORDER BY seq;
 
 EXECUTE
-'CREATE TABLE test1 AS 
+'CREATE TABLE test1 AS
 SELECT
     node::BIGINT, edge::BIGINT, round(cost, 12) AS cost, round(agg_cost, 12) AS agg_cost
 FROM
@@ -69,7 +68,7 @@ SELECT node, edge, round(cost::numeric, 12) AS cost, round(agg_cost::numeric, 12
     -1, 6.8, driving_side := 'r', details := false);
 
 EXECUTE
-'CREATE TABLE test2 AS 
+'CREATE TABLE test2 AS
 SELECT
     node::BIGINT, edge::BIGINT, cost::FLOAT, agg_cost::FLOAT
 FROM
@@ -104,7 +103,7 @@ SELECT node, edge, round(cost::numeric, 12) AS cost, round(agg_cost::numeric, 12
 ORDER BY seq;
 
 EXECUTE
-'CREATE TABLE test3 AS 
+'CREATE TABLE test3 AS
 SELECT
     node::BIGINT, edge::BIGINT, cost::FLOAT, agg_cost::FLOAT
 FROM
@@ -132,7 +131,7 @@ SELECT set_eq('q3',
 
 
 EXECUTE
-'CREATE TABLE test4 AS 
+'CREATE TABLE test4 AS
 SELECT
     node::BIGINT, cost::FLOAT, agg_cost::FLOAT
 FROM
@@ -213,7 +212,7 @@ SELECT node, edge, round(cost::numeric, 12) AS cost, round(agg_cost::numeric, 12
     -1, 6.8, 'r', details := false);
 
 EXECUTE
-'CREATE TABLE test1 AS 
+'CREATE TABLE test1 AS
 SELECT
     node::BIGINT, edge::BIGINT, cost::FLOAT, agg_cost::FLOAT
 FROM
@@ -250,7 +249,7 @@ SELECT node, edge, round(cost::numeric, 12) AS cost, round(agg_cost::numeric, 12
 ORDER BY seq;
 
 EXECUTE
-'CREATE TABLE test2 AS 
+'CREATE TABLE test2 AS
 SELECT
     node::BIGINT, edge::BIGINT, cost::FLOAT, agg_cost::FLOAT
 FROM
@@ -292,7 +291,7 @@ SELECT node, round(cost::numeric, 12) AS cost, round(agg_cost::numeric, 12) AS a
     -1, 6.8, 'b', details := false, directed:=false);
 
 EXECUTE
-'CREATE TABLE test3 AS 
+'CREATE TABLE test3 AS
 SELECT
     node::BIGINT, cost::FLOAT, agg_cost::FLOAT
 FROM

--- a/sql/driving_distance/withPointsDD.sql
+++ b/sql/driving_distance/withPointsDD.sql
@@ -9,6 +9,9 @@ Function's developer:
 Copyright (c) 2015 Celia Virginia Vergara Castillo
 Mail: vicky at erosion.dev
 
+Copyright (c) 2023 Yige Huang
+Mail: square1ge at gmail.com
+
 ------
 
 This program is free software; you can redistribute it and/or modify

--- a/sql/ksp/_withPointsKSP.sql
+++ b/sql/ksp/_withPointsKSP.sql
@@ -4,6 +4,9 @@ File: _withPointsKSP.sql
 Copyright (c) 2015 Celia Virginia Vergara Castillo
 vicky_vergara@hotmail.com
 
+Copyright (c) 2023 Abhinav Jain
+Mail: this.abhinav at gmail.com
+
 ------
 
 This program is free software; you can redistribute it and/or modify

--- a/sql/ksp/withPointsKSP.sql
+++ b/sql/ksp/withPointsKSP.sql
@@ -2,7 +2,7 @@
 File: withPointsKSP.sql
 
 Copyright (c) 2015 Celia Virginia Vergara Castillo
-vicky_vergara AT erosion.dev
+vicky AT erosion.dev
 
 Copyright (c) 2023 Abhinav Jain
 this.abhinav AT gmail.com

--- a/src/driving_distance/CMakeLists.txt
+++ b/src/driving_distance/CMakeLists.txt
@@ -1,7 +1,7 @@
 ADD_LIBRARY(driving_distance OBJECT
-    many_to_dist_withPointsDD.c
     driving_distance.c
+    many_to_dist_withPointsDD.c
 
-    withPoints_dd_driver.cpp
     drivedist_driver.cpp
+    withPoints_dd_driver.cpp
  )

--- a/src/driving_distance/drivedist_driver.cpp
+++ b/src/driving_distance/drivedist_driver.cpp
@@ -1,9 +1,8 @@
 /*PGR-GNU*****************************************************************
 File: drivedist_driver.cpp
 
-Generated with Template by:                                                                                             
-Copyright (c) 2023 pgRouting developers                                                                                 
-Mail: project AT pgrouting.org   
+Copyright (c) 2015 Celia Virginia Vergara Castillo
+Mail: vicky at erosion.dev
 
 Copyright (c) 2023 Aryan Gupta
 guptaaryan1010 AT gmail.com

--- a/src/driving_distance/driving_distance.c
+++ b/src/driving_distance/driving_distance.c
@@ -2,7 +2,7 @@
 File: driving_distance.c
 
 Copyright (c) 2015 Celia Virginia Vergara Castillo
-Mail: vickyi at erosion.dev
+Mail: vicky at erosion.dev
 
 Copyright (c) 2023 Aryan Gupta
 guptaaryan1010 AT gmail.com

--- a/src/driving_distance/many_to_dist_withPointsDD.c
+++ b/src/driving_distance/many_to_dist_withPointsDD.c
@@ -1,11 +1,6 @@
 /*PGR-GNU*****************************************************************
 File: many_to_dist_driving_distance.c
 
-Generated with Template by:
-Copyright (c) 2015 pgRouting developers
-Mail: project at pgrouting.org
-
-Function's developer:
 Copyright (c) 2015 Celia Virginia Vergara Castillo
 Mail: vicky at erosion.dev
 
@@ -72,11 +67,11 @@ void process(
             return;
         }
         if (!(d_side == 'r' || d_side == 'l') && directed) {
-            throw_error("Graph is directed", "Valid values are 'r', 'l'");
+            throw_error("Invalid value of 'driving side'", "Valid values are for directed graph are: 'r', 'l'");
             return;
         }
         if (!(d_side == 'b') && !directed) {
-            throw_error("Graph is undirected", "Valid value is only 'b'");
+            throw_error("Invalid value of 'driving side'", "Valid values are for undirected graph is: 'b'");
             return;
         }
     } else {

--- a/src/ksp/withPoints_ksp.c
+++ b/src/ksp/withPoints_ksp.c
@@ -76,11 +76,11 @@ processv4(
     driving_side[0] = (char) tolower(driving_side[0]);
     if (directed) {
         if (!((driving_side[0] == 'r') || (driving_side[0] == 'l'))) {
-                    elog(ERROR, "Driving side is not selected or Invalid Values");
-                    return;
-                }
+            throw_error("Invalid value of 'driving side'", "Valid values are for directed graph are: 'r', 'l'");
+            return;
+        }
     } else if (!(driving_side[0] == 'b')) {
-        elog(ERROR, "Driving side is not selected or Invalid Values");
+        throw_error("Invalid value of 'driving side'", "Valid values are for undirected graph is: 'b'");
         return;
     }
 

--- a/tools/release-scripts/notes2news.pl
+++ b/tools/release-scripts/notes2news.pl
@@ -19,6 +19,8 @@
  ********************************************************************PGR-GNU*/
 =cut
 use strict;
+use warnings;
+use File::Find;
 
 sub Usage {
   die "Usage: notes2news.pl (from the root of the repository or pre-commit hook)\n";
@@ -34,10 +36,57 @@ open($ofh, ">$out_file") || die "ERROR: failed to open '$out_file' for write! : 
 my $ifh;
 open($ifh, "$in_file") || die "ERROR: failed to open '$in_file' for read! : $!\n";
 
+
 my $skipping = 1;
+my $file = '';
+my $start = '';
+my $end = '';
 while (my $line = <$ifh>) {
   next if $skipping and $line !~ /^pgRouting/;
   $skipping = 0;
+
+  # get include filename
+  if ($line =~ /include/) {
+      $line =~ s/^.*include\:\: (.*)/$1/;
+      chomp $line;
+      $line =~ s/^\s+//;
+      $file = $line;
+      my @wanted_files;
+      find(
+          sub{
+              -f $_ && $_ =~ /$file/
+              && push @wanted_files,$File::Find::name
+          }, "doc"
+      );
+      foreach(@wanted_files){
+          print "wanted: $_\n"
+      }
+      $file = $wanted_files[0];
+      print "rewanted: $file\n";
+      next;
+  };
+
+  if ($line =~ /start\-after/) {
+      $line =~ s/start\-after\:\ (.*)/$1/;
+      $line =~ tr/://d;
+      chomp $line;
+      $line =~ s/^\s+//;
+      $start = $line;
+      next;
+  };
+
+  if ($line =~ /end\-before/) {
+      $line =~ s/end\-before\:\ (.*)/$1/;
+      $line =~ tr/://d;
+      chomp $line;
+      $line =~ s/^\s+//;
+      $end = $line;
+      print "--->      $file from $start to $end \n";
+      find_stuff($file, $start, $end);
+      next;
+  }
+
+
 
   # convert urls to markdown
   $line =~ s/`([^<]+?)\s*<([^>]+)>`__/\[$1\]($2)/g;
@@ -51,6 +100,24 @@ while (my $line = <$ifh>) {
   print $ofh $line;
 }
 
+
 close($ifh);
 close($ofh);
 
+sub find_stuff {
+    my ($file, $mstart, $mend) = @_;
+    print "$file from $mstart to $mend \n";
+    my $fh;
+    open($fh, "$file") || die "ERROR: failed to open '$file' for read! : $!\n";
+
+    print "different '$mstart'\n" if $mstart ne "Version 3.6.0";
+    my $skipping = 1;
+    while (my $line = <$fh>) {
+        next if $skipping and $line !~ /$mstart/;
+        $skipping = 0;
+        next if $line =~ /$mstart/;
+        print $ofh "  $line" if $line !~ /$mend/;
+        last if $line =~ /$mend/;
+    }
+    close($fh);
+}


### PR DESCRIPTION
Fixes
- migration documentation
  - reorganization of migration document. Keeping focus only on GSoC work (see image bellow)
  - Change examples to old/new documentation examples so that it is easier to see what is happening
- Licenses: some names were removed some new names were missing
- release notes & NEWS
  - Rewording in the availability section of the functions

Minor code changes
- Standardizing error message when for the invalid driving side.

Other:
- Change the way to write the history by using ``include`` sphinx command to include the text in availability of the functions
  - notes2news changes to get the information from the text in availability section of the functions
- Removal of trailing spaces

![image](https://github.com/pgRouting/pgrouting/assets/5035290/24b7480d-9f60-4926-a2dd-78ca2700ea38)



@pgRouting/admins
