### PR TITLE
Add macos-14 to macos CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,7 +41,12 @@ permissions:
 jobs:
   build:
     name: macos
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-14]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Supports #2618.

Changes proposed in this pull request:
- Add macos-14 to macos CI

@cvvergara (CC: @pgRouting/admins)
I created this PR to `main`  branch with referring the following ubuntu's `matrix.os` setup,
so could you check this ?
https://github.com/pgRouting/pgrouting/blob/main/.github/workflows/ubuntu.yml#L27-L34