### PR TITLE
(tool) remove trailing space on NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,11 +40,8 @@ milestone for 3.7.0
     * ``pgr_primDFS``
     * ``pgr_primBFS``
 
-  
   * Standarizing output columns to ``(seq, depth, start_vid, pred, node, edge, cost, agg_cost)``
-  
     * Added ``pred`` result columns.
-  
 
 **Experimental promoted to proposed.**
 
@@ -53,10 +50,8 @@ milestone for 3.7.0
 
   * ``pgr_lineGraph``
 
-  
     * Promoted to **proposed** signature.
     * Works for directed and undirected graphs.
-  
 
 **Code enhancement**
 
@@ -167,91 +162,61 @@ milestone for 3.6.0
 * [#2547](https://github.com/pgRouting/pgrouting/pull/2547) Standarize output
   and modifying signature pgr_KSP
 
-  
   * Result columns standarized to: ``(seq, path_id, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)``
   * ``pgr_ksp`` (One to One)
-  
     * Added ``start_vid`` and ``end_vid`` result columns.
-  
   * New overload functions:
-  
     * ``pgr_ksp`` (One to Many)
     * ``pgr_ksp`` (Many to One)
     * ``pgr_ksp`` (Many to Many)
     * ``pgr_ksp`` (Combinations)
-  
 
 * [#2548](https://github.com/pgRouting/pgrouting/pull/2548) Standarize output
   pgr_drivingdistance
 
-  
   * Standarizing output columns to ``(seq, depth, start_vid, pred, node, edge, cost, agg_cost)``
-  
     * ``pgr_drivingdistance`` (Single vertex)
-  
       * Added ``depth`` and ``start_vid`` result columns.
-  
     * ``pgr_drivingdistance`` (Multiple vertices)
-  
       * Result column name change: ``from_v`` to ``start_vid``.
       * Added ``depth`` and ``pred`` result columns.
-  
 
 **Proposed functions changes**
 
 * [#2544](https://github.com/pgRouting/pgrouting/pull/2544) Standarize output
   and modifying signature pgr_withPointsDD
 
-  
   * Signature change: ``driving_side`` parameter changed from named optional to
     unnamed compulsory **driving side**.
-  
     * ``pgr_withPointsDD`` (`Single vertex`)
     * ``pgr_withPointsDD`` (`Multiple vertices`)
-  
   * Standarizing output columns to ``(seq, depth, start_vid, pred, node, edge, cost, agg_cost)``
-  
     * ``pgr_withPointsDD`` (`Single vertex`)
-  
       * Added ``depth``, ``pred`` and ``start_vid`` column.
-  
     * ``pgr_withPointsDD`` (`Multiple vertices`)
-  
       * Added ``depth``, ``pred`` columns.
-  
   * When ``details`` is ``false``:
-  
     * Only points that are visited are removed, that is, points reached within the
       distance are included
-  
   * Deprecated signatures
-  
     * ``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)``
     * ``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,boolean,boolean)``
-  
 
 * [#2546](https://github.com/pgRouting/pgrouting/pull/2546) Standarize output
   and modifying signature pgr_withPointsKSP
 
-  
   * Standarizing output columns to ``(seq, path_id, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)``
   * ``pgr_withPointsKSP`` (One to One)
-  
     * Signature change: ``driving_side`` parameter changed from named optional to
       unnamed compulsory **driving side**.
     * Added ``start_vid`` and ``end_vid`` result columns.
-  
   * New overload functions
-  
     * ``pgr_withPointsKSP`` (One to Many)
     * ``pgr_withPointsKSP`` (Many to One)
     * ``pgr_withPointsKSP`` (Many to Many)
     * ``pgr_withPointsKSP`` (Combinations)
-  
   * Deprecated signature
-  
     * ``pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,boolean)``
-  
 
 **C/C++ code enhancements**
 

--- a/tools/release-scripts/notes2news.pl
+++ b/tools/release-scripts/notes2news.pl
@@ -143,7 +143,7 @@ sub find_stuff {
         next if $line =~ /$mstart/;
         $line =~ s/[\|]+//g;
         $line =~ s/($check)/$conversions{$1}/go;
-        print $ofh "  $line" if $line !~ /$mend/;
+        print $ofh "  $line" if $line !~ /$mend/ && $line ne "\n";
         last if $line =~ /$mend/;
     }
     close($fh);


### PR DESCRIPTION
Changes proposed in this pull request:
- Removes trailing spaces generated on notes2news.pl


@pgRouting/admins
