### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/locale/de/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/de/LC_MESSAGES/pgrouting_doc_strings.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.6.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-10 03:40+0000\n"
+"POT-Creation-Date: 2024-10-17 00:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15564,6 +15564,9 @@ msgid "postgres 11.0.0"
 msgstr ""
 
 msgid "postgis 3.0.0"
+msgstr ""
+
+msgid "g++ 13+ is supported"
 msgstr ""
 
 msgid "Code fixes"

--- a/locale/es/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/es/LC_MESSAGES/pgrouting_doc_strings.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.4.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-10 03:40+0000\n"
+"POT-Creation-Date: 2024-10-17 00:50+0000\n"
 "PO-Revision-Date: 2024-10-10 19:43+0000\n"
 "Last-Translator: DeepL <noreply-mt-deepl@weblate.org>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
@@ -18194,6 +18194,9 @@ msgstr ""
 msgid "postgis 3.0.0"
 msgstr "postgis 3.0.0"
 
+msgid "g++ 13+ is supported"
+msgstr ""
+
 msgid "Code fixes"
 msgstr "Corrección de código"
 
@@ -21826,4 +21829,3 @@ msgstr "pgr_withPointsDD es pgr_drivingDistance **con puntos**"
 
 msgid "pgr_withPointsvia is pgr_dijkstraVia **with points**"
 msgstr "pgr_withPoints es pgr_dijkstraVia **con puntos**"
-

--- a/locale/ja/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/ja/LC_MESSAGES/pgrouting_doc_strings.po
@@ -21,7 +21,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-10 03:40+0000\n"
+"POT-Creation-Date: 2024-10-17 00:50+0000\n"
 "PO-Revision-Date: 2024-09-23 01:16+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@erosion.dev>\n"
 "Language-Team: Japanese <https://weblate.osgeo.org/projects/pgrouting/"
@@ -15732,6 +15732,9 @@ msgstr ""
 #, fuzzy
 msgid "postgis 3.0.0"
 msgstr "バージョン 3.0.0"
+
+msgid "g++ 13+ is supported"
+msgstr ""
 
 msgid "Code fixes"
 msgstr ""

--- a/locale/ko/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/ko/LC_MESSAGES/pgrouting_doc_strings.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-10 03:40+0000\n"
+"POT-Creation-Date: 2024-10-17 00:50+0000\n"
 "PO-Revision-Date: 2022-12-13 12:30+0000\n"
 "Last-Translator: Hyung-Gyu Ryoo <hyunggyu.ryoo@gmail.com>\n"
 "Language-Team: Korean <https://weblate.osgeo.org/projects/pgrouting/"
@@ -15623,6 +15623,9 @@ msgid "postgres 11.0.0"
 msgstr ""
 
 msgid "postgis 3.0.0"
+msgstr ""
+
+msgid "g++ 13+ is supported"
 msgstr ""
 
 msgid "Code fixes"

--- a/locale/zh_Hans/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/zh_Hans/LC_MESSAGES/pgrouting_doc_strings.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.6.0-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-10 03:40+0000\n"
+"POT-Creation-Date: 2024-10-17 00:50+0000\n"
 "PO-Revision-Date: 2024-10-10 19:47+0000\n"
 "Last-Translator: DeepL <noreply-mt-deepl@weblate.org>\n"
 "Language-Team: Chinese (Simplified) <https://weblate.osgeo.org/projects/"
@@ -16762,6 +16762,9 @@ msgstr ""
 msgid "postgis 3.0.0"
 msgstr "版本3.0.0"
 
+msgid "g++ 13+ is supported"
+msgstr ""
+
 msgid "Code fixes"
 msgstr "代码修正"
 
@@ -20277,4 +20280,3 @@ msgstr "pgr_withPointsDD 是 **带有点** 的 pgr_drivenDistance"
 #, fuzzy
 msgid "pgr_withPointsvia is pgr_dijkstraVia **with points**"
 msgstr "pgr_withPointsvia 是 **带有点** 的"
-


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [pgRouting/pgRouting](https://weblate.osgeo.org/projects/pgrouting/pgrouting-develop/).


It also includes following components:

* [pgRouting/index](https://weblate.osgeo.org/projects/pgrouting/index/)



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widget/pgrouting/pgrouting-develop/horizontal-auto.svg)

**Reminder**: Do not squash, do a rebase