### PR TITLE
Remove bool from definition of a graph

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,11 +35,11 @@ milestone for 3.7.0
 
 **Code enhancement**
 
-* [#2599](https://github.com/pgRouting/pgrouting/pull/2599)  Driving distance
+* [#2599](https://github.com/pgRouting/pgrouting/pull/2599) Driving distance
   cleanup
-* [#2607](https://github.com/pgRouting/pgrouting/pull/2607)  Read postgresql
+* [#2607](https://github.com/pgRouting/pgrouting/pull/2607) Read postgresql
   data on C++
-* [#2614](https://github.com/pgRouting/pgrouting/pull/2614)  Clang tidy does
+* [#2614](https://github.com/pgRouting/pgrouting/pull/2614) Clang tidy does
   not work
 
 ## pgRouting 3.6

--- a/doc/lineGraph/pgr_lineGraph.rst
+++ b/doc/lineGraph/pgr_lineGraph.rst
@@ -40,6 +40,7 @@ Given a graph G, its line graph L(G) is a graph such that:
 - Each vertex of L(G) represents an edge of G
 - Two vertices of L(G) are adjacent if and only if their corresponding edges
   share a common endpoint in G.
+- Currently works for undirected graph.
 
 .. index::
     single: lineGraph - Experimental on v2.5
@@ -55,7 +56,7 @@ Signatures
    | Returns set of |result-lineg|
    | OR EMPTY SET
 
-:Example: For a **directed** graph
+:Example: For an **undirected** graph
 
 .. literalinclude:: doc-pgr_lineGraph.queries
    :start-after: -- q1

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -64,11 +64,11 @@ milestone for 3.7.0
 
 .. rubric:: Code enhancement
 
-* `#2599 <https://github.com/pgRouting/pgrouting/pull/2599>`__  Driving distance
+* `#2599 <https://github.com/pgRouting/pgrouting/pull/2599>`__ Driving distance
   cleanup
-* `#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__  Read postgresql
+* `#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ Read postgresql
   data on C++
-* `#2614 <https://github.com/pgRouting/pgrouting/pull/2614>`__  Clang tidy does
+* `#2614 <https://github.com/pgRouting/pgrouting/pull/2614>`__ Clang tidy does
   not work
 
 pgRouting 3.6

--- a/include/alphaShape/pgr_alphaShape.hpp
+++ b/include/alphaShape/pgr_alphaShape.hpp
@@ -53,7 +53,7 @@ using BG = boost::adjacency_list<
         boost::setS, boost::vecS,
         boost::undirectedS,
         XY_vertex, Basic_edge >;
-using G = graph::Pgr_base_graph <BG, XY_vertex, Basic_edge>;
+using G = graph::Pgr_base_graph <BG, XY_vertex, Basic_edge, false>;
 using E = boost::graph_traits<BG>::edge_descriptor;
 using V = boost::graph_traits<BG>::vertex_descriptor;
 

--- a/include/contraction/ch_graphs.hpp
+++ b/include/contraction/ch_graphs.hpp
@@ -48,12 +48,12 @@ namespace graph {
 using CHUndirectedGraph =  Pgr_contractionGraph <
     boost::adjacency_list < boost::listS, boost::vecS,
     boost::undirectedS,
-    CH_vertex, CH_edge>>;
+    CH_vertex, CH_edge>, false>;
 
 using CHDirectedGraph = Pgr_contractionGraph<
     boost::adjacency_list < boost::listS, boost::vecS,
     boost::bidirectionalS,
-    CH_vertex, CH_edge>>;
+    CH_vertex, CH_edge>, true>;
 
 
 }  // namespace graph

--- a/include/contraction/pgr_contractionGraph.hpp
+++ b/include/contraction/pgr_contractionGraph.hpp
@@ -47,8 +47,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 namespace pgrouting {
 namespace graph {
 
-template <class G>
-class Pgr_contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge> {
+template <class G, bool t_directed>
+class Pgr_contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed> {
  public:
      typedef typename boost::graph_traits < G >::vertex_descriptor V;
      typedef typename boost::graph_traits < G >::edge_descriptor E;
@@ -58,8 +58,8 @@ class Pgr_contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge> {
      /*!
        Prepares the _graph_ to be of type *directed*
        */
-     explicit Pgr_contractionGraph<G>(bool directed)
-         : Pgr_base_graph<G, CH_vertex, CH_edge >(directed) {
+     explicit Pgr_contractionGraph<G, t_directed>()
+         : Pgr_base_graph<G, CH_vertex, CH_edge, t_directed>() {
          }
 
      /*! @brief get the vertex descriptors of adjacent vertices of *v*

--- a/include/cpp_common/basic_vertex.hpp
+++ b/include/cpp_common/basic_vertex.hpp
@@ -63,7 +63,6 @@ class Basic_vertex {
      friend std::ostream& operator<<(std::ostream& log, const Basic_vertex &v);
  public:
      int64_t id;
-     size_t vertex_index;
 };
 
 size_t check_vertices(std::vector < Basic_vertex > vertices);

--- a/include/cpp_common/pgr_base_graph.hpp
+++ b/include/cpp_common/pgr_base_graph.hpp
@@ -265,7 +265,7 @@ class Pgr_base_graph {
        - inserts the vertices
        - The vertices must be checked (if necessary)  before calling the constructor
        */
-     Pgr_base_graph<G , T_V, T_E, t_directed>(
+     explicit Pgr_base_graph<G , T_V, T_E, t_directed>(
              const std::vector<T_V> &vertices)
          : graph(vertices.size()),
          m_is_directed(t_directed),

--- a/include/cpp_common/pgr_base_graph.hpp
+++ b/include/cpp_common/pgr_base_graph.hpp
@@ -266,7 +266,7 @@ class Pgr_base_graph {
        - The vertices must be checked (if necessary)  before calling the constructor
        */
      Pgr_base_graph<G , T_V, T_E, t_directed>(
-             const std::vector< T_V > &vertices, bool directed)
+             const std::vector<T_V> &vertices)
          : graph(vertices.size()),
          m_is_directed(t_directed),
          vertIndex(boost::get(boost::vertex_index, graph)),
@@ -295,7 +295,7 @@ class Pgr_base_graph {
      /**
        Prepares the _graph_ to be of type gtype with 0 vertices
        */
-     explicit Pgr_base_graph<G , T_V, T_E, t_directed>(bool directed)
+     explicit Pgr_base_graph<G , T_V, T_E, t_directed>()
          : graph(0),
          m_is_directed(t_directed),
          vertIndex(boost::get(boost::vertex_index, graph)),

--- a/include/cpp_common/pgr_base_graph.hpp
+++ b/include/cpp_common/pgr_base_graph.hpp
@@ -167,7 +167,7 @@ digraph.insert_edges(new_edges);
 */
 
 namespace graph {
-template <class G, typename Vertex, typename Edge>
+template <class G, typename Vertex, typename Edge, bool t_directed>
 class Pgr_base_graph;
 
 }  // namespace graph
@@ -186,32 +186,32 @@ typedef graph::Pgr_base_graph <
 boost::adjacency_list < boost::vecS, boost::vecS,
     boost::undirectedS,
     Basic_vertex, Basic_edge >,
-    Basic_vertex, Basic_edge > UndirectedGraph;
+    Basic_vertex, Basic_edge, false > UndirectedGraph;
 
 typedef graph::Pgr_base_graph <
 boost::adjacency_list < boost::vecS, boost::vecS,
     boost::bidirectionalS,
     Basic_vertex, Basic_edge >,
-    Basic_vertex, Basic_edge > DirectedGraph;
+    Basic_vertex, Basic_edge , true> DirectedGraph;
 
 typedef graph::Pgr_base_graph <
 boost::adjacency_list < boost::listS, boost::vecS,
     boost::undirectedS,
     XY_vertex, Basic_edge >,
-    XY_vertex, Basic_edge > xyUndirectedGraph;
+    XY_vertex, Basic_edge , false> xyUndirectedGraph;
 
 typedef graph::Pgr_base_graph <
 boost::adjacency_list < boost::listS, boost::vecS,
     boost::bidirectionalS,
     XY_vertex, Basic_edge >,
-    XY_vertex, Basic_edge > xyDirectedGraph;
+    XY_vertex, Basic_edge , true> xyDirectedGraph;
 
 /**@}*/
 
 
 namespace graph {
 
-template <typename G, typename T_V, typename T_E>
+template <typename G, typename T_V, typename T_E, bool t_directed>
 class Pgr_base_graph {
  public:
      /** @name Graph related types
@@ -265,10 +265,10 @@ class Pgr_base_graph {
        - inserts the vertices
        - The vertices must be checked (if necessary)  before calling the constructor
        */
-     Pgr_base_graph<G , T_V, T_E>(
+     Pgr_base_graph<G , T_V, T_E, t_directed>(
              const std::vector< T_V > &vertices, bool directed)
          : graph(vertices.size()),
-         m_is_directed(directed),
+         m_is_directed(t_directed),
          vertIndex(boost::get(boost::vertex_index, graph)),
          propmapIndex(mapIndex) {
              // This code does not work with contraction
@@ -295,9 +295,9 @@ class Pgr_base_graph {
      /**
        Prepares the _graph_ to be of type gtype with 0 vertices
        */
-     explicit Pgr_base_graph<G , T_V, T_E >(bool directed)
+     explicit Pgr_base_graph<G , T_V, T_E, t_directed>(bool directed)
          : graph(0),
-         m_is_directed(directed),
+         m_is_directed(t_directed),
          vertIndex(boost::get(boost::vertex_index, graph)),
          propmapIndex(mapIndex) {
          }
@@ -539,15 +539,15 @@ class Pgr_base_graph {
      /** @name only for debug */
      /**@{*/
      friend std::ostream& operator<<(
-             std::ostream &log, const Pgr_base_graph< G, T_V, T_E > &g) {
-         typename Pgr_base_graph< G, T_V, T_E >::EO_i out, out_end;
+             std::ostream &log, const Pgr_base_graph<G, T_V, T_E, t_directed> &g) {
+         typename Pgr_base_graph<G, T_V, T_E, t_directed>::EO_i out, out_end;
 
-         for (auto vi = vertices(g.graph).first;
-                 vi != vertices(g.graph).second; ++vi) {
+         auto vs = boost::vertices(g.graph);
+         for (auto vi = vs.first; vi != vs.second; ++vi) {
              if ((*vi) >= g.num_vertices()) break;
              log << (*vi) << ": " << " out_edges_of(" << g.graph[(*vi)] << "):";
-             for (boost::tie(out, out_end) = out_edges(*vi, g.graph);
-                     out != out_end; ++out) {
+             auto es = boost::out_edges(*vi, g.graph);
+             for (auto out = es.first; out != es.second; ++out) {
                  log << ' '
                      << g.graph[*out].id << "=("
                      << g[g.source(*out)].id << ", "

--- a/include/lineGraph/pgr_lineGraph.hpp
+++ b/include/lineGraph/pgr_lineGraph.hpp
@@ -46,8 +46,8 @@ namespace pgrouting {
 
 namespace graph {
 
-template <class G, typename T_V, typename T_E>
-class Pgr_lineGraph : public Pgr_base_graph<G, T_V, T_E> {
+template <class G, typename T_V, typename T_E, bool t_directed>
+class Pgr_lineGraph : public Pgr_base_graph<G, T_V, T_E, t_directed> {
  public:
     typedef typename boost::graph_traits < G >::vertex_descriptor V;
     typedef typename boost::graph_traits < G >::edge_descriptor E;
@@ -56,20 +56,20 @@ class Pgr_lineGraph : public Pgr_base_graph<G, T_V, T_E> {
     typedef typename boost::graph_traits < G >::in_edge_iterator EI_i;
 
 
-    explicit Pgr_lineGraph< G, T_V, T_E >(bool directed)
-        : Pgr_base_graph< G, T_V, T_E >(directed) {
+    explicit Pgr_lineGraph<G, T_V, T_E, t_directed>(bool directed)
+        : Pgr_base_graph<G, T_V, T_E, t_directed>() {
         }
 
-    explicit Pgr_lineGraph< G, T_V, T_E >(const pgrouting::DirectedGraph &digraph)
-        : Pgr_base_graph< G, T_V, T_E >(true) {
+    explicit Pgr_lineGraph<G, T_V, T_E, t_directed>(const pgrouting::DirectedGraph &digraph)
+        : Pgr_base_graph<G, T_V, T_E, true>() {
             insert_vertices(digraph);
             create_edges(digraph);
         }
 
 
     friend std::ostream& operator<<(
-            std::ostream &log, const Pgr_lineGraph< G, T_V, T_E > &g) {
-        typename Pgr_base_graph< G, T_V, T_E >::EO_i out, out_end;
+            std::ostream &log, const Pgr_lineGraph<G, T_V, T_E, t_directed> &g) {
+        typename Pgr_base_graph<G, T_V, T_E, t_directed>::EO_i out, out_end;
 
         for (auto vi = vertices(g.graph).first;
                 vi != vertices(g.graph).second; ++vi) {

--- a/include/lineGraph/pgr_lineGraphFull.hpp
+++ b/include/lineGraph/pgr_lineGraphFull.hpp
@@ -44,8 +44,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 namespace pgrouting {
 namespace graph {
 
-template <class G, typename T_V, typename T_E>
-class Pgr_lineGraphFull : public Pgr_base_graph<G, T_V, T_E> {
+template <class G, typename T_V, typename T_E, bool t_directed>
+class Pgr_lineGraphFull : public Pgr_base_graph<G, T_V, T_E, t_directed> {
  public:
     typedef typename boost::graph_traits < G >::vertex_descriptor V;
     typedef typename boost::graph_traits < G >::edge_descriptor E;
@@ -55,20 +55,20 @@ class Pgr_lineGraphFull : public Pgr_base_graph<G, T_V, T_E> {
     typedef typename boost::graph_traits < G >::in_edge_iterator EI_i;
 
 
-    explicit Pgr_lineGraphFull< G, T_V, T_E >(bool directed)
-        : Pgr_base_graph< G, T_V, T_E >(directed),
+    explicit Pgr_lineGraphFull< G, T_V, T_E, t_directed>(bool directed)
+        : Pgr_base_graph<G, T_V, T_E, t_directed>(),
         m_num_edges(0) {
         }
 
-    explicit Pgr_lineGraphFull< G, T_V, T_E >(const pgrouting::DirectedGraph &digraph)
-        : Pgr_base_graph< G, T_V, T_E >(true) {
+    explicit Pgr_lineGraphFull<G, T_V, T_E, t_directed>(const pgrouting::DirectedGraph &digraph)
+        : Pgr_base_graph<G, T_V, T_E, t_directed>() {
             apply_transformation(digraph);
             store_edge_costs(digraph);
         }
 
     friend std::ostream& operator<<(
-            std::ostream &log, const Pgr_lineGraphFull< G, T_V, T_E > &g) {
-        typename Pgr_base_graph< G, T_V, T_E >::EO_i out, out_end;
+            std::ostream &log, const Pgr_lineGraphFull<G, T_V, T_E, t_directed> &g) {
+        typename Pgr_base_graph<G, T_V, T_E, t_directed>::EO_i out, out_end;
 
         for (auto vi = vertices(g.graph).first;
                 vi != vertices(g.graph).second; ++vi) {

--- a/src/allpairs/floydWarshall_driver.cpp
+++ b/src/allpairs/floydWarshall_driver.cpp
@@ -72,12 +72,12 @@ pgr_do_floydWarshall(
 
         if (directed) {
             log << "Processing Directed graph\n";
-            pgrouting::DirectedGraph digraph(directed);
+            pgrouting::DirectedGraph digraph;
             digraph.insert_edges(edges);
             pgr_floydWarshall(digraph, *return_count, return_tuples);
         } else {
             log << "Processing Undirected graph\n";
-            pgrouting::UndirectedGraph undigraph(directed);
+            pgrouting::UndirectedGraph undigraph;
             undigraph.insert_edges(edges);
             pgr_floydWarshall(undigraph, *return_count, return_tuples);
         }

--- a/src/allpairs/johnson_driver.cpp
+++ b/src/allpairs/johnson_driver.cpp
@@ -71,12 +71,12 @@ pgr_do_johnson(
 
         if (directed) {
             log << "Processing Directed graph\n";
-            pgrouting::DirectedGraph digraph(directed);
+            pgrouting::DirectedGraph digraph;
             digraph.insert_edges(edges);
             pgr_johnson(digraph, *return_count, return_tuples);
         } else {
             log << "Processing Undirected graph\n";
-            pgrouting::UndirectedGraph undigraph(directed);
+            pgrouting::UndirectedGraph undigraph;
             undigraph.insert_edges(edges);
             pgr_johnson(undigraph, *return_count, return_tuples);
         }

--- a/src/alpha_shape/pgr_alphaShape.cpp
+++ b/src/alpha_shape/pgr_alphaShape.cpp
@@ -165,8 +165,7 @@ struct CompareRadius {
 /*
  * Constructor
  */
-Pgr_alphaShape::Pgr_alphaShape(const std::vector<Edge_xy_t> &edges) :
-graph(false) {
+Pgr_alphaShape::Pgr_alphaShape(const std::vector<Edge_xy_t> &edges) {
     graph.insert_edges(edges);
     make_triangles();
 }

--- a/src/astar/astar_driver.cpp
+++ b/src/astar/astar_driver.cpp
@@ -106,11 +106,11 @@ void pgr_do_astar(
 
         std::deque<Path> paths;
         if (directed) {
-            pgrouting::xyDirectedGraph graph(directed);
+            pgrouting::xyDirectedGraph graph;
             graph.insert_edges(edges);
             paths = pgrouting::algorithms::astar(graph, combinations, heuristic, factor, epsilon, only_cost);
         } else {
-            pgrouting::xyUndirectedGraph graph(directed);
+            pgrouting::xyUndirectedGraph graph;
             graph.insert_edges(edges);
             paths = pgrouting::algorithms::astar(graph, combinations, heuristic, factor, epsilon, only_cost);
         }

--- a/src/bdAstar/bdAstar_driver.cpp
+++ b/src/bdAstar/bdAstar_driver.cpp
@@ -102,11 +102,11 @@ void pgr_do_bdAstar(
 
         std::deque<Path> paths;
         if (directed) {
-            pgrouting::xyDirectedGraph graph(directed);
+            pgrouting::xyDirectedGraph graph;
             graph.insert_edges(edges);
             paths = pgrouting::algorithms::bdastar(graph, combinations, heuristic, factor, epsilon, only_cost);
         } else {
-            pgrouting::xyUndirectedGraph graph(directed);
+            pgrouting::xyUndirectedGraph graph;
             graph.insert_edges(edges);
             paths = pgrouting::algorithms::bdastar(graph, combinations, heuristic, factor, epsilon, only_cost);
         }

--- a/src/bdDijkstra/bdDijkstra_driver.cpp
+++ b/src/bdDijkstra/bdDijkstra_driver.cpp
@@ -136,11 +136,11 @@ pgr_do_bdDijkstra(
         std::deque<Path> paths;
 
         if (directed) {
-            pgrouting::DirectedGraph graph(directed);
+            pgrouting::DirectedGraph graph;
             graph.insert_edges(edges);
             paths = pgr_bdDijkstra(graph, combinations, only_cost);
         } else {
-            pgrouting::UndirectedGraph graph(directed);
+            pgrouting::UndirectedGraph graph;
             graph.insert_edges(edges);
             paths = pgr_bdDijkstra(graph, combinations, only_cost);
         }

--- a/src/bellman_ford/bellman_ford_driver.cpp
+++ b/src/bellman_ford/bellman_ford_driver.cpp
@@ -151,11 +151,11 @@ pgr_do_bellman_ford(
 
         std::deque<Path> paths;
         if (directed) {
-            pgrouting::DirectedGraph digraph(directed);
+            pgrouting::DirectedGraph digraph;
             digraph.insert_edges(edges);
             paths = bellman_ford(digraph, combinations, only_cost);
         } else {
-            pgrouting::UndirectedGraph undigraph(directed);
+            pgrouting::UndirectedGraph undigraph;
             undigraph.insert_edges(edges);
             paths = bellman_ford(undigraph, combinations, only_cost);
         }

--- a/src/bellman_ford/edwardMoore_driver.cpp
+++ b/src/bellman_ford/edwardMoore_driver.cpp
@@ -146,11 +146,11 @@ pgr_do_edwardMoore(
 
         std::deque<Path> paths;
         if (directed) {
-            pgrouting::DirectedGraph digraph(directed);
+            pgrouting::DirectedGraph digraph;
             digraph.insert_edges(edges);
             paths = edwardMoore(digraph, combinations);
         } else {
-            pgrouting::UndirectedGraph undigraph(directed);
+            pgrouting::UndirectedGraph undigraph;
             undigraph.insert_edges(edges);
            paths = edwardMoore(undigraph, combinations);
         }

--- a/src/breadthFirstSearch/binaryBreadthFirstSearch_driver.cpp
+++ b/src/breadthFirstSearch/binaryBreadthFirstSearch_driver.cpp
@@ -179,7 +179,7 @@ pgr_do_binaryBreadthFirstSearch(
 
         std::deque< Path >paths;
         if (directed) {
-            pgrouting::DirectedGraph digraph(directed);
+            pgrouting::DirectedGraph digraph;
             digraph.insert_edges(edges);
 
             if (!(costCheck(digraph))) {
@@ -190,7 +190,7 @@ pgr_do_binaryBreadthFirstSearch(
             paths = binaryBreadthFirstSearch(digraph, combinations);
 
         } else {
-            pgrouting::UndirectedGraph undigraph(directed);
+            pgrouting::UndirectedGraph undigraph;
             undigraph.insert_edges(edges);
 
             if (!(costCheck(undigraph))) {

--- a/src/breadthFirstSearch/breadthFirstSearch_driver.cpp
+++ b/src/breadthFirstSearch/breadthFirstSearch_driver.cpp
@@ -118,12 +118,12 @@ pgr_do_breadthFirstSearch(
 
         std::vector<MST_rt> results;
         if (directed) {
-            pgrouting::DirectedGraph digraph(directed);
+            pgrouting::DirectedGraph digraph;
             digraph.insert_edges(edges);
             results = breadthFirstSearch(digraph, roots, max_depth);
 
         } else {
-            pgrouting::UndirectedGraph undigraph(directed);
+            pgrouting::UndirectedGraph undigraph;
             undigraph.insert_edges(edges);
             results = breadthFirstSearch(undigraph, roots, max_depth);
         }

--- a/src/circuits/hawickCircuits_driver.cpp
+++ b/src/circuits/hawickCircuits_driver.cpp
@@ -96,7 +96,7 @@ pgr_do_hawickCircuits(
 
         std::deque <circuits_rt> results;
 
-        pgrouting::DirectedGraph digraph(true);
+        pgrouting::DirectedGraph digraph;
         digraph.insert_edges(edges);
 
         results = pgr_hawickCircuits(digraph);

--- a/src/coloring/bipartite_driver.cpp
+++ b/src/coloring/bipartite_driver.cpp
@@ -79,7 +79,7 @@ pgr_do_bipartite(
         hint = nullptr;
 
         std::string logstr;
-        pgrouting::UndirectedGraph undigraph(false);
+        pgrouting::UndirectedGraph undigraph;
         undigraph.insert_edges(edges);
         std::vector<II_t_rt> results;
         pgrouting::functions::Pgr_Bipartite <pgrouting::UndirectedGraph> fn_Bipartite;

--- a/src/coloring/sequentialVertexColoring_driver.cpp
+++ b/src/coloring/sequentialVertexColoring_driver.cpp
@@ -91,7 +91,7 @@ pgr_do_sequentialVertexColoring(
 
         std::vector <II_t_rt> results;
 
-        pgrouting::UndirectedGraph undigraph(false);
+        pgrouting::UndirectedGraph undigraph;
 
         undigraph.insert_edges(edges);
 

--- a/src/components/articulationPoints_driver.cpp
+++ b/src/components/articulationPoints_driver.cpp
@@ -77,7 +77,7 @@ pgr_do_articulationPoints(
         }
         hint = nullptr;
 
-        pgrouting::UndirectedGraph undigraph(false);
+        pgrouting::UndirectedGraph undigraph;
         undigraph.insert_edges(edges);
         auto results(pgrouting::algorithms::articulationPoints(undigraph));
 

--- a/src/components/biconnectedComponents_driver.cpp
+++ b/src/components/biconnectedComponents_driver.cpp
@@ -78,7 +78,7 @@ pgr_do_biconnectedComponents(
         }
         hint = nullptr;
 
-        pgrouting::UndirectedGraph undigraph(false);
+        pgrouting::UndirectedGraph undigraph;
         undigraph.insert_edges(edges);
         auto results(pgrouting::algorithms::biconnectedComponents(undigraph));
 

--- a/src/components/bridges_driver.cpp
+++ b/src/components/bridges_driver.cpp
@@ -76,7 +76,7 @@ pgr_do_bridges(
         }
         hint = nullptr;
 
-        pgrouting::UndirectedGraph undigraph(false);
+        pgrouting::UndirectedGraph undigraph;
         undigraph.insert_edges(edges);
         auto results = pgrouting::algorithms::bridges(undigraph);
 

--- a/src/components/connectedComponents_driver.cpp
+++ b/src/components/connectedComponents_driver.cpp
@@ -77,7 +77,7 @@ pgr_do_connectedComponents(
         }
         hint = nullptr;
 
-        pgrouting::UndirectedGraph undigraph(false);
+        pgrouting::UndirectedGraph undigraph;
         undigraph.insert_edges(edges);
         auto results(pgrouting::algorithms::pgr_connectedComponents(undigraph));
 

--- a/src/components/makeConnected_driver.cpp
+++ b/src/components/makeConnected_driver.cpp
@@ -79,7 +79,7 @@ pgr_do_makeConnected(
         }
         hint = nullptr;
 
-        pgrouting::UndirectedGraph undigraph(false);
+        pgrouting::UndirectedGraph undigraph;
         undigraph.insert_edges(edges);
         pgrouting::functions::Pgr_makeConnected<pgrouting::UndirectedGraph> fn_makeConnected;
         results = fn_makeConnected.makeConnected(undigraph);

--- a/src/components/strongComponents_driver.cpp
+++ b/src/components/strongComponents_driver.cpp
@@ -78,7 +78,7 @@ pgr_do_strongComponents(
         }
         hint = nullptr;
 
-        pgrouting::DirectedGraph digraph(true);
+        pgrouting::DirectedGraph digraph;
         digraph.insert_edges(edges);
         auto results(pgrouting::algorithms::strongComponents(digraph));
 

--- a/src/contraction/contractGraph_driver.cpp
+++ b/src/contraction/contractGraph_driver.cpp
@@ -227,7 +227,7 @@ pgr_do_contractGraph(
 
         if (directed) {
             using DirectedGraph = pgrouting::graph::CHDirectedGraph;
-            DirectedGraph digraph(directed);
+            DirectedGraph digraph;
 
             process_contraction(digraph, edges, forbid, ordering,
                     max_cycles);
@@ -238,7 +238,7 @@ pgr_do_contractGraph(
                     return_count);
         } else {
             using UndirectedGraph = pgrouting::graph::CHUndirectedGraph;
-            UndirectedGraph undigraph(directed);
+            UndirectedGraph undigraph;
             process_contraction(undigraph, edges, forbid, ordering,
                     max_cycles);
 

--- a/src/dagShortestPath/dagShortestPath_driver.cpp
+++ b/src/dagShortestPath/dagShortestPath_driver.cpp
@@ -119,11 +119,11 @@ pgr_do_dagShortestPath(
 
         std::deque<Path> paths;
         if (directed) {
-            pgrouting::DirectedGraph graph(directed);
+            pgrouting::DirectedGraph graph;
             graph.insert_edges(edges);
             paths = pgr_dagShortestPath(graph, combinations, only_cost);
         } else {
-            pgrouting::UndirectedGraph graph(directed);
+            pgrouting::UndirectedGraph graph;
             graph.insert_edges(edges);
             paths = pgr_dagShortestPath(graph, combinations, only_cost);
         }

--- a/src/dijkstra/dijkstraVia_driver.cpp
+++ b/src/dijkstra/dijkstraVia_driver.cpp
@@ -136,7 +136,7 @@ pgr_do_dijkstraVia(
 
         std::deque<Path>paths;
         if (directed) {
-            pgrouting::DirectedGraph digraph(directed);
+            pgrouting::DirectedGraph digraph;
             digraph.insert_edges(edges);
             pgrouting::pgr_dijkstraVia(
                     digraph,
@@ -146,7 +146,7 @@ pgr_do_dijkstraVia(
                     U_turn_on_edge,
                     log);
         } else {
-            pgrouting::UndirectedGraph undigraph(directed);
+            pgrouting::UndirectedGraph undigraph;
             undigraph.insert_edges(edges);
             pgrouting::pgr_dijkstraVia(
                     undigraph,

--- a/src/dijkstra/dijkstra_driver.cpp
+++ b/src/dijkstra/dijkstra_driver.cpp
@@ -165,11 +165,11 @@ pgr_do_dijkstra(
         std::deque<Path>paths;
 
         if (directed) {
-            pgrouting::DirectedGraph graph(directed);
+            pgrouting::DirectedGraph graph;
             graph.insert_edges(edges);
             paths =  pgrouting::algorithms::dijkstra(graph, combinations, only_cost, n);
         } else {
-            pgrouting::UndirectedGraph graph(directed);
+            pgrouting::UndirectedGraph graph;
             graph.insert_edges(edges);
             paths =  pgrouting::algorithms::dijkstra(graph, combinations, only_cost, n);
         }

--- a/src/dominator/lengauerTarjanDominatorTree_driver.cpp
+++ b/src/dominator/lengauerTarjanDominatorTree_driver.cpp
@@ -82,7 +82,7 @@ pgr_do_LTDTree(
 
         std::string logstr;
 
-        pgrouting::DirectedGraph digraph(true);
+        pgrouting::DirectedGraph digraph;
         digraph.insert_edges(edges);
         std::vector<II_t_rt> results;
         pgrouting::functions::Pgr_LTDTree<pgrouting::DirectedGraph> fn_LTDTree;

--- a/src/driving_distance/drivedist_driver.cpp
+++ b/src/driving_distance/drivedist_driver.cpp
@@ -90,11 +90,11 @@ pgr_do_drivingDistance(
         std::vector<std::map<int64_t, int64_t>> depths;
 
         if (directed) {
-            pgrouting::DirectedGraph digraph(directed);
+            pgrouting::DirectedGraph digraph;
             digraph.insert_edges(edges);
             paths = drivingDistance(digraph, roots, distance, equiCostFlag, depths, true);
         } else {
-            pgrouting::UndirectedGraph undigraph(directed);
+            pgrouting::UndirectedGraph undigraph;
             undigraph.insert_edges(edges);
             paths = drivingDistance(undigraph, roots, distance, equiCostFlag, depths, true);
         }

--- a/src/driving_distance/withPoints_dd_driver.cpp
+++ b/src/driving_distance/withPoints_dd_driver.cpp
@@ -125,12 +125,12 @@ pgr_do_withPointsDD(
         std::vector<std::map<int64_t, int64_t>> depths;
 
         if (directed) {
-            pgrouting::DirectedGraph digraph(directed);
+            pgrouting::DirectedGraph digraph;
             digraph.insert_edges(edges);
             digraph.insert_edges(pg_graph.new_edges());
             paths = drivingDistance(digraph, roots, distance, equiCost, depths, details);
         } else {
-            pgrouting::UndirectedGraph undigraph(directed);
+            pgrouting::UndirectedGraph undigraph;
             undigraph.insert_edges(edges);
             undigraph.insert_edges(pg_graph.new_edges());
             paths = drivingDistance(undigraph, roots, distance, equiCost, depths, details);

--- a/src/ksp/ksp_driver.cpp
+++ b/src/ksp/ksp_driver.cpp
@@ -110,11 +110,11 @@ void pgr_do_ksp(
         std::deque<Path>paths;
 
         if (directed) {
-            pgrouting::DirectedGraph graph(directed);
+            pgrouting::DirectedGraph graph;
             graph.insert_edges(edges);
             paths = pgrouting::algorithms::Yen(graph, combinations, k, heap_paths);
         } else {
-            pgrouting::UndirectedGraph graph(directed);
+            pgrouting::UndirectedGraph graph;
             graph.insert_edges(edges);
             paths = pgrouting::algorithms::Yen(graph, combinations, k, heap_paths);
         }

--- a/src/ksp/turnRestrictedPath_driver.cpp
+++ b/src/ksp/turnRestrictedPath_driver.cpp
@@ -145,7 +145,7 @@ pgr_do_turnRestrictedPath(
         std::string logstr;
         if (directed) {
             log << "Working with directed Graph\n";
-            pgrouting::DirectedGraph digraph(directed);
+            pgrouting::DirectedGraph digraph;
             Pgr_turnRestrictedPath < pgrouting::DirectedGraph > fn_TRSP;
             digraph.insert_edges(edges);
             log << digraph;
@@ -162,7 +162,7 @@ pgr_do_turnRestrictedPath(
                     strict);
         } else {
             log << "TODO Working with Undirected Graph\n";
-            pgrouting::UndirectedGraph undigraph(directed);
+            pgrouting::UndirectedGraph undigraph;
             Pgr_turnRestrictedPath < pgrouting::UndirectedGraph > fn_TRSP;
             undigraph.insert_edges(edges);
             paths = pgr_dijkstraTR(undigraph,

--- a/src/ksp/withPoints_ksp_driver.cpp
+++ b/src/ksp/withPoints_ksp_driver.cpp
@@ -137,13 +137,13 @@ pgr_do_withPointsKsp(
 
         std::deque<Path> paths;
         if (directed) {
-            pgrouting::DirectedGraph digraph(directed);
+            pgrouting::DirectedGraph digraph;
             digraph.insert_edges(edges);
             digraph.insert_edges(pg_graph.new_edges());
 
             paths = pgrouting::algorithms::Yen(digraph, combinations, k, heap_paths);
         } else {
-            pgrouting::UndirectedGraph undigraph(directed);
+            pgrouting::UndirectedGraph undigraph;
             undigraph.insert_edges(edges);
             undigraph.insert_edges(pg_graph.new_edges());
 

--- a/src/lineGraph/lineGraphFull_driver.cpp
+++ b/src/lineGraph/lineGraphFull_driver.cpp
@@ -99,13 +99,13 @@ pgr_do_lineGraphFull(
         }
         hint = nullptr;
 
-        pgrouting::DirectedGraph digraph(true);
+        pgrouting::DirectedGraph digraph;
         digraph.insert_edges_neg(edges);
 
         pgrouting::graph::Pgr_lineGraphFull<
             pgrouting::LinearDirectedGraph,
             pgrouting::Line_vertex,
-            pgrouting::Basic_edge > line(digraph);
+            pgrouting::Basic_edge, true> line(digraph);
 
         std::vector< Line_graph_full_rt > line_graph_edges;
         line_graph_edges = line.get_postgres_results_directed();

--- a/src/lineGraph/lineGraph_driver.cpp
+++ b/src/lineGraph/lineGraph_driver.cpp
@@ -97,14 +97,14 @@ pgr_do_lineGraph(
 
 
 
-        pgrouting::DirectedGraph digraph(directed);
+        pgrouting::DirectedGraph digraph;
         digraph.insert_edges_neg(edges);
 
         log << digraph << "\n";
         pgrouting::graph::Pgr_lineGraph<
             pgrouting::LinearDirectedGraph,
             pgrouting::Line_vertex,
-            pgrouting::Basic_edge> line(digraph);
+            pgrouting::Basic_edge, true> line(digraph);
         std::vector< Edge_rt > line_graph_edges;
         line_graph_edges = line.get_postgres_results_directed();
         auto count = line_graph_edges.size();

--- a/src/lineGraph/lineGraph_driver.cpp
+++ b/src/lineGraph/lineGraph_driver.cpp
@@ -64,7 +64,7 @@ void
 pgr_do_lineGraph(
         char *edges_sql,
 
-        bool directed,
+        bool,
         Edge_rt **return_tuples,
         size_t *return_count,
         char ** log_msg,

--- a/src/mincut/stoerWagner_driver.cpp
+++ b/src/mincut/stoerWagner_driver.cpp
@@ -87,7 +87,7 @@ pgr_do_stoerWagner(
 
         std::vector<StoerWagner_t> results;
 
-        pgrouting::UndirectedGraph undigraph(false);
+        pgrouting::UndirectedGraph undigraph;
         undigraph.insert_edges(edges);
         results = pgr_stoerWagner(
                     undigraph);

--- a/src/ordering/cuthillMckeeOrdering_driver.cpp
+++ b/src/ordering/cuthillMckeeOrdering_driver.cpp
@@ -104,7 +104,7 @@ void pgr_do_cuthillMckeeOrdering(
         hint = nullptr;
 
         std::vector<II_t_rt>results;
-        pgrouting::UndirectedGraph undigraph(false);
+        pgrouting::UndirectedGraph undigraph;
         undigraph.insert_edges(edges);
         results = cuthillMckeeOrdering(undigraph);
 

--- a/src/planar/isPlanar_driver.cpp
+++ b/src/planar/isPlanar_driver.cpp
@@ -73,7 +73,7 @@ pgr_do_isPlanar(
         }
         hint = nullptr;
 
-        pgrouting::UndirectedGraph undigraph(false);
+        pgrouting::UndirectedGraph undigraph;
         undigraph.insert_edges(edges);
         pgrouting::functions::Pgr_boyerMyrvold<pgrouting::UndirectedGraph> fn_isPlanar;
         result = fn_isPlanar.isPlanar(undigraph);

--- a/src/spanningTree/kruskal_driver.cpp
+++ b/src/spanningTree/kruskal_driver.cpp
@@ -84,7 +84,7 @@ pgr_do_kruskal(
 
         std::vector<MST_rt> results;
 
-        pgrouting::UndirectedGraph undigraph(false);
+        pgrouting::UndirectedGraph undigraph;
         undigraph.insert_edges(edges);
         pgrouting::functions::Pgr_kruskal<pgrouting::UndirectedGraph> kruskal;
 

--- a/src/spanningTree/prim_driver.cpp
+++ b/src/spanningTree/prim_driver.cpp
@@ -86,7 +86,7 @@ pgr_do_prim(
 
         std::vector<MST_rt> results;
 
-        pgrouting::UndirectedGraph undigraph(false);
+        pgrouting::UndirectedGraph undigraph;
         undigraph.insert_min_edges_no_parallel(edges);
         pgrouting::functions::Pgr_prim<pgrouting::UndirectedGraph> prim;
 

--- a/src/topologicalSort/topologicalSort_driver.cpp
+++ b/src/topologicalSort/topologicalSort_driver.cpp
@@ -91,7 +91,7 @@ pgr_do_topologicalSort(
         hint = nullptr;
 
         std::vector<I_rt> results;
-        pgrouting::DirectedGraph digraph(true);
+        pgrouting::DirectedGraph digraph;
         digraph.insert_edges(edges);
         results = pgr_topologicalSort(
                 digraph);

--- a/src/transitiveClosure/transitiveClosure_driver.cpp
+++ b/src/transitiveClosure/transitiveClosure_driver.cpp
@@ -126,7 +126,7 @@ pgr_do_transitiveClosure(
         }
         hint = nullptr;
 
-        pgrouting::DirectedGraph digraph(true);
+        pgrouting::DirectedGraph digraph;
         digraph.insert_edges(edges);
 
         get_postgres_result(

--- a/src/traversal/depthFirstSearch_driver.cpp
+++ b/src/traversal/depthFirstSearch_driver.cpp
@@ -123,7 +123,7 @@ pgr_do_depthFirstSearch(
             *log_msg = pgr_msg(edges_sql);
         } else {
             if (directed) {
-                pgrouting::DirectedGraph digraph(directed);
+                pgrouting::DirectedGraph digraph;
                 digraph.insert_edges(edges);
 
             results = pgr_depthFirstSearch(
@@ -132,7 +132,7 @@ pgr_do_depthFirstSearch(
                     directed,
                     max_depth);
             } else {
-                pgrouting::UndirectedGraph undigraph(directed);
+                pgrouting::UndirectedGraph undigraph;
                 undigraph.insert_edges(edges);
 
                 results = pgr_depthFirstSearch(

--- a/src/trsp/trspVia_driver.cpp
+++ b/src/trsp/trspVia_driver.cpp
@@ -180,7 +180,7 @@ pgr_do_trspVia(
 
         std::deque<Path> paths;
         if (directed) {
-            pgrouting::DirectedGraph digraph(directed);
+            pgrouting::DirectedGraph digraph;
             digraph.insert_edges(edges);
             pgrouting::pgr_dijkstraVia(
                     digraph,
@@ -190,7 +190,7 @@ pgr_do_trspVia(
                     U_turn_on_edge,
                     log);
         } else {
-            pgrouting::UndirectedGraph undigraph(directed);
+            pgrouting::UndirectedGraph undigraph;
             undigraph.insert_edges(edges);
             pgrouting::pgr_dijkstraVia(
                     undigraph,

--- a/src/trsp/trspVia_withPoints_driver.cpp
+++ b/src/trsp/trspVia_withPoints_driver.cpp
@@ -207,7 +207,7 @@ pgr_do_trspVia_withPoints(
 
         std::deque<Path> paths;
         if (directed) {
-            pgrouting::DirectedGraph digraph(vertices, directed);
+            pgrouting::DirectedGraph digraph;
             digraph.insert_edges(edges);
             digraph.insert_edges(pg_graph.new_edges());
             pgrouting::pgr_dijkstraVia(
@@ -218,7 +218,7 @@ pgr_do_trspVia_withPoints(
                     U_turn_on_edge,
                     log);
         } else {
-            pgrouting::UndirectedGraph undigraph(vertices, directed);
+            pgrouting::UndirectedGraph undigraph;
             undigraph.insert_edges(edges);
             undigraph.insert_edges(pg_graph.new_edges());
             pgrouting::pgr_dijkstraVia(

--- a/src/trsp/trsp_driver.cpp
+++ b/src/trsp/trsp_driver.cpp
@@ -151,14 +151,14 @@ pgr_do_trsp(
 
         std::deque<Path> paths;
         if (directed) {
-            pgrouting::DirectedGraph digraph(directed);
+            pgrouting::DirectedGraph digraph;
             digraph.insert_edges(edges);
 
             paths = pgr_dijkstra(
                     digraph,
                     combinations);
         } else {
-            pgrouting::UndirectedGraph undigraph(directed);
+            pgrouting::UndirectedGraph undigraph;
             undigraph.insert_edges(edges);
 
             paths = pgr_dijkstra(

--- a/src/trsp/trsp_withPoints_driver.cpp
+++ b/src/trsp/trsp_withPoints_driver.cpp
@@ -165,7 +165,7 @@ pgr_do_trsp_withPoints(
 
         std::deque<Path> paths;
         if (directed) {
-            pgrouting::DirectedGraph digraph(vertices, directed);
+            pgrouting::DirectedGraph digraph;
             digraph.insert_edges(edges);
             digraph.insert_edges(pg_graph.new_edges());
 
@@ -174,7 +174,7 @@ pgr_do_trsp_withPoints(
                     combinations,
                     false, (std::numeric_limits<size_t>::max)());
         } else {
-            pgrouting::UndirectedGraph undigraph(vertices, directed);
+            pgrouting::UndirectedGraph undigraph;
             undigraph.insert_edges(edges);
             undigraph.insert_edges(pg_graph.new_edges());
 

--- a/src/withPoints/withPointsVia_driver.cpp
+++ b/src/withPoints/withPointsVia_driver.cpp
@@ -169,7 +169,7 @@ pgr_do_withPointsVia(
 
         std::deque<Path> paths;
         if (directed) {
-            pgrouting::DirectedGraph digraph(vertices, directed);
+            pgrouting::DirectedGraph digraph(vertices);
             digraph.insert_edges(edges);
             digraph.insert_edges(pg_graph.new_edges());
             pgrouting::pgr_dijkstraVia(
@@ -180,7 +180,7 @@ pgr_do_withPointsVia(
                     U_turn_on_edge,
                     log);
         } else {
-            pgrouting::UndirectedGraph undigraph(vertices, directed);
+            pgrouting::UndirectedGraph undigraph(vertices);
             undigraph.insert_edges(edges);
             undigraph.insert_edges(pg_graph.new_edges());
             pgrouting::pgr_dijkstraVia(

--- a/src/withPoints/withPoints_driver.cpp
+++ b/src/withPoints/withPoints_driver.cpp
@@ -164,7 +164,7 @@ pgr_do_withPoints(
 
         std::deque<Path> paths;
         if (directed) {
-            pgrouting::DirectedGraph digraph(vertices, directed);
+            pgrouting::DirectedGraph digraph(vertices);
             digraph.insert_edges(edges);
             digraph.insert_edges(pg_graph.new_edges());
 
@@ -173,7 +173,7 @@ pgr_do_withPoints(
                     combinations,
                     only_cost, normal);
         } else {
-            pgrouting::UndirectedGraph undigraph(vertices, directed);
+            pgrouting::UndirectedGraph undigraph(vertices);
             undigraph.insert_edges(edges);
             undigraph.insert_edges(pg_graph.new_edges());
             paths = pgr_dijkstra(


### PR DESCRIPTION
Up to version 3.6 this has been used and it is redundant
The false means that the graph is `undirected`, and the name has  `undirected`
```
pgrouting::UndirectedGraph undigraph(false);
```
Change to 
```
pgrouting::UndirectedGraph undigraph;
```
Avoids possible errors like
```
pgrouting::UndirectedGraph undigraph(true);
pgrouting::DirectedGraph undigraph(false);
```

BTW while doing this, a bug about `pgr_lineGraph` was found.
Will open an issue later on describing the issue. But the work to fix it has been started. on #2625 

