### PR TITLE
Standardize deprecated messages

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -137,6 +137,12 @@ milestone for 3.6.0
 * [#2490](https://github.com/pgRouting/pgrouting/pull/2490) Automatic page
   history links.
 
+* ..rubric:: SQL standarization
+
+* [#2555](https://github.com/pgRouting/pgrouting/pull/2555) standarize
+  deprecated messages
+
+
 pgRouting 3.5.1 Release Notes
 -------------------------------------------------------------------------------
 

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -99,6 +99,12 @@ milestone for 3.6.0
 * `#2490 <https://github.com/pgRouting/pgrouting/pull/2490>`__ Automatic page
   history links.
 
+* ..rubric:: SQL standarization
+
+* `#2555 <https://github.com/pgRouting/pgrouting/pull/2555>`__ standarize
+  deprecated messages
+
+
 pgRouting 3.5.1 Release Notes
 -------------------------------------------------------------------------------
 

--- a/docqueries/src/migration.result
+++ b/docqueries/src/migration.result
@@ -70,7 +70,7 @@ SELECT * FROM pgr_trsp(
     FROM edges WHERE id != 16$$,
   15, 16,
   true, true);
-WARNING:  pgr_trsp(text,integer,integer,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,integer,boolean,boolean) deprecated signature on v3.4.0
  seq | id1 | id2 | cost
 -----+-----+-----+------
    0 |  15 |   3 |    1
@@ -114,7 +114,7 @@ SELECT * FROM pgr_trsp(
   true, true,
   $$SELECT to_cost, target_id::INTEGER, via_path
     FROM old_restrictions$$);
-WARNING:  pgr_trsp(text,integer,integer,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,integer,boolean,boolean) deprecated signature on v3.4.0
  seq | id1 | id2 | cost
 -----+-----+-----+------
    0 |  15 |   3 |    1
@@ -173,7 +173,7 @@ SELECT * FROM pgr_trsp(
     FROM edges$$,
   6, 0.3, 12, 0.6,
   true, true);
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq | id1 | id2 | cost
 -----+-----+-----+------
    0 |  -1 |   6 |  0.7
@@ -219,7 +219,7 @@ SELECT * FROM pgr_trsp(
   $$SELECT id::INTEGER, source::INTEGER, target::INTEGER, cost, reverse_cost FROM edges$$,
   6, 0.3, 12, 0.6, true, true,
   $$SELECT to_cost, target_id::INTEGER, via_path FROM old_restrictions$$);
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq | id1 | id2 | cost
 -----+-----+-----+------
    0 |  -1 |   6 |  0.7
@@ -285,7 +285,7 @@ SELECT * FROM pgr_trspViaVertices(
   $$SELECT id::INTEGER, source::INTEGER, target::INTEGER, cost, reverse_cost FROM edges$$,
   ARRAY[6, 3, 6],
   true, true);
-WARNING:  pgr_trspViaVertices(text,anyarray,boolean,boolean,text) is been deprecated
+WARNING:  pgr_trspViaVertices(text,anyarray,boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |   6 |   4 |    1
@@ -332,7 +332,7 @@ SELECT * FROM pgr_trspViaVertices(
   ARRAY[6, 3, 6],
   true, true,
   $$SELECT to_cost, target_id::INTEGER, via_path FROM old_restrictions$$);
-WARNING:  pgr_trspViaVertices(text,anyarray,boolean,boolean,text) is been deprecated
+WARNING:  pgr_trspViaVertices(text,anyarray,boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |   6 |   4 |    1
@@ -408,7 +408,7 @@ SELECT * FROM pgr_trspViaEdges(
   $$SELECT id::INTEGER, source::INTEGER, target::INTEGER, cost, reverse_cost FROM edges$$,
   ARRAY[6, 12, 4], ARRAY[0.3, 0.6, 0.7],
   true, true);
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |  -1 |   6 |  0.7
@@ -478,9 +478,9 @@ SELECT * FROM pgr_trspViaEdges(
   ARRAY[6, 12, 4], ARRAY[0.3, 0.6, 0.7],
   true, true,
   $$SELECT to_cost, target_id::INTEGER, via_path FROM old_restrictions$$);
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |  -1 |   6 |  0.7
@@ -557,7 +557,7 @@ SELECT * FROM pgr_maxCardinalityMatch(
   $$SELECT id, source, target, cost AS going, reverse_cost AS coming FROM edges$$,
   directed => true
 );
-WARNING:  pgr_maxCardinalityMatch(text,boolean) deprecated on v3.4.0
+WARNING:  pgr_maxCardinalityMatch(text,boolean) deprecated signature on v3.4.0
  seq | edge | source | target
 -----+------+--------+--------
    1 |    1 |      5 |      6
@@ -790,7 +790,7 @@ SELECT * FROM pgr_withPointsDD(
   $$SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id$$,
   $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
   -1, 3.3);
-WARNING:  pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean) is been deprecated
+WARNING:  pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean) deprecated signature on 3.6.0
  seq | node | edge | cost | agg_cost
 -----+------+------+------+----------
    1 |   -1 |   -1 |    0 |        0
@@ -809,7 +809,7 @@ SELECT * FROM pgr_withPointsDD(
   $$SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id$$,
   $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
   -1, 3.3, driving_side => 'r');
-WARNING:  pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean) is been deprecated
+WARNING:  pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean) deprecated signature on 3.6.0
  seq | node | edge | cost | agg_cost
 -----+------+------+------+----------
    1 |   -1 |   -1 |    0 |        0
