### PR TITLE
Recover macos test

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Test
         run: |
           export PATH=$(brew --prefix)/Cellar/perl/$(perl -e 'print substr($^V, 1)')/bin:$PATH
-          brew services start postgresql
+          pg_ctl -D $(brew --prefix)/var/postgresql@14 start
           createuser -s postgres
           createdb ___pgr___test___
           bash ./tools/testers/pg_prove_tests.sh postgres 5432 Release

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-14]
+        os: [macos-latest]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -66,24 +66,20 @@ jobs:
         run: |
           cd build
           make -j
-          sudo make install
+          make install
 
       - name: Install pgTAP
-        if: false
         run: |
           git clone https://github.com/theory/pgtap.git pgTapExtension
           cd pgTapExtension
           make -j
-          sudo make install
-          sudo cpan TAP::Parser::SourceHandler::pgTAP
-          sudo find /usr/local -name pg_prove
-          sudo ln -s  /usr/local/Cellar/perl/5.32.1_1/bin/pg_prove  symlink it into /usr/local/bin
+          make install
+          cpan TAP::Parser::SourceHandler::pgTAP
 
       - name: Test
-        if: false
         run: |
-          export PATH=/usr/local/Cellar/perl/$(perl -e 'print substr($^V, 1)')/bin:$PATH
-          pg_ctl -D /usr/local/var/postgres start
+          export PATH=$(brew --prefix)/Cellar/perl/$(perl -e 'print substr($^V, 1)')/bin:$PATH
+          pg_ctl -D $(brew --prefix)/var/postgres start
           createuser -s postgres
           createdb ___pgr___test___
           bash ./tools/testers/pg_prove_tests.sh postgres 5432 Release

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -75,6 +75,7 @@ jobs:
           make -j
           make install
           cpan TAP::Parser::SourceHandler::pgTAP
+          ln -s $(find `brew --prefix` -name pg_prove) symlink it into $(brew --prefix)/bin
 
       - name: Test
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Test
         run: |
           export PATH=$(brew --prefix)/Cellar/perl/$(perl -e 'print substr($^V, 1)')/bin:$PATH
-          pg_ctl -D $(brew --prefix)/var/postgres start
+          brew services start postgresql
           createuser -s postgres
           createdb ___pgr___test___
           bash ./tools/testers/pg_prove_tests.sh postgres 5432 Release


### PR DESCRIPTION
Related with PR #2619.

Changes proposed in this pull request:
- Recover macos test
  - Update homebrew path after macOS Intel => Silicon update.

Example CI results:
- Before:
  - Job: https://github.com/sanak/pgrouting/actions/runs/9336541789
  - Total duration: 30m 6s
- After:
  - Job: https://github.com/sanak/pgrouting/actions/runs/9336551609
  - Total duration: 37m 18s
  - Test summary: https://github.com/sanak/pgrouting/actions/runs/9336551609/job/25697256003#step:7:41034

@pgRouting/admins