### PR TITLE
(CI/winnie) simplify code of winnie build script

### DIFF
--- a/tools/scripts/test_shell.sh
+++ b/tools/scripts/test_shell.sh
@@ -29,7 +29,7 @@ do
   if [ "${f}" = "tools/developer/addNewVersionLink.sh" ] ; then
     result=$(shellcheck --exclude=SC2046,SC2016 "${f}")
   elif [ "${f}" = "ci/winnie/build_pgrouting.sh" ] ; then
-    result=$(shellcheck --exclude=SC2046,SC2016,SC2141,SC2086 "${f}")
+    result=$(shellcheck --exclude=SC2116,SC2046,SC2016,SC2141,SC2086 "${f}")
   else
     result=$(shellcheck --exclude=SC2141 "${f}")
   fi


### PR DESCRIPTION
Fixes #2708

Changes proposed in this pull request:
- Script for winnie is simplified
- TAPTEST variable added to verbose test a particular directory
  - suitable for developers 
- DEBUG variable added 
  - When true: Compilation is verbose, script variable contents are shown, build_type is "Debug"
  - When false: build_type is "Release"
- BOOST_VER  to be captured, defaults to 1.78.0

Set up in winnie:
pgRouting_PGVersionEDB: TAPTEST = "", DEBUG= not set (aka false),  BOOST_VER=1.78.0
Branch develop: TAPTEST = "", DEBUG=true, BOOST_VER=1.78.0
Branch main: TAPTEST = "", DEBUG=true, BOOST_VER=1.78.0
For other branches like pgRouting_matrix_branch_tagged_3_7 will catch the defaults from pgRouting_PGVersionEDB on the new variables.


@pgRouting/admins
