### PR TITLE
Remove seq from path rt

### DIFF
--- a/include/c_types/path_rt.h
+++ b/include/c_types/path_rt.h
@@ -38,7 +38,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #endif
 
 struct Path_rt {
-    int seq;
     int64_t start_id;
     int64_t end_id;
     int64_t node;

--- a/include/chinese/pgr_chinesePostman.hpp
+++ b/include/chinese/pgr_chinesePostman.hpp
@@ -274,10 +274,8 @@ PgrDirectedChPPGraph::BuildResultPath() {
         newElement.cost = edge_t.cost;
         if (resultPath.empty()) {
             /* adding the first row because is a cycle */
-            newElement.seq = 1;
             newElement.agg_cost = 0.0;
         } else {
-            newElement.seq = resultPath.back().seq + 1;
             newElement.agg_cost = resultPath.back().agg_cost + resultPath.back().cost;
         }
         resultPath.push_back(newElement);
@@ -287,10 +285,8 @@ PgrDirectedChPPGraph::BuildResultPath() {
     newElement.edge = -1;
     newElement.cost = 0;
     if (resultPath.empty()) {
-        newElement.seq = 1;
         newElement.agg_cost = 0.0;
     } else {
-        newElement.seq = resultPath.back().seq + 1;
         newElement.agg_cost =
             resultPath.back().agg_cost + resultPath.back().cost;
     }

--- a/pgtap/mincut/stoerWagner/compare_components.pg
+++ b/pgtap/mincut/stoerWagner/compare_components.pg
@@ -98,7 +98,7 @@ SELECT CASE WHEN (SELECT boost FROM pgr_full_version()) < '1.80' THEN
   collect_tap(set_eq('stoerWagner7', 'VALUES (1, 1, 1, 1)', '6: Compare the mincut of subgraph with actual result'))
 ELSE
   collect_tap(set_eq('stoerWagner7', 'VALUES (1, 14, 1, 1)', '6: Compare the mincut of subgraph with actual result'))
-END CASE;
+END;
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/src/astar/astar.c
+++ b/src/astar/astar.c
@@ -185,8 +185,10 @@ _pgr_astar(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
+        int64_t seq = call_cntr == 0?  1 : result_tuples[call_cntr - 1].start_id;
+
         values[0] = Int32GetDatum((int32_t)call_cntr + 1);
-        values[1] = Int32GetDatum(result_tuples[call_cntr].seq);
+        values[1] = Int32GetDatum(seq);
         values[2] = Int64GetDatum(result_tuples[call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[call_cntr].end_id);
         values[4] = Int64GetDatum(result_tuples[call_cntr].node);
@@ -194,6 +196,7 @@ _pgr_astar(PG_FUNCTION_ARGS) {
         values[6] = Float8GetDatum(result_tuples[call_cntr].cost);
         values[7] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
 
+        result_tuples[call_cntr].start_id = result_tuples[call_cntr].edge < 0? 1 : seq + 1;
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/bdAstar/bdAstar.c
+++ b/src/bdAstar/bdAstar.c
@@ -181,8 +181,10 @@ _pgr_bdastar(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum((int32_t)call_cntr + 1);
-        values[1] = Int32GetDatum(result_tuples[call_cntr].seq);
+        int64_t seq = call_cntr == 0?  1 : result_tuples[call_cntr - 1].start_id;
+
+        values[0] = Int32GetDatum(call_cntr + 1);
+        values[1] = Int32GetDatum(seq);
         values[2] = Int64GetDatum(result_tuples[call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[call_cntr].end_id);
         values[4] = Int64GetDatum(result_tuples[call_cntr].node);
@@ -190,6 +192,7 @@ _pgr_bdastar(PG_FUNCTION_ARGS) {
         values[6] = Float8GetDatum(result_tuples[call_cntr].cost);
         values[7] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
 
+        result_tuples[call_cntr].start_id = result_tuples[call_cntr].edge < 0? 1 : seq + 1;
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/bdDijkstra/bdDijkstra.c
+++ b/src/bdDijkstra/bdDijkstra.c
@@ -163,14 +163,18 @@ PGDLLEXPORT Datum _pgr_bddijkstra(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum((int32_t)call_cntr + 1);
-        values[1] = Int32GetDatum(result_tuples[call_cntr].seq);
+        int64_t seq = call_cntr == 0?  1 : result_tuples[call_cntr - 1].start_id;
+
+        values[0] = Int32GetDatum(call_cntr + 1);
+        values[1] = Int32GetDatum(seq);
         values[2] = Int64GetDatum(result_tuples[call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[call_cntr].end_id);
         values[4] = Int64GetDatum(result_tuples[call_cntr].node);
         values[5] = Int64GetDatum(result_tuples[call_cntr].edge);
         values[6] = Float8GetDatum(result_tuples[call_cntr].cost);
         values[7] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
+
+        result_tuples[call_cntr].start_id = result_tuples[call_cntr].edge < 0? 1 : seq + 1;
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/bellman_ford/bellman_ford.c
+++ b/src/bellman_ford/bellman_ford.c
@@ -167,14 +167,18 @@ _pgr_bellmanford(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum((int32_t)funcctx->call_cntr + 1);
-        values[1] = Int32GetDatum(result_tuples[funcctx->call_cntr].seq);
+        int64_t seq = funcctx->call_cntr == 0?  1 : result_tuples[funcctx->call_cntr - 1].start_id;
+
+        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[1] = Int32GetDatum(seq);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].end_id);
         values[4] = Int64GetDatum(result_tuples[funcctx->call_cntr].node);
         values[5] = Int64GetDatum(result_tuples[funcctx->call_cntr].edge);
         values[6] = Float8GetDatum(result_tuples[funcctx->call_cntr].cost);
         values[7] = Float8GetDatum(result_tuples[funcctx->call_cntr].agg_cost);
+
+        result_tuples[funcctx->call_cntr].start_id = result_tuples[funcctx->call_cntr].edge < 0? 1 : seq + 1;
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/bellman_ford/edwardMoore.c
+++ b/src/bellman_ford/edwardMoore.c
@@ -160,14 +160,18 @@ PGDLLEXPORT Datum _pgr_edwardmoore(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum((int32_t)funcctx->call_cntr + 1);
-        values[1] = Int32GetDatum(result_tuples[funcctx->call_cntr].seq);
+        int64_t seq = funcctx->call_cntr == 0?  1 : result_tuples[funcctx->call_cntr - 1].start_id;
+
+        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[1] = Int32GetDatum(seq);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].end_id);
         values[4] = Int64GetDatum(result_tuples[funcctx->call_cntr].node);
         values[5] = Int64GetDatum(result_tuples[funcctx->call_cntr].edge);
         values[6] = Float8GetDatum(result_tuples[funcctx->call_cntr].cost);
         values[7] = Float8GetDatum(result_tuples[funcctx->call_cntr].agg_cost);
+
+        result_tuples[funcctx->call_cntr].start_id = result_tuples[funcctx->call_cntr].edge < 0? 1 : seq + 1;
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/breadthFirstSearch/binaryBreadthFirstSearch.c
+++ b/src/breadthFirstSearch/binaryBreadthFirstSearch.c
@@ -160,14 +160,18 @@ PGDLLEXPORT Datum _pgr_binarybreadthfirstsearch(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum((int32_t)funcctx->call_cntr + 1);
-        values[1] = Int32GetDatum(result_tuples[funcctx->call_cntr].seq);
+        int64_t seq = funcctx->call_cntr == 0?  1 : result_tuples[funcctx->call_cntr - 1].start_id;
+
+        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[1] = Int32GetDatum(seq);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].end_id);
         values[4] = Int64GetDatum(result_tuples[funcctx->call_cntr].node);
         values[5] = Int64GetDatum(result_tuples[funcctx->call_cntr].edge);
         values[6] = Float8GetDatum(result_tuples[funcctx->call_cntr].cost);
         values[7] = Float8GetDatum(result_tuples[funcctx->call_cntr].agg_cost);
+
+        result_tuples[funcctx->call_cntr].start_id = result_tuples[funcctx->call_cntr].edge < 0? 1 : seq + 1;
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/chinese/chinesePostman_driver.cpp
+++ b/src/chinese/chinesePostman_driver.cpp
@@ -86,7 +86,6 @@ pgr_do_directedChPP(
         if (only_cost) {
             if (minCost >= 0.0) {
                 Path_rt edge = {};
-                edge.seq = -1;
                 edge.node = edge.edge = -1;
                 edge.cost = edge.agg_cost = minCost;
                 pathEdges.push_back(edge);

--- a/src/common/basePath_SSEC.cpp
+++ b/src/common/basePath_SSEC.cpp
@@ -245,7 +245,7 @@ void Path::generate_postgres_data(
         auto cost = std::fabs(e.cost - (std::numeric_limits<double>::max)()) < 1?
             std::numeric_limits<double>::infinity() : e.cost;
 
-        (*postgres_data)[sequence] = {i, start_id(), end_id(), e.node, e.edge, cost, agg_cost};
+        (*postgres_data)[sequence] = {start_id(), end_id(), e.node, e.edge, cost, agg_cost};
         ++i;
         ++sequence;
     }
@@ -272,7 +272,6 @@ void Path::get_pg_nksp_path(
         Path_rt **ret_path,
         size_t &sequence) const {
     for (unsigned int i = 0; i < path.size(); i++) {
-        (*ret_path)[sequence].seq = static_cast<int>(i + 1);
         (*ret_path)[sequence].start_id = start_id();
         (*ret_path)[sequence].end_id = end_id();
         (*ret_path)[sequence].node = path[i].node;
@@ -290,7 +289,6 @@ void Path::get_pg_turn_restricted_path(
         Path_rt **ret_path,
         size_t &sequence, int routeId) const {
     for (unsigned int i = 0; i < path.size(); i++) {
-        (*ret_path)[sequence].seq = static_cast<int>(i + 1);
         (*ret_path)[sequence].start_id = routeId;
         (*ret_path)[sequence].end_id = end_id();
         (*ret_path)[sequence].node = path[i].node;

--- a/src/dagShortestPath/dagShortestPath.c
+++ b/src/dagShortestPath/dagShortestPath.c
@@ -167,12 +167,16 @@ PGDLLEXPORT Datum _pgr_dagshortestpath(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum((int32_t)funcctx->call_cntr + 1);
-        values[1] = Int32GetDatum(result_tuples[funcctx->call_cntr].seq);
+        int64_t seq = funcctx->call_cntr == 0?  1 : result_tuples[funcctx->call_cntr - 1].start_id;
+
+        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[1] = Int32GetDatum(seq);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].node);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].edge);
         values[4] = Float8GetDatum(result_tuples[funcctx->call_cntr].cost);
         values[5] = Float8GetDatum(result_tuples[funcctx->call_cntr].agg_cost);
+
+        result_tuples[funcctx->call_cntr].start_id = result_tuples[funcctx->call_cntr].edge < 0? 1 : seq + 1;
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/dijkstra/dijkstra.c
+++ b/src/dijkstra/dijkstra.c
@@ -220,14 +220,18 @@ _pgr_dijkstra(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum((int32_t)call_cntr + 1);
-        values[1] = Int32GetDatum(result_tuples[call_cntr].seq);
+        int64_t seq = call_cntr == 0?  1 : result_tuples[call_cntr - 1].start_id;
+
+        values[0] = Int32GetDatum(call_cntr + 1);
+        values[1] = Int32GetDatum(seq);
         values[2] = Int64GetDatum(result_tuples[call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[call_cntr].end_id);
         values[4] = Int64GetDatum(result_tuples[call_cntr].node);
         values[5] = Int64GetDatum(result_tuples[call_cntr].edge);
         values[6] = Float8GetDatum(result_tuples[call_cntr].cost);
         values[7] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
+
+        result_tuples[call_cntr].start_id = result_tuples[call_cntr].edge < 0? 1 : seq + 1;
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/ksp/ksp.c
+++ b/src/ksp/ksp.c
@@ -199,10 +199,11 @@ _pgr_ksp(PG_FUNCTION_ARGS) {
                 path_id = path[funcctx->call_cntr - 1].start_id;
             }
         }
+        int64_t seq = funcctx->call_cntr == 0?  1 : path[funcctx->call_cntr - 1].end_id;
 
         values[0] = Int32GetDatum(funcctx->call_cntr + 1);
         values[1] = Int32GetDatum(path_id);
-        values[2] = Int32GetDatum(path[funcctx->call_cntr].seq);
+        values[2] = Int32GetDatum(seq);
         if (PG_NARGS() != 6) {
             values[3] = Int64GetDatum(path[funcctx->call_cntr].start_id);
             values[4] = Int64GetDatum(path[funcctx->call_cntr].end_id);
@@ -213,6 +214,7 @@ _pgr_ksp(PG_FUNCTION_ARGS) {
         values[n - 1] = Float8GetDatum(path[funcctx->call_cntr].agg_cost);
 
         path[funcctx->call_cntr].start_id = path_id;
+        path[funcctx->call_cntr].end_id = path[funcctx->call_cntr].edge < 0? 1 : seq + 1;
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/ksp/turnRestrictedPath.c
+++ b/src/ksp/turnRestrictedPath.c
@@ -177,14 +177,17 @@ _pgr_turnrestrictedpath(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int32GetDatum((int32_t)funcctx->call_cntr + 1);
-        values[1] = Int32GetDatum((int32_t)path[funcctx->call_cntr].start_id + 1);
-        values[2] = Int32GetDatum(path[funcctx->call_cntr].seq);
+        int64_t seq = funcctx->call_cntr == 0?  1 : path[funcctx->call_cntr - 1].start_id;
+
+        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[1] = Int32GetDatum(path[funcctx->call_cntr].start_id + 1);
+        values[2] = Int32GetDatum(seq);
         values[3] = Int64GetDatum(path[funcctx->call_cntr].node);
         values[4] = Int64GetDatum(path[funcctx->call_cntr].edge);
         values[5] = Float8GetDatum(path[funcctx->call_cntr].cost);
         values[6] = Float8GetDatum(path[funcctx->call_cntr].agg_cost);
 
+        path[funcctx->call_cntr].start_id = path[funcctx->call_cntr].edge < 0? 1 : seq + 1;
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/ksp/withPoints_ksp.c
+++ b/src/ksp/withPoints_ksp.c
@@ -251,10 +251,11 @@ PGDLLEXPORT Datum _pgr_withpointsksp(PG_FUNCTION_ARGS) {
                 path_id = result_tuples[funcctx->call_cntr - 1].start_id;
             }
         }
+        int64_t seq = funcctx->call_cntr == 0?  1 : result_tuples[funcctx->call_cntr - 1].end_id;
 
         values[0] = Int32GetDatum(funcctx->call_cntr + 1);
         values[1] = Int32GetDatum(path_id);
-        values[2] = Int32GetDatum(result_tuples[funcctx->call_cntr].seq);
+        values[2] = Int32GetDatum(seq);
         if (PG_NARGS() != 9) {
             values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].start_id);
             values[4] = Int64GetDatum(result_tuples[funcctx->call_cntr].end_id);
@@ -265,6 +266,7 @@ PGDLLEXPORT Datum _pgr_withpointsksp(PG_FUNCTION_ARGS) {
         values[n - 1] = Float8GetDatum(result_tuples[funcctx->call_cntr].agg_cost);
 
         result_tuples[funcctx->call_cntr].start_id = path_id;
+        result_tuples[funcctx->call_cntr].end_id = result_tuples[funcctx->call_cntr].edge < 0? 1 : seq + 1;
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/max_flow/edge_disjoint_paths_driver.cpp
+++ b/src/max_flow/edge_disjoint_paths_driver.cpp
@@ -169,7 +169,7 @@ pgr_do_edge_disjoint_paths(
          */
         auto prev = paths[0];
         for (auto &r : paths) {
-            if (r.seq == 1) {
+            if (&r == &paths[0] || prev.edge < 0) {
                 r.agg_cost = 0;
             } else {
                 r.agg_cost = prev.agg_cost + prev.cost;

--- a/src/max_flow/pgr_maxflow.cpp
+++ b/src/max_flow/pgr_maxflow.cpp
@@ -282,7 +282,6 @@ PgrFlowGraph::get_edge_disjoint_paths(
         size_t j;
         for (j = 0; j < size - 1; j++) {
             Path_rt edge = {};
-            edge.seq = static_cast<int>(j + 1);
             edge.start_id = paths[i][0];
             edge.end_id = paths[i][size - 1];
             edge.node = paths[i][j];
@@ -293,7 +292,6 @@ PgrFlowGraph::get_edge_disjoint_paths(
             path_elements.push_back(edge);
         }
         Path_rt edge = {};
-        edge.seq = static_cast<int>(j + 1);
         edge.start_id = paths[i][0];
         edge.end_id = paths[i][size - 1];
         edge.node = paths[i][j];

--- a/src/trsp/new_trsp.c
+++ b/src/trsp/new_trsp.c
@@ -161,11 +161,10 @@ _pgr_trspv4(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        int path_id = call_cntr == 0? 0 : result_tuples[call_cntr - 1].seq;
-        path_id += result_tuples[call_cntr].seq == 1? 1 : 0;
+        int64_t path_seq = call_cntr == 0?  1 : result_tuples[call_cntr - 1].start_id;
 
         values[0] = Int32GetDatum((int32_t)call_cntr + 1);
-        values[1] = Int32GetDatum(result_tuples[call_cntr].seq);
+        values[1] = Int32GetDatum(path_seq);
         values[2] = Int64GetDatum(result_tuples[call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[call_cntr].end_id);
         values[4] = Int64GetDatum(result_tuples[call_cntr].node);
@@ -173,7 +172,7 @@ _pgr_trspv4(PG_FUNCTION_ARGS) {
         values[6] = Float8GetDatum(result_tuples[call_cntr].cost);
         values[7] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
 
-        result_tuples[call_cntr].seq = path_id;
+        result_tuples[call_cntr].start_id = result_tuples[call_cntr].edge < 0? 1 : path_seq + 1;
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
 
@@ -258,11 +257,10 @@ _v4trsp(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        int path_id = call_cntr == 0? 0 : result_tuples[call_cntr - 1].seq;
-        path_id += result_tuples[call_cntr].seq == 1? 1 : 0;
+        int64_t path_seq = call_cntr == 0?  1 : result_tuples[call_cntr - 1].start_id;
 
         values[0] = Int32GetDatum((int32_t)call_cntr + 1);
-        values[1] = Int32GetDatum(result_tuples[call_cntr].seq);
+        values[1] = Int32GetDatum(path_seq);
         values[2] = Int64GetDatum(result_tuples[call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[call_cntr].end_id);
         values[4] = Int64GetDatum(result_tuples[call_cntr].node);
@@ -270,7 +268,7 @@ _v4trsp(PG_FUNCTION_ARGS) {
         values[6] = Float8GetDatum(result_tuples[call_cntr].cost);
         values[7] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
 
-        result_tuples[call_cntr].seq = path_id;
+        result_tuples[call_cntr].start_id = result_tuples[call_cntr].edge < 0? 1 : path_seq + 1;
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
 
@@ -344,8 +342,10 @@ _trsp(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int64GetDatum((int64_t)call_cntr + 1);
-        values[1] = Int32GetDatum(result_tuples[call_cntr].seq);
+        int64_t path_seq = call_cntr == 0?  1 : result_tuples[call_cntr - 1].start_id;
+
+        values[0] = Int32GetDatum(call_cntr + 1);
+        values[1] = Int32GetDatum(path_seq);
         values[2] = Int64GetDatum(result_tuples[call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[call_cntr].end_id);
         values[4] = Int64GetDatum(result_tuples[call_cntr].node);
@@ -353,8 +353,9 @@ _trsp(PG_FUNCTION_ARGS) {
         values[6] = Float8GetDatum(result_tuples[call_cntr].cost);
         values[7] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
 
-        tuple = heap_form_tuple(tuple_desc, values, nulls);
+        result_tuples[call_cntr].start_id = result_tuples[call_cntr].edge < 0? 1 : path_seq + 1;
 
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);
 
         pfree(values);

--- a/src/trsp/trsp_withPoints.c
+++ b/src/trsp/trsp_withPoints.c
@@ -204,11 +204,9 @@ _pgr_trsp_withpoints(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        int path_id = call_cntr == 0? 0 : result_tuples[call_cntr - 1].seq;
-        path_id += result_tuples[call_cntr].seq == 1? 1 : 0;
-
-        values[0] = Int32GetDatum((int32_t)call_cntr + 1);
-        values[1] = Int32GetDatum(result_tuples[call_cntr].seq);
+        int64_t seq = call_cntr == 0? 1 : result_tuples[call_cntr - 1].start_id;
+        values[0] = Int32GetDatum(call_cntr + 1);
+        values[1] = Int32GetDatum(seq);
         values[2] = Int64GetDatum(result_tuples[call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[call_cntr].end_id);
         values[4] = Int64GetDatum(result_tuples[call_cntr].node);
@@ -216,7 +214,7 @@ _pgr_trsp_withpoints(PG_FUNCTION_ARGS) {
         values[6] = Float8GetDatum(result_tuples[call_cntr].cost);
         values[7] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
 
-        result_tuples[call_cntr].seq = path_id;
+        result_tuples[call_cntr].start_id = result_tuples[call_cntr].edge < 0? 1 : seq + 1;
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/withPoints/withPoints.c
+++ b/src/withPoints/withPoints.c
@@ -202,15 +202,18 @@ _pgr_withpoints(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
+        int64_t seq = funcctx->call_cntr == 0?  1 : result_tuples[funcctx->call_cntr - 1].start_id;
 
-        values[0] = Int32GetDatum((int32_t)funcctx->call_cntr + 1);
-        values[1] = Int32GetDatum(result_tuples[funcctx->call_cntr].seq);
+        values[0] = Int32GetDatum(funcctx->call_cntr + 1);
+        values[1] = Int32GetDatum(seq);
         values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].start_id);
         values[3] = Int64GetDatum(result_tuples[funcctx->call_cntr].end_id);
         values[4] = Int64GetDatum(result_tuples[funcctx->call_cntr].node);
         values[5] = Int64GetDatum(result_tuples[funcctx->call_cntr].edge);
         values[6] = Float8GetDatum(result_tuples[funcctx->call_cntr].cost);
         values[7] = Float8GetDatum(result_tuples[funcctx->call_cntr].agg_cost);
+
+        result_tuples[funcctx->call_cntr].start_id = result_tuples[funcctx->call_cntr].edge < 0? 1 : seq + 1;
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);


### PR DESCRIPTION
- Removes `seq` from `Path_rt` to save some memory
- Fixes a case statement on pgtap/stoerWagner

@pgRouting/admins
