### PR TITLE
Remove the Boost_VERSION_MACRO define from C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,6 @@ find_package(Boost ${BOOST_MINIMUM_VERSION} REQUIRED)
 if (NOT Boost_VERSION_MACRO)
     set(Boost_VERSION_MACRO ${Boost_VERSION})
 endif()
-add_definitions(-DBoost_VERSION_MACRO=${Boost_VERSION_MACRO})
 set(BOOST_VERSION "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
 
 include(CheckCCompilerFlag)

--- a/include/coloring/pgr_edgeColoring.hpp
+++ b/include/coloring/pgr_edgeColoring.hpp
@@ -33,6 +33,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <boost/config.hpp>
 #include <boost/graph/adjacency_list.hpp>
+#include <boost/version.hpp>
 
 #include "c_types/edge_t.h"
 #include "c_types/ii_t_rt.h"
@@ -59,7 +60,7 @@ class Pgr_edgeColoring : public Pgr_messages {
     Pgr_edgeColoring(Edge_t*, size_t);
     Pgr_edgeColoring() = delete;
 
-#if Boost_VERSION_MACRO >= 106800
+#if BOOST_VERSION >= 106800
     friend std::ostream& operator<<(std::ostream &, const Pgr_edgeColoring&);
 #endif
 

--- a/include/tsp/tsp.hpp
+++ b/include/tsp/tsp.hpp
@@ -37,6 +37,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <boost/config.hpp>
 #include <boost/graph/adjacency_list.hpp>
+#include <boost/version.hpp>
 
 #include "c_types/iid_t_rt.h"
 #include "c_types/coordinate_t.h"
@@ -77,7 +78,7 @@ class TSP : public Pgr_messages {
     TSP(Coordinate_t *, size_t, bool);
     TSP() = delete;
 
-#if Boost_VERSION_MACRO >= 106800
+#if BOOST_VERSION >= 106800
     friend std::ostream& operator<<(std::ostream &, const TSP&);
 #endif
     bool has_vertex(int64_t id) const;

--- a/src/alpha_shape/pgr_alphaShape.cpp
+++ b/src/alpha_shape/pgr_alphaShape.cpp
@@ -41,7 +41,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <boost/geometry/algorithms/num_points.hpp>
 #include <boost/geometry/algorithms/append.hpp>
 #include <boost/geometry/algorithms/area.hpp>
-#if Boost_VERSION_MACRO >= 107500
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 107500
 #    include <boost/geometry/strategies/strategies.hpp>
 #else
 #    include <boost/geometry/strategies/agnostic/point_in_point.hpp>

--- a/src/tsp/tsp.cpp
+++ b/src/tsp/tsp.cpp
@@ -36,6 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <boost/graph/connected_components.hpp>
 #include <boost/graph/dijkstra_shortest_paths.hpp>
 #include <boost/graph/graph_utility.hpp>
+#include <boost/version.hpp>
 
 #include "cpp_common/identifiers.hpp"
 #include "cpp_common/pgr_messages.h"
@@ -508,7 +509,7 @@ TSP::get_edge_id(E e) const {
 
 
 
-#if Boost_VERSION_MACRO >= 106800
+#if BOOST_VERSION >= 106800
 std::ostream& operator<<(std::ostream &log, const TSP& data) {
     log << "Number of Vertices is:" << num_vertices(data.graph) << "\n";
     log << "Number of Edges is:" << num_edges(data.graph) << "\n";


### PR DESCRIPTION
Boost provides a header, <boost/version.hpp>, which provides a BOOST_VERSION macro with the same semantics.

This change simplifies the build process and makes this project easier to incorporate in other build systems.

Fixes # .

Changes proposed in this pull request:
-
-
-

@pgRouting/admins
