### PR TITLE
Doc double space removal

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -750,7 +750,7 @@ on Github.
 
 **Issues fixes**
 
-* [#232](https://github.com/pgRouting/pgrouting/issues/232):  Honor client
+* [#232](https://github.com/pgRouting/pgrouting/issues/232): Honor client
   cancel requests in C /C++ code
 
 
@@ -908,7 +908,7 @@ on Github.
 
 * Experimental functions
 
-  * pgr_labelGraph  -  Use the components family of functions instead.
+  * pgr_labelGraph - Use the components family of functions instead.
   * Max flow - functions were renamed on v2.5.0
 
     * pgr_maxFlowPushRelabel
@@ -1012,7 +1012,7 @@ on Github.
 
 **New experimental functions**
 
-*  pgr_lineGraphFull
+* pgr_lineGraphFull
 
 **Bug fixes**
 
@@ -1427,7 +1427,7 @@ on Github.
 
 - Signature fix
 
-  - pgr_dijkstra  -- to match what is documented
+  - pgr_dijkstra -- to match what is documented
 
 
 **New Functions**
@@ -1457,8 +1457,8 @@ on Github.
 
 **Deprecated functions:**
 
-- pgr_apspWarshall  use pgr_floydWarshall instead
-- pgr_apspJohnson   use pgr_Johnson instead
+- pgr_apspWarshall use pgr_floydWarshall instead
+- pgr_apspJohnson use pgr_Johnson instead
 - pgr_kDijkstraCost use pgr_dijkstraCost instead
 - pgr_kDijkstraPath use pgr_dijkstra instead
 

--- a/doc/allpairs/allpairs-family.rst
+++ b/doc/allpairs/allpairs-family.rst
@@ -51,9 +51,9 @@ The main characteristics are:
 
 - For the undirected graph, the results are symmetric.
 
-  - The  `agg_cost` of `(u, v)` is the same as for `(v, u)`.
+  - The `agg_cost` of `(u, v)` is the same as for `(v, u)`.
 
-- When  `start_vid` = `end_vid`, the `agg_cost` = 0.
+- When `start_vid` = `end_vid`, the `agg_cost` = 0.
 
 - **Recommended, use a bounding box of no more than 3500 edges.**
 
@@ -153,11 +153,11 @@ The tested query is:
 
      SELECT count(*) FROM pgr_floydWarshall(
         'SELECT gid as id, source, target, cost, reverse_cost
-         FROM ways where id <=  <SIZE>');
+         FROM ways where id <= <SIZE>');
 
      SELECT count(*) FROM pgr_johnson(
         'SELECT gid as id, source, target, cost, reverse_cost
-         FROM ways where id <=  <SIZE>');
+         FROM ways where id <= <SIZE>');
 
 The results of this tests are presented as:
 

--- a/doc/astar/aStar-family.rst
+++ b/doc/astar/aStar-family.rst
@@ -42,8 +42,8 @@ The main Characteristics are:
 * Process works for directed and undirected graphs.
 * Ordering is:
 
-  *  first by ``start_vid`` (if exists)
-  *  then by ``end_vid``
+  * first by ``start_vid`` (if exists)
+  * then by ``end_vid``
 
 * Values are returned when there is a path.
 * Let :math:`v` and :math:`u` be nodes on the graph:
@@ -132,12 +132,12 @@ Factor
 .. rubric:: Analysis 1
 
 Working with cost/reverse_cost as length in degrees, x/y in lat/lon:
-Factor = 1   (no need to change units)
+Factor = 1 (no need to change units)
 
 .. rubric:: Analysis 2
 
 Working with cost/reverse_cost as length in meters, x/y in lat/lon:
-Factor =  would depend on the location of the points:
+Factor = would depend on the location of the points:
 
 .. list-table::
    :width: 81
@@ -148,7 +148,7 @@ Factor =  would depend on the location of the points:
      - Conversion
      - Factor
    * - 45
-     - 1 longitude degree is  78846.81 m
+     - 1 longitude degree is 78846.81 m
      - 78846
    * - 0
      - 1 longitude degree is 111319.46 m

--- a/doc/astar/pgr_aStarCost.rst
+++ b/doc/astar/pgr_aStarCost.rst
@@ -56,7 +56,7 @@ using the A* algorithm.
 
 - For undirected graphs, the results are symmetric.
 
-  - The  `agg_cost` of `(u, v)` is the same as for `(v, u)`.
+  - The `agg_cost` of `(u, v)` is the same as for `(v, u)`.
 
 - The returned values are ordered in ascending order:
 
@@ -91,7 +91,7 @@ One to One
    :class: signatures
 
    | pgr_aStarCost(`Edges SQL`_, **start vid**, **end vid**, [**options**])
-   |  **options:** ``[directed, heuristic, factor, epsilon]``
+   | **options:** ``[directed, heuristic, factor, epsilon]``
 
    | RETURNS SET OF |matrix-result|
    | OR EMPTY SET

--- a/doc/bdAstar/pgr_bdAstarCost.rst
+++ b/doc/bdAstar/pgr_bdAstarCost.rst
@@ -57,7 +57,7 @@ using the bidirectional A* algorithm.
 
 - For undirected graphs, the results are symmetric.
 
-  - The  `agg_cost` of `(u, v)` is the same as for `(v, u)`.
+  - The `agg_cost` of `(u, v)` is the same as for `(v, u)`.
 
 - The returned values are ordered in ascending order:
 

--- a/doc/bdDijkstra/bdDijkstra-family.rst
+++ b/doc/bdDijkstra/bdDijkstra-family.rst
@@ -21,7 +21,7 @@ Bidirectional Dijkstra - Family of functions
   paths.
 * :doc:`pgr_bdDijkstraCost` - Bidirectional Dijkstra to calculate the cost of
   the shortest paths
-* :doc:`pgr_bdDijkstraCostMatrix` - Bidirectional Dijkstra algorithm  to create
+* :doc:`pgr_bdDijkstraCostMatrix` - Bidirectional Dijkstra algorithm to create
   a matrix of costs of the shortest paths.
 
 .. index to here

--- a/doc/bdDijkstra/pgr_bdDijkstra.rst
+++ b/doc/bdDijkstra/pgr_bdDijkstra.rst
@@ -92,7 +92,7 @@ One to One
    | RETURNS SET OF |result-1-1|
    | OR EMPTY SET
 
-:Example: From vertex :math:`6` to vertex  :math:`10` on a **directed** graph
+:Example: From vertex :math:`6` to vertex :math:`10` on a **directed** graph
 
 .. literalinclude:: doc-pgr_bdDijkstra.queries
     :start-after: -- q2

--- a/doc/bdDijkstra/pgr_bdDijkstraCost.rst
+++ b/doc/bdDijkstra/pgr_bdDijkstraCost.rst
@@ -83,7 +83,7 @@ One to One
    | RETURNS SET OF |matrix-result|
    | OR EMPTY SET
 
-:Example: From vertex :math:`6` to vertex  :math:`10` on a **directed** graph
+:Example: From vertex :math:`6` to vertex :math:`10` on a **directed** graph
 
 .. literalinclude:: doc-pgr_bdDijkstraCost.queries
     :start-after: -- q2

--- a/doc/bellman_ford/pgr_edwardMoore.rst
+++ b/doc/bellman_ford/pgr_edwardMoore.rst
@@ -13,7 +13,7 @@
 ``pgr_edwardMoore - Experimental``
 ===============================================================================
 
-``pgr_edwardMoore`` —  Returns the shortest path using Edward-Moore algorithm.
+``pgr_edwardMoore`` — Returns the shortest path using Edward-Moore algorithm.
 
 
 .. include:: experimental.rst

--- a/doc/breadthFirstSearch/pgr_binaryBreadthFirstSearch.rst
+++ b/doc/breadthFirstSearch/pgr_binaryBreadthFirstSearch.rst
@@ -54,7 +54,7 @@ unweighted graph, i.e. the distance is the minimal number of edges that you
 need to traverse from the source to another vertex. We can interpret such a
 graph also as a weighted graph, where every edge has the weight :math:`1`.
 If not alledges in graph have the same weight, that we need a more general
-algorithm, like Dijkstra's Algorithm  which runs in :math:`O(|E|log|V|)` time.
+algorithm, like Dijkstra's Algorithm which runs in :math:`O(|E|log|V|)` time.
 
 However if the weights are more constrained, we can use a faster algorithm.
 This algorithm, termed as 'Binary Breadth First Search' as well as '0-1 BFS',
@@ -111,7 +111,7 @@ One to One
    | RETURNS SET OF |result-1-1|
    | OR EMPTY SET
 
-:Example: From vertex :math:`6` to vertex  :math:`10` on a **directed** graph
+:Example: From vertex :math:`6` to vertex :math:`10` on a **directed** graph
 
 .. literalinclude:: doc-pgr_binaryBreadthFirstSearch.queries
    :start-after: -- q1

--- a/doc/circuits/pgr_hawickCircuits.rst
+++ b/doc/circuits/pgr_hawickCircuits.rst
@@ -13,7 +13,7 @@
 ``pgr_hawickCircuits - Experimental``
 ===============================================================================
 
-``pgr_hawickCircuits`` —  Returns the list of cirucits using hawick circuits algorithm.
+``pgr_hawickCircuits`` — Returns the list of cirucits using hawick circuits algorithm.
 
 .. figure:: images/boost-inside.jpeg
    :target: https://www.boost.org/libs/graph/doc/hawick_circuits.html

--- a/doc/coloring/pgr_bipartite.rst
+++ b/doc/coloring/pgr_bipartite.rst
@@ -44,7 +44,7 @@ colored with the same color.
 - The algorithm works in undirected graph only.
 - The returned values are not ordered.
 - The algorithm checks graph is bipartite or not. If it is bipartite then it
-  returns the node along with two    colors `0` and `1` which represents two
+  returns the node along with two colors `0` and `1` which represents two
   different sets.
 - If graph is not bipartite then algorithm returns empty set.
 - Running time: :math:`O(V + E)`

--- a/doc/coloring/pgr_edgeColoring.rst
+++ b/doc/coloring/pgr_edgeColoring.rst
@@ -55,7 +55,7 @@ no two adjacent edges have the same color.
   - When the graph is bipartite
 
     - the chromatic number :math:`x'(G)` (minimum number of
-      colors needed for proper edge coloring of graph)  is equal to the degree
+      colors needed for proper edge coloring of graph) is equal to the degree
       :math:`\Delta + 1` of the graph, (:math:`x'(G) = \Delta`)
 
 - The algorithm tries to assign the least possible color to every edge.

--- a/doc/components/pgr_biconnectedComponents.rst
+++ b/doc/components/pgr_biconnectedComponents.rst
@@ -27,7 +27,7 @@
 
   * Return columns change:
 
-    *  ``n_seq`` is removed
+    * ``n_seq`` is removed
     * ``seq`` changed type to ``BIGINT``
 
   * **Official** function

--- a/doc/components/pgr_connectedComponents.rst
+++ b/doc/components/pgr_connectedComponents.rst
@@ -27,7 +27,7 @@ a DFS-based approach.
 
   * Return columns change:
 
-    *  ``n_seq`` is removed
+    * ``n_seq`` is removed
     * ``seq`` changed type to ``BIGINT``
 
   * **Official** function

--- a/doc/components/pgr_strongComponents.rst
+++ b/doc/components/pgr_strongComponents.rst
@@ -27,7 +27,7 @@ using Tarjan's algorithm based on DFS.
 
   * Return columns change:
 
-    *  ``n_seq`` is removed
+    * ``n_seq`` is removed
     * ``seq`` changed type to ``BIGINT``
 
   * **Official** function

--- a/doc/contraction/contraction-family.rst
+++ b/doc/contraction/contraction-family.rst
@@ -124,7 +124,7 @@ Dead end vertex on directed graph
 
         rankdir=LR;
         G -> {u, v, w} [dir=none, weight=1, penwidth=3];
-        {x, y} -> G  [dir=none, weight=1, penwidth=3];
+        {x, y} -> G [dir=none, weight=1, penwidth=3];
         u -> a -> u;
         v -> b;
         {w, v} -> c;
@@ -358,7 +358,7 @@ nodes:
 Contracting :math:`w`,
 
 * The vertex :math:`w` is removed from the graph
-* The edges :math:`v \rightarrow w` and  :math:`w \rightarrow z` are removed
+* The edges :math:`v \rightarrow w` and :math:`w \rightarrow z` are removed
   from the graph.
 * A new edge :math:`v \rightarrow z` is inserted represented with red color.
 
@@ -379,7 +379,7 @@ Contracting :math:`w`,
 Contracting :math:`v`:
 
 * The vertex :math:`v` is removed from the graph
-* The edges :math:`u \rightarrow v` and  :math:`v \rightarrow z` are removed
+* The edges :math:`u \rightarrow v` and :math:`v \rightarrow z` are removed
   from the graph.
 * A new edge :math:`u \rightarrow z` is inserted represented with red color.
 

--- a/doc/contraction/pgr_contraction.rst
+++ b/doc/contraction/pgr_contraction.rst
@@ -57,8 +57,8 @@ The main Characteristics are:
 
 - The returned values include
 
-  -  the added edges by linear contraction.
-  -  the modified vertices by dead end contraction.
+  - the added edges by linear contraction.
+  - the modified vertices by dead end contraction.
 
 - The returned values are ordered as follows:
 
@@ -154,7 +154,7 @@ Edges SQL
 Result Columns
 -------------------------------------------------------------------------------
 
-Returns set of  |result-contract|
+Returns set of |result-contract|
 
 The function returns a single row. The columns of the row are:
 

--- a/doc/dagShortestPath/pgr_dagShortestPath.rst
+++ b/doc/dagShortestPath/pgr_dagShortestPath.rst
@@ -87,8 +87,8 @@ Signatures
 .. admonition:: \ \
    :class: signatures
 
-   | pgr_dagShortestPath(`Edges SQL`_, **start vid**,  **end vid**)
-   | pgr_dagShortestPath(`Edges SQL`_, **start vid**,  **end vids**)
+   | pgr_dagShortestPath(`Edges SQL`_, **start vid**, **end vid**)
+   | pgr_dagShortestPath(`Edges SQL`_, **start vid**, **end vids**)
    | pgr_dagShortestPath(`Edges SQL`_, **start vids**, **end vid**)
    | pgr_dagShortestPath(`Edges SQL`_, **start vids**, **end vids**)
    | pgr_dagShortestPath(`Edges SQL`_, `Combinations SQL`_)
@@ -106,12 +106,12 @@ One to One
 .. admonition:: \ \
    :class: signatures
 
-   | pgr_dagShortestPath(`Edges SQL`_, **start vid**,  **end vid**)
+   | pgr_dagShortestPath(`Edges SQL`_, **start vid**, **end vid**)
 
    | RETURNS SET OF |result-1-1|
    | OR EMPTY SET
 
-:Example: From vertex :math:`5` to vertex  :math:`11` on a **directed** graph
+:Example: From vertex :math:`5` to vertex :math:`11` on a **directed** graph
 
 .. literalinclude:: doc-pgr_dagShortestPath.queries
    :start-after: -- q2
@@ -126,7 +126,7 @@ One to Many
 .. admonition:: \ \
    :class: signatures
 
-   | pgr_dagShortestPath(`Edges SQL`_, **start vid**,  **end vids**)
+   | pgr_dagShortestPath(`Edges SQL`_, **start vid**, **end vids**)
 
    | RETURNS SET OF |result-1-1|
    | OR EMPTY SET

--- a/doc/dijkstra/dijkstra-family.rst
+++ b/doc/dijkstra/dijkstra-family.rst
@@ -121,13 +121,13 @@ Parameters
      - Identifier of the starting vertex of the path.
    * - **start vids**
      - ``ARRAY[BIGINT]``
-     -  Array of identifiers of starting vertices.
+     - Array of identifiers of starting vertices.
    * - **end vid**
      - ``BIGINT``
      - Identifier of the ending vertex of the path.
    * - **end vids**
      - ``ARRAY[BIGINT]``
-     -  Array of identifiers of ending vertices.
+     - Array of identifiers of ending vertices.
 
 .. dijkstra_parameters_end
 
@@ -180,7 +180,7 @@ Given the following query:
 
 pgr_dijkstra(:math:`sql, start_{vid}, end_{vid}, directed`)
 
-where  :math:`sql = \{(id_i, source_i, target_i, cost_i, reverse\_cost_i)\}`
+where :math:`sql = \{(id_i, source_i, target_i, cost_i, reverse\_cost_i)\}`
 
 and
 
@@ -193,7 +193,7 @@ The graphs are defined as follows:
 
 The weighted directed graph, :math:`G_d(V,E)`, is definied by:
 
-* the set of vertices  :math:`V`
+* the set of vertices :math:`V`
 
   - :math:`V = source \cup target \cup {start_{vid}} \cup  {end_{vid}}`
 
@@ -212,7 +212,7 @@ The weighted directed graph, :math:`G_d(V,E)`, is definied by:
 
 The weighted undirected graph, :math:`G_u(V,E)`, is definied by:
 
-* the set of vertices  :math:`V`
+* the set of vertices :math:`V`
 
   - :math:`V = source \cup target \cup {start_v{vid}} \cup  {end_{vid}}`
 
@@ -268,7 +268,7 @@ where:
 
 In other words: The algorithm returns a the shortest path between
 :math:`start_{vid}` and :math:`end_{vid}`, if it exists, in terms of a sequence
-of nodes  and of edges,
+of nodes and of edges,
 
 - :math:`path\_seq` indicates the relative position in the path of the
   :math:`node` or :math:`edge`.

--- a/doc/dijkstra/pgr_dijkstra.rst
+++ b/doc/dijkstra/pgr_dijkstra.rst
@@ -106,7 +106,7 @@ One to One
    | RETURNS SET OF |short-generic-result|
    | OR EMPTY SET
 
-:Example: From vertex :math:`6` to vertex  :math:`10` on a **directed** graph
+:Example: From vertex :math:`6` to vertex :math:`10` on a **directed** graph
 
 .. literalinclude:: doc-pgr_dijkstra.queries
     :start-after: -- q2

--- a/doc/dijkstra/pgr_dijkstraCost.rst
+++ b/doc/dijkstra/pgr_dijkstraCost.rst
@@ -84,7 +84,7 @@ One to One
    | RETURNS SET OF |matrix-result|
    | OR EMPTY SET
 
-:Example: From vertex :math:`6` to vertex  :math:`10` on a **directed** graph
+:Example: From vertex :math:`6` to vertex :math:`10` on a **directed** graph
 
 .. literalinclude:: doc-pgr_dijkstraCost.queries
     :start-after: -- q2

--- a/doc/driving_distance/pgr_drivingDistance.rst
+++ b/doc/driving_distance/pgr_drivingDistance.rst
@@ -58,7 +58,7 @@ Signatures
 .. admonition:: \ \
    :class: signatures
 
-   | pgr_drivingDistance(`Edges SQL`_, **Root vid**,  **distance**, [``directed``])
+   | pgr_drivingDistance(`Edges SQL`_, **Root vid**, **distance**, [``directed``])
    | pgr_drivingDistance(`Edges SQL`_, **Root vids**, **distance**, [**options**])
    | **options:** [directed, equicost]
 
@@ -73,7 +73,7 @@ Single Vertex
 .. admonition:: \ \
    :class: signatures
 
-   | pgr_drivingDistance(`Edges SQL`_, **Root vid**,  **distance**, [``directed``])
+   | pgr_drivingDistance(`Edges SQL`_, **Root vid**, **distance**, [``directed``])
 
    | RETURNS SET OF |result-spantree|
 

--- a/doc/pickDeliver/VRP-category.rst
+++ b/doc/pickDeliver/VRP-category.rst
@@ -441,7 +441,7 @@ Return columns
 
      RETURNS SET OF
       (seq, vehicle_seq, vehicle_id, stop_seq, stop_type,
-          travel_time, arrival_time, wait_time, service_time,  departure_time)
+          travel_time, arrival_time, wait_time, service_time, departure_time)
       UNION
       (summary row)
 
@@ -629,7 +629,7 @@ The `capacity` of a vehicle, can be measured in:
 The `demand` request of the pickup-deliver orders must use the same units as the
 units used in the vehicle's `capacity`.
 
-To handle problems like:  10 (equal dimension) boxes of apples and 5 kg of
+To handle problems like: 10 (equal dimension) boxes of apples and 5 kg of
 feathers that are to be transported (not packed in boxes).
 
 * If the vehicle's **capacity** is measured in `boxes`, a conversion of `kg of

--- a/doc/src/cost-category.rst
+++ b/doc/src/cost-category.rst
@@ -59,7 +59,7 @@ The main Characteristics are:
 
 * Depending on the function and its parameters, the results can be symmetric.
 
-  * The  **aggregate cost** of :math:`(u, v)` is the same as for :math:`(v, u)`.
+  * The **aggregate cost** of :math:`(u, v)` is the same as for :math:`(v, u)`.
 
 * Any duplicated value in the start or end vertex identifiers are ignored.
 

--- a/doc/src/costMatrix-category.rst
+++ b/doc/src/costMatrix-category.rst
@@ -126,7 +126,7 @@ Parameters
      - `Edges SQL`_ as described below
    * - **start vids**
      - ``ARRAY[BIGINT]``
-     -  Array of identifiers of starting vertices.
+     - Array of identifiers of starting vertices.
 
 .. costMatrix_parameters_end
 
@@ -152,7 +152,7 @@ Parameters
      - `Points SQL`_ as described below
    * - **start vids**
      - ``ARRAY[BIGINT]``
-     -  Array of identifiers of starting vertices.
+     - Array of identifiers of starting vertices.
 
 .. costMatrix_withPoints_parameters_end
 

--- a/doc/src/experimental.rst
+++ b/doc/src/experimental.rst
@@ -13,7 +13,7 @@
 Experimental Functions
 ===============================================================================
 
-..  begin-warn-expr
+.. begin-warn-expr
 
 .. warning:: Possible server crash
 
@@ -37,7 +37,7 @@ Experimental Functions
     - Might depend on a proposed function of pgRouting
     - Might depend on a deprecated function of pgRouting
 
-..  end-warn-expr
+.. end-warn-expr
 
 .. rubric:: Families
 

--- a/doc/src/migration.rst
+++ b/doc/src/migration.rst
@@ -472,7 +472,7 @@ The default values on this query are:
 
 .. rubric:: On undirected graph ``r`` could be used as **driving side**
 
-Also ``l`` could be used as  **driving side**
+Also ``l`` could be used as **driving side**
 
 .. literalinclude:: migration.queries
    :start-after: --withpointsdd4
@@ -757,8 +757,8 @@ Signature to be migrated:
 
 Migrate by using:
 
-*  :doc:`pgr_dijkstra` when there are no restrictions,
-*  :doc:`pgr_trsp` (One to One) when there are restrictions.
+* :doc:`pgr_dijkstra` when there are no restrictions,
+* :doc:`pgr_trsp` (One to One) when there are restrictions.
 
 
 Migrating ``pgr_trsp`` (Vertices) using ``pgr_dijkstra``
@@ -891,8 +891,8 @@ For these migration guide the following points will be used:
 
 Migrate by using:
 
-*  :doc:`pgr_withPoints` when there are no restrictions,
-*  :doc:`pgr_trsp_withPoints` (One to One) when there are restrictions.
+* :doc:`pgr_withPoints` when there are no restrictions,
+* :doc:`pgr_trsp_withPoints` (One to One) when there are restrictions.
 
 Migrating ``pgr_trsp`` (Edges) using ``pgr_withPoints``
 ...............................................................................
@@ -1022,8 +1022,8 @@ Signature to be migrated:
 
 Migrate by using:
 
-*  :doc:`pgr_dijkstraVia` when there are no restrictions,
-*  :doc:`pgr_trspVia` when there are restrictions.
+* :doc:`pgr_dijkstraVia` when there are no restrictions,
+* :doc:`pgr_trspVia` when there are restrictions.
 
 Migrating ``pgr_trspViaVertices`` using ``pgr_dijkstraVia``
 ...............................................................................
@@ -1160,8 +1160,8 @@ And will travel thru the following Via points :math:`4\rightarrow3\rightarrow6`
 
 Migrate by using:
 
-*  :doc:`pgr_withPointsVia` when there are no restrictions,
-*  :doc:`pgr_trspVia_withPoints` when there are restrictions.
+* :doc:`pgr_withPointsVia` when there are no restrictions,
+* :doc:`pgr_trspVia_withPoints` when there are restrictions.
 
 Migrating ``pgr_trspViaEdges`` using ``pgr_withPointsVia``
 ...............................................................................

--- a/doc/src/pgRouting-concepts.rst
+++ b/doc/src/pgRouting-concepts.rst
@@ -115,7 +115,7 @@ The weighted directed graph, :math:`G_d(V,E)`:
     \ge 0 \}`
   * Edges where ``cost`` is non negative are part of the graph.
 
-* the set of vertices  :math:`V`
+* the set of vertices :math:`V`
 
   * :math:`V = \{source_{id} \cup target_{id}\}`
   * All vertices in ``source`` and ``target`` are part of the graph.
@@ -138,7 +138,7 @@ The data is representing the following graph:
 .. graphviz::
 
    digraph G {
-    1 -> 2 [label="  1(5)"];
+    1 -> 2 [label="1(5)"];
     3;
    }
 
@@ -157,14 +157,14 @@ For the following data:
    :start-after: -- g1
    :end-before: -- g2
 
-Edge :math:`2` (:math:`1  \frac{\;\;\;\;\;}{} 3`) is not part of the graph.
+Edge :math:`2` (:math:`1 \frac{\;\;\;\;\;}{} 3`) is not part of the graph.
 
 The data is representing the following graph:
 
 .. graphviz::
 
    graph G {
-    1 -- 2 [label="  1(5)"];
+    1 -- 2 [label="1(5)"];
     3;
    }
 
@@ -189,7 +189,7 @@ The weighted directed graph, :math:`G_d(V,E)`, is defined by:
   * Edges :math:`(target \rightarrow source)` where ``reverse_cost`` is non
     negative are part of the graph.
 
-* The set of vertices  :math:`V`:
+* The set of vertices :math:`V`:
 
   * :math:`V = \{source_{id} \cup target_{id}\}`
   * All vertices in ``source`` and ``target`` are part of the graph.
@@ -211,18 +211,18 @@ For the following data:
 
 Edges not part of the graph:
 
-* :math:`2` (:math:`1  \rightarrow 3`)
-* :math:`3` (:math:`3  \rightarrow 2`)
+* :math:`2` (:math:`1 \rightarrow 3`)
+* :math:`3` (:math:`3 \rightarrow 2`)
 
 The data is representing the following graph:
 
 .. graphviz::
 
    digraph G {
-    1 -> 2 [label="  1(5)"];
-    2 -> 1 [label="  1(2)"];
-    3 -> 1 [label="  2(4)"];
-    2 -> 3 [label="  3(7)"];
+    1 -> 2 [label="1(5)"];
+    2 -> 1 [label="1(2)"];
+    3 -> 1 [label="2(4)"];
+    2 -> 3 [label="3(7)"];
    }
 
 .. rubric:: Undirected graph
@@ -246,25 +246,25 @@ For the following data:
 
 Edges not part of the graph:
 
-* :math:`2` (:math:`1  \frac{\;\;\;\;\;}{} 3`)
-* :math:`3` (:math:`3  \frac{\;\;\;\;\;}{} 2`)
+* :math:`2` (:math:`1 \frac{\;\;\;\;\;}{} 3`)
+* :math:`3` (:math:`3 \frac{\;\;\;\;\;}{} 2`)
 
 The data is representing the following graph:
 
 .. graphviz::
 
    graph G {
-    1 -- 2 [label="  1(5)"];
-    2 -- 1 [label="  1(2)"];
-    3 -- 1 [label="  2(4)"];
-    2 -- 3 [label="  3(7)"];
+    1 -- 2 [label="1(5)"];
+    2 -- 1 [label="1(2)"];
+    3 -- 1 [label="2(4)"];
+    2 -- 3 [label="3(7)"];
    }
 
 Graphs without geometries
 -------------------------------------------------------------------------------
 
 Personal relationships, genealogy, file dependency problems can be solved
-using pgRouting. Those problems, normally,  do not come with geometries associated
+using pgRouting. Those problems, normally, do not come with geometries associated
 with the graph.
 
 .. contents::
@@ -305,15 +305,15 @@ Where:
     rankdir="LR";
     1 [color="red"];
     5 [color="green"];
-    1 -- 2 [label="  (7)"];
-    5 -- 6 [label="  (9)"];
-    1 -- 3 [label="  (9)"];
-    1 -- 6 [label="  (14)"];
-    2 -- 3 [label="  (10)"];
-    2 -- 4 [label="  (13)"];
-    3 -- 4 [label="  (11)"];
-    3 -- 6 [label="  (2)"];
-    4 -- 5 [label="  (6)"];
+    1 -- 2 [label="(7)"];
+    5 -- 6 [label="(9)"];
+    1 -- 3 [label="(9)"];
+    1 -- 6 [label="(14)"];
+    2 -- 3 [label="(10)"];
+    2 -- 4 [label="(13)"];
+    3 -- 4 [label="(11)"];
+    3 -- 6 [label="(2)"];
+    4 -- 5 [label="(6)"];
    }
 
 
@@ -390,15 +390,15 @@ To go from :math:`1` to :math:`5` the path goes thru the following vertices:
     rankdir="LR";
     1 [color="red"];
     5 [color="green"];
-    1 -- 2 [label="  (7)"];
-    5 -- 6 [label="  (9)", color="blue"];
-    1 -- 3 [label="  (9)", color="blue"];
-    1 -- 6 [label="  (14)"];
-    2 -- 3 [label="  (10)"];
-    2 -- 4 [label="  (13)"];
-    3 -- 4 [label="  (11)"];
-    3 -- 6 [label="  (2)", color="blue"];
-    4 -- 5 [label="  (6)"];
+    1 -- 2 [label="(7)"];
+    5 -- 6 [label="(9)", color="blue"];
+    1 -- 3 [label="(9)", color="blue"];
+    1 -- 6 [label="(14)"];
+    2 -- 3 [label="(10)"];
+    2 -- 4 [label="(13)"];
+    3 -- 4 [label="(11)"];
+    3 -- 6 [label="(2)", color="blue"];
+    4 -- 5 [label="(6)"];
    }
 
 Vertex information
@@ -907,7 +907,7 @@ For example, for this :doc:`pgr_dijkstra` signature:
 .. admonition:: \ \
    :class: signatures
 
-   pgr_dijkstra(`Edges SQL`_, **start vid**, **end vid**  [, ``directed``])
+   pgr_dijkstra(`Edges SQL`_, **start vid**, **end vid** [, ``directed``])
 
 * `Edges SQL`_:
 
@@ -1109,7 +1109,7 @@ General without ``id``
    * - ``cost``
      - **ANY-NUMERICAL**
      -
-     - Weight of the edge  (``source``, ``target``)
+     - Weight of the edge (``source``, ``target``)
    * - ``reverse_cost``
      - **ANY-NUMERICAL**
      - -1
@@ -1159,7 +1159,7 @@ General with (X,Y)
    * - ``cost``
      - **ANY-NUMERICAL**
      -
-     - Weight of the edge  (``source``, ``target``)
+     - Weight of the edge (``source``, ``target``)
 
        * When negative: edge (``source``, ``target``) does not exist, therefore
          it's not part of the graph.
@@ -1231,7 +1231,7 @@ Flow
    * - ``capacity``
      - **ANY-INTEGER**
      -
-     - Weight of the edge  (``source``, ``target``)
+     - Weight of the edge (``source``, ``target``)
    * - ``reverse_capacity``
      - **ANY-INTEGER**
      - -1
@@ -1278,7 +1278,7 @@ Where:
    * - ``capacity``
      - **ANY-INTEGER**
      -
-     - Capacity of the edge  (``source``, ``target``)
+     - Capacity of the edge (``source``, ``target``)
 
        - When negative: edge (``target``, ``source``) does not exist, therefore
          it's not part of the graph.
@@ -1292,7 +1292,7 @@ Where:
    * - ``cost``
      - **ANY-NUMERICAL**
      -
-     - Weight of the edge  (``source``, ``target``) if it exist
+     - Weight of the edge (``source``, ``target``) if it exist
    * - ``reverse_cost``
      - **ANY-NUMERICAL**
      - :math:`-1`
@@ -1441,10 +1441,10 @@ Parameters for the Via functions
      - ``BOOLEAN``
      - ``true``
      - * When ``true`` departing from a visited vertex will not try to avoid
-         using the edge used to reach it.  In other words, U turn using the edge
+         using the edge used to reach it. In other words, U turn using the edge
          with same identifier is allowed.
        * When ``false`` when a departing from a visited vertex tries to avoid
-         using the edge used to reach it.  In other words, U turn using the edge
+         using the edge used to reach it. In other words, U turn using the edge
          with same identifier is used when no other path is found.
 
 
@@ -1589,7 +1589,7 @@ agg_cost)``
 
        * When positive is the identifier of the starting vertex.
        * When negative is the identifier of the starting point.
-       * Returned on `Many to One`_  and `Many to Many`_
+       * Returned on `Many to One`_ and `Many to Many`_
    * - ``end_pid``
      - ``BIGINT``
      - Identifier of an ending vertex/point of the path.
@@ -1905,7 +1905,7 @@ How to contribute
 
 .. rubric:: Wiki
 
-* Edit an existing  `pgRouting Wiki
+* Edit an existing `pgRouting Wiki
   <https://github.com/pgRouting/pgrouting/wiki>`__ page.
 * Or create a new Wiki page
 

--- a/doc/src/pgRouting-introduction.rst
+++ b/doc/src/pgRouting-introduction.rst
@@ -81,7 +81,7 @@ Yige Huang
 
 
 And all the people that give us a little of their time making comments, finding
-issues, making pull requests etc.  in any of our products: osm2pgrouting,
+issues, making pull requests etc. in any of our products: osm2pgrouting,
 pgRouting, pgRoutingLayer, workshop.
 
 

--- a/doc/src/proposed.rst
+++ b/doc/src/proposed.rst
@@ -13,7 +13,7 @@
 Proposed Functions
 ==================================
 
-..  stable-begin-warning
+.. stable-begin-warning
 
 .. warning:: Proposed functions for next mayor release.
 
@@ -27,7 +27,7 @@ Proposed Functions
     - pgTap tests have being done. But might need more.
     - Documentation might need refinement.
 
-..  stable-end-warning
+.. stable-end-warning
 
 .. rubric:: Families
 

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -142,7 +142,7 @@ Changes on the documentation to the following:
 
 * Fix winnie build
 
-.. rubric::  Code fixes
+.. rubric:: Code fixes
 
 * Fix clang warnings
 
@@ -712,7 +712,7 @@ on Github.
 
 .. rubric:: Issues fixes
 
-* `#232 <https://github.com/pgRouting/pgrouting/issues/232>`__:  Honor client
+* `#232 <https://github.com/pgRouting/pgrouting/issues/232>`__: Honor client
   cancel requests in C /C++ code
 
 
@@ -870,7 +870,7 @@ on Github.
 
 * Experimental functions
 
-  * pgr_labelGraph  -  Use the components family of functions instead.
+  * pgr_labelGraph - Use the components family of functions instead.
   * Max flow - functions were renamed on v2.5.0
 
     * pgr_maxFlowPushRelabel
@@ -974,7 +974,7 @@ on Github.
 
 .. rubric:: New experimental functions
 
-*  pgr_lineGraphFull
+* pgr_lineGraphFull
 
 .. rubric:: Bug fixes
 
@@ -1389,7 +1389,7 @@ on Github.
 
 - Signature fix
 
-  - pgr_dijkstra  -- to match what is documented
+  - pgr_dijkstra -- to match what is documented
 
 
 .. rubric:: New Functions
@@ -1419,8 +1419,8 @@ on Github.
 
 .. rubric:: Deprecated functions:
 
-- pgr_apspWarshall  use pgr_floydWarshall instead
-- pgr_apspJohnson   use pgr_Johnson instead
+- pgr_apspWarshall use pgr_floydWarshall instead
+- pgr_apspJohnson use pgr_Johnson instead
 - pgr_kDijkstraCost use pgr_dijkstraCost instead
 - pgr_kDijkstraPath use pgr_dijkstra instead
 

--- a/doc/src/routingFunctions.rst
+++ b/doc/src/routingFunctions.rst
@@ -146,7 +146,7 @@ Functions by categories
    :start-after: index from here
    :end-before: index to here
 
-..  to-here
+.. to-here
 
 .. toctree::
     :hidden:

--- a/doc/src/sampledata.rst
+++ b/doc/src/sampledata.rst
@@ -86,7 +86,7 @@ corresponds to the segment on the oposite direction of the geometry.
    :start-after: --EDGE TABLE CREATE start
    :end-before: --EDGE TABLE CREATE end
 
-Starting on  PostgreSQL 12::
+Starting on PostgreSQL 12::
 
    ...
    x1 FLOAT GENERATED ALWAYS AS (ST_X(ST_StartPoint(geom))) STORED,

--- a/doc/topology/pgr_analyzeGraph.rst
+++ b/doc/topology/pgr_analyzeGraph.rst
@@ -41,7 +41,7 @@ The function returns:
 
 .. rubric:: Prerequisites
 
-The  edge table to be analyzed must contain a source column and a target column
+The edge table to be analyzed must contain a source column and a target column
 filled with id's of the vertices of the segments and the corresponding vertices
 table <edge_table>_vertices_pgr that stores the vertices information.
 
@@ -56,15 +56,15 @@ The analyze graph function accepts the following parameters:
 :edge_table: ``text`` Network table name. (may contain the schema name as well)
 :tolerance: ``float8`` Snapping tolerance of disconnected edges. (in projection
             unit)
-:the_geom: ``text``  Geometry column name of the network table. Default value is
+:the_geom: ``text`` Geometry column name of the network table. Default value is
            ``the_geom``.
-:id: ``text``  Primary key column name of the network table. Default value is
+:id: ``text`` Primary key column name of the network table. Default value is
      ``id``.
 :source: ``text`` Source column name of the network table. Default value is
          ``source``.
-:target: ``text``  Target column name of the network table.  Default value is
+:target: ``text`` Target column name of the network table. Default value is
          ``target``.
-:rows_where: ``text``   Condition to select  a subset or rows.  Default value is
+:rows_where: ``text`` Condition to select a subset or rows. Default value is
              ``true`` to indicate all rows.
 
 The function returns:
@@ -73,7 +73,7 @@ The function returns:
 
   * Uses the vertices table: <edge_table>_vertices_pgr.
   * Fills completely the ``cnt`` and ``chk`` columns of the vertices table.
-  * Returns the analysis of the section of the network defined by  ``rows_where``
+  * Returns the analysis of the section of the network defined by ``rows_where``
 
 - ``FAIL`` when the analysis was not completed due to an error.
 
@@ -94,7 +94,7 @@ The structure of the vertices table is:
 :id: ``bigint`` Identifier of the vertex.
 :cnt: ``integer`` Number of vertices in the edge_table that reference this
       vertex.
-:chk: ``integer``  Indicator that the vertex might have a problem.
+:chk: ``integer`` Indicator that the vertex might have a problem.
 :ein: ``integer`` Number of vertices in the edge_table that reference this
       vertex as incoming. See :doc:`pgr_analyzeOneWay <pgr_analyzeOneWay>`.
 :eout: ``integer`` Number of vertices in the edge_table that reference this
@@ -118,7 +118,7 @@ Usage when the edge table's columns MATCH the default values:
 
 We get the same result as the simplest way to use the function.
 
-.. warning::  An error would occur when
+.. warning:: An error would occur when
 
    the arguments are not given in the appropriate order:
 
@@ -190,7 +190,7 @@ The arguments need to be given in the order described in the parameters:
    :start-after: -- q13
    :end-before: -- q13.1
 
-.. warning::  An error would occur when
+.. warning:: An error would occur when
    the arguments are not given in the appropriate order: In this example, the
    column ``gid`` of the table ``mytable`` is passed to the function as the
    geometry column, and the geometry column ``mygeom`` is passed to the function

--- a/doc/topology/pgr_analyzeOneWay.rst
+++ b/doc/topology/pgr_analyzeOneWay.rst
@@ -50,7 +50,7 @@ your network to make repairs and/or report the problem back to your data vendor.
 
 .. rubric:: Prerequisites
 
-The  edge table to be analyzed must contain a source column and a target column
+The edge table to be analyzed must contain a source column and a target column
 filled with id's of the vertices of the segments and the corresponding vertices
 table <edge_table>_vertices_pgr that stores the vertices information.
 
@@ -80,10 +80,10 @@ Parameters
          ``oneway``.
 :source: ``text`` Source column name of the network table. Default value is
          ``source``.
-:target: ``text``  Target column name of the network table.  Default value is
+:target: ``text`` Target column name of the network table. Default value is
          ``target``.
 :two_way_if_null: ``boolean`` flag to treat oneway NULL values as
-                  bi-directional.  Default value is ``true``.
+                  bi-directional. Default value is ``true``.
 
 .. note::
    It is strongly recommended to use the named notation. See
@@ -117,7 +117,7 @@ The structure of the vertices table is:
 :id: ``bigint`` Identifier of the vertex.
 :cnt: ``integer`` Number of vertices in the edge_table that reference this
       vertex. See :doc:`pgr_analyzeGgraph <pgr_analyzeGraph>`.
-:chk: ``integer``  Indicator that the vertex might have a problem. See
+:chk: ``integer`` Indicator that the vertex might have a problem. See
       :doc:`pgr_analyzeGraph <pgr_analyzeGraph>`.
 :ein: ``integer`` Number of vertices in the edge_table that reference this
       vertex as incoming.

--- a/doc/topology/pgr_createTopology.rst
+++ b/doc/topology/pgr_createTopology.rst
@@ -51,18 +51,18 @@ The topology creation function accepts the following parameters:
 :edge_table: ``text`` Network table name. (may contain the schema name AS well)
 :tolerance: ``float8`` Snapping tolerance of disconnected edges. (in projection
             unit)
-:the_geom: ``text``  Geometry column name of the network table. Default value is
+:the_geom: ``text`` Geometry column name of the network table. Default value is
            ``the_geom``.
-:id: ``text``  Primary key column name of the network table. Default value is
+:id: ``text`` Primary key column name of the network table. Default value is
      ``id``.
 :source: ``text`` Source column name of the network table. Default value is
          ``source``.
-:target: ``text``  Target column name of the network table.  Default value is
+:target: ``text`` Target column name of the network table. Default value is
          ``target``.
-:rows_where: ``text``   Condition to SELECT a subset or rows.  Default value is
+:rows_where: ``text`` Condition to SELECT a subset or rows. Default value is
              ``true`` to indicate all rows that where ``source`` or ``target``
              have a null value, otherwise the condition is used.
-:clean: ``boolean`` Clean any previous topology.  Default value is ``false``.
+:clean: ``boolean`` Clean any previous topology. Default value is ``false``.
 
 .. warning::
 
@@ -107,7 +107,7 @@ The structure of the vertices table is:
 :id: ``bigint`` Identifier of the vertex.
 :cnt: ``integer`` Number of vertices in the edge_table that reference this
       vertex. See :doc:`pgr_analyzeGraph`.
-:chk: ``integer``  Indicator that the vertex might have a problem. See
+:chk: ``integer`` Indicator that the vertex might have a problem. See
       :doc:`pgr_analyzeGraph`.
 :ein: ``integer`` Number of vertices in the edge_table that reference this
       vertex AS incoming. See :doc:`pgr_analyzeOneWay`.

--- a/doc/topology/pgr_createVerticesTable.rst
+++ b/doc/topology/pgr_createVerticesTable.rst
@@ -44,17 +44,17 @@ Signatures
 Parameters
 -------------------------------------------------------------------------------
 
-The reconstruction of the vertices table  function accepts the following
+The reconstruction of the vertices table function accepts the following
 parameters:
 
 :edge_table: ``text`` Network table name. (may contain the schema name as well)
-:the_geom: ``text``  Geometry column name of the network table. Default value is
+:the_geom: ``text`` Geometry column name of the network table. Default value is
            ``the_geom``.
 :source: ``text`` Source column name of the network table. Default value is
          ``source``.
-:target: ``text``  Target column name of the network table.  Default value is
+:target: ``text`` Target column name of the network table. Default value is
          ``target``.
-:rows_where: ``text``   Condition to SELECT a subset or rows.  Default value is
+:rows_where: ``text`` Condition to SELECT a subset or rows. Default value is
              ``true`` to indicate all rows.
 
 .. warning::
@@ -94,7 +94,7 @@ The structure of the vertices table is:
 :id: ``bigint`` Identifier of the vertex.
 :cnt: ``integer`` Number of vertices in the edge_table that reference this
       vertex. See :doc:`pgr_analyzeGraph`.
-:chk: ``integer``  Indicator that the vertex might have a problem. See
+:chk: ``integer`` Indicator that the vertex might have a problem. See
       :doc:`pgr_analyzeGraph`.
 :ein: ``integer`` Number of vertices in the edge_table that reference this
       vertex as incoming. See :doc:`pgr_analyzeOneWay`.
@@ -276,7 +276,7 @@ The example uses the :doc:`sampledata` network.
 See Also
 -------------------------------------------------------------------------------
 
-* :doc:`topology-functions`  for an overview of a topology for routing
+* :doc:`topology-functions` for an overview of a topology for routing
   algorithms.
 * :doc:`pgr_createTopology` <pgr_create_topology>` to create a topology based on
   the geometry.

--- a/doc/topology/pgr_nodeNetwork.rst
+++ b/doc/topology/pgr_nodeNetwork.rst
@@ -70,7 +70,7 @@ Parameters
            ``the_geom``.
 :table_ending: ``text`` Suffix for the new table's. Default value is ``noded``.
 
-The output table will have for  ``edge_table_noded``
+The output table will have for ``edge_table_noded``
 
 :id: ``bigint`` Unique identifier for the table
 :old_id: ``bigint``  Identifier of the edge in original table

--- a/doc/topology/topology-functions.rst
+++ b/doc/topology/topology-functions.rst
@@ -38,13 +38,13 @@ Additional functions to analyze a graph:
 The following functions modify the database directly therefore the user must
 have special permissions given by the administrators to use them.
 
-- :doc:`pgr_createTopology` -  create a topology based on the geometry.
+- :doc:`pgr_createTopology` - create a topology based on the geometry.
 - :doc:`pgr_createVerticesTable` - reconstruct the vertices table based on
   the source and target information.
-- :doc:`pgr_analyzeGraph`  - to analyze the edges and vertices of the edge
+- :doc:`pgr_analyzeGraph` - to analyze the edges and vertices of the edge
   table.
 - :doc:`pgr_analyzeOneWay` - to analyze directionality of the edges.
-- :doc:`pgr_nodeNetwork`  -to create nodes to a not noded edge table.
+- :doc:`pgr_nodeNetwork` - to create nodes to a not noded edge table.
 
 .. topology_index_end
 

--- a/doc/traversal/BFS-category.rst
+++ b/doc/traversal/BFS-category.rst
@@ -63,7 +63,7 @@ Parameters
 
    * - **root vids**
      - ``ARRAY`` [ **ANY-INTEGER** ]
-     -  Array of identifiers of the root vertices.
+     - Array of identifiers of the root vertices.
 
         * :math:`0` values are ignored
         * For optimization purposes, any duplicated value is ignored.

--- a/doc/trsp/pgr_trsp.rst
+++ b/doc/trsp/pgr_trsp.rst
@@ -103,7 +103,7 @@ One to One
    | RETURNS SET OF |short-generic-result|
    | OR EMPTY SET
 
-:Example: From vertex :math:`6` to vertex  :math:`10` on an undirected graph.
+:Example: From vertex :math:`6` to vertex :math:`10` on an undirected graph.
 
 .. literalinclude:: doc-trsp.queries
    :start-after: -- q2

--- a/doc/trsp/pgr_turnRestrictedPath.rst
+++ b/doc/trsp/pgr_turnRestrictedPath.rst
@@ -47,7 +47,7 @@ Signatures
    | RETURNS SET OF |ksp-result|
    | OR EMPTY SET
 
-:Example: From vertex :math:`3` to vertex  :math:`8` on a directed graph
+:Example: From vertex :math:`3` to vertex :math:`8` on a directed graph
 
 .. literalinclude:: doc-pgr_turnRestrictedPath.queries
    :start-after: -- q1
@@ -134,13 +134,13 @@ No results because the only path available follows a restriction.
    :start-after: -- q2
    :end-before: -- q3
 
-:Example: From vertex :math:`3` to vertex  :math:`8` on an undirected graph
+:Example: From vertex :math:`3` to vertex :math:`8` on an undirected graph
 
 .. literalinclude:: doc-pgr_turnRestrictedPath.queries
    :start-after: -- q3
    :end-before: -- q4
 
-:Example: From vertex :math:`3` to vertex  :math:`8` with more alternatives
+:Example: From vertex :math:`3` to vertex :math:`8` with more alternatives
 
 .. literalinclude:: doc-pgr_turnRestrictedPath.queries
    :start-after: -- q4

--- a/doc/tsp/TSP-family.rst
+++ b/doc/tsp/TSP-family.rst
@@ -54,7 +54,7 @@ The traveling sales person problem was studied in the 18th century by
 mathematicians **Sir William Rowam Hamilton** and **Thomas Penyngton Kirkman**.
 
 A discussion about the work of Hamilton & Kirkman
-can be found in the book **Graph Theory (Biggs et  al. 1976)**.
+can be found in the book **Graph Theory (Biggs et al. 1976)**.
 
 * ISBN-13: 978-0198539162
 * ISBN-10: 0198539169
@@ -70,8 +70,8 @@ To calculate the number of different tours through :math:`n` cities:
 
 - Given a starting city,
 - There are :math:`n-1` choices for the second city,
-- And  :math:`n-2` choices for the third city, etc.
-- Multiplying these together we get :math:`(n-1)!  = (n-1) (n-2) . .  1`.
+- And :math:`n-2` choices for the third city, etc.
+- Multiplying these together we get :math:`(n-1)! = (n-1) (n-2) . . 1`.
 - Now since the travel costs do not depend on the direction taken around the
   tour:
 

--- a/doc/tsp/pgr_TSP.rst
+++ b/doc/tsp/pgr_TSP.rst
@@ -97,7 +97,7 @@ Description
         `(u, v)`
       - if ``agg_cost`` differs between one or more instances of edge `(u, v)`
       - The minimum value of the ``agg_cost`` all instances of edge `(u, v)`
-        is going to be considered as the ``agg_cost`` of edge  `(u, v)`
+        is going to be considered as the ``agg_cost`` of edge `(u, v)`
       - Some (or all) traveling costs on edges will still might not obey the
         triangle inequality.
 

--- a/doc/tsp/pgr_TSPeuclidean.rst
+++ b/doc/tsp/pgr_TSPeuclidean.rst
@@ -99,7 +99,7 @@ Parameters
 =================== ===========  ======================================
 Parameter           Type         Description
 =================== ===========  ======================================
-`Coordinates SQL`_  ``TEXT``      `Coordinates SQL`_ as described below
+`Coordinates SQL`_ ``TEXT``      `Coordinates SQL`_ as described below
 =================== ===========  ======================================
 
 TSP optional parameters
@@ -181,7 +181,7 @@ Getting a geometry of the tour
 Visual results
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 Visualy, The first image is the `optimal solution
-<https://www.math.uwaterloo.ca/tsp/world/witour.html>`__  and the second image
+<https://www.math.uwaterloo.ca/tsp/world/witour.html>`__ and the second image
 is the solution obtained with ``pgr_TSPeuclidean``.
 
 .. image:: images/wi29optimal.png

--- a/doc/tsp/pgr_TSPeuclidean.rst
+++ b/doc/tsp/pgr_TSPeuclidean.rst
@@ -99,7 +99,7 @@ Parameters
 =================== ===========  ======================================
 Parameter           Type         Description
 =================== ===========  ======================================
-`Coordinates SQL`_ ``TEXT``      `Coordinates SQL`_ as described below
+`Coordinates SQL`_  ``TEXT``      `Coordinates SQL`_ as described below
 =================== ===========  ======================================
 
 TSP optional parameters

--- a/doc/utilities/pgr_findCloseEdges.rst
+++ b/doc/utilities/pgr_findCloseEdges.rst
@@ -291,7 +291,7 @@ Returns set of |result-find|
 .. rubric:: Many point results
 
 * The green nodes are the **original points**
-* The geometry ``geom``, marked as **g1** and **g2**  are the **original
+* The geometry ``geom``, marked as **g1** and **g2** are the **original
   points**
 * The geometry ``edge``, marked as **edge1** and **edge2** is a line that
   connects the **original point** with the closest point on the :math:`sp

--- a/doc/withPoints/pgr_withPoints.rst
+++ b/doc/withPoints/pgr_withPoints.rst
@@ -165,7 +165,7 @@ Many to Many
    | RETURNS SET OF |pid-m-m|
    | OR EMTPY SET
 
-:Example: From point :math:`1` and vertex :math:`6`  to point :math:`3` and
+:Example: From point :math:`1` and vertex :math:`6` to point :math:`3` and
           vertex :math:`1`
 
 .. literalinclude:: doc-pgr_withPoints.queries

--- a/doc/withPoints/pgr_withPointsCost.rst
+++ b/doc/withPoints/pgr_withPointsCost.rst
@@ -75,7 +75,7 @@ The main characteristics are:
 
   - For **undirected** graphs, the results are **symmetric**.
 
-    - The  `agg_cost` of `(u, v)` is the same as for `(v, u)`.
+    - The `agg_cost` of `(u, v)` is the same as for `(v, u)`.
 
   - For optimization purposes, any duplicated value in the `start_vids` or
     `end_vids` is ignored.
@@ -100,7 +100,7 @@ Signatures
    | pgr_withPointsCost(`Edges SQL`_, 'Points SQL`_, **start vids**, **end vid**, [**options**])
    | pgr_withPointsCost(`Edges SQL`_, 'Points SQL`_, **start vids**, **end vids**, [**options**])
    | pgr_withPointsCost(`Edges SQL`_, 'Points SQL`_, `Combinations SQL`_, [**options**])
-   | **options:**  ``[directed, driving_side]``
+   | **options:** ``[directed, driving_side]``
 
    | RETURNS SET OF |matrix-pid|
    | OR EMPTY SET
@@ -118,7 +118,7 @@ One to One
    :class: signatures
 
    | pgr_withPointsCost(`Edges SQL`_, 'Points SQL`_, **start vid**, **end vid**, [**options**])
-   | **options:**  ``[directed, driving_side]``
+   | **options:** ``[directed, driving_side]``
 
    | RETURNS SET OF |matrix-pid|
    | OR EMPTY SET
@@ -139,7 +139,7 @@ One to Many
    :class: signatures
 
    | pgr_withPointsCost(`Edges SQL`_, `Points SQL`_, **start vid**, **end vids**, [**options**])
-   | **options:**  ``[directed, driving_side]``
+   | **options:** ``[directed, driving_side]``
 
    | RETURNS SET OF |matrix-pid|
    | OR EMPTY SET
@@ -161,7 +161,7 @@ Many to One
    :class: signatures
 
    | pgr_withPointsCost(`Edges SQL`_, `Points SQL`_, **start vids**, **end vid**, [**options**])
-   | **options:**  ``[directed, driving_side]``
+   | **options:** ``[directed, driving_side]``
 
    | RETURNS SET OF |matrix-pid|
    | OR EMPTY SET
@@ -182,12 +182,12 @@ Many to Many
    :class: signatures
 
    | pgr_withPointsCost(`Edges SQL`_, `Points SQL`_, **start vids**, **end vids**, [**options**])
-   | **options:**  ``[directed, driving_side]``
+   | **options:** ``[directed, driving_side]``
 
    | RETURNS SET OF |matrix-pid|
    | OR EMPTY SET
 
-:Example: From point :math:`15` and vertex :math:`6`  to point :math:`3` and
+:Example: From point :math:`15` and vertex :math:`6` to point :math:`3` and
           vertex :math:`1`
 
 .. literalinclude:: doc-pgr_withPointsCost.queries
@@ -204,7 +204,7 @@ Combinations
    :class: signatures
 
    | pgr_withPointsCost(`Edges SQL`_, `Points SQL`_, `Combinations SQL`_, [**options**])
-   | **options:**  ``[directed, driving_side]``
+   | **options:** ``[directed, driving_side]``
 
    | RETURNS SET OF |matrix-pid|
    | OR EMPTY SET

--- a/doc/withPoints/pgr_withPointsCostMatrix.rst
+++ b/doc/withPoints/pgr_withPointsCostMatrix.rst
@@ -56,7 +56,7 @@ Signatures
    :class: signatures
 
    | pgr_withPointsCostMatrix(`Edges SQL`_, `Points SQL`_, **start vids**, [**options**])
-   | **options:**  ``[directed, driving_side]``
+   | **options:** ``[directed, driving_side]``
 
    | RETURNS SET OF |matrix-result|
    | OR EMPTY SET

--- a/doc/withPoints/pgr_withPointsKSP.rst
+++ b/doc/withPoints/pgr_withPointsKSP.rst
@@ -71,7 +71,7 @@ Signatures
    | pgr_withPointsKSP(`Edges SQL`_, `Points SQL`_, **start vids**, **end vid**, **K**, **driving_side**, [**options**])
    | pgr_withPointsKSP(`Edges SQL`_, `Points SQL`_, **start vids**, **end vids**, **K**, **driving_side**, [**options**])
    | pgr_withPointsKSP(`Edges SQL`_, `Points SQL`_, `Combinations SQL`_, **K**, **driving_side**, [**options**])
-   | **options:**  ``[directed, heap_paths, details]``
+   | **options:** ``[directed, heap_paths, details]``
 
    | RETURNS SET OF |ksp-result|
    | OR EMPTY SET
@@ -86,7 +86,7 @@ One to One
    :class: signatures
 
    | pgr_withPointsKSP(`Edges SQL`_, `Points SQL`_, **start vid**, **end vid**, **K**, **driving_side**, [**options**])
-   | **options:**  ``[directed, heap_paths, details]``
+   | **options:** ``[directed, heap_paths, details]``
 
    | RETURNS SET OF |nksp-result|
    | OR EMTPY SET
@@ -112,7 +112,7 @@ One to Many
    :class: signatures
 
    | pgr_withPointsKSP(`Edges SQL`_, `Points SQL`_, **start vid**, **end vids**, **K**, **driving_side**, [**options**])
-   | **options:**  ``[directed, heap_paths, details]``
+   | **options:** ``[directed, heap_paths, details]``
 
    | RETURNS SET OF |ksp-result|
    | OR EMTPY SET
@@ -134,7 +134,7 @@ Many to One
    :class: signatures
 
    | pgr_withPointsKSP(`Edges SQL`_, `Points SQL`_, **start vids**, **end vid**, **K**, **driving_side**, [**options**])
-   | **options:**  ``[directed, heap_paths, details]``
+   | **options:** ``[directed, heap_paths, details]``
 
    | RETURNS SET OF |ksp-result|
    | OR EMTPY SET
@@ -156,7 +156,7 @@ Many to Many
    :class: signatures
 
    | pgr_withPointsKSP(`Edges SQL`_, `Points SQL`_, **start vids**, **end vids**, **K**, **driving_side**, [**options**])
-   | **options:**  ``[directed, heap_paths, details]``
+   | **options:** ``[directed, heap_paths, details]``
 
    | RETURNS SET OF |nksp-result|
    | OR EMTPY SET
@@ -178,7 +178,7 @@ Combinations
    :class: signatures
 
    | pgr_withPointsKSP(`Edges SQL`_, `Points SQL`_, `Combinations SQL`_, **K**, **driving_side**, [**options**])
-   | **options:**  ``[directed, heap_paths, details]``
+   | **options:** ``[directed, heap_paths, details]``
 
    | RETURNS SET OF |ksp-result|
    | OR EMTPY SET


### PR DESCRIPTION
Changes proposed in this pull request:
- double space removal on English documentation

To avoid confusion because Weblate generates warning when translation has double space.

@pgRouting/admins