@@ -823,7 +823,7 @@ SELECT * FROM pgr_withPointsDD(
   $$SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id$$,
   $$SELECT pid, edge_id, fraction, side from pointsOfInterest$$,
   -1, 3.3, directed => true, driving_side => 'b');
-WARNING:  pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean) is been deprecated
+WARNING:  pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean) deprecated signature on 3.6.0
  seq | node | edge | cost | agg_cost
 -----+------+------+------+----------
    1 |   -1 |   -1 |    0 |        0

--- a/docqueries/trsp/four_edges.result
+++ b/docqueries/trsp/four_edges.result
@@ -30,7 +30,7 @@ SELECT * FROM pgr_trsp(
   719, 0,
   718, 0,
   true, true, NULL);
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq |  id1  | id2 |    cost
 -----+-------+-----+------------
    0 | 52163 | 717 | 977.000001
@@ -51,7 +51,7 @@ SELECT * FROM pgr_trsp(
   (SELECT source::int  FROM four_edges WHERE id = 719),
   (SELECT source::int  FROM four_edges WHERE id = 718),
   true, true, NULL);
-WARNING:  pgr_trsp(text,integer,integer,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,integer,boolean,boolean) deprecated signature on v3.4.0
  seq |  id1  | id2 | cost
 -----+-------+-----+------
    0 | 52163 | 717 |  977
@@ -66,7 +66,7 @@ SELECT * FROM pgr_trsp(
   719, 0,
   718, 0,
   true, true, NULL);
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq |  id1  | id2 |    cost
 -----+-------+-----+------------
    0 | 52163 | 717 | 977.000001
@@ -110,7 +110,7 @@ SELECT * FROM pgr_trsp(
   719, 0.5,
   718, 0,
   true, true, NULL);
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq |  id1  | id2 |    cost
 -----+-------+-----+------------
    0 |    -1 | 719 | 89.7000005
@@ -157,7 +157,7 @@ SELECT * FROM pgr_trsp(
   719, 0,
   718, 0.5,
   true, true, NULL);
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq |  id1  | id2 |    cost
 -----+-------+-----+-------------
    0 | 52163 | 717 |  977.000001
