### PR TITLE
(C++) adding missing include to be fully compatible with C++13

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@ milestone for 3.6.3
   * postgres 11.0.0
   * postgis 3.0.0
 
+* g++ 13+ is supported
+
 **Code fixes**
 
 * Fix warnings from cpplint.

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -51,6 +51,8 @@ milestone for 3.6.3
   * postgres 11.0.0
   * postgis 3.0.0
 
+* g++ 13+ is supported
+
 .. rubric:: Code fixes
 
 * Fix warnings from cpplint.

--- a/docqueries/mincut/doc-stoerWagner.result
+++ b/docqueries/mincut/doc-stoerWagner.result
@@ -8,7 +8,7 @@ SELECT * FROM pgr_stoerWagner(
   FROM edges WHERE id < 17');
  seq | edge | cost | mincut
 -----+------+------+--------
-   1 |    6 |    1 |      1
+   1 |   14 |    1 |      1
 (1 row)
 
 /* -- q2 */

--- a/include/cpp_common/basePath_SSEC.hpp
+++ b/include/cpp_common/basePath_SSEC.hpp
@@ -45,7 +45,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "c_types/mst_rt.h"
 #include "cpp_common/path_t.h"
 #include "cpp_common/pgr_base_graph.hpp"
-#include "cpp_common/rule.h"
+#include "cpp_common/rule.hpp"
 
 namespace pgrouting {
 

--- a/include/cpp_common/rule.h
+++ b/include/cpp_common/rule.h
@@ -29,6 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <vector>
 #include <sstream>
+#include <cstdint>
 
 typedef struct Restriction_t Restriction_t;
 

--- a/include/cpp_common/rule.hpp
+++ b/include/cpp_common/rule.hpp
@@ -1,6 +1,6 @@
 /*PGR-GNU*****************************************************************
 
-FILE: rule.h
+FILE: rule.hpp
 
 Copyright (c) 2017 pgRouting developers
 Mail: project@pgrouting.org

--- a/include/cpp_common/rule.hpp
+++ b/include/cpp_common/rule.hpp
@@ -23,8 +23,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 
-#ifndef INCLUDE_CPP_COMMON_RULE_H_
-#define INCLUDE_CPP_COMMON_RULE_H_
+#ifndef INCLUDE_CPP_COMMON_RULE_HPP_
+#define INCLUDE_CPP_COMMON_RULE_HPP_
 
 
 #include <vector>
@@ -77,4 +77,4 @@ class Rule {
 }  // namespace trsp
 }  // namespace pgrouting
 
-#endif  // INCLUDE_CPP_COMMON_RULE_H_
+#endif  // INCLUDE_CPP_COMMON_RULE_HPP_

--- a/include/trsp/pgr_trspHandler.h
+++ b/include/trsp/pgr_trspHandler.h
@@ -42,7 +42,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "cpp_common/basePath_SSEC.hpp"
 #include "trsp/edgeInfo.h"
-#include "cpp_common/rule.h"
+#include "cpp_common/rule.hpp"
 #include "cpp_common/pgr_messages.h"
 
 namespace pgrouting {

--- a/include/yen/pgr_turnRestrictedPath.hpp
+++ b/include/yen/pgr_turnRestrictedPath.hpp
@@ -42,7 +42,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "cpp_common/basePath_SSEC.hpp"
 #include "cpp_common/compPaths.h"
 #include "cpp_common/pgr_messages.h"
-#include "cpp_common/rule.h"
+#include "cpp_common/rule.hpp"
 
 namespace pgrouting {
 namespace yen {

--- a/src/cpp_common/rule.cpp
+++ b/src/cpp_common/rule.cpp
@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 
-#include "cpp_common/rule.h"
+#include "cpp_common/rule.hpp"
 
 #include <vector>
 #include <algorithm>

--- a/src/ksp/turnRestrictedPath_driver.cpp
+++ b/src/ksp/turnRestrictedPath_driver.cpp
@@ -37,7 +37,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "cpp_common/pgr_alloc.hpp"
 #include "cpp_common/pgr_assert.h"
 
-#include "cpp_common/rule.h"
+#include "cpp_common/rule.hpp"
 
 #include "cpp_common/basePath_SSEC.hpp"
 #include "c_types/restriction_t.h"

--- a/src/trsp/trspVia_driver.cpp
+++ b/src/trsp/trspVia_driver.cpp
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "dijkstra/pgr_dijkstraVia.hpp"
 #include "c_types/routes_t.h"
 #include "c_types/restriction_t.h"
-#include "cpp_common/rule.h"
+#include "cpp_common/rule.hpp"
 #include "cpp_common/combinations.h"
 #include "cpp_common/pgr_alloc.hpp"
 #include "cpp_common/pgr_assert.h"

--- a/src/trsp/trspVia_withPoints_driver.cpp
+++ b/src/trsp/trspVia_withPoints_driver.cpp
@@ -33,7 +33,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "withPoints/pgr_withPoints.hpp"
 #include "c_types/routes_t.h"
 #include "c_types/restriction_t.h"
-#include "cpp_common/rule.h"
+#include "cpp_common/rule.hpp"
 #include "cpp_common/combinations.h"
 #include "cpp_common/pgr_alloc.hpp"
 #include "cpp_common/pgr_assert.h"

--- a/src/trsp/trsp_driver.cpp
+++ b/src/trsp/trsp_driver.cpp
@@ -40,7 +40,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <cassert>
 
 #include "trsp/pgr_trspHandler.h"
-#include "cpp_common/rule.h"
+#include "cpp_common/rule.hpp"
 #include "cpp_common/pgr_assert.h"
 #include "cpp_common/pgr_alloc.hpp"
 #include "cpp_common/combinations.h"

--- a/src/trsp/trsp_withPoints_driver.cpp
+++ b/src/trsp/trsp_withPoints_driver.cpp
@@ -40,7 +40,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <map>
 
 #include "trsp/pgr_trspHandler.h"
-#include "cpp_common/rule.h"
+#include "cpp_common/rule.hpp"
 #include "cpp_common/pgr_assert.h"
 #include "cpp_common/pgr_alloc.hpp"
 #include "cpp_common/combinations.h"


### PR DESCRIPTION
Fixes #2639 .

Changes proposed in this pull request:
- add missing include

@pgRouting/admins
