### PR TITLE
(doc) Documentation standards

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -90,7 +90,7 @@ milestone for 3.7.0
 
   * ``pgr_lineGraph``
 
-    * Promoted to **proposed** signature.
+    * Function promoted to proposed.
     * Works for directed and undirected graphs.
 
 **Code enhancement**
@@ -133,7 +133,7 @@ milestone for 3.6.3
 
 **Documentation**
 
-* Results of documentation queries adujsted to boost 1.83.0 version:
+* Results of documentation queries adujsted to  1.83.0 version:
 
   * pgr_edgeDisjointPaths
   * pgr_stoerWagner
@@ -185,39 +185,39 @@ milestone for 3.6.0
 
   * Standarizing output columns to ``(seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)``
 
-    * ``pgr_aStar`` (`One to One`) added ``start_vid`` and ``end_vid`` columns.
-    * ``pgr_aStar`` (`One to Many`) added ``end_vid`` column.
-    * ``pgr_aStar`` (`Many to One`) added ``start_vid`` column.
+    * pgr_aStar(One to One) added ``start_vid`` and ``end_vid`` columns.
+    * pgr_aStar(One to Many) added ``end_vid`` column.
+    * pgr_aStar(Many to One) added ``start_vid`` column.
 
 * [#2523](https://github.com/pgRouting/pgrouting/pull/2523) Standarize output
   pgr_bdAstar
 
   * Standarizing output columns to ``(seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)``
 
-    * ``pgr_bdAstar`` (`One to One`) added ``start_vid`` and ``end_vid``
+    * pgr_bdAstar(One to One) added ``start_vid`` and ``end_vid``
       columns.
-    * ``pgr_bdAstar`` (`One to Many`) added ``end_vid`` column.
-    * ``pgr_bdAstar`` (`Many to One`) added ``start_vid`` column.
+    * pgr_bdAstar(One to Many) added ``end_vid`` column.
+    * pgr_bdAstar(Many to One) added ``start_vid`` column.
 
 * [#2547](https://github.com/pgRouting/pgrouting/pull/2547) Standarize output
   and modifying signature pgr_KSP
 
   * Result columns standarized to: ``(seq, path_id, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)``
-  * ``pgr_ksp`` (One to One)
+  * pgr_ksp(One to One)
     * Added ``start_vid`` and ``end_vid`` result columns.
-  * New overload functions:
-    * ``pgr_ksp`` (One to Many)
-    * ``pgr_ksp`` (Many to One)
-    * ``pgr_ksp`` (Many to Many)
-    * ``pgr_ksp`` (Combinations)
+  * New proposed signatures:
+    * pgr_ksp(One to Many)
+    * pgr_ksp(Many to One)
+    * pgr_ksp(Many to Many)
+    * pgr_ksp(Combinations)
 
 * [#2548](https://github.com/pgRouting/pgrouting/pull/2548) Standarize output
   pgr_drivingdistance
 
   * Standarizing output columns to ``(seq, depth, start_vid, pred, node, edge, cost, agg_cost)``
-    * ``pgr_drivingdistance`` (Single vertex)
+    * pgr_drivingdistance(Single vertex)
       * Added ``depth`` and ``start_vid`` result columns.
-    * ``pgr_drivingdistance`` (Multiple vertices)
+    * pgr_drivingdistance(Multiple vertices)
       * Result column name change: ``from_v`` to ``start_vid``.
       * Added ``depth`` and ``pred`` result columns.
 
@@ -228,35 +228,35 @@ milestone for 3.6.0
 
   * Signature change: ``driving_side`` parameter changed from named optional to
     unnamed compulsory **driving side**.
-    * ``pgr_withPointsDD`` (`Single vertex`)
-    * ``pgr_withPointsDD`` (`Multiple vertices`)
+    * pgr_withPointsDD(Single vertex)
+    * pgr_withPointsDD(Multiple vertices)
   * Standarizing output columns to ``(seq, depth, start_vid, pred, node, edge, cost, agg_cost)``
-    * ``pgr_withPointsDD`` (`Single vertex`)
+    * pgr_withPointsDD(Single vertex)
       * Added ``depth``, ``pred`` and ``start_vid`` column.
-    * ``pgr_withPointsDD`` (`Multiple vertices`)
+    * pgr_withPointsDD(Multiple vertices)
       * Added ``depth``, ``pred`` columns.
   * When ``details`` is ``false``:
     * Only points that are visited are removed, that is, points reached within the
       distance are included
   * Deprecated signatures
-    * ``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)``
-    * ``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,boolean,boolean)``
+    * pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)``
+    * pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,boolean,boolean)``
 
 * [#2546](https://github.com/pgRouting/pgrouting/pull/2546) Standarize output
   and modifying signature pgr_withPointsKSP
 
   * Standarizing output columns to ``(seq, path_id, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)``
-  * ``pgr_withPointsKSP`` (One to One)
+  * pgr_withPointsKSP(One to One)
     * Signature change: ``driving_side`` parameter changed from named optional to
       unnamed compulsory **driving side**.
     * Added ``start_vid`` and ``end_vid`` result columns.
-  * New overload functions
-    * ``pgr_withPointsKSP`` (One to Many)
-    * ``pgr_withPointsKSP`` (Many to One)
-    * ``pgr_withPointsKSP`` (Many to Many)
-    * ``pgr_withPointsKSP`` (Combinations)
+  * New proposed signatures
+    * pgr_withPointsKSP(One to Many)
+    * pgr_withPointsKSP(Many to One)
+    * pgr_withPointsKSP(Many to Many)
+    * pgr_withPointsKSP(Combinations)
   * Deprecated signature
-    * ``pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,boolean)``
+    * pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,boolean)``
 
 **C/C++ code enhancements**
 
@@ -342,9 +342,9 @@ milestone for 3.5.0
 
   * Standarizing output columns to ``(seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)``
 
-    * ``pgr_dijkstra`` (`One to One`) added ``start_vid`` and ``end_vid`` columns.
-    * ``pgr_dijkstra`` (`One to Many`) added ``end_vid`` column.
-    * ``pgr_dijkstra`` (`Many to One`) added ``start_vid`` column.
+    * pgr_dijkstra(One to One) added ``start_vid`` and ``end_vid`` columns.
+    * pgr_dijkstra(One to Many) added ``end_vid`` column.
+    * pgr_dijkstra(Many to One) added ``start_vid`` column.
 
 ## pgRouting 3.4
 
@@ -386,59 +386,59 @@ milestone for 3.4.0
 * [#1891](https://github.com/pgRouting/pgrouting/issues/1891):
   pgr_ksp doesn't give all correct shortest path
 
-**New proposed functions**
+**New proposed functions.**
 
 * With points
 
-  * ``pgr_withPointsVia`` (One Via)
+  * pgr_withPointsVia(One Via)
 
 * Turn Restrictions
 
   * Via with turn restrictions
 
-    * ``pgr_trspVia`` (One Via)
-    * ``pgr_trspVia_withPoints`` (One Via)
+    * pgr_trspVia(One Via)
+    * pgr_trspVia_withPoints(One Via)
 
-  * ``pgr_trsp``
+  * pgr_trsp
 
-    * ``pgr_trsp`` (One to One)
-    * ``pgr_trsp`` (One to Many)
-    * ``pgr_trsp`` (Many to One)
-    * ``pgr_trsp`` (Many to Many)
-    * ``pgr_trsp`` (Combinations)
+    * pgr_trsp(One to One)
+    * pgr_trsp(One to Many)
+    * pgr_trsp(Many to One)
+    * pgr_trsp(Many to Many)
+    * pgr_trsp(Combinations)
 
   * ``pgr_trsp_withPoints``
 
-    * ``pgr_trsp_withPoints`` (One to One)
-    * ``pgr_trsp_withPoints`` (One to Many)
-    * ``pgr_trsp_withPoints`` (Many to One)
-    * ``pgr_trsp_withPoints`` (Many to Many)
-    * ``pgr_trsp_withPoints`` (Combinations)
+    * pgr_trsp_withPoints(One to One)
+    * pgr_trsp_withPoints(One to Many)
+    * pgr_trsp_withPoints(Many to One)
+    * pgr_trsp_withPoints(Many to Many)
+    * pgr_trsp_withPoints(Combinations)
 
 * Topology
 
-  * ``pgr_degree``
+  * pgr_degree
 
 * Utilities
 
-  * ``pgr_findCloseEdges`` (One point)
-  * ``pgr_findCloseEdges`` (Many points)
+  * pgr_findCloseEdges(One point)
+  * pgr_findCloseEdges(Many points)
 
 **New experimental functions**
 
 * Ordering
 
-  * ``pgr_cuthillMckeeOrdering``
+  * pgr_cuthillMckeeOrdering
 
 * Unclassified
 
-  * ``pgr_hawickCircuits``
+  * pgr_hawickCircuits
 
 **Official functions changes**
 
 * Flow functions
 
-  * ``pgr_maxCardinalityMatch(text)``
+  * pgr_maxCardinalityMatch(text)``
 
     * Deprecating ``pgr_maxCardinalityMatch(text,boolean)``
 
@@ -446,10 +446,10 @@ milestone for 3.4.0
 
 * Turn Restrictions
 
-  * ``pgr_trsp(text,integer,integer,boolean,boolean,text)``
-  * ``pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)``
-  * ``pgr_trspViaVertices(text,anyarray,boolean,boolean,text)``
-  * ``pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)``
+  * pgr_trsp(text,integer,integer,boolean,boolean,text)
+  * pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)
+  * pgr_trspViaVertices(text,anyarray,boolean,boolean,text)
+  * pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)
 
 ## pgRouting 3.3
 
@@ -485,7 +485,7 @@ milestone for 3.3.3
 
 * Flow functions
 
-  * ``pgr_maxCardinalityMatch(text,boolean)``
+  * pgr_maxCardinalityMatch(text,boolean)
 
     * Ignoring optional boolean parameter, as the algorithm works only for
       undirected graphs.
@@ -671,7 +671,7 @@ on Github.
 
 * pgr_sequentialVertexColoring
 
-**New proposed functions**
+**New proposed functions.**
 
 * Astar
 
@@ -782,7 +782,7 @@ milestone for 3.1.0
 ](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.0%22)
 on Github.
 
-**New proposed functions**
+**New proposed functions.**
 
 * pgr_dijkstra(combinations)
 * pgr_dijkstraCost(combinations)

--- a/doc/allpairs/allpairs-family.rst
+++ b/doc/allpairs/allpairs-family.rst
@@ -7,22 +7,22 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 
 .. index:: All Pairs Family
+
+|
 
 All Pairs - Family of Functions
 ===============================================================================
 
 The following functions work on all vertices pair combinations
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_floydWarshall` - Floyd-Warshall's algorithm.
 * :doc:`pgr_johnson` - Johnson's algorithm
 
-.. index to here
+.. official-end
 
 .. toctree::
     :hidden:

--- a/doc/allpairs/pgr_floydWarshall.rst
+++ b/doc/allpairs/pgr_floydWarshall.rst
@@ -7,22 +7,17 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: All Pairs Family ; pgr_floydWarshall
    single: floydWarshall
+
+|
 
 ``pgr_floydWarshall``
 ===============================================================================
 
 ``pgr_floydWarshall`` - Returns the sum of the costs of the shortest path for
 each pair of nodes in the graph using Floyd-Warshall algorithm.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/floyd_warshall_shortest.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -46,6 +41,8 @@ We use Boost's implementation which runs in :math:`\Theta(V^3)` time,
 .. include:: allpairs-family.rst
    :start-after: characteristics_start
    :end-before: characteristics_end
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -102,9 +99,9 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`pgr_johnson`
+* :doc:`sampledata`
 * Boost `floyd-Warshall
   <https://www.boost.org/libs/graph/doc/floyd_warshall_shortest.html>`_
-* Queries uses the :doc:`sampledata` network.
 
 .. rubric:: Indices and tables
 

--- a/doc/allpairs/pgr_johnson.rst
+++ b/doc/allpairs/pgr_johnson.rst
@@ -7,22 +7,17 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: All Pairs Family ; pgr_johnson
    single: johnson
+
+|
 
 ``pgr_johnson``
 ===============================================================================
 
 ``pgr_johnson`` - Returns the sum of the costs of the shortest path for each
 pair of nodes in the graph using Floyd-Warshall algorithm.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/johnson_all_pairs_shortest.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -45,6 +40,8 @@ It usees the Boost's implementation which runs in :math:`O(V E \log V)` time,
 .. include:: allpairs-family.rst
    :start-after: characteristics_start
    :end-before: characteristics_end
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -100,9 +97,9 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`pgr_floydWarshall`
+* :doc:`sampledata`
 * Boost `Johnson
   <https://www.boost.org/libs/graph/doc/johnson_all_pairs_shortest.html>`_
-* Queries uses the :doc:`sampledata` network.
 
 .. rubric:: Indices and tables
 

--- a/doc/alpha_shape/pgr_alphaShape.rst
+++ b/doc/alpha_shape/pgr_alphaShape.rst
@@ -7,11 +7,11 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 
 .. index::
     single: alphaShape
+
+|
 
 ``pgr_alphaShape``
 ===============================================================================
@@ -60,6 +60,8 @@ Characteristics
 * When the total number of points is less than 3, returns an EMPTY geometry
 
 
+|Boost| Boost Graph Inside
+
 Signatures
 -------------------------------------------------------------------------------
 .. rubric:: Summary
@@ -103,7 +105,7 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`pgr_drivingDistance`
-* :doc:`sampledata` network.
+* :doc:`sampledata`
 * `ST_ConcaveHull <https://postgis.net/docs/ST_ConcaveHull.html>`__
 
 .. rubric:: Indices and tables

--- a/doc/astar/aStar-family.rst
+++ b/doc/astar/aStar-family.rst
@@ -7,9 +7,9 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: single: aStar Family
+
+|
 
 A* - Family of functions
 ===============================================================================
@@ -18,13 +18,13 @@ The A* (pronounced "A Star") algorithm is based on Dijkstra's algorithm with a
 heuristic that allow it to solve most shortest path problems by evaluation only
 a sub-set of the overall graph.
 
-.. index from here
+.. official-start
 
 - :doc:`pgr_aStar` - A* algorithm for the shortest path.
 - :doc:`pgr_aStarCost` - Get the aggregate cost of the shortest paths.
 - :doc:`pgr_aStarCostMatrix` - Get the cost matrix of the shortest paths.
 
-.. index to here
+.. official-end
 
 .. toctree::
     :hidden:
@@ -180,7 +180,7 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`bdAstar-family`
-* https://www.boost.org/libs/graph/doc/astar_search.html
+* `Boost: A* search <https://www.boost.org/libs/graph/doc/astar_search.html>`__
 * https://en.wikipedia.org/wiki/A*_search_algorithm
 
 .. rubric:: Indices and tables

--- a/doc/astar/pgr_aStar.rst
+++ b/doc/astar/pgr_aStar.rst
@@ -7,21 +7,16 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: aStar Family ; pgr_aStar
    single: aStar
+
+|
 
 ``pgr_aStar``
 ===============================================================================
 
 ``pgr_aStar`` — Shortest path using the A* algorithm.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/astar_search.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -29,37 +24,37 @@
 
   * Standarizing output columns to |short-generic-result|
 
-    * ``pgr_aStar`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns.
-    * ``pgr_aStar`` (`One to Many`_) added ``end_vid`` column.
-    * ``pgr_aStar`` (`Many to One`_) added ``start_vid`` column.
+    * pgr_aStar(One to One) added ``start_vid`` and ``end_vid`` columns.
+    * pgr_aStar(One to Many) added ``end_vid`` column.
+    * pgr_aStar(Many to One) added ``start_vid`` column.
 
 * Version 3.2.0
 
-  * New **proposed** signature:
+  * New proposed signature:
 
-    * ``pgr_aStar`` (`Combinations`_)
+    * pgr_aStar(Combinations)
 
 * Version 3.0.0
 
-  * **Official** function
+  * Function promoted to **official**.
 
 * Version 2.4.0
 
-  * New **Proposed** signatures:
+  * New proposed signatures:
 
-    * ``pgr_aStar`` (`One to Many`_)
-    * ``pgr_aStar`` (`Many to One`_)
-    * ``pgr_aStar`` (`Many to Many`_)
+    * pgr_aStar(One to Many)
+    * pgr_aStar(Many to One)
+    * pgr_aStar(Many to Many)
 
 * Version 2.3.0
 
-  * Signature change on ``pgr_astar`` (`One to One`_)
+  * Signature change on pgr_astar(One to One)
 
     * Old signature no longer supported
 
 * Version 2.0.0
 
-  * **Official** ``pgr_aStar`` (`One to One`_)
+  * **Official** pgr_aStar(One to One)
 
 Description
 -------------------------------------------------------------------------------
@@ -73,10 +68,12 @@ Description
 * The results are equivalent to the union of the results of the `pgr_aStar(`
   `One to One`_ `)` on the:
 
-  * ``pgr_aStar`` (`One to Many`_)
-  * ``pgr_aStar`` (`Many to One`_)
-  * ``pgr_aStar`` (`Many to Many`_)
-  * ``pgr_aStar`` (`Combinations`_)
+  * pgr_aStar(One to Many)
+  * pgr_aStar(Many to One)
+  * pgr_aStar(Many to Many)
+  * pgr_aStar(Combinations)
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------

--- a/doc/astar/pgr_aStarCost.rst
+++ b/doc/astar/pgr_aStarCost.rst
@@ -7,38 +7,33 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 
 .. index::
    single: aStar Family ; pgr_aStarCost
    single: aStarCost
 
-pgr_aStarCost
+|
+
+``pgr_aStarCost``
 ===============================================================================
 
 ``pgr_aStarCost`` - Total cost of the shortest path using the A* algorithm.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/astar_search.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
 * Version 3.2.0
 
-  * New **proposed** signature:
+  * New proposed signature:
 
-    * ``pgr_aStarCost`` (`Combinations`_)
+    * pgr_aStarCost(Combinations)
 
 * Version 3.0.0
 
-  * **Official** function
+  * Function promoted to **official**.
 
 * Version 2.4.0
 
-  * New **proposed** function
+  * New proposed function.
 
 Description
 -------------------------------------------------------------------------------
@@ -66,6 +61,8 @@ using the A* algorithm.
 
   - `start_vid` ascending
   - `end_vid` ascending
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -275,6 +272,7 @@ See Also
 * :doc:`aStar-family`
 * :doc:`cost-category`
 * :doc:`sampledata`
+* `Boost: A* search <https://www.boost.org/libs/graph/doc/astar_search.html>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/astar/pgr_aStarCostMatrix.rst
+++ b/doc/astar/pgr_aStarCostMatrix.rst
@@ -7,32 +7,28 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 
 .. index::
    single: aStar Family ; pgr_aStarCostMatrix
+   single: Cost Matrix Category ; pgr_aStarCostMatrix
    single: aStarCostMatrix
+
+|
 
 ``pgr_aStarCostMatrix``
 ===============================================================================
 
 ``pgr_aStarCostMatrix`` - Calculates the a cost matrix using :doc:`pgr_aStar`.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org//libs/graph/doc/astar_search.html
-
-   Boost Graph Inside
-
 .. rubric:: Availability
 
 * Version 3.0.0
 
-  * **Official** function
+  * Function promoted to **official**.
 
 * Version 2.4.0
 
-  * New **proposed** function
+  * New proposed function.
 
 Description
 -------------------------------------------------------------------------------
@@ -55,6 +51,8 @@ Description
     * cost from `v` to `u` is :math:`0`
 
 * When the graph is **undirected** the cost matrix is symmetric
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -131,6 +129,7 @@ See Also
 * :doc:`costMatrix-category`
 * :doc:`TSP-family`
 * :doc:`sampledata`
+* `Boost: A* search <https://www.boost.org/libs/graph/doc/astar_search.html>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/bdAstar/bdAstar-family.rst
+++ b/doc/bdAstar/bdAstar-family.rst
@@ -7,9 +7,9 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: Bidirectional A* Family
+
+|
 
 Bidirectional A* - Family of functions
 ===============================================================================
@@ -17,7 +17,7 @@ Bidirectional A* - Family of functions
 The bidirectional A* (pronounced "A Star") algorithm is based on the A*
 algorithm.
 
-.. index from here
+.. official-start
 
 - :doc:`pgr_bdAstar` - Bidirectional A* algorithm for obtaining paths.
 - :doc:`pgr_bdAstarCost` - Bidirectional A* algorithm to calculate the cost of
@@ -25,7 +25,7 @@ algorithm.
 - :doc:`pgr_bdAstarCostMatrix` - Bidirectional A* algorithm to calculate a cost
   matrix of paths.
 
-.. index to here
+.. official-end
 
 .. toctree::
     :hidden:
@@ -62,7 +62,7 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`aStar-family`
-* https://www.boost.org/libs/graph/doc/astar_search.html
+* `Boost <https://www.boost.org/libs/graph/doc/astar_search.html>`__
 * https://en.wikipedia.org/wiki/A*_search_algorithm
 
 .. rubric:: Indices and tables

--- a/doc/bdAstar/pgr_bdAstar.rst
+++ b/doc/bdAstar/pgr_bdAstar.rst
@@ -7,21 +7,16 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Bidirectional A* Family ; pgr_bdAstar
    single: bdAstar
+
+|
 
 ``pgr_bdAstar``
 ===============================================================================
 
 ``pgr_bdAstar`` — Shortest path using the bidirectional A* algorithm.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/astar_search.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -29,15 +24,15 @@
 
   * Standarizing output columns to |short-generic-result|
 
-    * ``pgr_bdAstar`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns.
-    * ``pgr_bdAstar`` (`One to Many`_) added ``end_vid`` column.
-    * ``pgr_bdAstar`` (`Many to One`_) added ``start_vid`` column.
+    * pgr_bdAstar(One to One) added ``start_vid`` and ``end_vid`` columns.
+    * pgr_bdAstar(One to Many) added ``end_vid`` column.
+    * pgr_bdAstar(Many to One) added ``start_vid`` column.
 
 * Version 3.2.0
 
-  * New **proposed** signature:
+  * New proposed signature:
 
-    * ``pgr_bdAstar`` (`Combinations`_)
+    * pgr_bdAstar(Combinations)
 
 * Version 3.0.0
 
@@ -47,17 +42,17 @@
 
   * New **Proposed** signatures:
 
-    * ``pgr_bdAstar`` (`One to Many`_)
-    * ``pgr_bdAstar`` (`Many to One`_)
-    * ``pgr_bdAstar`` (`Many to Many`_)
+    * pgr_bdAstar(One to Many)
+    * pgr_bdAstar(Many to One)
+    * pgr_bdAstar(Many to Many)
 
-  * Signature change on ``pgr_bdAstar`` (`One to One`_)
+  * Signature change on pgr_bdAstar(One to One)
 
     * Old signature no longer supported
 
 * Version 2.0.0
 
-  * **Official** ``pgr_bdAstar`` (`One to One`_)
+  * **Official** pgr_bdAstar(One to One)
 
 Description
 -------------------------------------------------------------------------------
@@ -68,13 +63,15 @@ Description
    :start-after: astar general info start
    :end-before: astar general info end
 
-* The results are equivalent to the union of the results of the `pgr_bdAStar(`
-  `One to One`_ `)` on the:
+* The results are equivalent to the union of the results of the
+  pgr_bdAStar(One to One) on the:
 
-  * ``pgr_bdAstar`` (`One to Many`_)
-  * ``pgr_bdAstar`` (`Many to One`_)
-  * ``pgr_bdAstar`` (`Many to Many`_)
-  * ``pgr_bdAstar`` (`Combinations`_)
+  * pgr_bdAstar(One to Many)
+  * pgr_bdAstar(Many to One)
+  * pgr_bdAstar(Many to Many)
+  * pgr_bdAstar(Combinations)
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -106,7 +103,7 @@ One to One
    :class: signatures
 
    | pgr_bdAstar(`Edges SQL`_, **start vid**, **end vid**, [**options**])
-   | **options:** ``[directed, heuristic, factor, epsilon]``
+   | **options:** [directed, heuristic, factor, epsilon]``
 
    | Returns set of |short-generic-result|
    | OR EMPTY SET
@@ -286,7 +283,7 @@ See Also
 * :doc:`aStar-family`
 * :doc:`bdAstar-family`
 * :doc:`sampledata`
-* https://www.boost.org/libs/graph/doc/astar_search.html
+* `Boost: A* search <https://www.boost.org/libs/graph/doc/astar_search.html>`__
 * https://en.wikipedia.org/wiki/A*_search_algorithm
 
 .. rubric:: Indices and tables

--- a/doc/bdAstar/pgr_bdAstarCost.rst
+++ b/doc/bdAstar/pgr_bdAstarCost.rst
@@ -7,30 +7,25 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Bidirectional A* Family ; pgr_bdAstarCost
    single: bdAstarCost
 
