### PR TITLE
(CI) Just one file for all languages on release

### DIFF
--- a/.github/workflows/boost_version.yml
+++ b/.github/workflows/boost_version.yml
@@ -19,6 +19,7 @@ name: Boost supported versions
 # - boost::geometry has not changed anything we use
 #
 # boost::graph
+# - 1.86 does not support C++11 (Aug 2024)
 # - 1.84 is failing its own tests (Jul 2022)
 # - 1.83 transitive closure & stoer wagner changed on 83 (Jul 2022)
 # - 1.80 changed on 1.80 (Aug 2022)
@@ -69,7 +70,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          boost_minor: [56, 68, 75, 76, 77, 78, 79, 80, 83, 84]
+          boost_minor: [56, 68, 75, 76, 77, 78, 79, 80, 83, 84, 86]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,8 @@ jobs:
           export PATH=/usr/lib/postgresql/${PGVER}/bin:$PATH
           mkdir build
           cd build
-          cmake -DPOSTGRESQL_VERSION=${PGVER} -DDOC_USE_BOOTSTRAP=ON -DWITH_DOC=ON -DBUILD_DOXY=ON -DCMAKE_BUILD_TYPE=Release -DES=ON ..
+          cmake -DPOSTGRESQL_VERSION=${PGVER} -DDOC_USE_BOOTSTRAP=ON -DWITH_DOC=ON -DBUILD_DOXY=ON -DCMAKE_BUILD_TYPE=Release \
+              -DES=ON -DZH_HANS=ON..
 
       - name: Build
         run: |
@@ -140,26 +141,15 @@ jobs:
         run: |
           cd build/doc
 
-          cp -r html doc-v${PGROUTING_VERSION}-en-es
-          tar -zcvf doc-v${PGROUTING_VERSION}-en-es.tar.gz doc-v${PGROUTING_VERSION}-en-es
-
-          cp -r html doc-v${PGROUTING_VERSION}-en
-          rm -rf doc-v${PGROUTING_VERSION}-en/es
-          tar -zcvf doc-v${PGROUTING_VERSION}-en.tar.gz doc-v${PGROUTING_VERSION}-en
-
-          cp -r html doc-v${PGROUTING_VERSION}-es
-          rm -rf doc-v${PGROUTING_VERSION}-es/en
-          perl -pi -e 's/en\/index.html/es\/index.html/g' doc-v${PGROUTING_VERSION}-es/index.html
-          tar -zcvf doc-v${PGROUTING_VERSION}-es.tar.gz doc-v${PGROUTING_VERSION}-es
+          cp -r html doc-v${PGROUTING_VERSION}
+          tar -zcvf doc-v${PGROUTING_VERSION}.tar.gz doc-v${PGROUTING_VERSION}
 
           cd ../..
           grep -Pzo "(?s)pgRouting ${PGROUTING_VERSION//./\\.} Release Notes.*?(?=pgRouting .\..\.. Release Notes)" NEWS.md | tr '\0' '\n' > release_body.txt
           echo "**Attachments**" >> release_body.txt
           echo "File | Contents" >> release_body.txt
           echo "| --- | --- |" >> release_body.txt
-          echo "| \`doc-v${PGROUTING_VERSION}-en-es.tar.gz\` | English and Spanish documentation. Redirection to English" >> release_body.txt
-          echo "| \`doc-v${PGROUTING_VERSION}-en.tar.gz\`|English documentation. Redirection to English" >> release_body.txt
-          echo "| \`doc-v${PGROUTING_VERSION}-es.tar.gz\`|Spanish documentation. Redirection to Spanish" >> release_body.txt
+          echo "| \`doc-v${PGROUTING_VERSION}tar.gz\` | English and Spanish documentation. Redirection to English" >> release_body.txt
           echo "| \`pgrouting-${PGROUTING_VERSION}.tar.gz\` | tar.gz of the release" >> release_body.txt
           echo "| \`pgrouting-${PGROUTING_VERSION}.zip\`| zip of the release" >> release_body.txt
           cat release_body.txt
@@ -172,9 +162,7 @@ jobs:
           draft: true
           prerelease: false
           files: |
-            build/doc/doc-v${{ env.PGROUTING_VERSION }}-en-es.tar.gz
-            build/doc/doc-v${{ env.PGROUTING_VERSION }}-en.tar.gz
-            build/doc/doc-v${{ env.PGROUTING_VERSION }}-es.tar.gz
+            build/doc/doc-v${{ env.PGROUTING_VERSION }}.tar.gz
             ${{ github.event.repository.name }}-${{ env.PGROUTING_VERSION }}.zip
             ${{ github.event.repository.name }}-${{ env.PGROUTING_VERSION }}.tar.gz
 

--- a/tools/scripts/test_license.sh
+++ b/tools/scripts/test_license.sh
@@ -25,13 +25,12 @@ mylicensecheck() {
 }
 
 DIR=$(git rev-parse --show-toplevel)
-
 pushd "${DIR}" > /dev/null || exit
-missing=$(! { mylicensecheck src & mylicensecheck  sql &  mylicensecheck include & mylicensecheck pgtap;}  | grep "No copyright\|UNKNOWN")
+{ mylicensecheck src & mylicensecheck  sql &  mylicensecheck include & mylicensecheck pgtap;}  | grep "No copyright\|UNKNOWN"
 missing1=$(mylicensecheck doc | grep "No copyright")
 missing2=$(grep --files-without-match 'Creative Commons' doc/*/*.rst)
 missing3=$(mylicensecheck docqueries | grep "No copyright")
-missing4=$(grep --files-without-match 'Creative Commons' "$(git ls-files docqueries | grep '.sql')")
+missing4=$(grep --files-without-match 'Creative Commons' docqueries/*/*.sql)
 popd > /dev/null || exit
 
 #mylicensecheck doc


### PR DESCRIPTION
We have now a new language, so when releasing just create one documentation zip  instead of one per language


@pgRouting/admins
