### PR TITLE
Fix #2565 Returning empty results when vertex does not exist

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,11 @@ Changes on the documentation to the following:
 
   * using bootstrap_version 2 because 3+ does not do dropdowns
 
+**Issue fixes**
+
+* [#2565](https://github.com/pgRouting/pgrouting/issues/2565)
+  pgr_pgr_lengauerTarjanDominatorTree triggers an assertion
+
 **SQL enhancements**
 
 * [#2561](https://github.com/pgRouting/pgrouting/issues/2561) Not use

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -38,6 +38,11 @@ Changes on the documentation to the following:
 
   * using bootstrap_version 2 because 3+ does not do dropdowns
 
+.. rubric:: Issue fixes
+
+* `#2565 <https://github.com/pgRouting/pgrouting/issues/2565>`__
+  pgr_pgr_lengauerTarjanDominatorTree triggers an assertion
+
 .. rubric:: SQL enhancements
 
 * `#2561 <https://github.com/pgRouting/pgrouting/issues/2561>`__ Not use

--- a/include/dominator/pgr_lengauerTarjanDominatorTree_driver.hpp
+++ b/include/dominator/pgr_lengauerTarjanDominatorTree_driver.hpp
@@ -60,6 +60,7 @@ class Pgr_LTDTree : public pgrouting::Pgr_messages {
                     int64_t root
                     ){
                 std::vector<II_t_rt> results;
+                if (!graph.has_vertex(root)) return results;
                 std::vector<int64_t> idoms = std::vector<int64_t>(boost::num_vertices(graph.graph), -1);
                 auto dominatorTree =
                 make_iterator_property_map

--- a/pgtap/dominator/lengauerTarjanDominatorTree/edge_cases.pg
+++ b/pgtap/dominator/lengauerTarjanDominatorTree/edge_cases.pg
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  ********************************************************************PGR-GNU*/
 BEGIN;
 UPDATE edges SET cost = sign(cost), reverse_cost = sign(reverse_cost);
-SELECT CASE WHEN NOT min_version('3.2.0') THEN plan(1) ELSE plan(11) END;
+SELECT CASE WHEN NOT min_version('3.2.0') THEN plan(1) ELSE plan(12) END;
 
 CREATE OR REPLACE FUNCTION edge_cases()
 RETURNS SETOF TEXT AS
@@ -63,8 +63,8 @@ WHERE id = 1;
 RETURN QUERY
 SELECT set_eq('q2', $$VALUES (1, 5, 5, 1, 1)$$, 'graph2: u<->u');
 
-/*
-PERFORM todo('triggers an assertion when the vertex does not exist', 1);
+IF min_version('3.5.1') THEN
+
 PREPARE ltd_test2_1 AS
 SELECT *
 FROM pgr_lengauerTarjanDominatorTree(
@@ -72,7 +72,13 @@ FROM pgr_lengauerTarjanDominatorTree(
 );
 RETURN QUERY
 SELECT lives_ok('ltd_test2_1', 'test2: Triggers an assertion');
-*/
+
+ELSE
+
+  RETURN QUERY
+  SELECT skip(1, 'triggers an assertion when the vertex does not exist');
+
+END IF;
 
 PREPARE ltd_test2 AS
 SELECT *


### PR DESCRIPTION
Fixes #2565  .

Changes proposed in this pull request:
- C/C++ Check the existence of the vertex and return empty set when it does not exist

@pgRouting/admins