-pgr_bdAstarCost
+|
+
+``pgr_bdAstarCost``
 ===============================================================================
 
 ``pgr_bdAstarCost`` - Total cost of the shortest path using the bidirectional
 A* algorithm.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/astar_search.html
-
-   Boost Graph Inside
-
 .. rubric:: Availability
 
 * Version 3.2.0
 
-  * New **proposed** signature:
+  * New proposed signature:
 
-    * ``pgr_bdAstarCost`` (`Combinations`_)
+    * pgr_bdAstarCost(Combinations)
 
 * Version 3.0.0
 
@@ -38,7 +33,7 @@ A* algorithm.
 
 * Version 2.4.0
 
-  * New **proposed** function
+  * New proposed function.
 
 Description
 -------------------------------------------------------------------------------
@@ -66,6 +61,8 @@ using the bidirectional A* algorithm.
 
   - `start_vid` ascending
   - `end_vid` ascending
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -275,6 +272,7 @@ See Also
 * :doc:`bdAstar-family`
 * :doc:`cost-category`
 * :doc:`sampledata`
+* `Boost: A* search <https://www.boost.org/libs/graph/doc/astar_search.html>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/bdAstar/pgr_bdAstarCostMatrix.rst
+++ b/doc/bdAstar/pgr_bdAstarCostMatrix.rst
@@ -7,21 +7,17 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Bidirectional A* Family ; pgr_bdAstarCostMatrix
+   single: Cost Matrix Category ; pgr_bdAstarCostMatrix
    single: bdAstarCostMatrix
+
+|
 
 ``pgr_bdAstarCostMatrix``
 ===============================================================================
 
 ``pgr_bdAstarCostMatrix`` - Calculates the a cost matrix using :doc:`pgr_aStar`.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org//libs/graph/doc/astar_search.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -31,7 +27,7 @@
 
 * Version 2.5.0
 
-  * New **proposed** function
+  * New proposed function.
 
 Description
 -------------------------------------------------------------------------------
@@ -54,6 +50,8 @@ Description
     * cost from `v` to `u` is :math:`0`
 
 * When the graph is **undirected** the cost matrix is symmetric
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -130,6 +128,7 @@ See Also
 * :doc:`costMatrix-category`
 * :doc:`TSP-family`
 * :doc:`sampledata`
+* `Boost: A* search <https://www.boost.org/libs/graph/doc/astar_search.html>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/bdDijkstra/bdDijkstra-family.rst
+++ b/doc/bdDijkstra/bdDijkstra-family.rst
@@ -7,15 +7,15 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 
 .. index:: Bidirectional Dijkstra Family
+
+|
 
 Bidirectional Dijkstra - Family of functions
 ===============================================================================
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_bdDijkstra` - Bidirectional Dijkstra algorithm for the shortest
   paths.
@@ -24,7 +24,7 @@ Bidirectional Dijkstra - Family of functions
 * :doc:`pgr_bdDijkstraCostMatrix` - Bidirectional Dijkstra algorithm to create
   a matrix of costs of the shortest paths.
 
-.. index to here
+.. official-end
 
 .. toctree::
     :hidden:

--- a/doc/bdDijkstra/pgr_bdDijkstra.rst
+++ b/doc/bdDijkstra/pgr_bdDijkstra.rst
@@ -7,11 +7,11 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Bidirectional Dijkstra Family ; pgr_bdDijkstra
    single: bdDijkstra
+
+|
 
 ``pgr_bdDijkstra``
 ===============================================================================
@@ -19,40 +19,35 @@
 ``pgr_bdDijkstra`` — Returns the shortest path using Bidirectional Dijkstra
 algorithm.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
-
 .. rubric:: Availability:
 
 * Version 3.2.0
 
-  * New **proposed** signature:
+  * New proposed signature:
 
-    * pgr_bdDijkstra(`Combinations`_)
+    * pgr_bdDijkstra(Combinations)
 
 * Version 3.0.0
 
-  * **Official** function
+  * **Official** function.
 
 * Version 2.5.0
 
-  * New **Proposed** functions:
+  * New Proposed signatures:
 
-    * ``pgr_bdDijkstra`` (`One to Many`_)
-    * ``pgr_bdDijkstra`` (`Many to One`_)
-    * ``pgr_bdDijkstra`` (`Many to Many`_)
+    * pgr_bdDijkstra(One to Many)
+    * pgr_bdDijkstra(Many to One)
+    * pgr_bdDijkstra(Many to Many)
 
 * Version 2.4.0
 
-  * Signature change on ``pgr_bdDijsktra`` (`One to One`_)
+  * Signature change on pgr_bdDijsktra(One to One)
 
     * Old signature no longer supported
 
 * Version 2.0.0
 
-  * **Official** ``pgr_bdDijkstra`` (`One to One`_)
+  * **Official** pgr_bdDijkstra(One to One)
 
 
 Description
@@ -63,6 +58,8 @@ Description
 .. include:: bdDijkstra-family.rst
    :start-after: description start
    :end-before: description end
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -256,7 +253,6 @@ See Also
 
 * :doc:`bdDijkstra-family`
 * :doc:`sampledata`
-* https://www.cs.princeton.edu/courses/archive/spr06/cos423/Handouts/EPP%20shortest%20path%20algorithms.pdf
 * https://en.wikipedia.org/wiki/Bidirectional_search
 
 .. rubric:: Indices and tables

--- a/doc/bdDijkstra/pgr_bdDijkstraCost.rst
+++ b/doc/bdDijkstra/pgr_bdDijkstraCost.rst
@@ -7,11 +7,11 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Bidirectional Dijkstra Family ; pgr_bdDijkstraCost
    single: bdDijkstraCost
+
+|
 
 ``pgr_bdDijkstraCost``
 ===============================================================================
@@ -19,18 +19,13 @@
 ``pgr_bdDijkstraCost`` — Returns the shortest path's cost using Bidirectional
 Dijkstra algorithm.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
-
 .. rubric:: Availability
 
 * Version 3.2.0
 
-  * New **proposed** signature:
+  * New proposed signature:
 
-    * ``pgr_bdDijkstraCost`` (`Combinations`_)
+    * pgr_bdDijkstraCost(Combinations)
 
 * Version 3.0.0
 
@@ -38,7 +33,7 @@ Dijkstra algorithm.
 
 * Version 2.5.0
 
-  * New **proposed** function
+  * New proposed function.
 
 
 Description
@@ -54,6 +49,8 @@ using the bidirectional Dijkstra Algorithm.
 .. include:: cost-category.rst
     :start-after: cost_traits_start
     :end-before: cost_traits_end
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -247,7 +244,6 @@ See Also
 
 * :doc:`bdDijkstra-family`
 * :doc:`sampledata`
-* https://www.cs.princeton.edu/courses/archive/spr06/cos423/Handouts/EPP%20shortest%20path%20algorithms.pdf
 * https://en.wikipedia.org/wiki/Bidirectional_search
 
 .. rubric:: Indices and tables

--- a/doc/bdDijkstra/pgr_bdDijkstraCostMatrix.rst
+++ b/doc/bdDijkstra/pgr_bdDijkstraCostMatrix.rst
@@ -7,23 +7,18 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Bidirectional Dijkstra Family ; pgr_bdDijkstraCostMatrix
+   single: Cost Matrix Category ; pgr_bdDijkstraCostMatrix
    single: bdDijkstraCostMatrix
+
+|
 
 ``pgr_bdDijkstraCostMatrix``
 ===============================================================================
 
 ``pgr_bdDijkstraCostMatrix`` - Calculates a cost matrix using
 :doc:`pgr_bdDijkstra`.
-
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -33,7 +28,7 @@
 
 * Version 2.5.0
 
-  * New **proposed** function
+  * New proposed function.
 
 Description
 -------------------------------------------------------------------------------
@@ -47,6 +42,8 @@ Using bidirectional Dijkstra algorithm, calculate and return a cost matrix.
 .. include:: costMatrix-category.rst
     :start-after: costMatrix_details_start
     :end-before: costMatrix_details_end
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------

--- a/doc/bellman_ford/pgr_bellmanFord.rst
+++ b/doc/bellman_ford/pgr_bellmanFord.rst
@@ -7,42 +7,32 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: Shortest Path Category; pgr_bellmanFord
-   single: bellmanFord
+   single: Shortest Path Category; pgr_bellmanFord - Experimental
+   single: bellmanFord - Experimental
+
+|
 
 ``pgr_bellmanFord - Experimental``
 ===============================================================================
 
 ``pgr_bellmanFord`` — Shortest path using Bellman-Ford algorithm.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/bellman_ford_shortest.html
-
-   Boost Graph Inside
-
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.2.0
 
-  * New **experimental** signature:
+  * New experimental signature:
 
-    * ``pgr_bellmanFord`` (`Combinations`_)
+    * pgr_bellmanFord(Combinations)
 
 * Version 3.0.0
 
-  * New **experimental** signatures:
-
-    * ``pgr_bellmanFord`` (`One to One`_)
-    * ``pgr_bellmanFord`` (`One to Many`_)
-    * ``pgr_bellmanFord`` (`Many to One`_)
-    * ``pgr_bellmanFord`` (`Many to Many`_)
+  * New experimental function.
 
 Description
 -------------------------------------------------------------------------------
@@ -81,6 +71,7 @@ implementation can be used with a directed graph and an undirected graph.
 
   * Running time: :math:`O(| start\_vids | * ( V * E))`
 
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -100,7 +91,7 @@ Signatures
    | OR EMPTY SET
 
 .. index::
-   single: bellmanFord ; One to One - Experimental on v3.0
+   single: bellmanFord - Experimental; One to One - Experimental on v3.0
 
 One to One
 ...............................................................................
@@ -120,7 +111,7 @@ One to One
    :end-before: -- q3
 
 .. index::
-   single: bellmanFord ; One to Many - Experimental on v3.0
+   single: bellmanFord - Experimental ; One to Many - Experimental on v3.0
 
 One to Many
 ...............................................................................
@@ -141,7 +132,7 @@ One to Many
    :end-before: -- q4
 
 .. index::
-   single: bellmanFord ; Many to One - Experimental on v3.0
+   single: bellmanFord - Experimental ; Many to One - Experimental on v3.0
 
 Many to One
 ...............................................................................
@@ -162,7 +153,7 @@ Many to One
    :end-before: -- q5
 
 .. index::
-    single: bellmanFord ; Many to Many - Experimental on v3.0
+    single: bellmanFord - Experimental; Many to Many - Experimental on v3.0
 
 Many to Many
 ...............................................................................
@@ -183,7 +174,7 @@ Many to Many
    :end-before: -- q51
 
 .. index::
-    single: bellmanFord ; Combinations - Experimental on v3.2
+    single: bellmanFord - Experimental; Combinations - Experimental on v3.2
 
 Combinations
 ...............................................................................
@@ -272,8 +263,12 @@ Additional Examples
 See Also
 -------------------------------------------------------------------------------
 
-* https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm
 * :doc:`sampledata`
+* `Boost: Belman Ford <https://www.boost.org/libs/graph/doc/bellman_ford_shortest.html>`__
+* https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm
+
+   Boost Graph Inside
+
 
 .. rubric:: Indices and tables
 

--- a/doc/bellman_ford/pgr_edwardMoore.rst
+++ b/doc/bellman_ford/pgr_edwardMoore.rst
@@ -7,38 +7,33 @@
     Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
+.. index::
+   single: Shortest Path Category; pgr_edwardMoore - Experimental
+   single: edwardMoore - Experimental
+
 |
 
-.. index::
-   single: Shortest Path Category; pgr_edwardMoore
-   single: edwardMoore
-
-``pgr_edwardMoore - Experimental``
+``pgr_edwardMoore`` - Experimental
 ===============================================================================
 
 ``pgr_edwardMoore`` — Returns the shortest path using Edward-Moore algorithm.
 
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.2.0
 
-  * New **experimental** signature:
+  * New experimental signature:
 
-    * ``pgr_edwardMoore`` (`Combinations`_)
+    * pgr_edwardMoore(Combinations)
 
 * Version 3.0.0
 
-  * New **experimental** signatures:
-
-    * ``pgr_edwardMoore`` (`One to One`_)
-    * ``pgr_edwardMoore`` (`One to Many`_)
-    * ``pgr_edwardMoore`` (`Many to One`_)
-    * ``pgr_edwardMoore`` (`Many to Many`_)
+  * New experimental function.
 
 Description
 -------------------------------------------------------------------------------
@@ -84,6 +79,8 @@ and is at-worst,as good as Bellman-Ford algorithm
   * Worst case: :math:`O(| V | * | E |)`
   * Average case: :math:`O( | E | )`
 
+|Boost| Boost Graph Inside
+
 Signatures
 -------------------------------------------------------------------------------
 
@@ -102,7 +99,7 @@ Signatures
    | OR EMPTY SET
 
 .. index::
-    single: edwardMoore ; One to One - Experimental on v3.0
+    single: edwardMoore - Experimental ; One to One - Experimental on v3.0
 
 One to One
 ...............................................................................
@@ -122,7 +119,7 @@ One to One
    :end-before: -- q3
 
 .. index::
-    single: edwardMoore ; One to Many - Experimental on v3.0
+    single: edwardMoore - Experimental ; One to Many - Experimental on v3.0
 
 One to Many
 ...............................................................................
@@ -143,7 +140,7 @@ One to Many
    :end-before: -- q4
 
 .. index::
-    single: edwardMoore ; Many to One - Experimental on v3.0
+    single: edwardMoore - Experimental ; Many to One - Experimental on v3.0
 
 Many to One
 ...............................................................................
@@ -164,7 +161,7 @@ Many to One
    :end-before: -- q5
 
 .. index::
-    single: edwardMoore ; Many to Many - Experimental on v3.0
+    single: edwardMoore - Experimental ; Many to Many - Experimental on v3.0
 
 Many to Many
 ...............................................................................
@@ -185,7 +182,7 @@ Many to Many
    :end-before: -- q51
 
 .. index::
-    single: edwardMoore ; Combinations - Experimental on v3.2
+    single: edwardMoore - Experimental ; Combinations - Experimental on v3.2
 
 Combinations
 ...............................................................................

--- a/doc/categories/BFS-category.rst
+++ b/doc/categories/BFS-category.rst
@@ -7,19 +7,19 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
+.. index:: Breadth First Search Category
 
-.. index:: BFS Category
+|
 
 BFS - Category
 ===============================================================================
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_kruskalBFS`
 * :doc:`pgr_primBFS`
 
-.. index to here
+.. official-end
 
 
 Traversal using breadth first search.

--- a/doc/categories/DFS-category.rst
+++ b/doc/categories/DFS-category.rst
@@ -7,28 +7,28 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: Depth First Search Category
+
+|
 
 DFS - Category
 ===============================================================================
 
 Traversal using Depth First Search.
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_kruskalDFS`
 * :doc:`pgr_primDFS`
 
-.. index to here
+.. official-end
 
 
 .. rubric:: Proposed
 
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
+   :start-after: warning-begin
+   :end-before: end-warning
 
 * :doc:`pgr_depthFirstSearch` - Depth first search traversal of the graph.
 

--- a/doc/categories/KSP-category.rst
+++ b/doc/categories/KSP-category.rst
@@ -7,30 +7,30 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: K Shortest Paths Category
+
+|
 
 K shortest paths - Category
 ===============================================================================
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_KSP` - Yen's algorithm based on pgr_dijkstra
 
-.. index to here
+.. official-end
 
 .. rubric:: Proposed
 
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
+   :start-after: warning-begin
+   :end-before: end-warning
 
-.. index proposed from here
+.. proposed-start
 
 * :doc:`pgr_withPointsKSP` - Yen's algorithm based on pgr_withPoints
 
-.. index proposed to here
+.. proposed-end
 
 
 .. rubric:: Indices and tables

--- a/doc/categories/VRP-category.rst
+++ b/doc/categories/VRP-category.rst
@@ -7,18 +7,18 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: Vehicle Routing Functions Category
+
+|
 
 Vehicle Routing Functions - Category
 ===============================================================================
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
-.. index experimental from here
+.. experimental-start
 
 * Pickup and delivery problem
 
@@ -29,7 +29,7 @@ Vehicle Routing Functions - Category
 
   - :doc:`pgr_vrpOneDepot` - From a single depot, distributes orders
 
-.. index experimental to here
+.. experimental-end
 
 .. contents::
 
@@ -767,7 +767,7 @@ See Also
 -------------------------------------------------------------------------------
 
 * https://en.wikipedia.org/wiki/Vehicle_routing_problem
-* The queries use the :doc:`sampledata` network.
+* :doc:`sampledata`
 
 .. rubric:: Indices and tables
 

--- a/doc/categories/cost-category.rst
+++ b/doc/categories/cost-category.rst
@@ -7,16 +7,16 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 
 
 .. index:: Cost Category
 
+|
+
 Cost - Category
 ===============================================================================
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_aStarCost`
 * :doc:`pgr_bdAstarCost`
@@ -24,19 +24,19 @@ Cost - Category
 * :doc:`pgr_bdDijkstraCost`
 * :doc:`pgr_dijkstraNearCost`
 
-.. index to here
+.. official-end
 
 .. rubric:: Proposed
 
 .. include:: proposed.rst
-    :start-after: begin-warning
+    :start-after: warning-begin
     :end-before: end-warning
 
-.. index proposed from here
+.. proposed-start
 
 * :doc:`pgr_withPointsCost`
 
-.. index proposed to here
+.. proposed-end
 
 
 General Information

--- a/doc/categories/costMatrix-category.rst
+++ b/doc/categories/costMatrix-category.rst
@@ -7,34 +7,34 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: Cost Matrix Category
+
+|
 
 Cost Matrix - Category
 ===============================================================================
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_aStarCostMatrix`
 * :doc:`pgr_dijkstraCostMatrix`
 * :doc:`pgr_bdAstarCostMatrix`
 * :doc:`pgr_bdDijkstraCostMatrix`
 
-.. index to here
+.. official-end
 
 
 .. rubric:: proposed
 
 .. include:: proposed.rst
-    :start-after: begin-warning
+    :start-after: warning-begin
     :end-before: end-warning
 
-.. index proposed from here
+.. proposed-start
 
 * :doc:`pgr_withPointsCostMatrix`
 
-.. index proposed to here
+.. proposed-end
 
 General Information
 -------------------------------------------------------------------------------

--- a/doc/categories/drivingDistance-category.rst
+++ b/doc/categories/drivingDistance-category.rst
@@ -7,14 +7,14 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: Driving Distance Category
+
+|
 
 Driving Distance - Category
 ===============================================================================
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_drivingDistance` - Driving Distance based on Dijkstra's algorithm
 * :doc:`pgr_primDD` - Driving Distance based on Prim's algorithm
@@ -23,19 +23,19 @@ Driving Distance - Category
 
   * :doc:`pgr_alphaShape` - Alpha shape computation
 
-.. index to here
+.. official-end
 
 .. rubric:: Proposed
 
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
+   :start-after: warning-begin
+   :end-before: end-warning
 
-.. index proposed from here
+.. proposed-start
 
 * :doc:`pgr_withPointsDD` - Driving Distance based on pgr_withPoints
 
-.. index proposed to here
+.. proposed-end
 
 .. toctree::
     :hidden:

--- a/doc/categories/spanningTree-family.rst
+++ b/doc/categories/spanningTree-family.rst
@@ -7,19 +7,19 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: Spanning Tree Category
+
+|
 
 Spanning Tree - Category
 ===============================================================================
 
-.. index from here
+.. official-start
 
 * :doc:`kruskal-family`
 * :doc:`prim-family`
 
-.. index to here
+.. official-end
 
 A spanning tree of an undirected graph is a tree that includes all the vertices
 of G with the minimum possible number of edges.

--- a/doc/categories/via-category.rst
+++ b/doc/categories/via-category.rst
@@ -7,9 +7,9 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: Via Category
+
+|
 
 Via - Category
 ===============================================================================
@@ -17,7 +17,7 @@ Via - Category
 .. rubric:: proposed
 
 .. include:: proposed.rst
-    :start-after: begin-warning
+    :start-after: warning-begin
     :end-before: end-warning
 
 .. proposed start

--- a/doc/categories/withPoints-category.rst
+++ b/doc/categories/withPoints-category.rst
@@ -7,9 +7,9 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
     ****************************************************************************
 
-|
-
 .. index:: With Points Category
+
+|
 
 withPoints - Category
 ===============================================================================
@@ -17,7 +17,7 @@ withPoints - Category
 When points are added to the graph.
 
 .. include:: proposed.rst
-   :start-after: begin-warning
+   :start-after: warning-begin
    :end-before: end-warning
 
 .. proposed start

--- a/doc/chinese/chinesePostmanProblem-family.rst
+++ b/doc/chinese/chinesePostmanProblem-family.rst
@@ -9,16 +9,15 @@
 
 |
 
-
 Chinese Postman Problem - Family of functions (Experimental)
 ===============================================================================
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_chinesePostman`
 * :doc:`pgr_chinesePostmanCost`
 
-.. index to here
+.. official-end
 
 .. toctree::
   :hidden:
@@ -27,8 +26,8 @@ Chinese Postman Problem - Family of functions (Experimental)
   pgr_chinesePostmanCost
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 Description
 -------------------------------------------------------------------------------

--- a/doc/chinese/pgr_chinesePostman.rst
+++ b/doc/chinese/pgr_chinesePostman.rst
@@ -7,9 +7,12 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
+.. index::
+   single: Cost Category ; pgr_chinesePostman - Experimental
+   single: Miscellaneous Algorithms ; pgr_chinesePostman - Experimental
+   single: chinesePostman - Experimental on v3.0
 
-* **Supported versions**
+|
 
 ``pgr_chinesePostman`` - Experimental
 ===============================================================================
@@ -18,14 +21,14 @@
 every edge in a directed graph and starts and ends on the same vertex.
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.0.0
 
-  * New **experimental** signature
+  * New experimental function.
 
 Description
 -------------------------------------------------------------------------------
@@ -36,11 +39,10 @@ Description
 
 - Returns ``EMPTY SET`` on a disconnected graph
 
+|Boost| Boost Graph Inside
+
 Signatures
 -------------------------------------------------------------------------------
-
-.. index::
-    single: chinesePostman - Experimental on v3.0
 
 .. admonition:: \ \
    :class: signatures

--- a/doc/chinese/pgr_chinesePostmanCost.rst
+++ b/doc/chinese/pgr_chinesePostmanCost.rst
@@ -7,8 +7,12 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
+.. index::
+   single: Cost Category ; pgr_chinesePostmanCost - Experimental
+   single: Miscellaneous Algorithms ; pgr_chinesePostmanCost - Experimental
+   single: chinesePostmanCost - Experimental on v3.0
 
+|
 
 ``pgr_chinesePostmanCost`` - Experimental
 ===============================================================================
@@ -18,14 +22,14 @@ which contains every edge in a directed graph and starts and ends on the same
 vertex.
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.0.0
 
-  * New **experimental** signature
+  * New experimental function.
 
 Description
 -------------------------------------------------------------------------------
@@ -36,11 +40,10 @@ Description
 
 - Return value when the graph if disconnected
 
+|Boost| Boost Graph Inside
+
 Signatures
 -------------------------------------------------------------------------------
-
-.. index::
-    single: chinesePostmanCost - Experimental on v3.0
 
 .. admonition:: \ \
    :class: signatures

--- a/doc/circuits/pgr_hawickCircuits.rst
+++ b/doc/circuits/pgr_hawickCircuits.rst
@@ -7,32 +7,26 @@
     Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Miscellaneous Algorithms ; pgr_hawickCircuits
    single: Hawick Circuits - Experimental on v3.4
+
+|
 
 ``pgr_hawickCircuits - Experimental``
 ===============================================================================
 
 ``pgr_hawickCircuits`` — Returns the list of cirucits using hawick circuits algorithm.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/hawick_circuits.html
-
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.4.0
 
-  * New **experimental** signature:
-
-    * ``pgr_hawickCircuits``
-
+  * New experimental function.
 
 Description
 -------------------------------------------------------------------------------
@@ -60,6 +54,8 @@ implemenent this variation.
   - where :math:`|E|` is the number of edges in the graph,
   - :math:`|V|` is the number of vertices in the graph.
   - :math:`|c|` is the number of circuts in the graph.
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------

--- a/doc/coloring/coloring-family.rst
+++ b/doc/coloring/coloring-family.rst
@@ -7,9 +7,9 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
+.. index:: Coloring Family
+
 |
-
-
 
 Coloring - Family of functions
 ===============================================================================
@@ -17,29 +17,29 @@ Coloring - Family of functions
 .. rubric:: Proposed
 
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
+   :start-after: warning-begin
+   :end-before: end-warning
 
-.. index proposed from here
+.. proposed-start
 
 * :doc:`pgr_sequentialVertexColoring` - Vertex coloring algorithm using greedy
   approach.
 
-.. index proposed to here
+.. proposed-end
 
 .. rubric:: Experimental
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_bipartite` - Bipartite graph algorithm using a DFS-based coloring
   approach.
 * :doc:`pgr_edgeColoring` - Edge Coloring algorithm using Vizing's theorem.
 
