### PR TITLE
Fix requires

### DIFF
--- a/sql/common/pgrouting.control
+++ b/sql/common/pgrouting.control
@@ -3,5 +3,4 @@ comment = 'pgRouting Extension'
 default_version = '${PROJECT_VERSION}'
 module_pathname = '${PROJECT_MODULE_PATHNAME}'
 relocatable = true
-requires = 'plpgsql'
-requires = 'postgis'
+requires = 'plpgsql,postgis'


### PR DESCRIPTION
The postgresl control file parser do not add up multiple occurences of the same keyword.  In practice it's not a big deal as plpgsql is installed by default.

Fixes # .

Changes proposed in this pull request:
-
-
-

@pgRouting/admins
