### PR TITLE
Add macos-14 to macos CI with fixing build error

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,7 +41,12 @@ permissions:
 jobs:
   build:
     name: macos
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-14]
 
     steps:
       - name: Checkout repository

--- a/src/cpp_common/combinations.cpp
+++ b/src/cpp_common/combinations.cpp
@@ -24,13 +24,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 
-#include "cpp_common/combinations.hpp"
-
 #include <map>
 #include <set>
 #include <deque>
 #include <vector>
 #include <string>
+#include "cpp_common/combinations.hpp"
 #include "cpp_common/pgdata_getters.hpp"
 #include "cpp_common/basePath_SSEC.hpp"
 


### PR DESCRIPTION
Fixes #2618, #2616.

Changes proposed in this pull request:
- This is a same fix in #2619, but for `develop` branch.
- I just cherry-pick commit: https://github.com/pgRouting/pgrouting/commit/24d25b3e2ebfb1780d9fe92baff446e64fddc8b3, because merging `main` into `develop` seems not to be a current workflow.
- Fix macos-14 build error (#2616)

@pgRouting/admins