-.. index to here
+.. official-end
 
 
 .. toctree::
@@ -88,18 +88,7 @@ Column           Type        Description
 See Also
 -------------------------------------------------------------------------------
 
-.. include:: pgr_sequentialVertexColoring.rst
-    :start-after: see also start
-    :end-before: see also end
-
-.. include:: pgr_bipartite.rst
-    :start-after: see also start
-    :end-before: see also end
-
-.. include:: pgr_edgeColoring.rst
-    :start-after: see also start
-    :end-before: see also end
-
+* `Boost: <https://www.boost.org/libs/graph/doc/table_of_contents.html>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/coloring/pgr_bipartite.rst
+++ b/doc/coloring/pgr_bipartite.rst
@@ -7,30 +7,27 @@
     Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
+.. index::
+   single: Coloring Family ; pgr_bipartite - Experimental
+   single: bipartite - Experimental on v3.2
+
 |
 
-
-pgr_bipartite -Experimental
+``pgr_bipartite`` - Experimental
 ===============================================================================
 
 ``pgr_bipartite`` — Disjoint sets of vertices such that no two vertices within
 the same set are adjacent.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/is_bipartite.html
-
-   Boost Graph Inside
-
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.2.0
 
-  * New **experimental** signature
-
+  * New experimental function.
 
 Description
 -------------------------------------------------------------------------------
@@ -49,12 +46,10 @@ colored with the same color.
 - If graph is not bipartite then algorithm returns empty set.
 - Running time: :math:`O(V + E)`
 
+|Boost| Boost Graph Inside
+
 Signatures
 -------------------------------------------------------------------------------
-
-.. index::
-    single: bipartite - Experimental on v3.2
-
 
 .. admonition:: \ \
    :class: signatures
@@ -118,16 +113,12 @@ Edges in blue represent odd length cycle subgraph.
 See Also
 -------------------------------------------------------------------------------
 
-.. see also start
-
 * `Boost: is_bipartite
   <https://www.boost.org/libs/graph/doc/is_bipartite.html>`__
 * `Wikipedia: bipartite graph
   <https://en.wikipedia.org/wiki/Bipartite_graph>`__
 
-.. see also end
-
-* :doc:`sampledata` network.
+* :doc:`sampledata`
 
 .. rubric:: Indices and tables
 

--- a/doc/coloring/pgr_edgeColoring.rst
+++ b/doc/coloring/pgr_edgeColoring.rst
@@ -7,30 +7,27 @@
     Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
+.. index::
+   single: Coloring Family ; pgr_edgeColoring - Experimental
+   single: edgeColoring - Experimental on v3.3
+
 |
 
-
-pgr_edgeColoring - Experimental
+``pgr_edgeColoring`` - Experimental
 ===============================================================================
 
 ``pgr_edgeColoring`` — Returns the edge coloring of undirected and loop-free
 graphs
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/edge_coloring.html
-
-   Boost Graph Inside
-
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-exp
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.3.0
 
-  * New **experimental** signature
-
+  * New experimental function.
 
 Description
 -------------------------------------------------------------------------------
@@ -70,11 +67,10 @@ no two adjacent edges have the same color.
     - where :math:`|E|` is the number of edges in the graph,
     - :math:`|V|` is the number of vertices in the graph.
 
+|Boost| Boost Graph Inside
+
 Signatures
 ------------------------------------------------------------------------------
-
-.. index::
-    single: edgeColoring - Experimental on v3.3
 
 .. admonition:: \ \
    :class: signatures
@@ -120,15 +116,10 @@ Result columns
 See Also
 -------------------------------------------------------------------------------
 
-* The queries use the :doc:`sampledata` network.
-
-.. see also start
-
-* `Boost: Edge Coloring Algorithm documentation
+* :doc:`sampledata`
+* `Boost: Edge Coloring
   <https://www.boost.org/libs/graph/doc/edge_coloring.html>`__
 * `Wikipedia: Graph coloring <https://en.wikipedia.org/wiki/Graph_coloring>`__
-
-.. see also end
 
 .. rubric:: Indices and tables
 

--- a/doc/coloring/pgr_sequentialVertexColoring.rst
+++ b/doc/coloring/pgr_sequentialVertexColoring.rst
@@ -7,33 +7,31 @@
     Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
+.. index::
+   single: Coloring Family ; pgr_sequentialVertexColoring - Proposed
+   single: sequentialVertexColoring - Proposed on v3.3
+
 |
 
-
-pgr_sequentialVertexColoring - Proposed
+``pgr_sequentialVertexColoring`` - Proposed
 ===============================================================================
 
 ``pgr_sequentialVertexColoring`` — Returns the vertex coloring of an undirected
 graph, using greedy approach.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/sequential_vertex_coloring.html
-
-   Boost Graph Inside
-
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.3.0
 
-  * Promoted to **proposed** signature
+  * Function promoted to proposed.
 
 * Version 3.2.0
 
-  * New **experimental** signature
+  * New experimental function.
 
 
 Description
@@ -60,11 +58,10 @@ manner, such that no edge connects two identically colored vertices.
   - :math:`d` is the maximum degree of the vertices in the graph,
   - :math:`k` is the number of colors used.
 
+|Boost| Boost Graph Inside
+
 Signatures
 ------------------------------------------------------------------------------
-
-.. index::
-    single: sequentialVertexColoring - Proposed on v3.3
 
 .. admonition:: \ \
    :class: signatures
@@ -110,15 +107,10 @@ Result columns
 See Also
 -------------------------------------------------------------------------------
 
-* The queries use the :doc:`sampledata` network.
-
-.. see also start
-
-* `Boost: Sequential Vertex Coloring algorithm documentation
+* :doc:`sampledata`
+* `Boost: Sequential Vertex Coloring
   <https://www.boost.org/libs/graph/doc/sequential_vertex_coloring.html>`__
 * `Wikipedia: Graph coloring <https://en.wikipedia.org/wiki/Graph_coloring>`__
-
-.. see also end
 
 .. rubric:: Indices and tables
 

--- a/doc/components/components-family.rst
+++ b/doc/components/components-family.rst
@@ -7,15 +7,15 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: Components Family
+
+|
 
 Components - Family of functions
 ===============================================================================
 
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_connectedComponents` - Connected components of an undirected graph.
 * :doc:`pgr_strongComponents` - Strongly connected components of a directed
@@ -25,19 +25,19 @@ Components - Family of functions
 * :doc:`pgr_articulationPoints` - Articulation points of an undirected graph.
 * :doc:`pgr_bridges` - Bridges of an undirected graph.
 
-.. index to here
+.. official-end
 
 .. rubric:: Experimental
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
-.. index experimental from here
+.. experimental-start
 
 * :doc:`pgr_makeConnected` - Details of edges to make graph connected.
 
-.. index experimental to here
+.. experimental-end
 
 
 .. toctree::

--- a/doc/components/pgr_articulationPoints.rst
+++ b/doc/components/pgr_articulationPoints.rst
@@ -7,23 +7,18 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 
 .. index::
    single: Components Family ; pgr_articulationPoints
    single: articulationPoints
+
+|
 
 ``pgr_articulationPoints``
 ===============================================================================
 
 ``pgr_articulationPoints`` - Return the articulation points of an undirected
 graph.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/biconnected_components.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -34,7 +29,7 @@ graph.
 
 * Version 2.5.0
 
-  * New **experimental** function
+  * New experimental function.
 
 Description
 -------------------------------------------------------------------------------
@@ -53,6 +48,8 @@ This implementation can only be used with an undirected graph.
   - ``node`` ascending
 
 - Running time: :math:`O(V + E)`
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -114,8 +111,8 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`components-family`
-* The queries use the :doc:`sampledata` network.
-* Boost: `Biconnected components & articulation points
+* :doc:`sampledata`
+* `Boost: Biconnected components & articulation points
   <https://www.boost.org/libs/graph/doc/biconnected_components.html>`__
 * wikipedia: `Biconnected component
   <https://en.wikipedia.org/wiki/Biconnected_component>`__

--- a/doc/components/pgr_biconnectedComponents.rst
+++ b/doc/components/pgr_biconnectedComponents.rst
@@ -7,22 +7,17 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 
 .. index::
    single: Components Family ; pgr_biconnectedComponents
    single: biconnectedComponents
 
+|
+
 ``pgr_biconnectedComponents``
 ===============================================================================
 
 ``pgr_biconnectedComponents`` — Biconnected components of an undirected graph.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/biconnected_components.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -30,14 +25,14 @@
 
   * Result columns change:
 
-    * ``n_seq`` is removed
-    * ``seq`` changed type to ``BIGINT``
+    * n_seq`` is removed
+    * seq`` changed type to ``BIGINT``
 
   * **Official** function
 
 * Version 2.5.0
 
-  * New **experimental** function
+  * New experimental function.
 
 
 Description
@@ -61,6 +56,8 @@ only be contained in a single biconnected component.
   - ``edge`` ascending.
 
 - Running time: :math:`O(V + E)`
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -128,8 +125,8 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`components-family`
-* The queries use the :doc:`sampledata` network.
-* Boost: `Biconnected components
+* :doc:`sampledata`
+* `Boost: Biconnected components & articulation points
   <https://www.boost.org/libs/graph/doc/biconnected_components.html>`__
 * wikipedia: `Biconnected component
   <https://en.wikipedia.org/wiki/Biconnected_component>`__

--- a/doc/components/pgr_bridges.rst
+++ b/doc/components/pgr_bridges.rst
@@ -7,21 +7,16 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Components Family ; pgr_bridges
    single: bridges
+
+|
 
 ``pgr_bridges``
 ===============================================================================
 
 ``pgr_bridges`` - Return the bridges of an undirected graph.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/connected_components.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -32,7 +27,7 @@
 
 * Version 2.5.0
 
-  * New **experimental** function
+  * New experimental function.
 
 Description
 -------------------------------------------------------------------------------
@@ -49,6 +44,8 @@ This implementation can only be used with an undirected graph.
   - ``edge`` ascending
 
 - Running time: :math:`O(E * (V + E))`
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -108,7 +105,8 @@ See Also
 -------------------------------------------------------------------------------
 
 * https://en.wikipedia.org/wiki/Bridge_%28graph_theory%29
-* The queries use the :doc:`sampledata` network.
+* :doc:`sampledata`
+* `Boost: connected components <https://www.boost.org/libs/graph/doc/connected_components.html>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/components/pgr_connectedComponents.rst
+++ b/doc/components/pgr_connectedComponents.rst
@@ -7,22 +7,17 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Components Family ; pgr_connectedComponents
    single: connectedComponents
 
-pgr_connectedComponents
+|
+
+``pgr_connectedComponents``
 ===============================================================================
 
 ``pgr_connectedComponents`` — Connected components of an undirected graph using
 a DFS-based approach.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/connected_components.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -30,14 +25,14 @@ a DFS-based approach.
 
   * Result columns change:
 
-    * ``n_seq`` is removed
-    * ``seq`` changed type to ``BIGINT``
+    * n_seq`` is removed
+    * seq`` changed type to ``BIGINT``
 
-  * **Official** function
+  * Function propoted to **Official**.
 
 * Version 2.5.0
 
-  * New **experimental** function
+  * New experimental function.
 
 
 Description
@@ -59,8 +54,7 @@ from each other.
 
 - Running time: :math:`O(V + E)`
 
-.. index::
-    single: connectedComponents
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -143,8 +137,8 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`components-family`
-* The queries use the :doc:`sampledata` network.
-* Boost: `Connected components
+* :doc:`sampledata`
+* `Boost: Connected components
   <https://www.boost.org/libs/graph/doc/connected_components.html>`__
 * wikipedia: `Connected component
   <https://en.wikipedia.org/wiki/Connected_component_(graph_theory)>`__

--- a/doc/components/pgr_makeConnected.rst
+++ b/doc/components/pgr_makeConnected.rst
@@ -7,31 +7,27 @@
     Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: Components Family ; pgr_makeConnected
+   single: Components Family ; pgr_makeConnected - Experimental
    single: makeConnected - Experimental on v3.2
+
+
+|
 
 ``pgr_makeConnected`` - Experimental
 ===============================================================================
 
 ``pgr_makeConnected`` — Set of edges that will connect the graph.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/make_connected.html
-
-   Boost Graph Inside
-
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.2.0
 
-  * New **experimental** function
+  * New experimental function.
 
 
 Description
@@ -55,6 +51,8 @@ The main characteristics are:
 - The algorithm does not considers geometric topology in the calculations.
 - Running time: :math:`O(V + E)`
 
+|Boost| Boost Graph Inside
+
 Signatures
 -------------------------------------------------------------------------------
 
@@ -66,8 +64,7 @@ Signatures
    | Returns set of |result-component-make|
    | OR EMPTY SET
 
-:Example: Query done on :doc:`sampledata` network gives the list of edges that
-          are needed to connect the graph.
+:Example: List of edges that are needed to connect the graph.
 
 .. literalinclude:: makeConnected.queries
    :start-after: -- q1
@@ -116,8 +113,9 @@ Returns set of |result-component-make|
 See Also
 -------------------------------------------------------------------------------
 
-* https://www.boost.org/libs/graph/doc/make_connected.html
-* The queries use the :doc:`sampledata` network.
+* `Boost: make connected
+  <https://www.boost.org/libs/graph/doc/make_connected.html>`__
+* :doc:`sampledata`
 
 .. rubric:: Indices and tables
 

--- a/doc/components/pgr_strongComponents.rst
+++ b/doc/components/pgr_strongComponents.rst
@@ -7,22 +7,17 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Components Family ; pgr_strongComponents
    single: strongComponents
+
+|
 
 ``pgr_strongComponents``
 ===============================================================================
 
 ``pgr_strongComponents`` — Strongly connected components of a directed graph
 using Tarjan's algorithm based on DFS.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/strong_components.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -37,7 +32,7 @@ using Tarjan's algorithm based on DFS.
 
 * Version 2.5.0
 
-  * New **experimental** function
+  * New experimental function.
 
 
 Description
@@ -56,6 +51,8 @@ all reachable from each other.
   - ``node`` ascending
 
 - Running time: :math:`O(V + E)`
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -106,8 +103,8 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`components-family`
-* The queries use the :doc:`sampledata` network.
-* Boost: `Strong components
+* :doc:`sampledata`
+* `Boost: Strong components
   <https://www.boost.org/libs/graph/doc/strong_components.html>`__
 * wikipedia: `Strongly connected component
   <https://en.wikipedia.org/wiki/Strongly_connected_component>`__

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -392,6 +392,10 @@ rst_epilog="""
 .. |result-disjoint-m-m| replace:: ``(seq, path_id, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)``
 .. |result-mincut| replace:: ``(seq, edge, cost, mincut)``
 .. |result-pickdrop| replace:: ``(seq, vehicle_number, vehicle_id, stop, order_id, stop_type, cargo, travel_time, arrival_time, wait_time, service_time, departure_time)``
+.. |boost| image:: images/boost-inside.jpeg
+   :target: https://www.boost.org/libs/graph
+   :alt: Boost Graph inside
+   :height: 18
 .. |epilog_end| replace:: just a marker for notes2news
 """
 

--- a/doc/contraction/contraction-family.rst
+++ b/doc/contraction/contraction-family.rst
@@ -7,19 +7,19 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 
 .. index:: Contraction Family
+
+|
 
 Contraction - Family of functions
 ===============================================================================
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_contraction`
 
-.. index to here
+.. official-end
 
 .. toctree::
     :hidden:

--- a/doc/contraction/pgr_contraction.rst
+++ b/doc/contraction/pgr_contraction.rst
@@ -7,21 +7,18 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
+
+.. index:: 
+   single: Contraction Family ; pgr_contraction
+   single: contraction
+
 |
-
-
-.. index:: Contraction Family ; pgr_contraction
 
 ``pgr_contraction``
 ===============================================================================
 
 ``pgr_contraction`` — Performs graph contraction and returns the contracted
 vertices and edges.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -34,7 +31,7 @@ vertices and edges.
 
 * Version 2.3.0
 
-  * New **experimental** function
+  * New experimental function.
 
 
 Description
@@ -66,6 +63,7 @@ The main Characteristics are:
   - column ``id`` ascending when type is ``v``
   - column ``id`` descending when type is ``e``
 
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------

--- a/doc/dagShortestPath/pgr_dagShortestPath.rst
+++ b/doc/dagShortestPath/pgr_dagShortestPath.rst
@@ -7,40 +7,35 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
+.. index::
+   single: Shortest Path Category ; pgr_dagShortestPath - Experimental
+   single: Directed Acyclic Graph Category ; pgr_dagShortestPath - Experimental
+   single: dagShortestPath - Experimental
+
 |
 
-.. index::
-   single: Shortest Path Category ; pgr_dagShortestPath
-   single: Directed Acyclic Graph Category ; pgr_dagShortestPath
-   single: dagShortestPath
-
-pgr_dagShortestPath - Experimental
+``pgr_dagShortestPath`` - Experimental
 ===============================================================================
 
 ``pgr_dagShortestPath`` — Returns the shortest path for weighted directed
 acyclic graphs(DAG).
 In particular, the DAG shortest paths algorithm implemented by Boost.Graph.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/dag_shortest_paths.html
-
-   Boost Graph Inside
-
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.2.0
 
-  * New **experimental** function:
+  * New experimental function.
 
     * pgr_dagShortestPath(Combinations)
 
 * Version 3.0.0
 
-  * New **experimental** function
+  * New experimental function.
 
 
 Description
@@ -82,6 +77,7 @@ The main characteristics are:
 
   * Running time: :math:`O(| start\_vids | * (V + E))`
 
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -102,7 +98,7 @@ Signatures
 
 
 .. index::
-    single: dagShortestPath ; One to One - Experimental on v3.0
+    single: dagShortestPath - Experimental ; One to One - Experimental on v3.0
 
 One to One
 ...............................................................................
@@ -122,7 +118,7 @@ One to One
    :end-before: -- q3
 
 .. index::
-    single: dagShortestPath ; One to Many - Experimental on v3.0
+    single: dagShortestPath - Experimental ; One to Many - Experimental on v3.0
 
 One to Many
 ...............................................................................
@@ -142,7 +138,7 @@ One to Many
    :end-before: -- q4
 
 .. index::
-    single: dagShortestPath ; Many to One - Experimental on v3.0
+    single: dagShortestPath - Experimental ; Many to One - Experimental on v3.0
 
 Many to One
 ...............................................................................
@@ -162,7 +158,7 @@ Many to One
    :end-before: -- q5
 
 .. index::
-    single: dagShortestPath ; Many to Many - Experimental on v3.0
+    single: dagShortestPath - Experimental ; Many to Many - Experimental on v3.0
 
 Many to Many
 ...............................................................................
@@ -183,7 +179,7 @@ Many to Many
    :end-before: -- q51
 
 .. index::
-    single: dagShortestPath ; Combinations - Experimental on v3.2
+    single: dagShortestPath - Experimental ; Combinations - Experimental on v3.2
 
 Combinations
 ...............................................................................
@@ -266,6 +262,8 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`sampledata`
+* `Boost: DAG shortest paths
+  <https://www.boost.org/libs/graph/doc/dag_shortest_paths.html>`__
 * https://en.wikipedia.org/wiki/Topological_sorting
 
 .. rubric:: Indices and tables

--- a/doc/dijkstra/dijkstra-family.rst
+++ b/doc/dijkstra/dijkstra-family.rst
@@ -7,14 +7,14 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: Dijkstra Family
+
+|
 
 Dijkstra - Family of functions
 ===============================================================================
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_dijkstra` - Dijkstra's algorithm for the shortest paths.
 * :doc:`pgr_dijkstraCost` - Get the aggregate cost of the shortest paths.
@@ -24,22 +24,22 @@ Dijkstra - Family of functions
 * :doc:`pgr_KSP` - Use Yen algorithm with pgr_dijkstra to get the K shortest
   paths.
 
-.. index to here
+.. official-end
 
 .. rubric:: Proposed
 
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
+   :start-after: warning-begin
+   :end-before: end-warning
 
 
-.. index proposed from here
+.. proposed-start
 
 * :doc:`pgr_dijkstraVia` - Get a route of a seuence of vertices.
 * :doc:`pgr_dijkstraNear` - Get the route to the nearest vertex.
 * :doc:`pgr_dijkstraNearCost` - Get the cost to the nearest vertex.
 
-.. index proposed to here
+.. proposed-end
 
 .. toctree::
     :hidden:

--- a/doc/dijkstra/pgr_dijkstra.rst
+++ b/doc/dijkstra/pgr_dijkstra.rst
@@ -7,22 +7,17 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Dijkstra Family ; pgr_dijkstra
    single: Shortest Path Category ; pgr_dijkstra
    single: dijkstra
 
+|
+
 ``pgr_dijkstra``
 ===============================================================================
 
 ``pgr_dijkstra`` — Shortest path using Dijkstra algorithm.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/dijkstra_shortest_paths.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -30,35 +25,35 @@
 
   * Standarizing output columns to |short-generic-result|
 
-    * ``pgr_dijkstra`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns.
-    * ``pgr_dijkstra`` (`One to Many`_) added ``end_vid`` column.
-    * ``pgr_dijkstra`` (`Many to One`_) added ``start_vid`` column.
+    * pgr_dijkstra(One to One) added ``start_vid`` and ``end_vid`` columns.
+    * pgr_dijkstra(One to Many) added ``end_vid`` column.
+    * pgr_dijkstra(Many to One) added ``start_vid`` column.
 
 * Version 3.1.0
 
-  * New **Proposed** functions:
+  * New proposed signature:
 
-    * ``pgr_dijkstra`` (`Combinations`_)
+    * pgr_dijkstra(Combinations)
 
 * Version 3.0.0
 
-  * **Official** functions
+  * **Official** function.
 
 * Version 2.2.0
 
-  * New **proposed** functions:
+  * New proposed signatures:
 
-    * ``pgr_dijkstra`` (`One to Many`_)
-    * ``pgr_dijkstra`` (`Many to One`_)
-    * ``pgr_dijkstra`` (`Many to Many`_)
+    * pgr_dijkstra(One to Many)
+    * pgr_dijkstra(Many to One)
+    * pgr_dijkstra(Many to Many)
 
 * Version 2.1.0
 
-  * Signature change on ``pgr_dijkstra`` (`One to One`_)
+  * Signature change on pgr_dijkstra(One to One)
 
 * Version 2.0.0
 
-  * **Official** ``pgr_dijkstra`` (`One to One`_)
+  * **Official** pgr_dijkstra(One to One)
 
 
 Description
@@ -72,6 +67,7 @@ Description
     :start-after: dijkstra_details_start
     :end-before: dijkstra_details_end
 
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -600,11 +596,13 @@ The following examples find the path for :math:`\{6\}\rightarrow\{10\}`
    :start-after: -- q154
    :end-before: -- q16
 
-See Also
+e Also
 -------------------------------------------------------------------------------
 
+* :doc:`sampledata`
+* `Boost: Dijkstra shortest paths
+  <https://www.boost.org/libs/graph/doc/dijkstra_shortest_paths.html>`__
 * https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
-* The queries use the :doc:`sampledata` network.
 
 .. rubric:: Indices and tables
 

--- a/doc/dijkstra/pgr_dijkstraCost.rst
+++ b/doc/dijkstra/pgr_dijkstraCost.rst
@@ -7,13 +7,13 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 
 .. index::
    single: Dijkstra Family ; pgr_dijkstraCost
    single: Cost Category ; pgr_dijkstraCost
    single: dijkstraCost
+
+|
 
 ``pgr_dijkstraCost``
 ===============================================================================
@@ -21,22 +21,17 @@
 ``pgr_dijkstraCost`` - Total cost of the shortest path using Dijkstra
 algorithm.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/dijkstra_shortest_paths.html
-
-   Boost Graph Inside
-
 .. rubric:: Availability
 
 * Version 3.1.0
 
-  * New **proposed** signature:
+  * New proposed signature:
 
-    * ``pgr_dijkstraCost`` (`Combinations`_)
+    * pgr_dijkstraCost(Combinations)
 
 * Version 2.2.0
 
-  * New **Official** function
+  * New **official** function.
 
 
 Description
@@ -56,6 +51,8 @@ using Dijkstra Algorithm.
 .. include:: cost-category.rst
     :start-after: cost_traits_start
     :end-before: cost_traits_end
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -249,6 +246,8 @@ See Also
 
 * :doc:`dijkstra-family`
 * :doc:`sampledata`
