### PR TITLE
Deprecating min supported versions

### DIFF
--- a/.github/workflows/boost_version.yml
+++ b/.github/workflows/boost_version.yml
@@ -20,6 +20,7 @@ name: Boost supported versions
 #
 # boost::graph
 # - 1.84 is failing its own tests (Jul 2022)
+# - 1.83 transitive closure & stoer wagner changed on 83 (Jul 2022)
 # - 1.80 changed on 1.80 (Aug 2022)
 # - 1.75 requires C++14 (Dec 2020)
 # - 1.68 changed on 1.68 (Aug 2018)
@@ -67,7 +68,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          boost_minor: [56, 68, 75, 76, 77, 78, 79, 80, 84]
+          boost_minor: [56, 68, 75, 76, 77, 78, 79, 80, 83, 84]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           tools/release-scripts/notes2news.pl
           if git status | grep 'NEWS.md'; then echo "NEWS.md is not up to date"; exit 1; fi
-          if ! grep -q $(grep -Po '(?<=project\(PGROUTING VERSION )[^;]+' CMakeLists.txt) NEWS.md; then echo "Missing section in NEWS"; exit 1; fi
+          if ! grep -q $(grep -Po '(?<=project\(PGROUTING VERSION )[^;]+' CMakeLists.txt) NEWS.md; then echo "Missing section in NEWS.md"; exit 1; fi
 
   License_check:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # pgRouting - Routing on PostgreSQL
 
-[![Join the chat at https://gitter.im/pgRouting/pgrouting](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/pgRouting/pgrouting?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at
+https://gitter.im/pgRouting/pgrouting](https://badges.gitter.im/Join%20Chat.svg)](https://app.gitter.im/#/room/#pgrouting:osgeo.org)
+[Join discourse](https://discourse.osgeo.org/c/pgrouting/15)
+
 
 ## Branches
 
@@ -9,6 +12,9 @@
 
 For the complete list of releases go to:
 https://github.com/pgRouting/pgrouting/releases
+
+For the release notes go to: https://docs.pgrouting.org/latest/en/release_notes.html
+
 
 ## LINKS
 
@@ -27,44 +33,32 @@ pgRouting extends the PostGIS/PostgreSQL geospatial database to provide geospati
 This library contains the following features:
 
 * All Pairs Shortest Path Algorithms
-
 * A-star algorithm
-
 * Bi-directional algorithms
-
 * A variety of applications of Dijkstra algorithms
-
   * Cost functions
   * With points
-
 * Driving Distance
   * With points
-
 * Yen's algorithm
-
 * Traveling Sales Person (TSP)
 
 and many more.
 
-The latest documentation: http://docs.pgrouting.org/latest
+The latest documentation: https://docs.pgrouting.org/latest
 
 ## REQUIREMENTS
 
 ### Building requirements
 
 * perl
-
 * C and C++ compilers
   * Compiling with Boost 1.56 up to Boost 1.74 requires C++ Compiler with C++03 or C++11 standard support
   * Compiling with Boost 1.75 requires C++ Compiler with C++14 standard support
-
-* Postgresql = Supported version by PostgreSQL
-
+* Postgresql = Supported [version](https://www.postgresql.org/support/versioning/) by PostgreSQL
 * The Boost Graph Library (BGL) >= 1.56
-
 * CMake >= 3.2
-
-* Sphinx >= 4.0.0
+* 7.0 > Sphinx >= 4.0.0
 
 ### User's requirements
 


### PR DESCRIPTION
This PR is about versions of PostgresSQL, boost, etc are supported on 3.7 

@pgRouting/admins