@@ -202,7 +202,7 @@ SELECT * FROM pgr_trsp(
   719, 0.5,
   718, 0.5,
   true, true, NULL);
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq |  id1  | id2 |    cost
 -----+-------+-----+-------------
    0 |    -1 | 719 |  89.7000005

--- a/docqueries/trsp/issue693.result
+++ b/docqueries/trsp/issue693.result
@@ -14,7 +14,7 @@ SELECT pgr_trsp(
           'SELECT gid as id, source::int4, target::int4, length::float8 as cost, length::float8 as reverse_cost FROM routing',
           1, 0.1, 1, 0.9, false, true
     );
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
    pgr_trsp
 ---------------
  (0,-1,1,1000)

--- a/docqueries/trsp/issue704.result
+++ b/docqueries/trsp/issue704.result
@@ -20,7 +20,7 @@ FROM pgr_trsp(
     true,      /* has_reverse_cost? */
     null /* include the turn restrictions */
 ) PG ;
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq |  node  |  edge  |   cost
 -----+--------+--------+----------
    0 | 408918 | 582877 | 229.0450
@@ -38,7 +38,7 @@ FROM pgr_trsp(
     true,      /* has_reverse_cost? */
     null /* include the turn restrictions */
 ) PG ;
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq | node |  edge  |   cost
 -----+------+--------+----------
    0 |   -1 | 582877 | 229.0450
@@ -56,7 +56,7 @@ FROM pgr_trsp(
     true,      /* has_reverse_cost? */
     $$SELECT 100::float AS to_cost, 25::INTEGER AS target_id, '32, 33'::TEXT AS via_path$$
 ) PG ;
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq | node |  edge  |   cost
 -----+------+--------+----------
    0 |   -1 | 582877 | 229.0450
@@ -73,7 +73,7 @@ FROM pgr_trsp(
     true,      /* has_reverse_cost? */
     $$SELECT 100::float AS to_cost, 25::INTEGER AS target_id, '32, 33'::TEXT AS via_path$$
 ) PG ;
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq | node |  edge  |   cost
 -----+------+--------+----------
    0 |   -1 | 582877 | 229.0450
@@ -89,7 +89,7 @@ FROM pgr_trsp(
     true,        /* directed graph? */
     true      /* has_reverse_cost? */
 );
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq |  node  |  edge  |   cost
 -----+--------+--------+----------
    0 | 408918 | 582877 | 458.0900

--- a/docqueries/trsp/issue717.result
+++ b/docqueries/trsp/issue717.result
@@ -30,7 +30,7 @@ SELECT * FROM pgr_trspViaVertices(
     true,  /* directed graph? */
     true  /* has_reverse_cost? */
 );