+* `Boost: Dijkstra shortest paths
+  <https://www.boost.org/libs/graph/doc/dijkstra_shortest_paths.html>`__
 * https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
 
 .. rubric:: Indices and tables

--- a/doc/dijkstra/pgr_dijkstraCostMatrix.rst
+++ b/doc/dijkstra/pgr_dijkstraCostMatrix.rst
@@ -7,22 +7,17 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Dijkstra Family ; pgr_dijkstraCostMatrix
    single: Cost Matrix Category ; pgr_dijkstraCostMatrix
    single: dijkstraCostMatrix
 
+|
+
 ``pgr_dijkstraCostMatrix``
 ===============================================================================
 
 ``pgr_dijkstraCostMatrix`` - Calculates a cost matrix using :doc:`pgr_dijkstra`.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -32,7 +27,7 @@
 
 * Version 2.3.0
 
-  * New **proposed** function
+  * New proposed function.
 
 Description
 -------------------------------------------------------------------------------
@@ -46,6 +41,8 @@ Using Dijkstra algorithm, calculate and return a cost matrix.
 .. include:: costMatrix-category.rst
     :start-after: costMatrix_details_start
     :end-before: costMatrix_details_end
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -114,6 +111,8 @@ See Also
 * :doc:`costMatrix-category`
 * :doc:`TSP-family`
 * :doc:`sampledata`
+* `Boost: Dijkstra shortest paths
+  <https://www.boost.org/libs/graph/doc/dijkstra_shortest_paths.html>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/dijkstra/pgr_dijkstraNear.rst
+++ b/doc/dijkstra/pgr_dijkstraNear.rst
@@ -7,12 +7,12 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: Dijkstra Family ; pgr_dijkstraNear
-   single: Near Category ; pgr_dijkstraNear
-   single: dijkstraNear
+   single: Dijkstra Family ; pgr_dijkstraNear - Proposed
+   single: Near Category ; pgr_dijkstraNear - Proposed
+   single: dijkstraNear - Proposed
+
+|
 
 ``pgr_dijkstraNear`` - Proposed
 ===============================================================================
@@ -21,23 +21,18 @@
 the nearest vertex.
 
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.3.0
 
-  * Promoted to **proposed** function
+  * Function promoted to proposed.
 
 * Version 3.2.0
 
-  * New **experimental** function
+  * New experimental function.
 
 
 Description
@@ -78,6 +73,8 @@ Characteristics
 
 .. dijkstraNear characteristics end
 
+|Boost| Boost Graph Inside
+
 Signatures
 -------------------------------------------------------------------------------
 
@@ -97,7 +94,7 @@ Signatures
    | OR EMPTY SET
 
 .. index::
-    single: dijkstraNear ; One to Many - Proposed on v3.3
+    single: dijkstraNear - Proposed; One to Many - Proposed on v3.3
 
 One to Many
 ...............................................................................
@@ -130,7 +127,7 @@ One to Many
 The result shows that station at vertex :math:`11` is the nearest.
 
 .. index::
-    single: dijkstraNear ; Many to One - Proposed on v3.3
+    single: dijkstraNear - Proposed; Many to One - Proposed on v3.3
 
 Many to One
 ...............................................................................
@@ -161,7 +158,7 @@ The result shows that station at vertex :math:`10` is the nearest and the next
 best is :math:`11`.
 
 .. index::
-    single: dijkstraNear ; Many to Many - Proposed on v3.3
+    single: dijkstraNear - Proposed; Many to Many - Proposed on v3.3
 
 Many to Many
 ...............................................................................
@@ -197,7 +194,7 @@ the first subway line and at vertex :math:`10` of the second subway line.
 Only `one` route is returned because `global` is ``true`` and `cap` is ``1``
 
 .. index::
-    single: dijkstraNear ; Combinations - Proposed on v3.3
+    single: dijkstraNear - Proposed; Combinations - Proposed on v3.3
 
 Combinations
 ...............................................................................
@@ -329,8 +326,9 @@ See Also
 
 * :doc:`dijkstra-family`
 * :doc:`pgr_dijkstraNearCost`
-* :doc:`sampledata` network.
-* boost: https://www.boost.org/libs/graph/doc/table_of_contents.html
+* :doc:`sampledata`
+* `Boost: Dijkstra shortest paths
+  <https://www.boost.org/libs/graph/doc/dijkstra_shortest_paths.html>`__
 * Wikipedia: https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
 
 .. rubric:: Indices and tables

--- a/doc/dijkstra/pgr_dijkstraNearCost.rst
+++ b/doc/dijkstra/pgr_dijkstraNearCost.rst
@@ -7,14 +7,14 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 
 .. index::
-   single: Dijkstra Family ; pgr_dijkstraNearCost
-   single: Near Category ; pgr_dijkstraNearCost
-   single: Cost Category ; pgr_dijkstraNearCost
-   single: dijkstraNearCost
+   single: Dijkstra Family ; pgr_dijkstraNearCost - Proposed
+   single: Near Category ; pgr_dijkstraNearCost - Proposed
+   single: Cost Category ; pgr_dijkstraNearCost - Proposed
+   single: dijkstraNearCost - Proposed
+
+|
 
 ``pgr_dijkstraNearCost`` - Proposed
 ===============================================================================
@@ -23,23 +23,18 @@
 to the nearest vertex.
 
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.3.0
 
-  * Promoted to **proposed** function
+  * Function promoted to proposed.
 
 * Version 3.2.0
 
-  * New **experimental** function
+  * New experimental function.
 
 
 Description
@@ -54,6 +49,8 @@ Characteristics
 .. include:: pgr_dijkstraNear.rst
     :start-after: dijkstraNear characteristics start
     :end-before: dijkstraNear characteristics end
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -74,7 +71,7 @@ Signatures
    | OR EMPTY SET
 
 .. index::
-    single: dijkstraNearCost ; One to Many - Proposed on v3.3
+    single: dijkstraNearCost - Proposed ; One to Many - Proposed on v3.3
 
 One to Many
 ...............................................................................
@@ -107,7 +104,7 @@ One to Many
 The result shows that station at vertex :math:`11` is the nearest.
 
 .. index::
-    single: dijkstraNearCost ; Many to One - Proposed on v3.3
+    single: dijkstraNearCost - Proposed ; Many to One - Proposed on v3.3
 
 Many to One
 ...............................................................................
@@ -138,7 +135,7 @@ The result shows that station at vertex :math:`10` is the nearest and the next
 best is :math:`11`.
 
 .. index::
-    single: dijkstraNearCost ; Many to Many - Proposed on v3.3
+    single: dijkstraNearCost - Proposed ; Many to Many - Proposed on v3.3
 
 Many to Many
 ...............................................................................
@@ -174,7 +171,7 @@ the first subway line and at vertex :math:`10` of the second subway line.
 Only `one` route is returned because `global` is ``true`` and `cap` is ``1``
 
 .. index::
-    single: dijkstraNearCost ; Combinations - Proposed on v3.3
+    single: dijkstraNearCost - Proposed ; Combinations - Proposed on v3.3
 
 Combinations
 ...............................................................................
@@ -285,8 +282,9 @@ See Also
 
 * :doc:`dijkstra-family`
 * :doc:`pgr_dijkstraNear`
-* :doc:`sampledata` network.
-* boost: https://www.boost.org/libs/graph/doc/table_of_contents.html
+* :doc:`sampledata`
+* `Boost: Dijkstra shortest paths
+  <https://www.boost.org/libs/graph/doc/dijkstra_shortest_paths.html>`__
 * Wikipedia: https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
 
 .. rubric:: Indices and tables

--- a/doc/dijkstra/pgr_dijkstraVia.rst
+++ b/doc/dijkstra/pgr_dijkstraVia.rst
@@ -7,12 +7,12 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: Dijkstra Family ; pgr_dijkstraVia
-   single: Via Category ; pgr_dijkstraVia
-   single: dijkstraVia
+   single: Dijkstra Family ; pgr_dijkstraVia - Proposed
+   single: Via Category ; pgr_dijkstraVia - Proposed
+   single: dijkstraVia - Proposed
+
+|
 
 ``pgr_dijkstraVia`` - Proposed
 ===============================================================================
@@ -20,19 +20,14 @@
 ``pgr_dijkstraVia`` — Route that goes through a list of vertices.
 
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 2.2.0
 
-  * New **proposed** function
+  * New proposed function.
 
 Description
 -------------------------------------------------------------------------------
@@ -44,11 +39,13 @@ shortest path between :math:`vertex_i` and :math:`vertex_{i+1}` for all :math:`i
 :Route: is a sequence of paths.
 :Path: is a section of the route.
 
+|Boost| Boost Graph Inside
+
 Signatures
 -------------------------------------------------------------------------------
 
 .. index::
-    single: dijkstraVia - Proposed on 2.2
+    single: dijkstraVia - Proposed ; One Via - Proposed on 2.2
 
 One Via
 ...............................................................................
@@ -163,7 +160,9 @@ See Also
 
 * :doc:`via-category`.
 * :doc:`dijkstra-family`.
-* :doc:`sampledata` network.
+* :doc:`sampledata`
+* `Boost: Dijkstra shortest paths
+  <https://www.boost.org/libs/graph/doc/dijkstra_shortest_paths.html>`__
 * https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
 
 .. rubric:: Indices and tables

--- a/doc/dominator/pgr_lengauerTarjanDominatorTree.rst
+++ b/doc/dominator/pgr_lengauerTarjanDominatorTree.rst
@@ -7,33 +7,27 @@
     Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Miscellaneous Algorithms ; pgr_lengauerTarjanDominatorTree
    single: lengauerTarjanDominatorTree - Experimental on v3.2
 
+|
 
-pgr_lengauerTarjanDominatorTree -Experimental
+``pgr_lengauerTarjanDominatorTree`` -Experimental
 ===============================================================================
 
 ``pgr_lengauerTarjanDominatorTree`` — Returns the immediate dominator of all
 vertices.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/lengauer_tarjan_dominator.htm
-
-   Boost Graph Inside
-
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.2.0
 
-  * New **experimental** function
+  * New experimental function.
 
 
 Description
@@ -49,6 +43,8 @@ The algorithm calculates the *immidiate dominator* of each vertex called
 - The algorithm returns *idom* of each vertex.
 - If the *root vertex* not present in the graph then it returns empty set.
 - Running time: :math:`O((V+E)log(V+E))`
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -118,7 +114,7 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`sampledata`
-* `Boost: Lengauer-Tarjan dominator tree algorithm
+* `Boost: Lengauer-Tarjan dominator
   <https://www.boost.org/libs/graph/doc/lengauer_tarjan_dominator.htm>`__
 * `Wikipedia: dominator tree
   <https://en.wikipedia.org/wiki/Dominator_(graph_theory)>`__

--- a/doc/driving_distance/pgr_drivingDistance.rst
+++ b/doc/driving_distance/pgr_drivingDistance.rst
@@ -7,21 +7,16 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Driving Distance Category ; pgr_drivingDistance
    single: drivingDistance
+
+|
 
 ``pgr_drivingDistance``
 ===============================================================================
 
 ``pgr_drivingDistance`` - Returns the driving distance from a start node.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -29,11 +24,11 @@
 
 * Standarizing output columns to |result-spantree|
 
-  * ``pgr_drivingdistance`` (Single vertex)
+  * pgr_drivingdistance(Single vertex)
 
     * Added ``depth`` and ``start_vid`` result columns.
 
-  * ``pgr_drivingdistance`` (Multiple vertices)
+  * pgr_drivingdistance(Multiple vertices)
 
     * Result column name change: ``from_v`` to ``start_vid``.
     * Added ``depth`` and ``pred`` result columns.
@@ -54,6 +49,8 @@ Description
 Using the Dijkstra algorithm, extracts all the nodes that have costs less than
 or equal to the value ``distance``.
 The edges extracted will conform to the corresponding spaning tree.
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -176,7 +173,7 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`pgr_alphaShape` - Alpha shape computation
-* :doc:`sampledata` network.
+* :doc:`sampledata`
 
 .. rubric:: Indices and tables
 

--- a/doc/ksp/pgr_KSP.rst
+++ b/doc/ksp/pgr_KSP.rst
@@ -7,38 +7,32 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
     single: K Shortest Paths Category ; pgr_KSP
     single: KSP
 
-pgr_KSP
+|
+
+``pgr_KSP``
 ===============================================================================
 
 ``pgr_KSP`` — Yen's algorithm for K shortest paths using Dijkstra.
-
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
 .. rubric:: Version 3.6.0
 
 * Result columns standarized to: |nksp-result|
-* ``pgr_ksp`` (One to One)
+* pgr_ksp(One to One)
 
   * Added ``start_vid`` and ``end_vid`` result columns.
 
-* New overload functions:
+* New proposed signatures:
 
-  * ``pgr_ksp`` (One to Many)
-  * ``pgr_ksp`` (Many to One)
-  * ``pgr_ksp`` (Many to Many)
-  * ``pgr_ksp`` (Combinations)
+  * pgr_ksp(One to Many)
+  * pgr_ksp(Many to One)
+  * pgr_ksp(Many to Many)
+  * pgr_ksp(Combinations)
 
 .. rubric:: Version 2.1.0
 
@@ -56,6 +50,8 @@ Description
 
 The K shortest path routing algorithm based on Yen's algorithm. "K" is the
 number of shortest paths desired.
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -97,7 +93,7 @@ One to One
     :end-before: --q2
 
 .. index::
-    single: KSP ; One to Many
+    single: KSP ; One to Many - Proposed on 3.6
 
 One to Many
 ...............................................................................
@@ -118,7 +114,7 @@ One to Many
     :end-before: --q3
 
 .. index::
-    single: KSP ; Many to One
+    single: KSP ; Many to One - Proposed in 3.6
 
 Many to One
 ...............................................................................
@@ -139,7 +135,7 @@ Many to One
     :end-before: --q4
 
 .. index::
-    single: KSP ; Many to Many
+    single: KSP ; Many to Many - Proposed in 3.6
 
 Many to Many
 ...............................................................................
@@ -160,7 +156,7 @@ Many to Many
     :end-before: --q5
 
 .. index::
-   single: KSP ; Combinations
+   single: KSP ; Combinations - Proposed in 3.6
 
 Combinations
 ...............................................................................

--- a/doc/lineGraph/pgr_lineGraph.rst
+++ b/doc/lineGraph/pgr_lineGraph.rst
@@ -7,32 +7,27 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Transformation Family ; pgr_lineGraph
    single: lineGraph - Proposed on v3.7
 
-pgr_lineGraph - Proposed
+|
+
+``pgr_lineGraph`` - Proposed
 ===============================================================================
 
 ``pgr_lineGraph`` — Transforms the given graph into its corresponding edge-based
 graph.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/dijkstra_shortest_paths.html
-
-   Boost Graph Inside
-
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.7.0
 
-  * Promoted to **proposed** signature.
+  * Function promoted to proposed.
   * Works for directed and undirected graphs.
 
 * Version 2.5.0
@@ -62,6 +57,8 @@ Given a graph :math:`G`, its line graph :math:`L(G)` is a graph such that:
 - When the graph is undirected the result is undirected.
 
   - The ``reverse_cost`` is always :math:`-1`.
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------

--- a/doc/lineGraph/pgr_lineGraphFull.rst
+++ b/doc/lineGraph/pgr_lineGraphFull.rst
@@ -7,11 +7,11 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Transformation Family ; pgr_lineGraphFull
    single: lineGraphFull - Experimental on v2.6
+
+|
 
 ``pgr_lineGraphFull`` - Experimental
 ===============================================================================
@@ -20,8 +20,8 @@
 the vertices from the original graph are converted to line graphs.
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
@@ -56,6 +56,8 @@ The main characteristics are:
 - Results are undefined when a negative vertex id is used in the input graph.
 - Results are undefined when a duplicated edge id is used in the input graph.
 - Running time: TBD
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -141,7 +143,7 @@ Additional Examples
 .. contents::
    :local:
 
-The examples of this section are based on the :doc:`sampledata` network.
+The examples of this section are based on the :doc:`sampledata`
 The examples include the subgraph including edges 4, 7, 8, and 10 with
 ``reverse_cost``.
 

--- a/doc/lineGraph/transformation-family.rst
+++ b/doc/lineGraph/transformation-family.rst
@@ -10,29 +10,31 @@
 
 .. index:: Transformation Family
 
+|
+
 Transformation - Family of functions
 ===============================================================================
 
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
+   :start-after: warning-begin
+   :end-before: end-warning
 
-.. index proposed from here
+.. proposed-start
 
 * :doc:`pgr_lineGraph` - Transformation algorithm for generating a Line Graph.
 
-.. index proposed to here
+.. proposed-end
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
-.. index experimental from here
+.. experimental-start
 
 * :doc:`pgr_lineGraphFull` - Transformation algorithm for generating a Line
   Graph out of each vertex in the input graph.
 
-.. index experimental to here
+.. experimental-end
 
 
 .. toctree::

--- a/doc/max_flow/flow-family.rst
+++ b/doc/max_flow/flow-family.rst
@@ -7,14 +7,14 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: Flow Family
+
+|
 
 Flow - Family of functions
 ===================================
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_maxFlow` - Only the Max flow calculation using Push and Relabel
   algorithm.
@@ -31,20 +31,20 @@ Flow - Family of functions
   * :doc:`pgr_maxCardinalityMatch` - Calculates a maximum cardinality matching
     in a graph.
 
-.. index to here
+.. official-end
 
 .. rubric:: Experimental
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
-.. index experimental from here
+.. experimental-start
 
 * :doc:`pgr_maxFlowMinCost` - Details of flow and cost on edges.
 * :doc:`pgr_maxFlowMinCost_Cost` - Only the Min Cost calculation.
 
-.. index experimental to here
+.. experimental-end
 
 .. toctree::
     :hidden:

--- a/doc/max_flow/pgr_boykovKolmogorov.rst
+++ b/doc/max_flow/pgr_boykovKolmogorov.rst
@@ -7,11 +7,11 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Flow Family ; pgr_boykovKolmogorov
    single: boykovKolmogorov
+
+|
 
 ``pgr_boykovKolmogorov``
 ===============================================================================
@@ -19,18 +19,13 @@
 ``pgr_boykovKolmogorov`` — Calculates the flow on the graph edges that maximizes
 the flow from the sources to the targets using Boykov Kolmogorov algorithm.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html
-
-   Boost Graph Inside
-
 .. Rubric:: Availability
 
 * Version 3.2.0
 
-  * New **proposed** signature
+  * New proposed signature
 
-    * ``pgr_boykovKolmogorov`` (`Combinations`_)
+    * pgr_boykovKolmogorov(Combinations)
 
 * Version 3.0.0
 
@@ -54,6 +49,8 @@ Description
     :end-before: characteristics_end
 
 * Running time: Polynomial
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -229,7 +226,8 @@ See Also
   * :doc:`pgr_edmondsKarp`
   * :doc:`pgr_pushRelabel`
 
-* https://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html
+* `Boost: Boykov Kolmogorov max flow
+  <https://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/max_flow/pgr_edgeDisjointPaths.rst
+++ b/doc/max_flow/pgr_edgeDisjointPaths.rst
@@ -7,11 +7,11 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: Flow Family ; edgeDisjointPaths
+   single: Flow Family ; pgr_edgeDisjointPaths
    single: edgeDisjointPaths
+
+|
 
 ``pgr_edgeDisjointPaths``
 ===============================================================================
@@ -20,16 +20,11 @@
 vertices.
 
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html
-
-   Boost Graph Inside
-
 .. Rubric:: Availability
 
 * Version 3.2.0
 
-  * New **proposed** function:
+  * New proposed signature:
 
     * pgr_edgeDisjointPaths(Combinations)
 
@@ -57,6 +52,8 @@ The main characterics are:
   - Returns EMPTY SET when source and destination are the same, or cannot be reached.
   - The graph can be directed or undirected.
   - Uses :doc:`pgr_boykovKolmogorov` to calculate the paths.
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -237,6 +234,8 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`flow-family`
+* `Boost: Boykov Kolmogorov max flow
+  <https://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/max_flow/pgr_edmondsKarp.rst
+++ b/doc/max_flow/pgr_edmondsKarp.rst
@@ -7,11 +7,11 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: Flow Family ; edmondsKarp
+   single: Flow Family ; pgr_edmondsKarp
    single: edmondsKarp
+
+|
 
 ``pgr_edmondsKarp``
 ===============================================================================
@@ -19,18 +19,13 @@
 ``pgr_edmondsKarp`` — Calculates the flow on the graph edges that maximizes the
 flow from the sources to the targets using Edmonds Karp Algorithm.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html
-
-   Boost Graph Inside
-
 .. Rubric:: Availability
 
 * Version 3.2.0
 
-  * New **proposed** signature
+  * New proposed signature
 
-    * ``pgr_edmondsKarp`` (`Combinations`_)
+    * pgr_edmondsKarp(Combinations)
 
 * Version 3.0.0
 
@@ -54,6 +49,8 @@ Description
     :end-before: characteristics_end
 
 * Running time: :math:`O( V * E ^ 2)`
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -229,7 +226,8 @@ See Also
   * :doc:`pgr_boykovKolmogorov`
   * :doc:`pgr_pushRelabel`
 
-* https://www.boost.org/libs/graph/doc/edmonds_karp_max_flow.html
+* `Boost: edmonds_karp_max_flow
+  <https://www.boost.org/libs/graph/doc/edmonds_karp_max_flow.html>`__
 * https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm
 
 .. rubric:: Indices and tables

--- a/doc/max_flow/pgr_maxCardinalityMatch.rst
+++ b/doc/max_flow/pgr_maxCardinalityMatch.rst
@@ -7,22 +7,17 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Flow Family ; pgr_maxCardinalityMatch
    single: maxCardinalityMatch
 
-pgr_maxCardinalityMatch
+|
+
+``pgr_maxCardinalityMatch``
 ===============================================================================
 
 ``pgr_maxCardinalityMatch`` — Calculates a maximum cardinality matching in a
 graph.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/maximum_matching.html
-
-   Boost Graph Inside
 
 .. Rubric:: Availability
 
@@ -33,13 +28,13 @@ graph.
   * Works for undirected graphs.
   * New signature
 
-    * ``pgr_maxCardinalityMatch(text)`` returns only ``edge`` column.
+    * pgr_maxCardinalityMatch(text)`` returns only ``edge`` column.
 
   * Deprecated signature
 
-    * ``pgr_maxCardinalityMatch(text,boolean)``
+    * pgr_maxCardinalityMatch(text,boolean)``
 
-      * ``directed => false`` when used.
+      * directed => false`` when used.
 
 * Version 3.0.0
 
@@ -74,6 +69,8 @@ The main characteristics are:
   * :math:`\alpha(E,V)` is the inverse of the `Ackermann function`_.
 
 .. _Ackermann function: https://en.wikipedia.org/wiki/Ackermann_function
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -162,7 +159,8 @@ See Also
 
 * :doc:`flow-family`
 * :doc:`migration`
-* https://www.boost.org/libs/graph/doc/maximum_matching.html
+* `Boost: maximum_matching
+  <https://www.boost.org/libs/graph/doc/maximum_matching.html>`__
 * https://en.wikipedia.org/wiki/Matching_%28graph_theory%29
 * https://en.wikipedia.org/wiki/Ackermann_function
 

--- a/doc/max_flow/pgr_maxFlow.rst
+++ b/doc/max_flow/pgr_maxFlow.rst
@@ -7,11 +7,11 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Flow Family ; pgr_maxFlow
    single: maxFlow
+
+|
 
 ``pgr_maxFlow``
 ===============================================================================
@@ -19,26 +19,21 @@
 ``pgr_maxFlow`` — Calculates the maximum flow in a directed graph from the
 source(s) to the targets(s) using the Push Relabel algorithm.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html
-
-   Boost Graph Inside
-
 .. Rubric:: Availability
 
 * Version 3.2.0
 
-  * New **proposed** signature
+  * New proposed signature
 
-    * ``pgr_maxFlow`` (`Combinations`_)
+    * pgr_maxFlow(Combinations)
 
 * Version 3.0.0
 
-  * **Official** function
+  *  Function promoted to **official**.
 
 * Version 2.4.0
 
-  * New **Proposed** function
+  * New **Proposed** function.
 
 
 Description
@@ -56,6 +51,8 @@ Description
 - Uses the :doc:`pgr_pushRelabel <pgr_pushRelabel>` algorithm.
 
 * Running time: :math:`O( V ^ 3)`
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -226,7 +223,8 @@ See Also
 
   * :doc:`pgr_pushRelabel`
 
-* https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html
+* `Boost: push relabel max flow
+  <https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html>`__
 * https://en.wikipedia.org/wiki/Push%E2%80%93relabel_maximum_flow_algorithm
 
 .. rubric:: Indices and tables

