### PR TITLE
Fix 2648 fail building under window mingw64

### DIFF
--- a/include/cpp_common/combinations.hpp
+++ b/include/cpp_common/combinations.hpp
@@ -28,11 +28,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #define INCLUDE_CPP_COMMON_COMBINATIONS_HPP_
 #pragma once
 
-extern "C" {
-#include <postgres.h>
-#include <utils/array.h>
-}
-
 #include <cstddef>
 #include <cstdint>
 #include <map>
@@ -40,11 +35,13 @@ extern "C" {
 #include <deque>
 #include <vector>
 
-#include "cpp_common/undefPostgresDefine.hpp"
 
 #include "c_types/ii_t_rt.h"
 #include "cpp_common/basePath_SSEC.hpp"
 #include "cpp_common/rule.hpp"
+
+
+typedef struct ArrayType ArrayType;
 
 namespace pgrouting {
 

--- a/include/cpp_common/get_data.hpp
+++ b/include/cpp_common/get_data.hpp
@@ -29,10 +29,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #define INCLUDE_CPP_COMMON_GET_DATA_HPP_
 #pragma once
 
+#include "c_common/postgres_connection.h"
+
 #include <vector>
 #include <string>
 
-#include "c_common/postgres_connection.h"
 #include "cpp_common/info_t.hpp"
 #include "cpp_common/get_check_data.hpp"
 #include "cpp_common/pgr_alloc.hpp"

--- a/include/cpp_common/interruption.hpp
+++ b/include/cpp_common/interruption.hpp
@@ -52,7 +52,9 @@ extern "C" {
     /*
      * https://doxygen.postgresql.org/c_8h.html#a166c1d950e659804f0e3247aad99a81f
      */
+#ifndef PGDLLIMPORT
 #define PGDLLIMPORT
+#endif
 
     /*
      * https://doxygen.postgresql.org/miscadmin_8h_source.html

--- a/include/cpp_common/pgdata_getters.hpp
+++ b/include/cpp_common/pgdata_getters.hpp
@@ -38,18 +38,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #define INCLUDE_CPP_COMMON_PGDATA_GETTERS_HPP_
 #pragma once
 
-extern "C" {
-#include <postgres.h>
-#include <utils/array.h>
-}
-
 #include <cstddef>
 #include <cstdint>
 #include <string>
 #include <set>
 #include <vector>
 
-#include "cpp_common/undefPostgresDefine.hpp"
 
 #include "cpp_common/info_t.hpp"
 #include "c_types/ii_t_rt.h"
@@ -64,6 +58,8 @@ extern "C" {
 #include "cpp_common/restriction_t.hpp"
 #include "cpp_common/point_on_edge_t.hpp"
 #include "cpp_common/vehicle_t.hpp"
+
+typedef struct ArrayType ArrayType;
 
 namespace pgrouting {
 namespace pgget {

--- a/include/cpp_common/undefPostgresDefine.hpp
+++ b/include/cpp_common/undefPostgresDefine.hpp
@@ -70,6 +70,14 @@ extern "C" {
 #undef vsnprintf
 #endif
 
+#ifdef unlink
+#undef unlink
+#endif
+
+#ifdef bind
+#undef bind
+#endif
+
 #endif
 
 #endif  // INCLUDE_CPP_COMMON_UNDEFPOSTGRESDEFINE_HPP_

--- a/include/max_flow/pgr_maximumcardinalitymatching.hpp
+++ b/include/max_flow/pgr_maximumcardinalitymatching.hpp
@@ -127,9 +127,9 @@ class PgrCardinalityGraph {
               ++vi) {
           boost::tie(e, exists) =
               boost::edge(*vi, mate_map[*vi], boost_graph);
-          if (((uint64_t)mate_map[*vi]
+          if ((static_cast<uint64_t>(mate_map[*vi])
                       != boost::graph_traits<G>::null_vertex())
-                  && (*vi < (uint64_t)mate_map[*vi])) {
+                  && (*vi < static_cast<uint64_t>(mate_map[*vi]))) {
               Only_int_rt matched_couple;
               matched_couple.source = get_vertex_id(*vi);
               matched_couple.target = get_vertex_id(mate_map[*vi]);

--- a/src/cpp_common/get_check_data.cpp
+++ b/src/cpp_common/get_check_data.cpp
@@ -564,10 +564,10 @@ int64_t getBigInt(
         throw std::string("Unexpected Null value in column ") + info.name;
     switch (info.type) {
         case INT2OID:
-            value = (int64_t) DatumGetInt16(binval);
+            value = static_cast<int64_t>(DatumGetInt16(binval));
             break;
         case INT4OID:
-            value = (int64_t) DatumGetInt32(binval);
+            value = static_cast<int64_t>(DatumGetInt32(binval));
             break;
         case INT8OID:
             value = DatumGetInt64(binval);

--- a/src/cpp_common/pgdata_getters.cpp
+++ b/src/cpp_common/pgdata_getters.cpp
@@ -35,6 +35,19 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 
+extern "C" {
+
+#include <postgres.h>
+#include <executor/spi.h>
+#include <funcapi.h>
+#include <utils/builtins.h>
+#include <access/htup_details.h>
+#include <fmgr.h>
+#include <utils/array.h>
+#include <catalog/pg_type.h>
+
+}
+
 #include "cpp_common/pgdata_getters.hpp"
 #include <vector>
 #include <string>

--- a/src/max_flow/pgr_maxflow.cpp
+++ b/src/max_flow/pgr_maxflow.cpp
@@ -85,7 +85,7 @@ void PgrFlowGraph::insert_edges_push_relabel(
                 boost::add_edge(v2, v1, graph);
             E_to_id.insert(std::pair<E, int64_t>(e1, edge.id));
             E_to_id.insert(std::pair<E, int64_t>(e1_rev, edge.id));
-            capacity[e1] = (int64_t) edge.cost;
+            capacity[e1] = static_cast<int64_t>(edge.cost);
             capacity[e1_rev] = 0;
             rev[e1] = e1_rev;
             rev[e1_rev] = e1;
@@ -96,7 +96,7 @@ void PgrFlowGraph::insert_edges_push_relabel(
                 boost::add_edge(v1, v2, graph);
             E_to_id.insert(std::pair<E, int64_t>(e2, edge.id));
             E_to_id.insert(std::pair<E, int64_t>(e2_rev, edge.id));
-            capacity[e2] = (int64_t) edge.reverse_cost;
+            capacity[e2] = static_cast<int64_t>(edge.reverse_cost);
             capacity[e2_rev] = 0;
             rev[e2] = e2_rev;
             rev[e2_rev] = e2;
@@ -119,9 +119,9 @@ void PgrFlowGraph::insert_edges(
             boost::add_edge(v2, v1, graph);
         E_to_id.insert(std::pair<E, int64_t>(e, edge.id));
         E_to_id.insert(std::pair<E, int64_t>(e_rev, edge.id));
-        capacity[e] = edge.cost > 0 ? (int64_t) edge.cost : 0;
+        capacity[e] = edge.cost > 0 ? static_cast<int64_t>(edge.cost) : 0;
         capacity[e_rev] = edge.reverse_cost > 0
-            ? (int64_t) edge.reverse_cost : 0;
+            ? static_cast<int64_t>(edge.reverse_cost) : 0;
         rev[e] = e_rev;
         rev[e_rev] = e;
     }

--- a/tools/scripts/code_checker.sh
+++ b/tools/scripts/code_checker.sh
@@ -43,6 +43,7 @@ if ! test -d code_linter; then
 fi
 
 DIRECTORY="$1"
+INCLUDE_ORDER="-build/include_order:src/cpp_common/pgdata_getters.cpp,-build/include_order:include/cpp_common/get_data.hpp"
 
 if test -z "$DIRECTORY"; then
     echo "--------------------"
@@ -52,11 +53,15 @@ if test -z "$DIRECTORY"; then
     echo "--------------------"
     echo "------ *.cpp  ------"
     echo "--------------------"
-    code_linter/cpplint/cpplint.py --filter=-runtime/references,-whitespace/indent_namespace  --linelength=120 src/*/*.cpp
+    code_linter/cpplint/cpplint.py --linelength=120 \
+        --filter=-runtime/references,-whitespace/indent_namespace,"${INCLUDE_ORDER}"  \
+        --linelength=120 src/*/*.cpp
+
     echo "--------------------"
     echo "------ HEADERS  ------"
     echo "--------------------"
-    code_linter/cpplint/cpplint.py --extensions=hpp,h --headers=hpp,h  --linelength=120 --filter=-runtime/references,-whitespace/indent_namespace \
+    code_linter/cpplint/cpplint.py --extensions=hpp,h --headers=hpp,h  --linelength=120 \
+        --filter=-runtime/references,-whitespace/indent_namespace,"${INCLUDE_ORDER}" \
         include/*/*.h* \
         include/*/*/*.h*
 
@@ -66,7 +71,8 @@ else
     echo "--------------------"
     echo "------ IN PLACE HEADERS  ------"
     echo "--------------------"
-    code_linter/cpplint/cpplint.py --extensions=hpp,h --headers=hpp,h  --linelength=120 --filter=-runtime/references \
+    code_linter/cpplint/cpplint.py --extensions=hpp,h --headers=hpp,h  --linelength=120 \
+        --filter=-runtime/references,-whitespace/indent_namespace,"${INCLUDE_ORDER}" \
         include/*/*.h* \
         include/*/*/*.h*
 
@@ -74,11 +80,17 @@ else
         echo "--------------------"
         echo "------   *.c  ------"
         echo "--------------------"
-        code_linter/cpplint/cpplint.py --extensions=c  --linelength=120 --filter=-readability/casting src/"$DIRECTORY"/*.c
+        code_linter/cpplint/cpplint.py --extensions=c  --linelength=120 \
+            --filter=-readability/casting \
+            src/"$DIRECTORY"/*.c
+
         echo "--------------------"
         echo "------ *.cpp  ------"
         echo "--------------------"
-        code_linter/cpplint/cpplint.py  --linelength=120 --filter=-runtime/references,-whitespace/indent_namespace src/"$DIRECTORY"/*.cpp
+        code_linter/cpplint/cpplint.py  --linelength=120 \
+            --filter=-runtime/references,-whitespace/indent_namespace,"${INCLUDE_ORDER}" \
+            src/"$DIRECTORY"/*.cpp
+
         echo "--------------------"
         echo "------   C HEADER  ------"
         echo "--------------------"
@@ -89,11 +101,9 @@ else
         echo "--------------------"
         echo "------ C++ HEADER  ------"
         echo "--------------------"
-        code_linter/cpplint/cpplint.py  --extensions=hpp,h --headers=hpp  --linelength=120 --filter=-runtime/references,-whitespace/indent_namespace include/"$DIRECTORY"/*.h*
-        echo "--------------------"
-        echo "------ this shouild fail  ------"
-        echo "--------------------"
-        code_linter/cpplint/cpplint.py src/"$DIRECTORY"/src/*.h*
+        code_linter/cpplint/cpplint.py  --extensions=hpp,h --headers=hpp,h  --linelength=120 \
+            --filter=-runtime/references,-whitespace/indent_namespace,"${INCLUDE_ORDER}" \
+            include/"$DIRECTORY"/*.h*
     fi
 fi
 


### PR DESCRIPTION
Fixes #2648 .

Changes proposed in this pull request:
- postgres includes must be the first includes
- forward declaration of ArrayType  on header to avoid postgres includes
- wrapped a define because it was already defined
- Adjusted the code_checker script to ignore include order where applicable

@pgRouting/admins
