### PR TITLE
Remove -dev before PR to main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ include(pgr/BuildType)
 
 project(PGROUTING VERSION 3.7.0
     LANGUAGES C CXX )
-set(PROJECT_VERSION_DEV "-dev")
+set(PROJECT_VERSION_DEV "")
 string(TOLOWER "${PROJECT_NAME}" PROJECT_NAME_LOWER)
 
 include(pgr/GitInfo)

--- a/locale/de/LC_MESSAGES/index.po
+++ b/locale/de/LC_MESSAGES/index.po
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) pgRouting Contributors - Version v3.7.0-dev
+# Copyright (C) pgRouting Contributors - Version v3.7.0
 # This file is distributed under the same license as the pgRouting package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #

--- a/locale/de/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/de/LC_MESSAGES/pgrouting_doc_strings.po
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) pgRouting Contributors - Version v3.7.0-dev
+# Copyright (C) pgRouting Contributors - Version v3.7.0
 # This file is distributed under the same license as the pgRouting package.
 # Regina Obe <regina@arrival3d.com>, 2023.
 msgid ""

--- a/locale/en/LC_MESSAGES/index.po
+++ b/locale/en/LC_MESSAGES/index.po
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) pgRouting Contributors - Version v3.7.0-dev
+# Copyright (C) pgRouting Contributors - Version v3.7.0
 # This file is distributed under the same license as the pgRouting package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 #

--- a/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) pgRouting Contributors - Version v3.7.0-dev
+# Copyright (C) pgRouting Contributors - Version v3.7.0
 # This file is distributed under the same license as the pgRouting package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 #

--- a/locale/es/LC_MESSAGES/index.po
+++ b/locale/es/LC_MESSAGES/index.po
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) pgRouting Contributors - Version v3.7.0-dev
+# Copyright (C) pgRouting Contributors - Version v3.7.0
 # This file is distributed under the same license as the pgRouting package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 #

--- a/locale/es/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/es/LC_MESSAGES/pgrouting_doc_strings.po
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) pgRouting Contributors - Version v3.7.0-dev
+# Copyright (C) pgRouting Contributors - Version v3.7.0
 # This file is distributed under the same license as the pgRouting package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 # Pedro Jose Rios Vergara <jose@georepublic.de>, 2022.

--- a/locale/ja/LC_MESSAGES/index.po
+++ b/locale/ja/LC_MESSAGES/index.po
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) pgRouting Contributors - Version v3.7.0-dev
+# Copyright (C) pgRouting Contributors - Version v3.7.0
 # This file is distributed under the same license as the pgRouting package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 #

--- a/locale/ja/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/ja/LC_MESSAGES/pgrouting_doc_strings.po
@@ -1,6 +1,6 @@
 # #-#-#-#-#  allpairs-family.po (pgRouting v3.4.0-dev)  #-#-#-#-#
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) pgRouting Contributors - Version v3.7.0-dev
+# Copyright (C) pgRouting Contributors - Version v3.7.0
 # This file is distributed under the same license as the pgRouting package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 # Translators:

--- a/locale/ko/LC_MESSAGES/index.po
+++ b/locale/ko/LC_MESSAGES/index.po
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) pgRouting Contributors - Version v3.7.0-dev
+# Copyright (C) pgRouting Contributors - Version v3.7.0
 # This file is distributed under the same license as the pgRouting package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #

--- a/locale/ko/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/ko/LC_MESSAGES/pgrouting_doc_strings.po
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) pgRouting Contributors - Version v3.7.0-dev
+# Copyright (C) pgRouting Contributors - Version v3.7.0
 # This file is distributed under the same license as the pgRouting package.
 # Regina Obe <regina@arrival3d.com>, 2022.
 # Hyung-Gyu Ryoo <hyunggyu.ryoo@gmail.com>, 2022.

--- a/locale/pot/index.pot
+++ b/locale/pot/index.pot
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) pgRouting Contributors - Version v3.7.0-dev
+# Copyright (C) pgRouting Contributors - Version v3.7.0
 # This file is distributed under the same license as the pgRouting package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #

--- a/locale/pot/pgrouting_doc_strings.pot
+++ b/locale/pot/pgrouting_doc_strings.pot
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) pgRouting Contributors - Version v3.7.0-dev
+# Copyright (C) pgRouting Contributors - Version v3.7.0
 # This file is distributed under the same license as the pgRouting package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: pgRouting v3.7.0-dev\n"
+"Project-Id-Version: pgRouting v3.7.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-10-17 00:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/locale/zh_Hans/LC_MESSAGES/index.po
+++ b/locale/zh_Hans/LC_MESSAGES/index.po
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) pgRouting Contributors - Version v3.7.0-dev
+# Copyright (C) pgRouting Contributors - Version v3.7.0
 # This file is distributed under the same license as the pgRouting package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #

--- a/locale/zh_Hans/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/zh_Hans/LC_MESSAGES/pgrouting_doc_strings.po
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) pgRouting Contributors - Version v3.7.0-dev
+# Copyright (C) pgRouting Contributors - Version v3.7.0
 # This file is distributed under the same license as the pgRouting package.
 # Regina Obe <regina@arrival3d.com>, 2023.
 # Wangdapeng <wangdapeng20191008@gmail.com>, 2023.


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove `-dev` from Build & references



@pgRouting/admins