--- a/doc/max_flow/pgr_maxFlowMinCost.rst
+++ b/doc/max_flow/pgr_maxFlowMinCost.rst
@@ -7,11 +7,11 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: Flow Family ; pgr_maxFlowMinCost
-   single: maxFlowMinCost
+   single: Flow Family ; pgr_maxFlowMinCost - Experimental
+   single: maxFlowMinCost - Experimental
+
+|
 
 ``pgr_maxFlowMinCost`` - Experimental
 ===============================================================================
@@ -19,30 +19,22 @@
 ``pgr_maxFlowMinCost`` — Calculates the edges that minimizes the total cost of
 the maximum flow on a graph
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html
-
-   Boost Graph Inside
-
-.. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
-
 .. rubric:: Availability
 
 * Version 3.2.0
 
-  * New **experimental** function:
+  * New experimental signature:
 
-    * ``pgr_maxFlowMinCost`` (`Combinations`_)
+    * pgr_maxFlowMinCost(Combinations)
 
 * Version 3.0.0
 
-* New **experimental** function
-
+  * New experimental function.
 
 Description
 -------------------------------------------------------------------------------
+
+|boost| graph inside.
 
 .. include::  flow-family.rst
     :start-after: characteristics_start
@@ -59,6 +51,12 @@ Description
   * where :math:`U` is the value of the max flow.
   * :math:`U` is upper bound on number of iterations. In many real world cases
     number of iterations is much smaller than :math:`U`.
+
+.. include:: experimental.rst
+   :start-after: warning-begin
+   :end-before: end-warning
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -78,7 +76,7 @@ Signatures
    | OR EMPTY SET
 
 .. index::
-    single: maxFlowMinCost ; One to One - Experimental on v3.0
+    single: maxFlowMinCost - Experimental ; One to One - Experimental on v3.0
 
 One to One
 ...............................................................................
@@ -98,7 +96,7 @@ One to One
    :end-before: -- q2
 
 .. index::
-    single: maxFlowMinCost ; One to Many - Experimental on v3.0
+    single: maxFlowMinCost - Experimental ; One to Many - Experimental on v3.0
 
 One to Many
 ...............................................................................
@@ -118,7 +116,7 @@ One to Many
    :end-before: -- q3
 
 .. index::
-    single: maxFlowMinCost ; Many to One - Experimental on v3.0
+    single: maxFlowMinCost - Experimental ; Many to One - Experimental on v3.0
 
 Many to One
 ...............................................................................
@@ -138,7 +136,7 @@ Many to One
    :end-before: -- q4
 
 .. index::
-    single: maxFlowMinCost ; Many to Many - Experimental on v3.0
+    single: maxFlowMinCost - Experimental ; Many to Many - Experimental on v3.0
 
 Many to Many
 ...............................................................................
@@ -158,7 +156,7 @@ Many to Many
    :end-before: -- q5
 
 .. index::
-    single: maxFlowMinCost ; Combinations -- Experimental on v3.2
+    single: maxFlowMinCost - Experimental ; Combinations -- Experimental on v3.2
 
 Combinations
 ...............................................................................
@@ -230,7 +228,8 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`flow-family`
-* https://www.boost.org/libs/graph/doc/successive_shortest_path_nonnegative_weights.html
+* `Boost: push relabel max flow
+  <https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/max_flow/pgr_maxFlowMinCost_Cost.rst
+++ b/doc/max_flow/pgr_maxFlowMinCost_Cost.rst
@@ -7,12 +7,12 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: Flow Family ; pgr_maxFlowMinCost_Cost
-   single: Cost Category ; pgr_maxFlowMinCost_Cost
-   single: maxFlowMinCost_Cost
+   single: Flow Family ; pgr_maxFlowMinCost_Cost - Experimental
+   single: Cost Category ; pgr_maxFlowMinCost_Cost - Experimental
+   single: maxFlowMinCost_Cost - Experimental
+
+|
 
 ``pgr_maxFlowMinCost_Cost`` - Experimental
 ===============================================================================
@@ -20,26 +20,17 @@
 ``pgr_maxFlowMinCost_Cost`` — Calculates the minimum total cost of the maximum
 flow on a graph
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html
-
-   Boost Graph Inside
-
-.. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
-
 .. rubric:: Availability
 
 * Version 3.2.0
 
-  * New **experimental** function:
+  * New experimental signature:
 
-    * ``pgr_maxFlowMinCost_Cost`` (`Combinations`_)
+    * pgr_maxFlowMinCost_Cost(Combinations)
 
 * Version 3.0.0
 
-  * New **experimental** function
+  * New experimental function.
 
 
 Description
@@ -66,6 +57,12 @@ Description
   * :math:`U` is upper bound on number of iterations.
     In many real world cases number of iterations is much smaller than :math:`U`.
 
+.. include:: experimental.rst
+   :start-after: warning-begin
+   :end-before: end-warning
+
+|Boost| Boost Graph Inside
+
 Signatures
 -------------------------------------------------------------------------------
 
@@ -83,7 +80,7 @@ Signatures
    | RETURNS FLOAT
 
 .. index::
-    single: maxFlowMinCost_Cost ; One to One - Experimental on v3.0
+    single: maxFlowMinCost_Cost - Experimental ; One to One - Experimental on v3.0
 
 One to One
 ...............................................................................
@@ -102,7 +99,7 @@ One to One
    :end-before: -- q2
 
 .. index::
-    single: maxFlowMinCost_Cost ; One to Many - Experimental on v3.0
+    single: maxFlowMinCost_Cost - Experimental ; One to Many - Experimental on v3.0
 
 One to Many
 ...............................................................................
@@ -121,7 +118,7 @@ One to Many
    :end-before: -- q4
 
 .. index::
-    single: maxFlowMinCost_Cost ; Many to One - Experimental on v3.0
+    single: maxFlowMinCost_Cost - Experimental ; Many to One - Experimental on v3.0
 
 Many to One
 ...............................................................................
@@ -140,7 +137,7 @@ Many to One
    :end-before: -- q3
 
 .. index::
-    single: maxFlowMinCost_Cost ; Many to Many - Experimental on v3.0
+    single: maxFlowMinCost_Cost - Experimental ; Many to Many - Experimental on v3.0
 
 Many to Many
 ...............................................................................
@@ -160,7 +157,7 @@ Many to Many
    :end-before: -- q5
 
 .. index::
-    single: maxFlowMinCost_Cost ; Combinations - Experimental on v3.2
+    single: maxFlowMinCost_Cost - Experimental ; Combinations - Experimental on v3.2
 
 Combinations
 ...............................................................................
@@ -233,7 +230,8 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`flow-family`
-* https://www.boost.org/libs/graph/doc/successive_shortest_path_nonnegative_weights.html
+* `Boost: push relabel max flow
+  <https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/max_flow/pgr_pushRelabel.rst
+++ b/doc/max_flow/pgr_pushRelabel.rst
@@ -7,11 +7,11 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Flow Family ; pgr_pushRelabel
    single: pushRelabel
+
+|
 
 ``pgr_pushRelabel``
 ===============================================================================
@@ -19,18 +19,13 @@
 ``pgr_pushRelabel`` — Calculates the flow on the graph edges that maximizes the
 flow from the sources to the targets using Push Relabel Algorithm.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html
-
-   Boost Graph Inside
-
 .. Rubric:: Availability
 
 * Version 3.2.0
 
-  * New **proposed** signature
+  * New proposed signature
 
-    * ``pgr_pushRelabel`` (`Combinations`_)
+    * pgr_pushRelabel(Combinations)
 
 * Version 3.0.0
 
@@ -43,7 +38,7 @@ flow from the sources to the targets using Push Relabel Algorithm.
 
 * Version 2.3.0
 
-  * New **Experimental** function
+  * New experimental function.
 
 
 Description
@@ -54,6 +49,8 @@ Description
     :end-before: characteristics_end
 
 * Running time: :math:`O( V ^ 3)`
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -229,7 +226,8 @@ See Also
   * :doc:`pgr_boykovKolmogorov`
   * :doc:`pgr_edmondsKarp`
 
-* https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html
+* `Boost: push relabel max flow
+  <https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html>`__
 * https://en.wikipedia.org/wiki/Push%E2%80%93relabel_maximum_flow_algorithm
 
 .. rubric:: Indices and tables

--- a/doc/metrics/metrics-family.rst
+++ b/doc/metrics/metrics-family.rst
@@ -7,10 +7,10 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 
 .. index:: Metrics Family
+
+|
 
 Metrics - Family of functions
 ===============================================================================
@@ -18,14 +18,14 @@ Metrics - Family of functions
 .. rubric:: Experimental
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
-.. index experimental from here
+.. experimental-start
 
 * :doc:`pgr_betweennessCentrality` - Calculates relative betweenness centrality using Brandes Algorithm
 
-.. index experimental to here
+.. experimental-end
 
 
 .. toctree::

--- a/doc/metrics/pgr_betweennessCentrality.rst
+++ b/doc/metrics/pgr_betweennessCentrality.rst
@@ -7,30 +7,25 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: Metrics Family ; pgr_betweennessCentrality
+   single: Metrics Family ; pgr_betweennessCentrality - Experimental
    single: betweennessCentrality - Experimental on v3.7
 
-``pgr_betweennessCentrality``
+|
+
+``pgr_betweennessCentrality`` - Experimental
 ===============================================================================
 
 ``pgr_betweennessCentrality`` - Calculates the relative betweeness centrality
 using Brandes Algorithm
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/doc/libs/1_84_0/libs/graph/doc/betweenness_centrality.html
-
-   Boost Graph Inside
-
 .. rubric:: Availability
 
 * Version 3.7.0
 
-  * New **experimental** function:
+  * New experimental function.
 
-    * ``pgr_betweennessCentrality``
+    * pgr_betweennessCentrality``
 
 Description
 -------------------------------------------------------------------------------
@@ -52,6 +47,8 @@ This implementation work for both directed and undirected graphs.
 - Running time:  :math:`\Theta(VE)`
 - Running space: :math:`\Theta(VE)`
 - Throws when there are no edges in the graph
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -141,9 +138,9 @@ Result columns
 See Also
 -------------------------------------------------------------------------------
 
-* Boost's `betweenness_centrality
+* :doc:`sampledata`
+* `Boost: betweenness centrality
   <https://www.boost.org/doc/libs/1_84_0/libs/graph/doc/betweenness_centrality.html>`_
-* Queries use the :doc:`sampledata` network.
 
 .. rubric:: Indices and tables
 

--- a/doc/mincut/pgr_stoerWagner.rst
+++ b/doc/mincut/pgr_stoerWagner.rst
@@ -11,19 +11,16 @@
    single: Miscellaneous Algorithms ; pgr_stoerWagner
    single: stoerWagner - Experimental on v3.0
 
-pgr_stoerWagner - Experimental
+|
+
+``pgr_stoerWagner`` - Experimental
 ===============================================================================
 
 ``pgr_stoerWagner`` — The min-cut of graph using stoerWagner algorithm.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/stoer_wagner_min_cut.html
-
-   Boost Graph Inside
-
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
@@ -67,6 +64,8 @@ weight on the cut determines whether it is a minimum cut.
   this function determines exactly one of the min-cuts as well as its weight.
 
 * Running time: :math:`O(V*E + V^2*log V)`.
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -135,6 +134,8 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`sampledata`
+* `Boost: Stoer Wagner min cut
+  <https://www.boost.org/libs/graph/doc/stoer_wagner_min_cut.html>`__
 * https://en.wikipedia.org/wiki/Stoer%E2%80%93Wagner_algorithm
 
 .. rubric:: Indices and tables

--- a/doc/ordering/ordering-family.rst
+++ b/doc/ordering/ordering-family.rst
@@ -7,9 +7,9 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: Ordering Family
+
+|
 
 Ordering - Family of functions
 ===============================================================================
@@ -17,17 +17,17 @@ Ordering - Family of functions
 .. rubric:: Experimental
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_cuthillMckeeOrdering` - Return reverse Cuthill-McKee ordering of an undirected graph.
 * :doc:`pgr_topologicalSort` - Linear ordering of the vertices for directed
   acyclic graph.
 
-.. index to here
+.. official-end
 
 .. toctree::
     :hidden:

--- a/doc/ordering/pgr_cuthillMckeeOrdering.rst
+++ b/doc/ordering/pgr_cuthillMckeeOrdering.rst
@@ -7,11 +7,11 @@
     Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Ordering Family ; pgr_cuthillMckeeOrdering
    single: pgr_cuthillMckeeOrdering
+
+|
 
 ``pgr_cuthillMckeeOrdering`` - Experimental
 ===============================================================================
@@ -19,20 +19,15 @@
 ``pgr_cuthillMckeeOrdering`` — Returns the reverse Cuthill-Mckee ordering of an undirected
 graphs
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/cuthill_mckee_ordering.html
-
-   Boost Graph Inside
-
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-exp
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.4.0
 
-  * New **experimental** function
+  * New experimental function.
 
 
 Description
@@ -54,6 +49,8 @@ each step, the adjacent vertices are placed in the queue in order of increasing 
 
   - where :math:`|V|` is the number of vertices,
   - :math:`m` is the maximum degree of the vertices in the graph.
+
+|Boost| Boost Graph Inside
 
 Signatures
 ------------------------------------------------------------------------------
@@ -109,7 +106,7 @@ Column           Type        Description
 See Also
 -------------------------------------------------------------------------------
 
-* The queries use the :doc:`sampledata` network.
+* :doc:`sampledata`
 * `Boost: Cuthill-McKee Ordering
   <https://www.boost.org/libs/graph/doc/cuthill_mckee_ordering.html>`__
 * `Wikipedia: Cuthill-McKee Ordering

--- a/doc/ordering/pgr_topologicalSort.rst
+++ b/doc/ordering/pgr_topologicalSort.rst
@@ -7,11 +7,11 @@
     Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Ordering Family ; pgr_topologicalSort
    single: topologicalSort - Experimental on v3.0
+
+|
 
 ``pgr_topologicalSort`` - Experimental
 ===============================================================================
@@ -19,20 +19,15 @@
 ``pgr_topologicalSort`` — Linear ordering of the vertices for directed acyclic
 graphs (DAG).
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/topological_sort.html
-
-   Boost Graph Inside
-
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.0.0
 
-  * New **experimental** function
+  * New experimental function.
 
 Description
 -------------------------------------------------------------------------------
@@ -53,6 +48,7 @@ The main characteristics are:
 
 * Running time: :math:`O(V + E)`
 
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -129,6 +125,8 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`sampledata`
+* `Boost: topological sort
+  <https://www.boost.org/libs/graph/doc/topological_sort.html>`__
 * https://en.wikipedia.org/wiki/Topological_sorting
 
 .. rubric:: Indices and tables

--- a/doc/pickDeliver/pgr_pickDeliver.rst
+++ b/doc/pickDeliver/pgr_pickDeliver.rst
@@ -7,11 +7,11 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Vehicle Routing Functions Category ; pgr_pickDeliver
    single: pickDeliver - Experimental on v3.0
+
+|
 
 ``pgr_pickDeliver`` - Experimental
 ===============================================================================
@@ -19,14 +19,14 @@
 ``pgr_pickDeliver`` - Pickup and delivery Vehicle Routing Problem
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.0.0
 
-  * New **experimental** function
+  * New experimental function.
 
 
 Synopsis

--- a/doc/pickDeliver/pgr_pickDeliverEuclidean.rst
+++ b/doc/pickDeliver/pgr_pickDeliverEuclidean.rst
@@ -7,11 +7,11 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Vehicle Routing Functions Category ; pgr_pickDeliverEuclidean
    single: pickDeliverEuclidean - Experimental on 3.0
+
+|
 
 ``pgr_pickDeliverEuclidean`` - Experimental
 ===============================================================================
@@ -19,15 +19,15 @@
 ``pgr_pickDeliverEuclidean`` - Pickup and delivery Vehicle Routing Problem
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.0.0
 
   * Replaces ``pgr_gsoc_vrppdtw``
-  * New **experimental** function
+  * New experimental function.
 
 
 Synopsis
@@ -200,7 +200,7 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`VRP-category`
-* The queries use the :doc:`sampledata` network.
+* :doc:`sampledata`
 
 .. rubric:: Indices and tables
 

--- a/doc/pickDeliver/pgr_vrpOneDepot.rst
+++ b/doc/pickDeliver/pgr_vrpOneDepot.rst
@@ -7,18 +7,18 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Vehicle Routing Functions Category ; pgr_vrpOneDepot
    single: vrpOneDepot - Experimental on v2.1.0
 
-pgr_vrpOneDepot - Experimental
+|
+
+``pgr_vrpOneDepot`` - Experimental
 ===============================================================================
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 **No documentation available**
 
@@ -26,7 +26,7 @@ pgr_vrpOneDepot - Experimental
 
 * Version 2.1.0
 
-  * New **experimental** function
+  * New experimental function.
 
 
 * **TBD**

--- a/doc/planar/pgr_isPlanar.rst
+++ b/doc/planar/pgr_isPlanar.rst
@@ -7,31 +7,26 @@
     Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Planar Family ; pgr_isPlanar
    single: isPlanar - Experimental on v3.2
+
+|
 
 ``pgr_isPlanar`` - Experimental
 ===============================================================================
 
 ``pgr_isPlanar`` — Returns a boolean depending upon the planarity of the graph.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/boyer_myrvold.html
-
-   Boost Graph Inside
-
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.2.0
 
-  * New **experimental** function
+  * New experimental function.
 
 
 Description
@@ -51,6 +46,8 @@ The main characteristics are:
 * Applicable only for **undirected** graphs.
 * The algorithm does not considers traversal costs in the calculations.
 * Running time: :math:`O(|V|)`
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -123,7 +120,8 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`sampledata`
-* https://www.boost.org/libs/graph/doc/boyer_myrvold.html
+* `Boost: Boyer Myrvold
+  <https://www.boost.org/libs/graph/doc/boyer_myrvold.html>`__
 
 .. rubric:: Indices and tables
 

--- a/doc/spanningTree/kruskal-family.rst
+++ b/doc/spanningTree/kruskal-family.rst
@@ -7,28 +7,23 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Spanning Tree Category ; Kruskal Family
    single: Kruskal Family
 
+|
+
 Kruskal - Family of functions
 ===============================================================================
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_kruskal`
 * :doc:`pgr_kruskalBFS`
 * :doc:`pgr_kruskalDD`
 * :doc:`pgr_kruskalDFS`
 
-.. index to here
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html
-
-   Boost Graph Inside
+.. official-end
 
 .. toctree::
     :hidden:
@@ -70,6 +65,7 @@ See Also
 
 * :doc:`spanningTree-family`
 * `Boost: Kruskal's algorithm <https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html>`__
+* `Boost: Prim's algorithm <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
 * `Wikipedia: Kruskal's algorithm <https://en.wikipedia.org/wiki/Kruskal's_algorithm>`__
 
 .. rubric:: Indices and tables

--- a/doc/spanningTree/pgr_kruskal.rst
+++ b/doc/spanningTree/pgr_kruskal.rst
@@ -7,22 +7,17 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: Kruskal Family ; pgr_kruska
+   single: Kruskal Family ; pgr_kruskal
    single: Spanning Tree Category ; pgr_kruskal
    single: kruskal
+
+|
 
 ``pgr_kruskal``
 ===============================================================================
 
 ``pgr_kruskal`` — Minimum spanning tree of a graph using Kruskal's algorithm.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -93,7 +88,7 @@ See Also
 
 * :doc:`spanningTree-family`
 * :doc:`kruskal-family`
-* The queries use the :doc:`sampledata` network.
+* :doc:`sampledata`
 * `Boost: Kruskal's algorithm
   <https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html>`__
 * `Wikipedia: Kruskal's algorithm

--- a/doc/spanningTree/pgr_kruskalBFS.rst
+++ b/doc/spanningTree/pgr_kruskalBFS.rst
@@ -7,24 +7,19 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Kruskal Family ; pgr_kruskalBFS
    single: Spanning Tree Category ; pgr_kruskalBFS
    single: Breadth First Search Category ; pgr_kruskalBFS
    single: kruskalBFS
 
+|
+
 ``pgr_kruskalBFS``
 ===============================================================================
 
 ``pgr_kruskalBFS`` — Kruskal's algorithm for Minimum Spanning Tree with breadth
 First Search ordering.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 

--- a/doc/spanningTree/pgr_kruskalDD.rst
+++ b/doc/spanningTree/pgr_kruskalDD.rst
@@ -7,8 +7,6 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 
 .. index::
    single: Kruskal Family ; pgr_kruskalDD
@@ -16,15 +14,12 @@
    single: Driving Distance Category ; pgr_kruskalDD
    single: kruskalDD
 
+|
+
 ``pgr_kruskalDD``
 ===============================================================================
 
 ``pgr_kruskalDD`` — Catchament nodes using Kruskal's algorithm.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -57,6 +52,8 @@ calculated minimum spanning tree.
 
 - Returned tree nodes from a root vertex are on Depth First Search order.
 - Depth First Search running time: :math:`O(E + V)`
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------

--- a/doc/spanningTree/pgr_kruskalDFS.rst
+++ b/doc/spanningTree/pgr_kruskalDFS.rst
@@ -7,24 +7,19 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Kruskal Family ; pgr_kruskalDFS
    single: Spanning Tree Category ; pgr_kruskalDFS
    single: Depth First Search Category ; pgr_kruskalBFS
    single: kruskalDFS
 
+|
+
 ``pgr_kruskalDFS``
 ===============================================================================
 
 ``pgr_kruskalDFS`` — Kruskal's algorithm for Minimum Spanning Tree with Depth
 First Search ordering.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/kruskal_min_spanning_tree.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -53,6 +48,8 @@ of the Minimum Spanning Tree created using Kruskal's algorithm.
 
 - Returned tree nodes from a root vertex are on Depth First Search order
 - Depth First Search Running time: :math:`O(E + V)`
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------

--- a/doc/spanningTree/pgr_prim.rst
+++ b/doc/spanningTree/pgr_prim.rst
@@ -7,22 +7,17 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Prim Family ; pgr_prim
    single: Spanning Tree Category ; pgr_prim
    single: prim
 
+|
+
 ``pgr_prim``
 ===============================================================================
 
 ``pgr_prim`` — Minimum spanning forest of a graph using Prim's algorithm.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -44,6 +39,7 @@ graph using Prim's algorithm.
 
 - EMPTY SET is returned when there are no edges in the graph.
 
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -94,7 +90,7 @@ See Also
 
 * :doc:`spanningTree-family`
 * :doc:`prim-family`
-* The queries use the :doc:`sampledata` network.
+* :doc:`sampledata`
 * `Boost: Prim's algorithm documentation
   <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
 * `Wikipedia: Prim's algorithm

--- a/doc/spanningTree/pgr_primBFS.rst
+++ b/doc/spanningTree/pgr_primBFS.rst
@@ -7,24 +7,19 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Prim Family ; pgr_primBFS
    single: Spanning Tree Category ; pgr_primBFS
    single: Breadth First Search Category ; pgr_primBFS
    single: primBFS
 
+|
+
 ``pgr_primBFS``
 ===============================================================================
 
 ``pgr_primBFS`` — Prim's algorithm for Minimum Spanning Tree with Depth First
 Search ordering.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -52,6 +47,8 @@ of the Minimum Spanning Tree created using Prims's algorithm.
 
 - Returned tree nodes from a root vertex are on Breath First Search order
 - Breath First Search Running time: :math:`O(E + V)`
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -140,7 +137,7 @@ See Also
 * :doc:`spanningTree-family`
 * :doc:`prim-family`
 * :doc:`sampledata`
-* `Boost: Prim's algorithm documentation
+* `Boost: Prim's algorithm
   <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
 * `Wikipedia: Prim's algorithm
   <https://en.wikipedia.org/wiki/Prim%27s_algorithm>`__

--- a/doc/spanningTree/pgr_primDD.rst
+++ b/doc/spanningTree/pgr_primDD.rst
@@ -7,23 +7,18 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Prim Family ; pgr_primDD
    single: Spanning Tree Category ; pgr_primDD
    single: Driving Distance Category ; pgr_primDD
    single: primDD
 
+|
+
 ``pgr_primDD``
 ===============================================================================
 
 ``pgr_primDD`` — Catchament nodes using Prim's algorithm.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -56,6 +51,8 @@ calculated minimum spanning tree.
 
 - Returned tree nodes from a root vertex are on Depth First Search order.
 - Depth First Search running time: :math:`O(E + V)`
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -138,7 +135,7 @@ See Also
 * :doc:`spanningTree-family`
 * :doc:`prim-family`
 * :doc:`sampledata`
-* `Boost: Prim's algorithm documentation
+* `Boost: Prim's algorithm
   <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
 * `Wikipedia: Prim's algorithm
   <https://en.wikipedia.org/wiki/Prim%27s_algorithm>`__

