### PR TITLE
(build) Adding policies and cmake min version set to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,20 @@
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
     message(FATAL_ERROR "In-source builds not allowed.
     Please make a new directory (called a build directory) and run CMake from there.
     You may need to remove CMakeCache.txt." )
 endif()
+
+if(POLICY CMP0144)
+    cmake_policy(SET CMP0144 OLD)
+endif()
+
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 OLD)
+endif()
+
+cmake_policy(SET CMP0148 OLD)
 
 #---------------------------------------------
 # Setting kind of build

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,14 @@ To see all issues & pull requests closed by this release see the [Git closed
 milestone for 3.7.2
 ](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.2%22)
 
+**Build**
+
+* [#2713](https://github.com/pgRouting/pgrouting/pull/2713) cmake missing
+  some policies and min version
+
+  - Using OLD policies: CMP0148, CMP0144, CMP0167
+  - Minimum cmake version 3.12
+
 **Bug fixes**
 
 * [#2707](https://github.com/pgRouting/pgrouting/pull/2707) Build failure in

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The latest documentation: https://docs.pgrouting.org/latest
 * Postgresql = Supported [version](https://www.postgresql.org/support/versioning/) by PostgreSQL
   * Not supporting v12 & under
 * The Boost Graph Library (BGL) >= 1.56
-* CMake >= 3.2
+* CMake >= 3.12
 * 7.0 > Sphinx >= 4.0.0
 
 ### User's requirements

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -45,6 +45,14 @@ To see all issues & pull requests closed by this release see the `Git closed
 milestone for 3.7.2
 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.2%22>`__
 
+.. rubric:: Build
+
+* `#2713 <https://github.com/pgRouting/pgrouting/pull/2713>`__ cmake missing
+  some policies and min version
+
+  - Using OLD policies: CMP0148, CMP0144, CMP0167
+  - Minimum cmake version 3.12
+
 .. rubric:: Bug fixes
 
 * `#2707 <https://github.com/pgRouting/pgrouting/pull/2707>`__ Build failure in


### PR DESCRIPTION
Fixes #2713

Changes proposed in this pull request:
- Use old policies: CMP0148, CMP0144, CMP0167
- cmake min version set to 3.12


@pgRouting/admins