-WARNING:  pgr_trspViaVertices(text,anyarray,boolean,boolean,text) is been deprecated
+WARNING:  pgr_trspViaVertices(text,anyarray,boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |   6 |   4 |    1
@@ -50,7 +50,7 @@ SELECT * FROM pgr_trspViaEdges(
     true,  /* directed graph? */
     true  /* has_reverse_cost? */
 );
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |  -1 |   4 |  0.5
@@ -71,7 +71,7 @@ SELECT * FROM pgr_trspViaEdges(
     true,  /* directed graph? */
     true  /* has_reverse_cost? */
 );
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |  -1 |   1 |  0.5
@@ -96,7 +96,7 @@ SELECT * FROM pgr_trspViaEdges(
     true,  /* directed graph? */
     true  /* has_reverse_cost? */
 );
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |  -1 |   1 |  0.5
@@ -120,7 +120,7 @@ SELECT * FROM pgr_trspViaVertices(
     true,  /* directed graph? */
     false  /* has_reverse_cost? */
 );
-WARNING:  pgr_trspViaVertices(text,anyarray,boolean,boolean,text) is been deprecated
+WARNING:  pgr_trspViaVertices(text,anyarray,boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
 (0 rows)
@@ -132,7 +132,7 @@ SELECT * FROM pgr_trspViaEdges(
     true,  /* directed graph? */
     false  /* has_reverse_cost? */
 );
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   2 |  -2 |   6 |  0.5
@@ -149,7 +149,7 @@ SELECT * FROM pgr_trspViaEdges(
     true,  /* directed graph? */
     false  /* has_reverse_cost? */
 );
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |  -1 |   1 |  0.5
@@ -166,7 +166,7 @@ SELECT * FROM pgr_trspViaEdges(
     true,  /* directed graph? */
     false  /* has_reverse_cost? */
 );
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |  -1 |   1 |  0.5
@@ -182,7 +182,7 @@ SELECT * FROM pgr_trspViaVertices(
     false,  /* directed graph? */
     true  /* has_reverse_cost? */
 );
-WARNING:  pgr_trspViaVertices(text,anyarray,boolean,boolean,text) is been deprecated
+WARNING:  pgr_trspViaVertices(text,anyarray,boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |   6 |   4 |    1
@@ -202,7 +202,7 @@ SELECT * FROM pgr_trspViaEdges(
     false,  /* directed graph? */
     true  /* has_reverse_cost? */
 );
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |  -1 |   4 |  0.5
@@ -223,7 +223,7 @@ SELECT * FROM pgr_trspViaEdges(
     false,  /* directed graph? */
     true  /* has_reverse_cost? */
 );
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |  -1 |   1 |  0.5
@@ -245,7 +245,7 @@ SELECT * FROM pgr_trspViaEdges(
     false,  /* directed graph? */
     true  /* has_reverse_cost? */
 );
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |  -1 |   1 |  0.5
@@ -266,7 +266,7 @@ SELECT * FROM pgr_trspViaVertices(
     false,  /* directed graph? */
     false  /* has_reverse_cost? */
 );
-WARNING:  pgr_trspViaVertices(text,anyarray,boolean,boolean,text) is been deprecated
+WARNING:  pgr_trspViaVertices(text,anyarray,boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |   6 |   4 |    1
@@ -286,7 +286,7 @@ SELECT * FROM pgr_trspViaEdges(
     false,  /* directed graph? */
     false  /* has_reverse_cost? */
 );
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |  -1 |   4 |  0.5
@@ -307,7 +307,7 @@ SELECT * FROM pgr_trspViaEdges(
     false,  /* directed graph? */
     false  /* has_reverse_cost? */
 );
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |  -1 |   1 |  0.5
@@ -329,7 +329,7 @@ SELECT * FROM pgr_trspViaEdges(
     false,  /* directed graph? */
     false  /* has_reverse_cost? */
 );
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |  -1 |   1 |  0.5

--- a/docqueries/trsp/trsp-any-02.result
+++ b/docqueries/trsp/trsp-any-02.result
@@ -29,7 +29,7 @@ select * from pgr_trsp(
     true, /* has_reverse_cost? */
     /* include the turn restrictions */
     'select to_cost, teid as target_id, feid||coalesce('',''||via,'''') as via_path from restrictions2');
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq | id1 | id2 |  cost
 -----+-----+-----+--------
    0 |  -1 |   1 | 0.5005

--- a/docqueries/trsp/trsp-renumber.result
+++ b/docqueries/trsp/trsp-renumber.result
@@ -6,7 +6,7 @@ SELECT * FROM pgr_trsp(
     'SELECT id::INTEGER, (source+10)::INTEGER AS source, (target+10)::INTEGER AS target, cost::FLOAT FROM edges',
     11, 27, false, false
 );
-WARNING:  pgr_trsp(text,integer,integer,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,integer,boolean,boolean) deprecated signature on v3.4.0
  seq | id1 | id2 | cost
 -----+-----+-----+------
    0 |  11 |   6 |    1
@@ -57,7 +57,7 @@ SELECT * FROM pgr_trsp(
     'SELECT to_cost, target_id::int4, via_path
     FROM old_restrictions'
 );
-WARNING:  pgr_trsp(text,integer,integer,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trsp(text,integer,integer,boolean,boolean) deprecated signature on v3.4.0
  seq | id1 | id2 | cost
 -----+-----+-----+------
    0 |   6 |   4 |    1

--- a/docqueries/trsp/trsp_vias-any-04.result
+++ b/docqueries/trsp/trsp_vias-any-04.result
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
         true,  /* has_reverse_cost? */
         /* include the turn restrictions */
         'SELECT to_cost, target_id::INTEGER, via_path FROM old_restrictions');
-WARNING:  pgr_trspViaVertices(text,anyarray,boolean,boolean,text) is been deprecated
+WARNING:  pgr_trspViaVertices(text,anyarray,boolean,boolean,text) deprecated function on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |   6 |   4 |    1
@@ -62,9 +62,9 @@ SELECT * FROM pgr_trspViaEdges(
         true,  /* has_reverse_cost? */
         /* include the turn restrictions */
         'SELECT to_cost, target_id::INTEGER, via_path FROM old_restrictions');
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |  -1 |   4 |  0.5
@@ -93,9 +93,9 @@ SELECT * FROM pgr_trspViaEdges(
         true,  /* has_reverse_cost? */
         /* include the turn restrictions */
         'SELECT to_cost, target_id::INTEGER, via_path FROM old_restrictions');
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |  -1 |   1 |  0.5
@@ -122,9 +122,9 @@ SELECT * FROM pgr_trspViaEdges(
         true,  /* has_reverse_cost? */
         /* include the turn restrictions */
         'SELECT to_cost, target_id::INTEGER, via_path FROM old_restrictions');
-WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
-WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0
+WARNING:  pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
+WARNING:  pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0
  seq | id1 | id2 | id3 | cost
 -----+-----+-----+-----+------
    1 |   1 |  -1 |   1 |  0.5

--- a/sql/driving_distance/_drivingDistance.sql
+++ b/sql/driving_distance/_drivingDistance.sql
@@ -74,4 +74,4 @@ LANGUAGE c VOLATILE STRICT;
 -- COMMENTS
 
 COMMENT ON FUNCTION _pgr_drivingDistance(TEXT, ANYARRAY, FLOAT, BOOLEAN, BOOLEAN)
-IS 'pgRouting deprecated function';
+IS 'pgRouting internal function deprecated on v3.6.0';

--- a/sql/driving_distance/_withPointsDD.sql
+++ b/sql/driving_distance/_withPointsDD.sql
@@ -88,4 +88,4 @@ LANGUAGE C VOLATILE STRICT;
 -- COMMENTS
 
 COMMENT ON FUNCTION _pgr_withPointsDD(TEXT, TEXT, ANYARRAY, FLOAT, BOOLEAN, CHAR, BOOLEAN, BOOLEAN)
-IS 'pgRouting deprecated function';
+IS 'pgRouting internal function deprecated on v3.6.0';

--- a/sql/driving_distance/withPointsDD.sql
+++ b/sql/driving_distance/withPointsDD.sql
@@ -145,7 +145,7 @@ CREATE FUNCTION pgr_withPointsDD(
 RETURNS SETOF RECORD AS
 $BODY$
 BEGIN
-    RAISE WARNING 'pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean) is been deprecated';
+    RAISE WARNING 'pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean) deprecated signature on 3.6.0';
     RETURN QUERY
     SELECT a.seq, a.node, a.edge, a.cost, a.agg_cost
     FROM _pgr_withPointsDD(_pgr_get_statement($1), _pgr_get_statement($2), ARRAY[$3]::BIGINT[], $4, $5, $6, $7, false) AS a;
@@ -177,10 +177,10 @@ CREATE FUNCTION pgr_withPointsDD(
 RETURNS SETOF RECORD AS
 $BODY$
 BEGIN
-  RAISE WARNING 'pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,boolean,boolean) is been deprecated';
+  RAISE WARNING 'pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,boolean,boolean) deprecated signature on v3.6.0';
   RETURN QUERY
-    SELECT *
-    FROM _pgr_withPointsDD(_pgr_get_statement($1), _pgr_get_statement($2), $3, $4, $5, $6, $7, $8);
+    SELECT a.seq, a.start_vid, a.node, a.edge, a.cost, a.agg_cost
+    FROM _pgr_withPointsDD(_pgr_get_statement($1), _pgr_get_statement($2), $3, $4, $5, $6, $7, $8) AS a;
 END;
 $BODY$
 LANGUAGE plpgsql VOLATILE STRICT
@@ -191,8 +191,9 @@ ROWS 1000;
 -- COMMENTS
 
 COMMENT ON FUNCTION pgr_withPointsDD(TEXT, TEXT, BIGINT, FLOAT, BOOLEAN, CHAR, BOOLEAN)
-IS 'pgRouting deprecated function';
-
+IS 'pgRouting deprecated signature on v3.6.0
+- Documentation: ${PROJECT_DOC_LINK}/pgr_withPointsDD.html';
 
 COMMENT ON FUNCTION pgr_withPointsDD(TEXT, TEXT, ANYARRAY, FLOAT, BOOLEAN, CHAR, BOOLEAN, BOOLEAN)
-IS 'pgRouting deprecated function';
+IS 'pgRouting deprecated signature on v3.6.0
+- Documentation: ${PROJECT_DOC_LINK}/pgr_withPointsDD.html';

--- a/sql/ksp/_withPointsKSP.sql
+++ b/sql/ksp/_withPointsKSP.sql
@@ -110,4 +110,4 @@ CREATE FUNCTION _pgr_withPointsKSP(
 -- COMMENTS
 
 COMMENT ON FUNCTION _pgr_withPointsKSP(TEXT, TEXT, BIGINT, BIGINT, INTEGER, BOOLEAN, BOOLEAN, CHAR, BOOLEAN)
-IS 'pgRouting deprecated function';
+IS 'pgRouting internal function deprecated on v3.6.0';

--- a/sql/ksp/withPointsKSP.sql
+++ b/sql/ksp/withPointsKSP.sql
@@ -289,7 +289,7 @@ CREATE FUNCTION pgr_withPointsKSP(
 RETURNS SETOF RECORD AS
 $BODY$
 BEGIN
-    RAISE WARNING 'pgr_withPointsKSP(text,text,bigint,bigint,integer,boolean,boolean,char,boolean) deprecated on v3.6.0';
+    RAISE WARNING 'pgr_withPointsKSP(text,text,bigint,bigint,integer,boolean,boolean,char,boolean) deprecated signature on v3.6.0';
     RETURN QUERY
     SELECT * FROM _pgr_withPointsKSP(_pgr_get_statement($1), _pgr_get_statement($2), $3, $4, $5, $6, $7, $8, $9);
 END
@@ -301,20 +301,5 @@ ROWS 1000;
 -- COMMENTS
 
 COMMENT ON FUNCTION pgr_withPointsKSP(TEXT, TEXT, BIGINT, BIGINT, INTEGER, BOOLEAN, BOOLEAN, CHAR, BOOLEAN)
-IS 'pgr_withPointsKSP
-- Deprecated signature in v3.6.0
-- PROPOSED
-- Parameters:
-    - Edges SQL with columns: id, source, target, cost [,reverse_cost]
-    - Points SQL with columns: [pid], edge_id, fraction[,side]
-    - From vertex identifier
-    - To vertex identifier
-    - K
-- Optional Parameters
-    - directed := true
-    - heap paths := false
-    - driving side := b
-    - details := false
-- Documentation:
-    - ${PROJECT_DOC_LINK}/pgr_withPointsKSP.html
-';
+IS 'pgr_withPointsKSP deprecated signature on v3.6.0
+- Documentation: ${PROJECT_DOC_LINK}/pgr_withPointsKSP.html';

--- a/sql/max_flow/maxCardinalityMatch.sql
+++ b/sql/max_flow/maxCardinalityMatch.sql
@@ -52,7 +52,7 @@ CREATE FUNCTION pgr_maxCardinalityMatch(
 RETURNS SETOF RECORD AS
 $BODY$
 BEGIN
-RAISE WARNING 'pgr_maxCardinalityMatch(text,boolean) deprecated on v3.4.0';
+RAISE WARNING 'pgr_maxCardinalityMatch(text,boolean) deprecated signature on v3.4.0';
 RETURN QUERY SELECT *
 FROM _pgr_maxCardinalityMatch(_pgr_get_statement($1), $2);
 END
@@ -63,18 +63,13 @@ ROWS 1000;
 
 -- COMMENTS
 COMMENT ON FUNCTION pgr_maxCardinalityMatch(TEXT, BOOLEAN)
-IS 'pgr_maxCardinalityMatch
-- DEPRECATED signature on v3.4.0
-- Use without boolean paramater
-- Regardless of boolen value it will work for undirected graphs
-- Documentation:
-  - ${PROJECT_DOC_LINK}/pgr_maxCardinalityMatch.html
-';
+IS 'pgr_maxCardinalityMatch deprecated signature on v3.4.0
+- Documentation: ${PROJECT_DOC_LINK}/pgr_maxCardinalityMatch.html';
 
 COMMENT ON FUNCTION pgr_maxCardinalityMatch(TEXT)
 IS 'pgr_maxCardinalityMatch
 - Parameters:
   - Edges SQL with columns: id, source, target, cost [,reverse_cost]
 - Documentation:
-- ${PROJECT_DOC_LINK}/pgr_maxCardinalityMatch.html
+  - ${PROJECT_DOC_LINK}/pgr_maxCardinalityMatch.html
 ';

--- a/sql/trsp/pgr_trsp.sql
+++ b/sql/trsp/pgr_trsp.sql
@@ -58,7 +58,7 @@ new_sql TEXT;
 restrictions_query TEXT;
 trsp_sql TEXT;
 BEGIN
-  RAISE WARNING 'pgr_trsp(text,integer,integer,boolean,boolean) deprecated on v3.4.0';
+  RAISE WARNING 'pgr_trsp(text,integer,integer,boolean,boolean) deprecated signature on v3.4.0';
     has_reverse =_pgr_parameter_check('dijkstra', edges_sql, false);
 
     new_sql := edges_sql;
@@ -159,7 +159,7 @@ BEGIN
     IF $2 IS NULL OR $3 IS NULL OR $4 IS NULL OR $5 IS NULL OR $6 IS NULL THEN
         RETURN;
     END IF;
-  RAISE WARNING 'pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated on v3.4.0';
+  RAISE WARNING 'pgr_trsp(text,integer,float,integer,float,boolean,boolean) deprecated signature on v3.4.0';
     has_reverse =_pgr_parameter_check('dijkstra', sql, false);
 
     new_sql := sql;
@@ -259,16 +259,10 @@ ROWS 1000;
 -- COMMENTS
 
 COMMENT ON FUNCTION pgr_trsp(TEXT, INTEGER, INTEGER, BOOLEAN, BOOLEAN, TEXT)
-IS 'pgr_trsp
-- DEPRECATED signature on v3.4.0
-- Documentation:
-  - ${PROJECT_DOC_LINK}/pgr_trsp.html
-';
+IS 'pgr_trsp deprecated signature on v3.4.0
+- Documentation: ${PROJECT_DOC_LINK}/pgr_trsp.html';
 
 
 COMMENT ON FUNCTION pgr_trsp(TEXT, INTEGER, FLOAT, INTEGER, FLOAT, BOOLEAN, BOOLEAN, TEXT)
-IS 'pgr_trsp
-- DEPRECATED signature on v3.4.0
-- Documentation:
-  - ${PROJECT_DOC_LINK}/pgr_trsp_withPoints.html
-';
+IS 'pgr_trsp deprecated signature on v3.4.0
+- Documentation: ${PROJECT_DOC_LINK}/pgr_trsp_withPoints.html';

--- a/sql/trsp/pgr_trspViaEdges.sql
+++ b/sql/trsp/pgr_trspViaEdges.sql
@@ -68,7 +68,7 @@ declare
     f float;
 
 begin
-  RAISE WARNING 'pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated on v3.4.0';
+  RAISE WARNING 'pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text) deprecated function on v3.4.0';
     SELECT 0::INTEGER AS seq, NULL::INTEGER AS id1, NULL::INTEGER AS id2, NULL::INTEGER AS id3, NULL::FLOAT AS cost INTO lrr;
     has_reverse =_pgr_parameter_check('dijkstra', sql, false);
     edges_sql := sql;
@@ -173,8 +173,5 @@ rows 1000;
 -- COMMENTS
 
 COMMENT ON FUNCTION pgr_trspViaEdges(TEXT, INTEGER[], FLOAT[], BOOLEAN, BOOLEAN, TEXT)
-IS 'pgr_trspViaEdges
-- DEPRECATED function on v3.4.0
-- Documentation:
-  - ${PROJECT_DOC_LINK}/pgr_trspVia_withPoints.html
-';
+IS 'pgr_trspViaEdges deprecated function on v3.4.0
+- Documentation: ${PROJECT_DOC_LINK}/pgr_trspVia_withPoints.html';

--- a/sql/trsp/pgr_trspViaVertices.sql
+++ b/sql/trsp/pgr_trspViaVertices.sql
@@ -56,7 +56,7 @@ DECLARE
 has_reverse BOOLEAN;
 new_sql TEXT;
 BEGIN
-  RAISE WARNING 'pgr_trspViaVertices(text,anyarray,boolean,boolean,text) is been deprecated';
+  RAISE WARNING 'pgr_trspViaVertices(text,anyarray,boolean,boolean,text) deprecated function on v3.4.0';
 
     has_reverse =_pgr_parameter_check('dijkstra', edges_sql, false);
 
@@ -94,8 +94,5 @@ ROWS 1000;
 -- COMMENTS
 
 COMMENT ON FUNCTION pgr_trspViaVertices(TEXT, ANYARRAY, BOOLEAN, BOOLEAN, TEXT)
-IS 'pgr_trspViaVertices
-- DEPRECATED function on v3.4.0
-- Documentation:
-  - ${PROJECT_DOC_LINK}/pgr_trspVia.html
-';
+IS 'pgr_trspViaVertices deprecated function on v3.4.0
+- Documentation: ${PROJECT_DOC_LINK}/pgr_trspVia.html';

--- a/sql/withPoints/withPointsVia.sql
+++ b/sql/withPoints/withPointsVia.sql
@@ -224,4 +224,4 @@ CREATE FUNCTION  _pgr_withPointsVia(
 
 
 COMMENT ON FUNCTION _pgr_withPointsVia(TEXT, BIGINT[], FLOAT[], BOOLEAN)
-IS 'pgRouting internal function DEPRECATED on v3.4.0';
+IS 'pgRouting internal function deprecated on v3.4.0';


### PR DESCRIPTION
Messages and comments of deprecated functions:

## Functions:
Message:
`pgr_name(parameter's types) deprecated [function/signature] on v[number]`
Comments:
```
IS 'pgr_name deprecated [function/signature] on v[number]
- Documentation: ${PROJECT_DOC_LINK}/pgr_[new]name.html'
```
## Internal functions:
Comments:
`pgRouting internal function deprecated on v[number]`