--- a/doc/spanningTree/pgr_primDFS.rst
+++ b/doc/spanningTree/pgr_primDFS.rst
@@ -7,24 +7,19 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Prim Family ; pgr_primDFS
    single: Spanning Tree Category ; pgr_primDFS
    single: Depth First Search Category ; pgr_primDFS
    single: primDFS
 
+|
+
 ``pgr_primDFS``
 ===============================================================================
 
 ``pgr_primDFS`` — Prim algorithm for Minimum Spanning Tree with Depth First
 Search ordering.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
@@ -52,6 +47,8 @@ of the Minimum Spanning Tree created using Prims's algorithm.
 
 - Returned tree nodes from a root vertex are on Depth First Search order
 - Depth First Search Running time: :math:`O(E + V)`
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -140,7 +137,7 @@ See Also
 * :doc:`spanningTree-family`
 * :doc:`prim-family`
 * :doc:`sampledata`
-* `Boost: Prim's algorithm documentation
+* `Boost: Prim's algorithm
   <https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html>`__
 * `Wikipedia: Prim's algorithm
   <https://en.wikipedia.org/wiki/Prim%27s_algorithm>`__

--- a/doc/spanningTree/prim-family.rst
+++ b/doc/spanningTree/prim-family.rst
@@ -7,28 +7,23 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Spanning Tree Category ; Prim Family
    single: Prim Family
 
+|
+
 Prim - Family of functions
 ===============================================================================
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_prim`
 * :doc:`pgr_primBFS`
 * :doc:`pgr_primDD`
 * :doc:`pgr_primDFS`
 
-.. index to here
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/prim_minimum_spanning_tree.html
-
-   Boost Graph Inside
+.. official-end
 
 .. toctree::
     :hidden:

--- a/doc/src/experimental.rst
+++ b/doc/src/experimental.rst
@@ -9,11 +9,10 @@
 
 |
 
-
 Experimental Functions
 ===============================================================================
 
-.. begin-warn-expr
+.. warning-begin
 
 .. warning:: Possible server crash
 
@@ -37,63 +36,63 @@ Experimental Functions
     - Might depend on a proposed function of pgRouting
     - Might depend on a deprecated function of pgRouting
 
-.. end-warn-expr
+.. end-warning
 
 .. rubric:: Families
 
 :doc:`flow-family`
 
 .. include:: flow-family.rst
-   :start-after: index experimental from here
-   :end-before: index experimental to here
+   :start-after: experimental-start
+   :end-before: experimental-end
 
 :doc:`chinesePostmanProblem-family`
 
 .. include:: chinesePostmanProblem-family.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`coloring-family`
 
 .. include:: coloring-family.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`transformation-family`
 
 .. include:: transformation-family.rst
-   :start-after: index experimental from here
-   :end-before: index experimental to here
+   :start-after: experimental-start
+   :end-before: experimental-end
 
 :doc:`traversal-family`
 
 .. include:: traversal-family.rst
-   :start-after: index experimental from here
-   :end-before: index experimental to here
+   :start-after: experimental-start
+   :end-before: experimental-end
 
 :doc:`components-family`
 
 .. include:: components-family.rst
-   :start-after: index experimental from here
-   :end-before: index experimental to here
+   :start-after: experimental-start
+   :end-before: experimental-end
 
 :doc:`ordering-family`
 
 .. include:: ordering-family.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`metrics-family`
 
 .. include:: metrics-family.rst
-   :start-after: index experimental from here
-   :end-before: index experimental to here
+   :start-after: experimental-start
+   :end-before: experimental-end
 
 :doc:`TRSP-family`
 
 .. include:: TRSP-family.rst
-   :start-after: index experimental from here
-   :end-before: index experimental to here
+   :start-after: experimental-start
+   :end-before: experimental-end
 
 .. toctree::
    :hidden:
@@ -109,8 +108,8 @@ Experimental Functions
 :doc:`VRP-category`
 
 .. include:: VRP-category.rst
-   :start-after: index experimental from here
-   :end-before: index experimental to here
+   :start-after: experimental-start
+   :end-before: experimental-end
 
 .. toctree::
   :hidden:

--- a/doc/src/migration.rst
+++ b/doc/src/migration.rst
@@ -9,7 +9,6 @@
 
 |
 
-
 Migration guide
 ===============================================================================
 
@@ -30,16 +29,16 @@ Migration of functions
    :local:
 
 
-Migration of ``pgr_aStar``
+Migration of pgr_aStar``
 -------------------------------------------------------------------------------
 
 Starting from `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__
 
 Signatures to be migrated:
 
-* ``pgr_aStar`` (`One to One`)
-* ``pgr_aStar`` (`One to Many`)
-* ``pgr_aStar`` (`Many to One`)
+* pgr_aStar(One to One)
+* pgr_aStar(One to Many)
+* pgr_aStar(Many to One)
 
 :Before Migration:
 
@@ -48,24 +47,24 @@ Signatures to be migrated:
   * Depending on the overload used, the columns ``start_vid`` and ``end_vid``
     might be missing:
 
-    * ``pgr_aStar`` (`One to One`) does not have ``start_vid`` and ``end_vid``.
-    * ``pgr_aStar`` (`One to Many`) does not have ``start_vid``.
-    * ``pgr_aStar`` (`Many to One`) does not have ``end_vid``.
+    * pgr_aStar(One to One) does not have ``start_vid`` and ``end_vid``.
+    * pgr_aStar(One to Many) does not have ``start_vid``.
+    * pgr_aStar(Many to One) does not have ``end_vid``.
 
 :Migration:
 
 * Be aware of the existence of the additional columns.
 
-* In ``pgr_aStar`` (`One to One`)
+* In pgr_aStar(One to One)
 
-  * ``start_vid`` contains the **start vid** parameter value.
-  * ``end_vid`` contains the **end vid** parameter value.
+  * start_vid`` contains the **start vid** parameter value.
+  * end_vid`` contains the **end vid** parameter value.
 
 .. literalinclude:: migration.queries
    :start-after: --astar1
    :end-before: --astar2
 
-* In ``pgr_aStar`` (`One to Many`)
+* In pgr_aStar(One to Many)
 
   * ``start_vid`` contains the **start vid** parameter value.
 
@@ -73,7 +72,7 @@ Signatures to be migrated:
    :start-after: --astar2
    :end-before: --astar3
 
-* In ``pgr_aStar`` (`Many to One`)
+* In pgr_aStar(Many to One)
 
   * ``end_vid`` contains the **end vid** parameter value.
 
@@ -106,9 +105,9 @@ Starting from `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__
 
 Signatures to be migrated:
 
-* ``pgr_bdAstar`` (`One to One`)
-* ``pgr_bdAstar`` (`One to Many`)
-* ``pgr_bdAstar`` (`Many to One`)
+* pgr_bdAstar(One to One)
+* pgr_bdAstar(One to Many)
+* pgr_bdAstar(Many to One)
 
 :Before Migration:
 
@@ -117,15 +116,15 @@ Signatures to be migrated:
   * Depending on the overload used, the columns ``start_vid`` and ``end_vid``
     might be missing:
 
-    * ``pgr_bdAstar`` (`One to One`) does not have ``start_vid`` and ``end_vid``.
-    * ``pgr_bdAstar`` (`One to Many`) does not have ``start_vid``.
-    * ``pgr_bdAstar`` (`Many to One`) does not have ``end_vid``.
+    * pgr_bdAstar(One to One) does not have ``start_vid`` and ``end_vid``.
+    * pgr_bdAstar(One to Many) does not have ``start_vid``.
+    * pgr_bdAstar(Many to One) does not have ``end_vid``.
 
 :Migration:
 
 * Be aware of the existence of the additional columns.
 
-* In ``pgr_bdAstar`` (`One to One`)
+* In pgr_bdAstar(One to One)
 
   * ``start_vid`` contains the **start vid** parameter value.
   * ``end_vid`` contains the **end vid** parameter value.
@@ -134,7 +133,7 @@ Signatures to be migrated:
    :start-after: --bdastar1
    :end-before: --bdastar2
 
-* In ``pgr_bdAstar`` (`One to Many`)
+* In pgr_bdAstar(One to Many)
 
   * ``start_vid`` contains the **start vid** parameter value.
 
@@ -142,7 +141,7 @@ Signatures to be migrated:
    :start-after: --bdastar2
    :end-before: --bdastar3
 
-* In ``pgr_bdAstar`` (`Many to One`)
+* In pgr_bdAstar(Many to One)
 
   * ``end_vid`` contains the **end vid** parameter value.
 
@@ -174,9 +173,9 @@ Starting from `v3.5.0 <https://docs.pgrouting.org/3.5/en/migration.html>`__
 
 Signatures to be migrated:
 
-* ``pgr_dijkstra`` (`One to One`)
-* ``pgr_dijkstra`` (`One to Many`)
-* ``pgr_dijkstra`` (`Many to One`)
+* pgr_dijkstra(One to One)
+* pgr_dijkstra(One to Many)
+* pgr_dijkstra(Many to One)
 
 :Before Migration:
 
@@ -185,16 +184,16 @@ Signatures to be migrated:
   * Depending on the overload used, the columns ``start_vid`` and ``end_vid``
     might be missing:
 
-    * ``pgr_dijkstra`` (`One to One`) does not have ``start_vid`` and
+    * pgr_dijkstra(One to One) does not have ``start_vid`` and
       ``end_vid``.
-    * ``pgr_dijkstra`` (`One to Many`) does not have ``start_vid``.
-    * ``pgr_dijkstra`` (`Many to One`) does not have ``end_vid``.
+    * pgr_dijkstra(One to Many) does not have ``start_vid``.
+    * pgr_dijkstra(Many to One) does not have ``end_vid``.
 
 :Migration:
 
 * Be aware of the existence of the additional columns.
 
-* In ``pgr_dijkstra`` (`One to One`)
+* In pgr_dijkstra(One to One)
 
   * ``start_vid`` contains the **start vid** parameter value.
   * ``end_vid`` contains the **end vid** parameter value.
@@ -203,7 +202,7 @@ Signatures to be migrated:
    :start-after: --dijkstra1
    :end-before: --dijkstra2
 
-* In ``pgr_dijkstra`` (`One to Many`)
+* In pgr_dijkstra(One to Many)
 
   * ``start_vid`` contains the **start vid** parameter value.
 
@@ -211,7 +210,7 @@ Signatures to be migrated:
    :start-after: --dijkstra2
    :end-before: --dijkstra3
 
-* In ``pgr_dijkstra`` (`Many to One`)
+* In pgr_dijkstra(Many to One)
 
   * ``end_vid`` contains the **end vid** parameter value.
 
@@ -244,18 +243,18 @@ Starting from `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__
 
 Signatures to be migrated:
 
-* ``pgr_drivingdistance`` (Single vertex)
-* ``pgr_drivingdistance`` (Multiple vertices)
+* pgr_drivingdistance(Single vertex)
+* pgr_drivingdistance(Multiple vertices)
 
 :Before Migration:
 
 Output columns were |result-dij-dd|
 
-* ``pgr_drivingdistance`` (Single vertex)
+* pgr_drivingdistance(Single vertex)
 
   * Does not have ``start_vid`` and ``depth`` result columns.
 
-* ``pgr_drivingdistance`` (Multiple vertices)
+* pgr_drivingdistance(Multiple vertices)
 
   * Has ``from_v`` instead of ``start_vid`` result column.
   * does not have ``depth`` result column.
@@ -349,7 +348,7 @@ Output columns were |result-bfs|
 Kruskal single vertex
 ...............................................................................
 
-Using ``pgr_KruskalDD`` as example.
+Using pgr_KruskalDD`` as example.
 Migration is similar to al the affected functions.
 
 Comparing with `this
@@ -402,7 +401,7 @@ Starting from `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__
 
 Signatures to be migrated:
 
-* ``pgr_KSP`` (One to One)
+* pgr_KSP(One to One)
 
 :Before Migration:
 
@@ -410,7 +409,7 @@ Signatures to be migrated:
 
   * the columns ``start_vid`` and ``end_vid`` do not exist.
 
-    * ``pgr_KSP`` (One to One) does not have ``start_vid`` and ``end_vid``.
+    * pgr_KSP(One to One) does not have ``start_vid`` and ``end_vid``.
 
 :Migration:
 
@@ -459,7 +458,7 @@ Migration is needed, because:
 * Works for undirected graphs.
 * New signature
 
-  * ``pgr_maxCardinalityMatch(text)`` returns only ``edge`` column.
+  * pgr_maxCardinalityMatch(text)`` returns only ``edge`` column.
   * The optional flag ``directed`` is removed.
 
 :Before migration:
@@ -489,7 +488,7 @@ Migration is needed, because:
    :start-after: --maxcard2
    :end-before: --maxcard3
 
-Migration of ``pgr_primDD`` / ``pgr_primBFS`` / ``pgr_primDFS``
+Migration of pgr_primDD`` / ``pgr_primBFS`` / ``pgr_primDFS``
 -------------------------------------------------------------------------------
 
 Starting from `v3.7.0 <https://docs.pgrouting.org/3.7/en/migration.html>`__
@@ -553,7 +552,7 @@ columns
 Prim multiple vertices
 ...............................................................................
 
-Using ``pgr_primDD`` as example.
+Using pgr_primDD`` as example.
 Migration is similar to al the affected functions.
 
 Comparing with `this
@@ -598,7 +597,7 @@ Signatures to be migrated:
   * Does not have ``start_vid``, ``pred`` and ``depth`` result columns.
   * ``driving_side`` parameter was named optional now it is compulsory unnamed.
 
-* ``pgr_withPointsDD`` (`Multiple vertices`)
+* ``pgr_withPointsDD`` (Multiple vertices)
 
   * Output columns were |result-m-1-no-seq|
   * Does not have ``depth`` and ``pred`` result columns.
@@ -728,7 +727,7 @@ And ``driving side`` parameter changed from named optional to unnamed compulsory
 
 Signatures to be migrated:
 
-* ``pgr_withPointsKSP`` (`One to One`)
+* pgr_withPointsKSP(One to One)
 
 :Before Migration:
 
@@ -749,7 +748,7 @@ Signatures to be migrated:
   * In undirected graph: valid values are [``b``, ``B``]
   * Using an invalid value throws an ``ERROR``.
 
-``pgr_withPointsKSP`` (`One to One`)
+``pgr_withPointsKSP`` (One to One)
 ...............................................................................
 
 Using
@@ -1024,7 +1023,7 @@ function been migrated then:
 * ``id1`` is the node
 * ``id2`` is the edge
 
-Migration of ``pgr_trsp`` (Edges)
+Migration of pgr_trsp(Edges)
 -------------------------------------------------------------------------------
 
 Signature to be migrated:

--- a/doc/src/proposed.rst
+++ b/doc/src/proposed.rst
@@ -13,7 +13,7 @@
 Proposed Functions
 ==================================
 
-.. stable-begin-warning
+.. warning-begin
 
 .. warning:: Proposed functions for next mayor release.
 
@@ -27,27 +27,27 @@ Proposed Functions
     - pgTap tests have being done. But might need more.
     - Documentation might need refinement.
 
-.. stable-end-warning
+.. end-warning
 
 .. rubric:: Families
 
 :doc:`dijkstra-family`
 
 .. include:: dijkstra-family.rst
-   :start-after: index proposed from here
-   :end-before: index proposed to here
+   :start-after: proposed-start
+   :end-before: proposed-end
 
 :doc:`withPoints-family`
 
 .. include:: withPoints-family.rst
-   :start-after: index proposed from here
-   :end-before: index proposed to here
+   :start-after: proposed-start
+   :end-before: proposed-end
 
 :doc:`TRSP-family`
 
 .. include:: TRSP-family.rst
-   :start-after: index proposed from here
-   :end-before: index proposed to here
+   :start-after: proposed-start
+   :end-before: proposed-end
 
 .. toctree::
    :hidden:
@@ -57,26 +57,26 @@ Proposed Functions
 :doc:`topology-functions`
 
 .. include:: topology-functions.rst
-   :start-after: topology_proposed_start
-   :end-before: topology_proposed_end
+   :start-after: proposed-start
+   :end-before: proposed-end
 
 :doc:`transformation-family`
 
 .. include:: transformation-family.rst
-   :start-after: index proposed from here
-   :end-before: index proposed to here
+   :start-after: proposed-start
+   :end-before: proposed-end
 
 :doc:`coloring-family`
 
 .. include:: coloring-family.rst
-   :start-after: index proposed from here
-   :end-before: index proposed to here
+   :start-after: proposed-start
+   :end-before: proposed-end
 
 :doc:`traversal-family`
 
 .. include:: traversal-family.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 .. toctree::
    :hidden:
@@ -89,26 +89,26 @@ Proposed Functions
 :doc:`cost-category`
 
 .. include:: cost-category.rst
-   :start-after: index proposed from here
-   :end-before: index proposed to here
+   :start-after: proposed-start
+   :end-before: proposed-end
 
 :doc:`costMatrix-category`
 
 .. include:: costMatrix-category.rst
-   :start-after: index proposed from here
-   :end-before: index proposed to here
+   :start-after: proposed-start
+   :end-before: proposed-end
 
 :doc:`drivingDistance-category`
 
 .. include:: drivingDistance-category.rst
-   :start-after: index proposed from here
-   :end-before: index proposed to here
+   :start-after: proposed-start
+   :end-before: proposed-end
 
 :doc:`KSP-category`
 
 .. include:: KSP-category.rst
-   :start-after: index proposed from here
-   :end-before: index proposed to here
+   :start-after: proposed-start
+   :end-before: proposed-end
 
 :doc:`via-category`
 

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -228,19 +228,19 @@ milestone for 3.6.0
 
   * Standarizing output columns to |short-generic-result|
 
-    * ``pgr_aStar`` (`One to One`) added ``start_vid`` and ``end_vid`` columns.
-    * ``pgr_aStar`` (`One to Many`) added ``end_vid`` column.
-    * ``pgr_aStar`` (`Many to One`) added ``start_vid`` column.
+    * pgr_aStar(One to One) added ``start_vid`` and ``end_vid`` columns.
+    * pgr_aStar(One to Many) added ``end_vid`` column.
+    * pgr_aStar(Many to One) added ``start_vid`` column.
 
 * `#2523 <https://github.com/pgRouting/pgrouting/pull/2523>`__ Standarize output
   pgr_bdAstar
 
   * Standarizing output columns to |short-generic-result|
 
-    * ``pgr_bdAstar`` (`One to One`) added ``start_vid`` and ``end_vid``
+    * pgr_bdAstar(One to One) added ``start_vid`` and ``end_vid``
       columns.
-    * ``pgr_bdAstar`` (`One to Many`) added ``end_vid`` column.
-    * ``pgr_bdAstar`` (`Many to One`) added ``start_vid`` column.
+    * pgr_bdAstar(One to Many) added ``end_vid`` column.
+    * pgr_bdAstar(Many to One) added ``start_vid`` column.
 
 * `#2547 <https://github.com/pgRouting/pgrouting/pull/2547>`__ Standarize output
   and modifying signature pgr_KSP
@@ -362,9 +362,9 @@ milestone for 3.5.0
 
   * Standarizing output columns to |short-generic-result|
 
-    * ``pgr_dijkstra`` (`One to One`) added ``start_vid`` and ``end_vid`` columns.
-    * ``pgr_dijkstra`` (`One to Many`) added ``end_vid`` column.
-    * ``pgr_dijkstra`` (`Many to One`) added ``start_vid`` column.
+    * pgr_dijkstra(One to One) added ``start_vid`` and ``end_vid`` columns.
+    * pgr_dijkstra(One to Many) added ``end_vid`` column.
+    * pgr_dijkstra(Many to One) added ``start_vid`` column.
 
 pgRouting 3.4
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -413,59 +413,59 @@ milestone for 3.4.0
 * `#1891 <https://github.com/pgRouting/pgrouting/issues/1891>`__:
   pgr_ksp doesn't give all correct shortest path
 
-.. rubric:: New proposed functions
+.. rubric:: New proposed functions.
 
 * With points
 
-  * ``pgr_withPointsVia`` (One Via)
+  * pgr_withPointsVia(One Via)
 
 * Turn Restrictions
 
   * Via with turn restrictions
 
-    * ``pgr_trspVia`` (One Via)
-    * ``pgr_trspVia_withPoints`` (One Via)
+    * pgr_trspVia(One Via)
+    * pgr_trspVia_withPoints(One Via)
 
-  * ``pgr_trsp``
+  * pgr_trsp
 
-    * ``pgr_trsp`` (One to One)
-    * ``pgr_trsp`` (One to Many)
-    * ``pgr_trsp`` (Many to One)
-    * ``pgr_trsp`` (Many to Many)
-    * ``pgr_trsp`` (Combinations)
+    * pgr_trsp(One to One)
+    * pgr_trsp(One to Many)
+    * pgr_trsp(Many to One)
+    * pgr_trsp(Many to Many)
+    * pgr_trsp(Combinations)
 
   * ``pgr_trsp_withPoints``
 
-    * ``pgr_trsp_withPoints`` (One to One)
-    * ``pgr_trsp_withPoints`` (One to Many)
-    * ``pgr_trsp_withPoints`` (Many to One)
-    * ``pgr_trsp_withPoints`` (Many to Many)
-    * ``pgr_trsp_withPoints`` (Combinations)
+    * pgr_trsp_withPoints(One to One)
+    * pgr_trsp_withPoints(One to Many)
+    * pgr_trsp_withPoints(Many to One)
+    * pgr_trsp_withPoints(Many to Many)
+    * pgr_trsp_withPoints(Combinations)
 
 * Topology
 
-  * ``pgr_degree``
+  * pgr_degree
 
 * Utilities
 
-  * ``pgr_findCloseEdges`` (One point)
-  * ``pgr_findCloseEdges`` (Many points)
+  * pgr_findCloseEdges(One point)
+  * pgr_findCloseEdges(Many points)
 
 .. rubric:: New experimental functions
 
 * Ordering
 
-  * ``pgr_cuthillMckeeOrdering``
+  * pgr_cuthillMckeeOrdering
 
 * Unclassified
 
-  * ``pgr_hawickCircuits``
+  * pgr_hawickCircuits
 
 .. rubric:: Official functions changes
 
 * Flow functions
 
-  * ``pgr_maxCardinalityMatch(text)``
+  * pgr_maxCardinalityMatch(text)``
 
     * Deprecating ``pgr_maxCardinalityMatch(text,boolean)``
 
@@ -473,10 +473,10 @@ milestone for 3.4.0
 
 * Turn Restrictions
 
-  * ``pgr_trsp(text,integer,integer,boolean,boolean,text)``
-  * ``pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)``
-  * ``pgr_trspViaVertices(text,anyarray,boolean,boolean,text)``
-  * ``pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)``
+  * pgr_trsp(text,integer,integer,boolean,boolean,text)
+  * pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)
+  * pgr_trspViaVertices(text,anyarray,boolean,boolean,text)
+  * pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)
 
 pgRouting 3.3
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -519,7 +519,7 @@ milestone for 3.3.3
 
 * Flow functions
 
-  * ``pgr_maxCardinalityMatch(text,boolean)``
+  * pgr_maxCardinalityMatch(text,boolean)
 
     * Ignoring optional boolean parameter, as the algorithm works only for
       undirected graphs.
@@ -715,7 +715,7 @@ on Github.
 
 * pgr_sequentialVertexColoring
 
-.. rubric:: New proposed functions
+.. rubric:: New proposed functions.
 
 * Astar
 
@@ -835,7 +835,7 @@ milestone for 3.1.0
 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.1.0%22>`_
 on Github.
 
-.. rubric:: New proposed functions
+.. rubric:: New proposed functions.
 
 * pgr_dijkstra(combinations)
 * pgr_dijkstraCost(combinations)

--- a/doc/src/routingFunctions.rst
+++ b/doc/src/routingFunctions.rst
@@ -7,8 +7,6 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 
 *******************************************************************************
 Function Families
@@ -21,81 +19,81 @@ Function Families
 :doc:`allpairs-family`
 
 .. include:: allpairs-family.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`aStar-family`
 
 .. include:: aStar-family.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 
 :doc:`bdAstar-family`
 
 .. include:: bdAstar-family.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`bdDijkstra-family`
 
 .. include:: bdDijkstra-family.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`components-family`
 
 .. include:: components-family.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`contraction-family`
 
 .. include:: contraction-family.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`dijkstra-family`
 
 .. include:: dijkstra-family.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`flow-family`
 
 .. include:: flow-family.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`kruskal-family`
 
 .. include:: kruskal-family.rst
-      :start-after: index from here
-      :end-before: index to here
+      :start-after: official-start
+      :end-before: official-end
 
 :doc:`prim-family`
 
 .. include:: prim-family.rst
-      :start-after: index from here
-      :end-before: index to here
+      :start-after: official-start
+      :end-before: official-end
 
 :doc:`reference`
 
 .. include:: reference.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`topology-functions`
 
 .. include:: topology-functions.rst
-   :start-after: topology_index_start
-   :end-before: topology_index_end
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`TSP-family`
 
 .. include:: TSP-family.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`pgr_trsp` - Turn Restriction Shortest Path (TRSP)
 
@@ -106,45 +104,45 @@ Functions by categories
 :doc:`cost-category`
 
 .. include:: cost-category.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`costMatrix-category`
 
 .. include:: costMatrix-category.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 
 :doc:`drivingDistance-category`
 
 .. include:: drivingDistance-category.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`KSP-category`
 
 .. include:: KSP-category.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`spanningTree-family`
 
 .. include:: spanningTree-family.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`BFS-category`
 
 .. include:: BFS-category.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 :doc:`DFS-category`
 
 .. include:: DFS-category.rst
-   :start-after: index from here
-   :end-before: index to here
+   :start-after: official-start
+   :end-before: official-end
 
 .. to-here
 

--- a/doc/topology/pgr_analyzeGraph.rst
+++ b/doc/topology/pgr_analyzeGraph.rst
@@ -7,13 +7,13 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Topology Family ; pgr_analyzeGraph
    single: analyzeGraph
 
-pgr_analyzeGraph
+|
+
+``pgr_analyzeGraph``
 ===============================================================================
 
 ``pgr_analyzeGraph`` — Analyzes the network topology.
@@ -278,12 +278,10 @@ Additional Examples
    :start-after: -- q28
    :end-before: -- q28.1
 
-The examples use the :doc:`sampledata` network.
-
-
 See Also
 -------------------------------------------------------------------------------
 
+* :doc:`sampledata`
 * :doc:`topology-functions`
 * :doc:`pgr_analyzeOneWay`
 * :doc:`pgr_createVerticesTable`

--- a/doc/topology/pgr_analyzeOneWay.rst
+++ b/doc/topology/pgr_analyzeOneWay.rst
@@ -7,13 +7,13 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Topology Family ; pgr_analyzeOneWay
    single: analyzeOneWay
 
-pgr_analyzeOneWay
+|
+
+``pgr_analyzeOneWay``
 ===============================================================================
 
 ``pgr_analyzeOneWay`` — Analyzes oneway Sstreets and identifies flipped segments.
@@ -59,6 +59,8 @@ table <edge_table>_vertices_pgr that stores the vertices information.
 
 - Use :doc:`pgr_createVerticesTable` to create the vertices table.
 - Use :doc:`pgr_createTopology` to create the topology and the vertices table.
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------

--- a/doc/topology/pgr_createTopology.rst
+++ b/doc/topology/pgr_createTopology.rst
@@ -7,13 +7,13 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Topology Family ; pgr_createTopology
    single: createTopology
 
-pgr_createTopology
+|
+
+``pgr_createTopology``
 ===============================================================================
 
 ``pgr_createTopology`` — Builds a network topology based on the geometry
@@ -34,6 +34,8 @@ The function returns:
 - ``OK`` after the network topology has been built and the vertices table
   created.
 - ``FAIL`` when the network topology was not built due to an error.
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -271,11 +273,10 @@ the rest of the edges.
    :start-after: --q17
    :end-before: --q17.1
 
-The example uses the :doc:`sampledata` network.
-
 See Also
 -------------------------------------------------------------------------------
 
+* :doc:`sampledata`
 * :doc:`topology-functions`
 * :doc:`pgr_createVerticesTable`
 * :doc:`pgr_analyzeGraph`

--- a/doc/topology/pgr_createVerticesTable.rst
+++ b/doc/topology/pgr_createVerticesTable.rst
@@ -7,13 +7,13 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Topology Family ; pgr_createVerticesTable
    single: createVerticesTable
 
-pgr_createVerticesTable
+|
+
+``pgr_createVerticesTable``
 ===============================================================================
 
 ``pgr_createVerticesTable`` — Reconstructs the vertices table based on the
@@ -33,6 +33,8 @@ The function returns:
 
 - ``OK`` after the vertices table has been reconstructed.
 - ``FAIL`` when the vertices table was not reconstructed due to an error.
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -274,11 +276,10 @@ values for the column names do not match the column names of the table.
    :start-after: --q17
    :end-before: --q17.1
 
-The example uses the :doc:`sampledata` network.
-
 See Also
 -------------------------------------------------------------------------------
 
+* :doc:`sampledata`
 * :doc:`topology-functions` for an overview of a topology for routing
   algorithms.
 * :doc:`pgr_createTopology` <pgr_create_topology>` to create a topology based on

--- a/doc/topology/pgr_degree.rst
+++ b/doc/topology/pgr_degree.rst
@@ -7,11 +7,11 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: Topology Family ; pgr_degree
-   single: degree
+   single: Topology Family ; pgr_degree - Proposed
+   single: degree - Proposed on v3.4
+
+|
 
 ``pgr_degree`` -- Proposed
 ===============================================================================
@@ -20,14 +20,14 @@
 
 
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.4.0
 
-  * New **proposed** function
+  * New proposed function.
 
 
 Description
@@ -36,11 +36,10 @@ Description
 Calculates the degree of the vertices of an **undirected** graph
 
 
+|Boost| Boost Graph Inside
+
 Signatures
 -------------------------------------------------------------------------------
-
-.. index::
-    single: pgr_degree - Proposed on v3.4
 
 .. admonition:: \ \
    :class: signatures

--- a/doc/topology/pgr_extractVertices.rst
+++ b/doc/topology/pgr_extractVertices.rst
@@ -7,21 +7,21 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Topology Family ; pgr_extractVertices
    single: extractVertices - Proposed on v3.3
 
-pgr_extractVertices -- Proposed
+|
+
+``pgr_extractVertices`` -- Proposed
 ===============================================================================
 
 ``pgr_extractVertices`` — Extracts the vertices information
 
 
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
@@ -31,7 +31,7 @@ pgr_extractVertices -- Proposed
 
 * Version 3.0.0
 
-  * New **experimental** function
+  * New experimental function.
 
 
 Description
@@ -43,6 +43,8 @@ of edges of a graph.
 * When the edge identifier is given, then it will also calculate the in and out
   edges
 
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------

--- a/doc/topology/pgr_nodeNetwork.rst
+++ b/doc/topology/pgr_nodeNetwork.rst
@@ -7,13 +7,13 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Topology Family ; pgr_nodeNetwork
    single: nodeNetwork
 
-pgr_nodeNetwork
+|
+
+``pgr_nodeNetwork``
 ===============================================================================
 
 ``pgr_nodeNetwork`` - Nodes an network edge table.

--- a/doc/topology/topology-functions.rst
+++ b/doc/topology/topology-functions.rst
@@ -7,9 +7,9 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: Topology Family
+
+|
 
 Topology - Family of Functions
 ===============================================================================
@@ -22,19 +22,7 @@ undirected, if an edge is one way on a directed graph, and depending on the
 final application needs, suitable topology(s) need to be
 created.
 
-pgRouting suplies some functions to create a routing topology and to analyze the
-topology.
-
-Additional functions to create a graph:
-
-* :doc:`contraction-family`
-
-Additional functions to analyze a graph:
-
-* :doc:`components-family`
-
-
-.. topology_index_start
+.. official-start
 
 The following functions modify the database directly therefore the user must
 have special permissions given by the administrators to use them.
@@ -47,17 +35,27 @@ have special permissions given by the administrators to use them.
 - :doc:`pgr_analyzeOneWay` - to analyze directionality of the edges.
 - :doc:`pgr_nodeNetwork` - to create nodes to a not noded edge table.
 
-.. topology_index_end
+.. official-end
 
+pgRouting supplies some functions to create a routing topology and to analyze the
+topology.
+
+Additional functions to create a graph:
+
+* :doc:`contraction-family`
+
+Additional functions to analyze a graph:
+
+* :doc:`components-family`
 
 
 .. rubric:: Proposed
 
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
+   :start-after: warning-begin
+   :end-before: end-warning
 
-.. topology_proposed_start
+.. proposed-start
 
 These proposed functions do not modify the database.
 
@@ -65,7 +63,7 @@ These proposed functions do not modify the database.
 - :doc:`pgr_extractVertices` - Extracts vertex information based on the edge
   table information.
 
-.. topology_proposed_end
+.. proposed-end
 
 .. toctree::
   :hidden:

--- a/doc/transitiveClosure/pgr_transitiveClosure.rst
+++ b/doc/transitiveClosure/pgr_transitiveClosure.rst
@@ -7,31 +7,26 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Miscellaneous Algorithms ; pgr_transitiveClosure
    single: transitiveClosure - Experimental on v3.0
+
+|
 
 ``pgr_transitiveClosure`` - Experimental
 ===============================================================================
 
 ``pgr_transitiveClosure`` — Transitive closure graph of a directed graph.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/transitive_closure.html
-
-   Boost Graph Inside
-
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.0.0
 
-  * New **experimental** function
+  * New experimental function.
 
 
 Description
@@ -52,6 +47,7 @@ The main characteristics are:
 * The returned graph is compresed
 * Running time: :math:`O(|V||E|)`
 
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -119,6 +115,7 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`sampledata`
+* `Boost: transitive closure <https://www.boost.org/libs/graph/doc/transitive_closure.html>`__
 * https://en.wikipedia.org/wiki/Transitive_closure
 
 .. rubric:: Indices and tables

--- a/doc/traversal/pgr_binaryBreadthFirstSearch.rst
+++ b/doc/traversal/pgr_binaryBreadthFirstSearch.rst
@@ -7,12 +7,12 @@
     Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: Traversal Family ; pgr_binaryBreadthFirstSearch
-   single: Breadth First Search Category ; pgr_binaryBreadthFirstSearch
-   single: binaryBreadthFirstSearch
+   single: Traversal Family ; pgr_binaryBreadthFirstSearch - Experimental
+   single: Breadth First Search Category ; pgr_binaryBreadthFirstSearch - Experimental
+   single: binaryBreadthFirstSearch - Experimental
+
+|
 
 ``pgr_binaryBreadthFirstSearch`` - Experimental
 ===============================================================================
@@ -23,31 +23,21 @@ graph.
 Any graph whose edge-weights belongs to the set {0,X}, where 'X' is any
 non-negative integer, is termed as a 'binary graph'.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/breadth_first_search.html
-
-   Boost Graph Inside
-
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.2.0
 
-  * New **experimental** signature:
+  * New experimental signature:
 
-    * pgr_binaryBreadthFirstSearch(`Combinations`_)
+    * pgr_binaryBreadthFirstSearch(Combinations)
 
 * Version 3.0.0
 
-  * New **experimental** signatures:
-
-    * pgr_binaryBreadthFirstSearch(`One to One`_)
-    * pgr_binaryBreadthFirstSearch(`One to Many`_)
-    * pgr_binaryBreadthFirstSearch(`Many to One`_)
-    * pgr_binaryBreadthFirstSearch(`Many to Many`_)
+  * New experimental function.
 
 Description
 -------------------------------------------------------------------------------
@@ -81,6 +71,8 @@ edge belongs to the set {0,X}, where 'X' is any non-negative real integer.
 
 * Running time: :math:`O(| start\_vids | * |E|)`
 
+|Boost| Boost Graph Inside
+
 Signatures
 -------------------------------------------------------------------------------
 
@@ -102,7 +94,7 @@ Signatures
 :math:`1``)
 
 .. index::
-    single: binaryBreadthFirstSearch ; One to One - Experimental on v3.0
+    single: binaryBreadthFirstSearch - Experimental ; One to One - Experimental on v3.0
 
 One to One
 ...............................................................................
@@ -122,7 +114,7 @@ One to One
    :end-before: -- q2
 
 .. index::
-    single: binaryBreadthFirstSearch ; One to Many - Experimental on v3.0
+    single: binaryBreadthFirstSearch - Experimental ; One to Many - Experimental on v3.0
 
 One to Many
 ...............................................................................
@@ -143,7 +135,7 @@ One to Many
    :end-before: -- q3
 
 .. index::
-    single: binaryBreadthFirstSearch ; Many to One - Experimental on v3.0
+    single: binaryBreadthFirstSearch - Experimental ; Many to One - Experimental on v3.0
 
 Many to One
 ...............................................................................
@@ -164,7 +156,7 @@ Many to One
    :end-before: -- q4
 
 .. index::
-    single: binaryBreadthFirstSearch ; Many to Many - Experimental on v3.0
+    single: binaryBreadthFirstSearch - Experimental ; Many to Many - Experimental on v3.0
 
 Many to Many
 ...............................................................................
@@ -185,7 +177,7 @@ Many to Many
    :end-before: -- q5
 
 .. index::
-    single: binaryBreadthFirstSearch ; Combinations - Experimental on v3.2
+    single: binaryBreadthFirstSearch - Experimental ; Combinations - Experimental on v3.2
 
 Combinations
 ...............................................................................
@@ -263,6 +255,8 @@ Additional Examples
 See Also
 -------------------------------------------------------------------------------
 * :doc:`sampledata`
+* `Boost: Breadth First Search
+  <https://www.boost.org/libs/graph/doc/breadth_first_search.html>`__
 * https://cp-algorithms.com/graph/01_bfs.html
 * https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm#Specialized_variants
 

--- a/doc/traversal/pgr_breadthFirstSearch.rst
+++ b/doc/traversal/pgr_breadthFirstSearch.rst
@@ -7,12 +7,12 @@
     Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: Traversal Family ; pgr_breadthFirstSearch
-   single: Breadth First Search Category ; pgr_breadthFirstSearch
-   single: breadthFirstSearch
+   single: Traversal Family ; pgr_breadthFirstSearch - Experimental
+   single: Breadth First Search Category ; pgr_breadthFirstSearch - Experimental
+   single: breadthFirstSearch - Experimental
+
+|
 
 ``pgr_breadthFirstSearch`` - Experimental
 ===============================================================================
@@ -20,23 +20,15 @@
 ``pgr_breadthFirstSearch`` — Returns the traversal order(s) using Breadth First
 Search algorithm.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/breadth_first_search.html
-
-   Boost Graph Inside
-
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.0.0
 
-  * New **experimental** signature:
-
-    * ``pgr_breadthFirstSearch`` (`Single Vertex`_)
-    * ``pgr_breadthFirstSearch`` (`Multiple Vertices`_)
+  * New experimental function.
 
 Description
 -------------------------------------------------------------------------------
@@ -51,6 +43,8 @@ particular depth.
   target depth level.
 * Running time: :math:`O(E + V)`
 
+|Boost| Boost Graph Inside
+
 Signatures
 -------------------------------------------------------------------------------
 
@@ -61,12 +55,12 @@ Signatures
 
    | pgr_breadthFirstSearch(`Edges SQL`_, **root vid**, [**options**])
    | pgr_breadthFirstSearch(`Edges SQL`_, **root vids**, [**options**])
-   | **options:** ``[max_depth, directed]``
+   | **options:** [max_depth, directed]``
 
    | Returns set of |result-bfs|
 
 .. index::
-    single: breadthFirstSearch ; Single vertex - Experimental on v3.0
+    single: breadthFirstSearch - Experimental ; Single vertex - Experimental on v3.0
 
 Single vertex
 ...............................................................................
@@ -75,7 +69,7 @@ Single vertex
    :class: signatures
 
    | pgr_breadthFirstSearch(`Edges SQL`_, **root vid**, [**options**])
-   | **options:** ``[max_depth, directed]``
+   | **options:** [max_depth, directed]``
 
    | Returns set of |result-bfs|
 
@@ -87,7 +81,7 @@ Single vertex
    :end-before: -- q2
 
 .. index::
-    single: breadthFirstSearch ; Multiple vertices - Experimental on v3.0
+    single: breadthFirstSearch - Experimental ; Multiple vertices - Experimental on v3.0
 
 Multiple vertices
 ...............................................................................
@@ -96,7 +90,7 @@ Multiple vertices
    :class: signatures
 
    | pgr_breadthFirstSearch(`Edges SQL`_, **root vids**, [**options**])
-   | **options:** ``[max_depth, directed]``
+   | **options:** [max_depth, directed]``
 
    | Returns set of |result-bfs|
 
@@ -178,7 +172,7 @@ See Also
 
 * :doc:`BFS-category`
 * :doc:`sampledata`
-* `Boost: Breadth First Search algorithm documentation
+* `Boost: Breadth First Search
   <https://www.boost.org/libs/graph/doc/breadth_first_search.html>`__
 * `Wikipedia: Breadth First Search algorithm
   <https://en.wikipedia.org/wiki/Breadth-first_search>`__

--- a/doc/traversal/pgr_depthFirstSearch.rst
+++ b/doc/traversal/pgr_depthFirstSearch.rst
@@ -7,12 +7,12 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: Traversal Family ; pgr_depthFirstSearch
-   single: Depth First Search Category ; pgr_depthFirstSearch
-   single: depthFirstSearch
+   single: Traversal Family ; pgr_depthFirstSearch - Proposed
+   single: Depth First Search Category ; pgr_depthFirstSearch - Proposed
+   single: depthFirstSearch - Proposed
+
+|
 
 ``pgr_depthFirstSearch`` - Proposed
 ===============================================================================
@@ -20,27 +20,19 @@
 ``pgr_depthFirstSearch`` — Returns a depth first search traversal of the graph.
 The graph can be directed or undirected.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/depth_first_search.html
-
-   Boost Graph Inside
-
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.3.0
 
-  * Promoted to **proposed** function
+  * Function promoted to proposed.
 
 * Version 3.2.0
 
-  * New **experimental** signatures:
-
-    * ``pgr_depthFirstSearch`` (`Single Vertex`_)
-    * ``pgr_depthFirstSearch`` (`Multiple Vertices`_)
+  * New experimental function.
 
 Description
 -------------------------------------------------------------------------------
@@ -64,6 +56,8 @@ continues until all the vertices reachable from the root vertex are visited.
 - The returned values are ordered in ascending order of `start_vid`.
 - Depth First Search Running time: :math:`O(E + V)`
 
+|Boost| Boost Graph Inside
+
 Signatures
 -------------------------------------------------------------------------------
 
@@ -79,7 +73,7 @@ Signatures
    | Returns set of |result-bfs|
 
 .. index::
-    single: depthFirstSearch ; Single vertex - Proposed on v3.3
+    single: depthFirstSearch - Proposed ; Single vertex - Proposed on v3.3
 
 Single vertex
 ...............................................................................
@@ -100,7 +94,7 @@ Single vertex
    :end-before: -- q2
 
 .. index::
-    single: depthFirstSearch ; Multiple vertices - Proposed on v3.3
+    single: depthFirstSearch - Proposed ; Multiple vertices - Proposed on v3.3
 
 Multiple vertices
 ...............................................................................
@@ -187,9 +181,9 @@ See Also
 
 * :doc:`DFS-category`
 * :doc:`sampledata`
-* `Boost: Depth First Search algorithm documentation
+* `Boost: Depth First Search
   <https://www.boost.org/libs/graph/doc/depth_first_search.html>`__
-* `Boost: Undirected DFS algorithm documentation
+* `Boost: Undirected DFS
   <https://www.boost.org/libs/graph/doc/undirected_dfs.html>`__
 * `Wikipedia: Depth First Search algorithm
   <https://en.wikipedia.org/wiki/Depth-first_search>`__

--- a/doc/traversal/traversal-family.rst
+++ b/doc/traversal/traversal-family.rst
@@ -7,9 +7,9 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: Traversal Family
+
+|
 
 Traversal - Family of functions
 ===============================================================================
@@ -17,28 +17,28 @@ Traversal - Family of functions
 .. rubric:: Proposed
 
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
+   :start-after: warning-begin
+   :end-before: end-warning
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_depthFirstSearch` - Depth first search traversal of the graph.
 
-.. index to here
+.. official-end
 
 .. rubric:: Experimental
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
-.. index experimental from here
+.. experimental-start
 
 * :doc:`pgr_breadthFirstSearch` - Breath first search traversal of the graph.
 * :doc:`pgr_binaryBreadthFirstSearch` - Breath first search traversal of the
   graph.
 
-.. index experimental to here
+.. experimental-end
 
 Aditionaly there are 2 categories under this family
 

--- a/doc/trsp/TRSP-family.rst
+++ b/doc/trsp/TRSP-family.rst
@@ -7,9 +7,9 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: Turn Restriction Shortest Path Family
+
+|
 
 TRSP - Family of functions
 ===============================================================================
@@ -19,17 +19,17 @@ When points are also given as input:
 .. rubric:: Proposed
 
 .. include:: proposed.rst
-   :start-after: begin-warning
+   :start-after: warning-begin
    :end-before: end-warning
 
-.. index proposed from here
+.. proposed-start
 
 - :doc:`pgr_trsp` - Vertex - Vertex routing with restrictions.
 - :doc:`pgr_trspVia` - Via Vertices routing with restrictions.
 - :doc:`pgr_trsp_withPoints` - Vertex/Point routing with restrictions.
 - :doc:`pgr_trspVia_withPoints` - Via Vertex/point routing with restrictions.
 
-.. index proposed to here
+.. proposed-end
 
 .. Warning:: Read the :doc:`migration` about how to migrate from the
    deprecated TRSP functionality to the new signatures or replacement functions.
@@ -37,14 +37,14 @@ When points are also given as input:
 .. rubric:: Experimental
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
-.. index experimental from here
+.. experimental-start
 
 - :doc:`pgr_turnRestrictedPath` - Routing with restrictions.
 
-.. index experimental to here
+.. experimental-end
 
 .. toctree::
     :hidden:

--- a/doc/trsp/pgr_trsp.rst
+++ b/doc/trsp/pgr_trsp.rst
@@ -7,26 +7,21 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Turn Restriction Shortest Path Family ; pgr_trsp
    single: Shortest Path Category ; pgr_trsp
    single: Restrictions Category ; pgr_trsp
    single: trsp
 
-pgr_trsp - Proposed
+|
+
+``pgr_trsp`` - Proposed
 ===============================================================================
 
 ``pgr_trsp`` - routing vertices with restrictions.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
-
 .. include:: proposed.rst
-   :start-after: begin-warning
+   :start-after: warning-begin
    :end-before: end-warning
 
 .. rubric:: Availability
@@ -35,25 +30,25 @@ pgr_trsp - Proposed
 
   * New proposed signatures
 
-    * ``pgr_trsp`` (`One to One`_)
-    * ``pgr_trsp`` (`One to Many`_)
-    * ``pgr_trsp`` (`Many to One`_)
-    * ``pgr_trsp`` (`Many to Many`_)
-    * ``pgr_trsp`` (`Combinations`_)
+    * pgr_trsp(One to One)
+    * pgr_trsp(One to Many)
+    * pgr_trsp(Many to One)
+    * pgr_trsp(Many to Many)
+    * pgr_trsp(Combinations)
 
   * Deprecated signatures
 
-    * ``pgr_trsp(text,integer,integer,boolean,boolean,text)``
-    * ``pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)``
-    * ``pgr_trspViaVertices(text,anyarray,boolean,boolean,text)``
-    * ``pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)``
+    * pgr_trsp(text,integer,integer,boolean,boolean,text)``
+    * pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)``
+    * pgr_trspViaVertices(text,anyarray,boolean,boolean,text)``
+    * pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)``
 
 * Version 2.1.0
 
   * New prototypes
 
-    * ``pgr_trspViaVertices``
-    * ``pgr_trspViaEdges``
+    * pgr_trspViaVertices``
+    * pgr_trspViaEdges``
 
 * Version 2.0.0
 
@@ -76,6 +71,8 @@ The general algorithm is as follows:
 * If the solution passes thru a restriction then.
 
   * Execute the **TRSP** algorithm with restrictions.
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------

--- a/doc/trsp/pgr_trspVia.rst
+++ b/doc/trsp/pgr_trspVia.rst
@@ -7,35 +7,30 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Turn Restriction Shortest Path Family ; pgr_trspVia
    single: Via Category ; pgr_trspVia
    single: Restrictions Category ; pgr_trspVia
    single: trspVia
 
+|
+
 ``pgr_trspVia`` - Proposed
 ===============================================================================
 
 ``pgr_trspVia`` Route that goes through a list of vertices with restrictions.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
-
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.4.0
 
-  * New proposed function:
+  * New proposed function.
 
-    * ``pgr_trspVia`` (`One Via`_)
+    * pgr_trspVia(One Via)
 
 Description
 -------------------------------------------------------------------------------
@@ -54,6 +49,7 @@ The general algorithm is as follows:
   * Execute the **TRSP** algorithm with restrictions for the paths.
   * **NOTE** when this is done, ``U_turn_on_edge`` flag is ignored.
 
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -236,7 +232,7 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`via-category`
-* :doc:`sampledata` network.
+* :doc:`sampledata`
 
 .. rubric:: Indices and tables
 

--- a/doc/trsp/pgr_trspVia_withPoints.rst
+++ b/doc/trsp/pgr_trspVia_withPoints.rst
@@ -7,8 +7,6 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Turn Restriction Shortest Path Family ; pgr_trspVia_withPoints
    single: Via Category ; pgr_trspVia_withPoints
@@ -16,28 +14,23 @@
    single: With Points Category ; pgr_trspVia_withPoints
    single: trspVia_withPoints
 
+|
+
 ``pgr_trspVia_withPoints`` - Proposed
 ===============================================================================
 
 ``pgr_trspVia_withPoints`` - Route that goes through a list of vertices and/or
 points with restrictions.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
-
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.4.0
 
-  * New proposed function:
-
-    ``pgr_trspVia_withPoints`` (`One Via`_)
+  * New proposed function.
 
 Description
 -------------------------------------------------------------------------------
@@ -65,6 +58,8 @@ The general algorithm is as follows:
   * **NOTE** when this is done, ``U_turn_on_edge`` flag is ignored.
 
 .. Note:: Do not use negative values on identifiers of the inner queries.
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -287,7 +282,7 @@ See Also
 * :doc:`TRSP-family`
 * :doc:`via-category`
 * :doc:`withPoints-category`
-* :doc:`sampledata` network.
+* :doc:`sampledata`
 
 .. rubric:: Indices and tables
 

--- a/doc/trsp/pgr_trsp_withPoints.rst
+++ b/doc/trsp/pgr_trsp_withPoints.rst
@@ -7,8 +7,6 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Turn Restriction Shortest Path Family ; pgr_trsp_withPoints
    single: Shortest Path Category ; pgr_trsp_withPoints
@@ -16,31 +14,22 @@
    single: With Points Category ; pgr_trsp_withPoints
    single: trsp_withPoints
 
-pgr_trsp_withPoints - Proposed
+|
+
+``pgr_trsp_withPoints`` - Proposed
 ===============================================================================
 
 ``pgr_trsp_withPoints`` Routing Vertex/Point with restrictions.
 
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
-
 .. include:: proposed.rst
-   :start-after: begin-warning
+   :start-after: warning-begin
    :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.4.0
 
-  * New proposed signatures:
-
-    * ``pgr_trsp_withPoints`` (`One to One`_)
-    * ``pgr_trsp_withPoints`` (`One to Many`_)
-    * ``pgr_trsp_withPoints`` (`Many to One`_)
-    * ``pgr_trsp_withPoints`` (`Many to Many`_)
-    * ``pgr_trsp_withPoints`` (`Combinations`_)
+  * New proposed function.
 
 Description
 -------------------------------------------------------------------------------
@@ -74,6 +63,8 @@ Characteristics:
   - end_vid ascending
 
 * Running time: :math:`O(|start\_vids|\times(V \log V + E))`
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------

--- a/doc/trsp/pgr_turnRestrictedPath.rst
+++ b/doc/trsp/pgr_turnRestrictedPath.rst
@@ -7,36 +7,37 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Turn Restriction Shortest Path Family ; pgr_turnRestrictedPath
    single: Shortest Path Category ; pgr_turnRestrictedPath
    single: Restrictions Category ; pgr_turnRestrictedPath
    single: turnRestrictedPath
 
+|
 
-pgr_turnRestrictedPath - Experimental
+``pgr_turnRestrictedPath`` - Experimental
 ===============================================================================
 
 ``pgr_turnRestrictedPath`` Using Yen's algorithm Vertex - Vertex routing with
 restrictions
 
 .. include:: experimental.rst
-   :start-after: begin-warn-expr
-   :end-before: end-warn-expr
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.0.0
 
-  * New experimental function
+  * New experimental function.
 
 Description
 -------------------------------------------------------------------------------
 
 Using Yen's algorithm to obtain K shortest paths and analyze the paths to select
 the paths that do not use the restrictions
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------

--- a/doc/tsp/TSP-family.rst
+++ b/doc/tsp/TSP-family.rst
@@ -7,19 +7,19 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: Traveling Sales Person Family
+
+|
 
 Traveling Sales Person - Family of functions
 ===============================================================================
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_TSP` - When input is given as matrix cell information.
 * :doc:`pgr_TSPeuclidean` - When input are coordinates.
 
-.. index to here
+.. official-end
 
 .. toctree::
     :hidden:
@@ -139,7 +139,7 @@ See Also
 
 .. rubric:: References
 
-* `Boost's metric appro's metric approximation
+* `Boost: metric TSP approx
   <https://www.boost.org/libs/graph/doc/metric_tsp_approx.html>`__
 * `University of Waterloo TSP <https://www.math.uwaterloo.ca/tsp/>`__
 * `Wikipedia: Traveling Salesman Problem

--- a/doc/tsp/pgr_TSP.rst
+++ b/doc/tsp/pgr_TSP.rst
@@ -7,22 +7,16 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Traveling Sales Person Family ; pgr_TSP
    single: pgr_TSP
 
+|
+
 ``pgr_TSP``
 ===============================================================================
 
-* ``pgr_TSP`` - Aproximation using *metric* algorithm.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/metric_tsp_approx.html
-
-   Boost Graph Inside
-
+* pgr_TSP`` - Aproximation using *metric* algorithm.
 
 .. rubric:: Availability:
 
@@ -107,6 +101,8 @@ Description
 - When the data is incomplete, but it is a connected graph:
 
   - the missing values will be calculated with dijkstra algorithm.
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -236,7 +232,7 @@ See Also
 
 * :doc:`TSP-family`
 * :doc:`sampledata`
-* `Boost's metric appro's metric approximation
+* `Boost: metric TSP approx
   <https://www.boost.org/libs/graph/doc/metric_tsp_approx.html>`__
 * `Wikipedia: Traveling Salesman Problem
   <https://en.wikipedia.org/wiki/Traveling_salesman_problem>`__

--- a/doc/tsp/pgr_TSPeuclidean.rst
+++ b/doc/tsp/pgr_TSPeuclidean.rst
@@ -7,22 +7,16 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Traveling Sales Person Family ; pgr_TSPeuclidean
    single: pgr_TSPeuclidean
 
+|
+
 ``pgr_TSPeuclidean``
 =============================================================================
 
-* ``pgr_TSPeuclidean`` - Aproximation using *metric* algorithm.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/metric_tsp_approx.html
-
-   Boost Graph Inside
-
+* pgr_TSPeuclidean`` - Aproximation using *metric* algorithm.
 
 .. rubric:: Availability:
 
@@ -73,6 +67,7 @@ Description
       2, 3.5, 1.0
       2, 3.6, 1.1
 
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -197,8 +192,8 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`TSP-family`
-* :doc:`sampledata` network.
-* `Boost's metric appro's metric approximation
+* :doc:`sampledata`
+* `Boost: metric TSP approx
   <https://www.boost.org/libs/graph/doc/metric_tsp_approx.html>`__
 * `University of Waterloo TSP <https://www.math.uwaterloo.ca/tsp/>`__
 * `Wikipedia: Traveling Salesman Problem

--- a/doc/utilities/pgr_findCloseEdges.rst
+++ b/doc/utilities/pgr_findCloseEdges.rst
@@ -7,30 +7,22 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: Utilities ; pgr_findCloseEdges
+   single: Utilities ; pgr_findCloseEdges - Proposed
    single: findCloseEdges
 
-``pgr_findCloseEdges``
+|
+
+``pgr_findCloseEdges`` - Proposed
 ===============================================================================
 
 ``pgr_findCloseEdges`` - Finds the close edges to a point geometry.
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/dijkstra_shortest_paths.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
 * Version 3.4.0
 
-  * New **proposed** signatures:
-
-    * ``pgr_findCloseEdges`` (`One point`_)
-    * ``pgr_findCloseEdges`` (`Many points`_)
+  * New proposed function.
 
 Description
 -------------------------------------------------------------------------------
@@ -41,7 +33,9 @@ point geometry.
 * The geometries must be in the same coordinate system (have the same SRID).
 * The code to do the calculations can be obtained for further specific
   adjustments needed by the application.
-* ``EMTPY SET`` is returned on dryrun executions
+* EMTPY SET`` is returned on dryrun executions
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -53,13 +47,13 @@ Signatures
 
    | pgr_findCloseEdges(`Edges SQL`_, **point**, **tolerance**, [**options**])
    | pgr_findCloseEdges(`Edges SQL`_, **points**, **tolerance**, [**options**])
-   | **options:** ``[cap, partial, dryrun]``
+   | **options:** [cap, partial, dryrun]``
 
    | Returns set of |result-find|
    | OR EMPTY SET
 
 .. index::
-    single: findCloseEdges ; One point - Proposed on 3.4
+    single: findCloseEdges - Proposed ; One point - Proposed on 3.4
 
 One point
 ...............................................................................
@@ -68,7 +62,7 @@ One point
    :class: signatures
 
    | pgr_findCloseEdges(`Edges SQL`_, **point**, **tolerance**, [**options**])
-   | **options:** ``[cap, partial, dryrun]``
+   | **options:** [cap, partial, dryrun]``
 
    | Returns set of |result-find|
    | OR EMPTY SET
@@ -94,7 +88,7 @@ One point
    :end-before: -- q2
 
 .. index::
-   single: findCloseEdges ; Many points - Proposed on 3.4
+   single: findCloseEdges - Proposed ; Many points - Proposed on 3.4
 
 Many points
 ...............................................................................

--- a/doc/version/pgr_full_version.rst
+++ b/doc/version/pgr_full_version.rst
@@ -7,11 +7,11 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Reference ; pgr_full_version
    single: full_version
+
+|
 
 ``pgr_full_version``
 ===============================================================================
@@ -29,6 +29,8 @@ Description
 -------------------------------------------------------------------------------
 
 Get complete details of pgRouting version information
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------

--- a/doc/version/pgr_version.rst
+++ b/doc/version/pgr_version.rst
@@ -7,12 +7,12 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 
 .. index::
    single: Reference ; pgr_version
    single: version
+
+|
 
 ``pgr_version``
 ===============================================================================

--- a/doc/version/reference.rst
+++ b/doc/version/reference.rst
@@ -7,20 +7,20 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: Reference
+
+|
 
 Reference
 ===============================================================================
 
-.. index from here
+.. official-start
 
 * :doc:`pgr_version`
 * :doc:`pgr_full_version`
 
-.. index to here
+.. official-end
 
 .. toctree::
     :hidden:

--- a/doc/withPoints/pgr_withPoints.rst
+++ b/doc/withPoints/pgr_withPoints.rst
@@ -7,13 +7,13 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: withPoints Family ; pgr_withPoints
    single: With Points Category ; pgr_withPoints
    single: Shortest Path Category ; pgr_withPoints
    single: withPoints
+
+|
 
 ``pgr_withPoints`` - Proposed
 ===============================================================================
@@ -22,25 +22,20 @@
 temporary vertices.
 
 .. include:: proposed.rst
-   :start-after: begin-warning
+   :start-after: warning-begin
    :end-before: end-warning
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
 * Version 3.2.0
 
-  * New **proposed** function:
+  * New proposed function.
 
     * pgr_withPoints(Combinations)
 
 * Version 2.2.0
 
-  * New **proposed** function
+  * New proposed function.
 
 Description
 -------------------------------------------------------------------------------
@@ -72,6 +67,8 @@ Using Dijkstra algorithm, find the shortest path
   - end_vid ascending
 
 * Running time: :math:`O(|start\_vids|\times(V \log V + E))`
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------

--- a/doc/withPoints/pgr_withPointsCost.rst
+++ b/doc/withPoints/pgr_withPointsCost.rst
@@ -7,13 +7,13 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: withPoints Family ; pgr_withPointsCost
-   single: With Points Category ; pgr_withPointsCost
-   single: Cost Category ; pgr_withPointsCost
+   single: withPoints Family ; pgr_withPointsCost - Proposed
+   single: With Points Category ; pgr_withPointsCost - Proposed
+   single: Cost Category ; pgr_withPointsCost - Proposed
    single: withPointsCost
+
+|
 
 ``pgr_withPointsCost`` - Proposed
 ===============================================================================
@@ -23,25 +23,20 @@ aggregate cost of the shortest path found, for the combination of points
 given.
 
 .. include:: proposed.rst
-   :start-after: begin-warning
+   :start-after: warning-begin
    :end-before: end-warning
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
 * Version 3.2.0
 
-  * New **proposed** function:
+  * New proposed signature:
 
     * pgr_withPointsCost(Combinations)
 
 * Version 2.2.0
 
-  * New **proposed** function
+  * New proposed function.
 
 
 Description
@@ -92,6 +87,8 @@ The main characteristics are:
 
   - Running time: :math:`O(|start\_vids|\times(V \log V + E))`
 
+|Boost| Boost Graph Inside
+
 Signatures
 -------------------------------------------------------------------------------
 
@@ -114,7 +111,7 @@ Signatures
    withPoints family of functions.
 
 .. index::
-    single: withPointsCost ; One To One - Proposed on v2.2
+    single: withPointsCost - Proposed ; One To One - Proposed on v2.2
 
 One to One
 ...............................................................................
@@ -135,7 +132,7 @@ One to One
    :end-before: -- q2
 
 .. index::
-    single: withPointsCost ; One To Many - Proposed on v2.2
+    single: withPointsCost - Proposed ; One To Many - Proposed on v2.2
 
 One to Many
 ...............................................................................
@@ -157,7 +154,7 @@ One to Many
    :end-before: -- q3
 
 .. index::
-    single: withPointsCost ; Many To One - Proposed on v2.2
+    single: withPointsCost - Proposed ; Many To One - Proposed on v2.2
 
 Many to One
 ...............................................................................
@@ -178,7 +175,7 @@ Many to One
    :end-before: -- q4
 
 .. index::
-    single: withPointsCost ; Many To Many - Proposed on v2.2
+    single: withPointsCost - Proposed ; Many To Many - Proposed on v2.2
 
 Many to Many
 ...............................................................................
@@ -200,7 +197,7 @@ Many to Many
    :end-before: -- q5
 
 .. index::
-    single: withPointsCost ; Combinations -- Proposed on v3.2
+    single: withPointsCost - Proposed ; Combinations -- Proposed on v3.2
 
 Combinations
 ...............................................................................
@@ -363,7 +360,7 @@ Traveling from point :math:`1` and vertex :math:`5` to points :math:`\{2, 3,
    :start-after: -- q8
    :end-before: -- q9
 
-The queries use the :doc:`sampledata` network.
+:doc:`sampledata`
 
 See Also
 -------------------------------------------------------------------------------

--- a/doc/withPoints/pgr_withPointsCostMatrix.rst
+++ b/doc/withPoints/pgr_withPointsCostMatrix.rst
@@ -7,13 +7,13 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: withPoints Family ; pgr_withPointsCostMatrix
-   single: With Points Category ; pgr_withPointsCostMatrix
-   single: Cost Matrix Category ; pgr_withPointsCostMatrix
+   single: withPoints Family ; pgr_withPointsCostMatrix - Proposed
+   single: With Points Category ; pgr_withPointsCostMatrix - Proposed
+   single: Cost Matrix Category ; pgr_withPointsCostMatrix - Proposed
    single: withPointsCostMatrix - proposed on v2.0
+
+|
 
 ``pgr_withPointsCostMatrix`` - proposed
 ===============================================================================
@@ -22,19 +22,14 @@
 :doc:`pgr_withPoints`.
 
 .. include:: proposed.rst
-   :start-after: begin-warning
+   :start-after: warning-begin
    :end-before: end-warning
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
 
 .. rubric:: Availability
 
 * Version 2.2.0
 
-  * New **proposed** function
+  * New proposed function.
 
 Description
 -------------------------------------------------------------------------------
@@ -48,6 +43,8 @@ Using Dijkstra algorithm, calculate and return a cost matrix.
 .. include:: costMatrix-category.rst
     :start-after: costMatrix_details_start
     :end-before: costMatrix_details_end
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------

--- a/doc/withPoints/pgr_withPointsDD.rst
+++ b/doc/withPoints/pgr_withPointsDD.rst
@@ -7,13 +7,13 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
-   single: withPoints Family ; pgr_withPointsDD
-   single: With Points Category ; pgr_withPointsDD
-   single: Driving Distance Category ; pgr_withPointsDD
-   single: withPointsDD
+   single: withPoints Family ; pgr_withPointsDD - Proposed
+   single: With Points Category ; pgr_withPointsDD - Proposed
+   single: Driving Distance Category ; pgr_withPointsDD - Proposed
+   single: withPointsDD - Proposed
+
+|
 
 ``pgr_withPointsDD`` - Proposed
 ===============================================================================
@@ -21,14 +21,8 @@
 ``pgr_withPointsDD`` - Returns the driving **distance** from a starting point.
 
 .. include:: proposed.rst
-   :start-after: begin-warning
+   :start-after: warning-begin
    :end-before: end-warning
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
-
 
 .. rubric:: Availability
 
@@ -37,16 +31,16 @@
 * Signature change: ``driving_side`` parameter changed from named optional to
   unnamed compulsory **driving side**.
 
-  * ``pgr_withPointsDD`` (`Single vertex`)
-  * ``pgr_withPointsDD`` (`Multiple vertices`)
+  * pgr_withPointsDD(Single vertex)
+  * pgr_withPointsDD(Multiple vertices)
 
 * Standarizing output columns to |result-spantree|
 
-  * ``pgr_withPointsDD`` (`Single vertex`)
+  * pgr_withPointsDD(Single vertex)
 
     * Added ``depth``, ``pred`` and ``start_vid`` column.
 
-  * ``pgr_withPointsDD`` (`Multiple vertices`)
+  * pgr_withPointsDD(Multiple vertices)
 
     * Added ``depth``, ``pred`` columns.
 
@@ -57,12 +51,12 @@
 
 * Deprecated signatures
 
-  * ``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)``
-  * ``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,boolean,boolean)``
+  * pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)``
+  * pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,boolean,boolean)``
 
 .. rubric:: Version 2.2.0
 
-* New **proposed** function
+* New proposed function.
 
 
 Description
@@ -72,6 +66,8 @@ Modify the graph to include points and using Dijkstra algorithm, extracts all
 the nodes and points that have costs less than or equal to the value
 ``**distance**`` from the starting point.
 The edges extracted will conform the corresponding spanning tree.
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -88,7 +84,7 @@ Signatures
    | OR EMPTY SET
 
 .. index::
-    single: withPointsDD ; Single Vertex - Proposed on v2.2
+    single: withPointsDD - Proposed ; Single Vertex - Proposed on v2.2
 
 Single vertex
 ...............................................................................
@@ -110,7 +106,7 @@ Single vertex
    :end-before: -- q3
 
 .. index::
-    single: withPointsDD ; Multiple Vertices - Proposed on v2.2
+    single: withPointsDD - Proposed ; Multiple Vertices - Proposed on v2.2
 
 Multiple vertices
 ...............................................................................

--- a/doc/withPoints/pgr_withPointsKSP.rst
+++ b/doc/withPoints/pgr_withPointsKSP.rst
@@ -7,13 +7,13 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: withPoints Family ; pgr_withPointsKSP
    single: With Points Category ; pgr_withPointsKSP
    single: K Shortest Paths Category ; pgr_withPointsKSP
    single: withPointsKSP
+
+|
 
 pgr_withPointsKSP - Proposed
 ===============================================================================
@@ -21,39 +21,32 @@ pgr_withPointsKSP - Proposed
 ``pgr_withPointsKSP`` — Yen's algorithm for K shortest paths using Dijkstra.
 
 .. include:: proposed.rst
-   :start-after: begin-warning
+   :start-after: warning-begin
    :end-before: end-warning
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
-
-.. rubric:: Availability
 
 .. rubric:: Version 3.6.0
 
 * Standarizing output columns to |nksp-result|
-* ``pgr_withPointsKSP`` (One to One)
+* pgr_withPointsKSP(One to One)
 
   * Signature change: ``driving_side`` parameter changed from named optional to
     unnamed compulsory **driving side**.
   * Added ``start_vid`` and ``end_vid`` result columns.
 
-* New overload functions
+* New proposed signatures
 
-  * ``pgr_withPointsKSP`` (One to Many)
-  * ``pgr_withPointsKSP`` (Many to One)
-  * ``pgr_withPointsKSP`` (Many to Many)
-  * ``pgr_withPointsKSP`` (Combinations)
+  * pgr_withPointsKSP(One to Many)
+  * pgr_withPointsKSP(Many to One)
+  * pgr_withPointsKSP(Many to Many)
+  * pgr_withPointsKSP(Combinations)
 
 * Deprecated signature
 
-  * ``pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,boolean)``
+  * pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,boolean)``
 
 .. rubric:: Version 2.2.0
 
-* New **proposed** function
+* New proposed function.
 
 
 Description
@@ -61,6 +54,8 @@ Description
 
 Modifies the graph to include the points defined in the `Points SQL`_ and
 using Yen algorithm, finds the :math:`K` shortest paths.
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -334,8 +329,6 @@ point :math:`2` with heap paths and details.
 .. literalinclude:: withPointsKSP.queries
    :start-after: --q8
    :end-before: --q9
-
-The queries use the :doc:`sampledata` network.
 
 See Also
 -------------------------------------------------------------------------------

--- a/doc/withPoints/pgr_withPointsVia.rst
+++ b/doc/withPoints/pgr_withPointsVia.rst
@@ -7,13 +7,13 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index::
    single: withPoints Family ; pgr_withPointsVia
    single: With Points Category ; pgr_withPointsVia
    single: Via Category ; pgr_withPointsVia
    single: withPointsVia
+
+|
 
 ``pgr_withPointsVia`` - Proposed
 ===============================================================================
@@ -22,19 +22,14 @@
 points.
 
 .. include:: proposed.rst
-   :start-after: stable-begin-warning
-   :end-before: stable-end-warning
-
-.. figure:: images/boost-inside.jpeg
-   :target: https://www.boost.org/libs/graph/doc/table_of_contents.html
-
-   Boost Graph Inside
+   :start-after: warning-begin
+   :end-before: end-warning
 
 .. rubric:: Availability
 
 * Version 3.4.0
 
-  * New **proposed** function ``pgr_withPointsVia`` (`One Via`_)
+  * New proposed function.
 
 Description
 -------------------------------------------------------------------------------
@@ -55,6 +50,8 @@ The general algorithm is as follows:
   * The vertices identifiers will remain positive.
 
 * Execute a :doc:`pgr_dijkstraVia`.
+
+|Boost| Boost Graph Inside
 
 Signatures
 -------------------------------------------------------------------------------
@@ -208,7 +205,7 @@ See Also
 
 * :doc:`withPoints-family`
 * :doc:`via-category`
-* :doc:`sampledata` network.
+* :doc:`sampledata`
 
 .. rubric:: Indices and tables
 

--- a/doc/withPoints/withPoints-family.rst
+++ b/doc/withPoints/withPoints-family.rst
@@ -7,9 +7,9 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-|
-
 .. index:: withPoints Family
+
+|
 
 withPoints - Family of functions
 ===============================================================================
@@ -17,10 +17,10 @@ withPoints - Family of functions
 When points are also given as input:
 
 .. include:: proposed.rst
-   :start-after: begin-warning
+   :start-after: warning-begin
    :end-before: end-warning
 
-.. index proposed from here
+.. proposed-start
 
 - :doc:`pgr_withPoints` - Route from/to points anywhere on the graph.
 - :doc:`pgr_withPointsCost` - Costs of the shortest paths.
@@ -29,7 +29,7 @@ When points are also given as input:
 - :doc:`pgr_withPointsDD` - Driving distance.
 - :doc:`pgr_withPointsVia` - Via routing
 
-.. index proposed to here
+.. proposed-end
 
 .. toctree::
     :hidden:


### PR DESCRIPTION
# Standard on labels

Use:
* `official-start` and `official-end`
* `proposed-start` and `proposed-end`
* `experimental-start` and `experimental-end`
* `warning-start` and `warning-end`

Example
```
.. official-start
<documentation>
.. official-end
```

# Availability and release notes 
* Use less bold & code markers

Example:
``pgr_aStar`` (`One to One`) -> pgr_aStar(One to One)

# Boost information

Make it smaller and the last thing before the signatures

Example:
**Before** 
![image](https://github.com/user-attachments/assets/e623728b-ca0b-4a8f-afc3-e4e1e3ab7f85)
**with this PR**
![image](https://github.com/user-attachments/assets/94fd30c2-0fb6-44fe-b034-05e1662b03bb)

The link original link to boost is placed on the `See also` section.

# Links from index

Place the index command before the `|` so when jumping from the index page the title can be seen completly.
```
.. index:: Via Category

|
```

# Sentence about `sampledata`

Use on the `See also` section:
```
* doc:`sampledata`
```
Instead of different sentences about using the sample data on the examples.

@pgRouting/admins
