### PR TITLE
Promotion of functions to official

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,40 @@
 
 ### pgRouting 4.0.0 Release Notes
 
+To see all issues & pull requests closed by this release see the [Git closed
+milestone for 4.0.0
+](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%204.0.0%22)
+
+**Functions promoted to official**
+
+* pgr_trsp
+* pgr_trspVia
+* pgr_trspVia_withPoints
+* pgr_trsp_withPoints
+* pgr_withPoints
+* pgr_withPointsCost
+* pgr_withPointsCostMatrix
+* pgr_withPointsDD
+* pgr_withPointsKSP
+* pgr_withPointsVia
+
+**Signatures promoted to official**
+
+* pgr_aStar(Combinations)
+* pgr_aStarCost(Combinations)
+* pgr_bdAstar(Combinations)
+* pgr_bdAstarCost(Combinations)
+* pgr_bdDijkstra(Combinations)
+* pgr_bdDijkstraCost(Combinations)
+* pgr_dijkstra(Combinations)
+* pgr_dijkstraCost(Combinations)
+* pgr_KSP(All signatures)
+* pgr_boykovKolmogorov(Combinations)
+* pgr_edmondsKarp(Combinations)
+* pgr_maxFlow(Combinations)
+* pgr_pushRelabel(Combinations)
+
+
 **Removal of deprecated functions and signatures**
 
 * ``pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)``

--- a/doc/astar/pgr_aStar.rst
+++ b/doc/astar/pgr_aStar.rst
@@ -20,6 +20,10 @@
 
 .. rubric:: Availability
 
+* Version 4.0.0
+
+  * Combinations signature promoted to official.
+
 * Version 3.6.0
 
   * Standarizing output columns to |short-generic-result|
@@ -184,7 +188,7 @@ Many to Many
    :end-before: -- q51
 
 .. index::
-    single: aStar ; Combinations - Proposed on v3.2
+    single: aStar ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/astar/pgr_aStarCost.rst
+++ b/doc/astar/pgr_aStarCost.rst
@@ -21,6 +21,10 @@
 
 .. rubric:: Availability
 
+* Version 4.0.0
+
+  * Combinations signature promoted to official.
+
 * Version 3.2.0
 
   * New proposed signature:
@@ -171,7 +175,7 @@ Many to Many
     :end-before: -- q51
 
 .. index::
-    single: aStarCost ; Combinations - Proposed on v3.2
+    single: aStarCost ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/bdAstar/pgr_bdAstar.rst
+++ b/doc/bdAstar/pgr_bdAstar.rst
@@ -20,6 +20,10 @@
 
 .. rubric:: Availability
 
+* Version 4.0.0
+
+  * Combinations signature promoted to official.
+
 * Version 3.6.0
 
   * Standarizing output columns to |short-generic-result|
@@ -182,7 +186,7 @@ Many to Many
    :end-before: -- q51
 
 .. index::
-    single: bdAstar ; Combinations - Proposed on v3.2
+    single: bdAstar ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/bdAstar/pgr_bdAstarCost.rst
+++ b/doc/bdAstar/pgr_bdAstarCost.rst
@@ -21,6 +21,10 @@ A* algorithm.
 
 .. rubric:: Availability
 
+* Version 4.0.0
+
+  * Combinations signature promoted to official.
+
 * Version 3.2.0
 
   * New proposed signature:
@@ -171,7 +175,7 @@ Many to Many
     :end-before: -- q51
 
 .. index::
-    single: bdAstarCost ; Combinations - Proposed on v3.2
+    single: bdAstarCost ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/bdDijkstra/pgr_bdDijkstra.rst
+++ b/doc/bdDijkstra/pgr_bdDijkstra.rst
@@ -21,6 +21,10 @@ algorithm.
 
 .. rubric:: Availability:
 
+* Version 4.0.0
+
+  * Combinations signature promoted to official.
+
 * Version 3.2.0
 
   * New proposed signature:
@@ -162,7 +166,7 @@ Many to Many
     :end-before: -- q51
 
 .. index::
-    single: bdDijkstra ; Combinations - Proposed on v3.2
+    single: bdDijkstra ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/bdDijkstra/pgr_bdDijkstraCost.rst
+++ b/doc/bdDijkstra/pgr_bdDijkstraCost.rst
@@ -21,6 +21,10 @@ Dijkstra algorithm.
 
 .. rubric:: Availability
 
+* Version 4.0.0
+
+  * Combinations signature promoted to official.
+
 * Version 3.2.0
 
   * New proposed signature:
@@ -153,7 +157,7 @@ Many to Many
     :end-before: -- q51
 
 .. index::
-    single: bdDijkstraCost ; Combinations - Proposed on v3.2
+    single: bdDijkstraCost ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/dijkstra/pgr_dijkstra.rst
+++ b/doc/dijkstra/pgr_dijkstra.rst
@@ -21,6 +21,10 @@
 
 .. rubric:: Availability
 
+* Version 4.0.0
+
+  * Combinations signature promoted to official.
+
 * Version 3.5.0
 
   * Standarizing output columns to |short-generic-result|
@@ -175,7 +179,7 @@ Many to Many
    :end-before: -- q51
 
 .. index::
-    single: dijkstra ; Combinations - Proposed on v3.1
+    single: dijkstra ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/dijkstra/pgr_dijkstraCost.rst
+++ b/doc/dijkstra/pgr_dijkstraCost.rst
@@ -23,6 +23,10 @@ algorithm.
 
 .. rubric:: Availability
 
+* Version 4.0.0
+
+  * Combinations signature promoted to official.
+
 * Version 3.1.0
 
   * New proposed signature:
@@ -155,7 +159,7 @@ Many to Many
     :end-before: -- q51
 
 .. index::
-    single: dijkstraCost ; Combinations - Proposed on v3.1
+    single: dijkstraCost ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/ksp/pgr_KSP.rst
+++ b/doc/ksp/pgr_KSP.rst
@@ -20,6 +20,10 @@
 
 .. rubric:: Availability
 
+* Version 4.0.0
+
+  * All signatures promoted to official.
+
 .. rubric:: Version 3.6.0
 
 * Result columns standarized to: |nksp-result|
@@ -93,7 +97,7 @@ One to One
     :end-before: --q2
 
 .. index::
-    single: KSP ; One to Many - Proposed on 3.6
+    single: KSP ; One to Many
 
 One to Many
 ...............................................................................
@@ -114,7 +118,7 @@ One to Many
     :end-before: --q3
 
 .. index::
-    single: KSP ; Many to One - Proposed in 3.6
+    single: KSP ; Many to One
 
 Many to One
 ...............................................................................
@@ -135,7 +139,7 @@ Many to One
     :end-before: --q4
 
 .. index::
-    single: KSP ; Many to Many - Proposed in 3.6
+    single: KSP ; Many to Many
 
 Many to Many
 ...............................................................................
@@ -156,7 +160,7 @@ Many to Many
     :end-before: --q5
 
 .. index::
-   single: KSP ; Combinations - Proposed in 3.6
+   single: KSP ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/max_flow/pgr_boykovKolmogorov.rst
+++ b/doc/max_flow/pgr_boykovKolmogorov.rst
@@ -21,6 +21,10 @@ the flow from the sources to the targets using Boykov Kolmogorov algorithm.
 
 .. Rubric:: Availability
 
+* Version 4.0.0
+
+  * Combinations signature promoted to official.
+
 * Version 3.2.0
 
   * New proposed signature:
@@ -150,7 +154,7 @@ Many to Many
    :end-before: -- q5
 
 .. index::
-    single: boykovKolmogorov ; Combinations - Proposed on v3.2
+    single: boykovKolmogorov ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/max_flow/pgr_edmondsKarp.rst
+++ b/doc/max_flow/pgr_edmondsKarp.rst
@@ -21,6 +21,10 @@ flow from the sources to the targets using Edmonds Karp Algorithm.
 
 .. Rubric:: Availability
 
+* Version 4.0.0
+
+  * Combinations signature promoted to official.
+
 * Version 3.2.0
 
   * New proposed signature:
@@ -150,7 +154,7 @@ Many to Many
    :end-before: -- q5
 
 .. index::
-    single: edmondsKarp ; Combinations - Proposed on v3.2
+    single: edmondsKarp ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/max_flow/pgr_maxFlow.rst
+++ b/doc/max_flow/pgr_maxFlow.rst
@@ -21,6 +21,10 @@ source(s) to the targets(s) using the Push Relabel algorithm.
 
 .. Rubric:: Availability
 
+* Version 4.0.0
+
+  * Combinations signature promoted to official.
+
 * Version 3.2.0
 
   * New proposed signature:
@@ -147,7 +151,7 @@ Many to Many
    :end-before: -- q5
 
 .. index::
-    single: maxFlow ; Combinations - Proposed on v3.2
+    single: maxFlow ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/max_flow/pgr_pushRelabel.rst
+++ b/doc/max_flow/pgr_pushRelabel.rst
@@ -21,6 +21,10 @@ flow from the sources to the targets using Push Relabel Algorithm.
 
 .. Rubric:: Availability
 
+* Version 4.0.0
+
+  * Combinations signature promoted to official.
+
 * Version 3.2.0
 
   * New proposed signature:
@@ -150,7 +154,7 @@ Many to Many
    :end-before: -- q5
 
 .. index::
-    single: pushRelabel ; Combinations - Proposed on v3.2
+    single: pushRelabel ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -39,6 +39,40 @@ pgRouting 4.0
 pgRouting 4.0.0 Release Notes
 -------------------------------------------------------------------------------
 
+To see all issues & pull requests closed by this release see the `Git closed
+milestone for 4.0.0
+<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%204.0.0%22>`__
+
+.. rubric:: Functions promoted to official
+
+* pgr_trsp
+* pgr_trspVia
+* pgr_trspVia_withPoints
+* pgr_trsp_withPoints
+* pgr_withPoints
+* pgr_withPointsCost
+* pgr_withPointsCostMatrix
+* pgr_withPointsDD
+* pgr_withPointsKSP
+* pgr_withPointsVia
+
+.. rubric:: Signatures promoted to official
+
+* pgr_aStar(Combinations)
+* pgr_aStarCost(Combinations)
+* pgr_bdAstar(Combinations)
+* pgr_bdAstarCost(Combinations)
+* pgr_bdDijkstra(Combinations)
+* pgr_bdDijkstraCost(Combinations)
+* pgr_dijkstra(Combinations)
+* pgr_dijkstraCost(Combinations)
+* pgr_KSP(All signatures)
+* pgr_boykovKolmogorov(Combinations)
+* pgr_edmondsKarp(Combinations)
+* pgr_maxFlow(Combinations)
+* pgr_pushRelabel(Combinations)
+
+
 .. rubric:: Removal of deprecated functions and signatures
 
 * ``pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)``

--- a/doc/trsp/pgr_trsp.rst
+++ b/doc/trsp/pgr_trsp.rst
@@ -15,16 +15,16 @@
 
 |
 
-``pgr_trsp`` - Proposed
+``pgr_trsp``
 ===============================================================================
 
 ``pgr_trsp`` - routing vertices with restrictions.
 
-.. include:: proposed.rst
-   :start-after: warning-begin
-   :end-before: end-warning
-
 .. rubric:: Availability
+
+* Version 4.0.0
+
+  * **Official** function.
 
 * Version 3.4.0
 
@@ -77,7 +77,7 @@ The general algorithm is as follows:
 Signatures
 -------------------------------------------------------------------------------
 
-.. rubric:: Proposed
+.. rubric:: Summary
 
 .. admonition:: \ \
    :class: signatures
@@ -92,7 +92,7 @@ Signatures
    | OR EMPTY SET
 
 .. index::
-    single: trsp ; One to One -- Proposed on v3.4
+    single: trsp ; One to One
 
 One to One
 ...............................................................................
@@ -112,7 +112,7 @@ One to One
    :end-before: -- q3
 
 .. index::
-    single: trsp ; One to Many -- Proposed on v3.4
+    single: trsp ; One to Many
 
 One to Many
 ...............................................................................
@@ -133,7 +133,7 @@ One to Many
    :end-before: -- q4
 
 .. index::
-    single: trsp ; Many to One -- Proposed on v3.4
+    single: trsp ; Many to One
 
 Many to One
 ...............................................................................
@@ -154,7 +154,7 @@ Many to One
    :end-before: -- q5
 
 .. index::
-    single: trsp ; Many to Many -- Proposed on v3.4
+    single: trsp ; Many to Many
 
 Many to Many
 ...............................................................................
@@ -176,7 +176,7 @@ Many to Many
    :end-before: -- q6
 
 .. index::
-    single: trsp ; Combinations - Proposed on v3.4
+    single: trsp ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/trsp/pgr_trsp.rst
+++ b/doc/trsp/pgr_trsp.rst
@@ -24,7 +24,7 @@
 
 * Version 4.0.0
 
-  * **Official** function.
+  * Function promoted to official.
 
 * Version 3.4.0
 

--- a/doc/trsp/pgr_trspVia.rst
+++ b/doc/trsp/pgr_trspVia.rst
@@ -15,22 +15,20 @@
 
 |
 
-``pgr_trspVia`` - Proposed
+``pgr_trspVia``
 ===============================================================================
 
 ``pgr_trspVia`` Route that goes through a list of vertices with restrictions.
 
-.. include:: proposed.rst
-   :start-after: warning-begin
-   :end-before: end-warning
-
 .. rubric:: Availability
+
+* Version 4.0.0
+
+  * **Official** function.
 
 * Version 3.4.0
 
   * New proposed function.
-
-    * pgr_trspVia(One Via)
 
 Description
 -------------------------------------------------------------------------------
@@ -55,7 +53,7 @@ Signatures
 -------------------------------------------------------------------------------
 
 .. index::
-    single: trspVia ; One Via - Proposed on v3.4
+    single: trspVia ; One Via
 
 One Via
 ...............................................................................

--- a/doc/trsp/pgr_trspVia.rst
+++ b/doc/trsp/pgr_trspVia.rst
@@ -24,7 +24,7 @@
 
 * Version 4.0.0
 
-  * **Official** function.
+  * Function promoted to official.
 
 * Version 3.4.0
 

--- a/doc/trsp/pgr_trspVia_withPoints.rst
+++ b/doc/trsp/pgr_trspVia_withPoints.rst
@@ -26,7 +26,7 @@ points with restrictions.
 
 * Version 4.0.0
 
-  * **Official** function.
+  * Function promoted to official.
 
 * Version 3.4.0
 

--- a/doc/trsp/pgr_trspVia_withPoints.rst
+++ b/doc/trsp/pgr_trspVia_withPoints.rst
@@ -16,17 +16,17 @@
 
 |
 
-``pgr_trspVia_withPoints`` - Proposed
+``pgr_trspVia_withPoints``
 ===============================================================================
 
 ``pgr_trspVia_withPoints`` - Route that goes through a list of vertices and/or
 points with restrictions.
 
-.. include:: proposed.rst
-   :start-after: warning-begin
-   :end-before: end-warning
-
 .. rubric:: Availability
+
+* Version 4.0.0
+
+  * **Official** function.
 
 * Version 3.4.0
 
@@ -65,7 +65,7 @@ Signatures
 -------------------------------------------------------------------------------
 
 .. index::
-    single: trspVia_withPoints ; One Via - Proposed on v3.4
+    single: trspVia_withPoints ; One Via
 
 One Via
 ...............................................................................

--- a/doc/trsp/pgr_trsp_withPoints.rst
+++ b/doc/trsp/pgr_trsp_withPoints.rst
@@ -25,7 +25,7 @@
 
 * Version 4.0.0
 
-  * **Official** function.
+  * Function promoted to official.
 
 * Version 3.4.0
 

--- a/doc/trsp/pgr_trsp_withPoints.rst
+++ b/doc/trsp/pgr_trsp_withPoints.rst
@@ -16,16 +16,16 @@
 
 |
 
-``pgr_trsp_withPoints`` - Proposed
+``pgr_trsp_withPoints``
 ===============================================================================
 
 ``pgr_trsp_withPoints`` Routing Vertex/Point with restrictions.
 
-.. include:: proposed.rst
-   :start-after: warning-begin
-   :end-before: end-warning
-
 .. rubric:: Availability
+
+* Version 4.0.0
+
+  * **Official** function.
 
 * Version 3.4.0
 
@@ -85,7 +85,7 @@ Signatures
    | OR EMPTY SET
 
 .. index::
-    single: trsp_withPoints ; One to One - Proposed on v3.4
+    single: trsp_withPoints ; One to One
 
 One to One
 ...............................................................................
@@ -107,7 +107,7 @@ One to One
    :end-before: --e2
 
 .. index::
-    single: trsp_withPoints ; One to Many - Proposed on v3.4
+    single: trsp_withPoints ; One to Many
 
 One to Many
 ...............................................................................
@@ -128,7 +128,7 @@ One to Many
    :end-before: --e3
 
 .. index::
-    single: trsp_withPoints ; Many to One - Proposed on v3.4
+    single: trsp_withPoints ; Many to One
 
 Many to One
 ...............................................................................
@@ -149,7 +149,7 @@ Many to One
    :end-before: --e4
 
 .. index::
-    single: trsp_withPoints ; Many to Many - Proposed on v3.4
+    single: trsp_withPoints ; Many to Many
 
 Many to Many
 ...............................................................................
@@ -171,7 +171,7 @@ Many to Many
    :end-before: --e5
 
 .. index::
-    single: trsp_withPoints ; Combinations - Proposed on v3.4
+    single: trsp_withPoints ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/withPoints/pgr_withPoints.rst
+++ b/doc/withPoints/pgr_withPoints.rst
@@ -15,21 +15,21 @@
 
 |
 
-``pgr_withPoints`` - Proposed
+``pgr_withPoints``
 ===============================================================================
 
 ``pgr_withPoints`` - Returns the shortest path in a graph with additional
 temporary vertices.
 
-.. include:: proposed.rst
-   :start-after: warning-begin
-   :end-before: end-warning
-
 .. rubric:: Availability
+
+* Version 4.0.0
+
+  * **Official** function.
 
 * Version 3.2.0
 
-  * New proposed function.
+  * New proposed signature:
 
     * pgr_withPoints(Combinations)
 
@@ -89,7 +89,7 @@ Signatures
    | OR EMTPY SET
 
 .. index::
-    single: withPoints ; One to One - Proposed on v2.2
+    single: withPoints ; One to One
 
 One to One
 ...............................................................................
@@ -110,7 +110,7 @@ One to One
    :end-before: -- q2
 
 .. index::
-    single: withPoints ; One to Many - Proposed on v2.2
+    single: withPoints ; One to Many
 
 One to Many
 ...............................................................................
@@ -132,7 +132,7 @@ One to Many
    :end-before: -- q3
 
 .. index::
-    single: withPoints ; Many to One - Proposed on v2.2
+    single: withPoints ; Many to One
 
 Many to One
 ...............................................................................
@@ -153,7 +153,7 @@ Many to One
    :end-before: -- q4
 
 .. index::
-    single: withPoints ; Many to Many - Proposed on v2.2
+    single: withPoints ; Many to Many
 
 Many to Many
 ...............................................................................
@@ -175,7 +175,7 @@ Many to Many
    :end-before: -- q5
 
 .. index::
-    single: withPoints ; Combinations - Proposed on v3.2
+    single: withPoints ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/withPoints/pgr_withPoints.rst
+++ b/doc/withPoints/pgr_withPoints.rst
@@ -25,7 +25,7 @@ temporary vertices.
 
 * Version 4.0.0
 
-  * **Official** function.
+  * Function promoted to official.
 
 * Version 3.2.0
 

--- a/doc/withPoints/pgr_withPointsCost.rst
+++ b/doc/withPoints/pgr_withPointsCost.rst
@@ -26,7 +26,7 @@ given.
 
 * Version 4.0.0
 
-  * **Official** function.
+  * Function promoted to official.
 
 * Version 3.2.0
 

--- a/doc/withPoints/pgr_withPointsCost.rst
+++ b/doc/withPoints/pgr_withPointsCost.rst
@@ -8,25 +8,25 @@
    ****************************************************************************
 
 .. index::
-   single: withPoints Family ; pgr_withPointsCost - Proposed
-   single: With Points Category ; pgr_withPointsCost - Proposed
-   single: Cost Category ; pgr_withPointsCost - Proposed
+   single: withPoints Family ; pgr_withPointsCost
+   single: With Points Category ; pgr_withPointsCost
+   single: Cost Category ; pgr_withPointsCost
    single: withPointsCost
 
 |
 
-``pgr_withPointsCost`` - Proposed
+``pgr_withPointsCost``
 ===============================================================================
 
 ``pgr_withPointsCost`` - Calculates the shortest path and returns only the
 aggregate cost of the shortest path found, for the combination of points
 given.
 
-.. include:: proposed.rst
-   :start-after: warning-begin
-   :end-before: end-warning
-
 .. rubric:: Availability
+
+* Version 4.0.0
+
+  * **Official** function.
 
 * Version 3.2.0
 
@@ -111,7 +111,7 @@ Signatures
    withPoints family of functions.
 
 .. index::
-    single: withPointsCost - Proposed ; One To One - Proposed on v2.2
+    single: withPointsCost ; One To One
 
 One to One
 ...............................................................................
@@ -132,7 +132,7 @@ One to One
    :end-before: -- q2
 
 .. index::
-    single: withPointsCost - Proposed ; One To Many - Proposed on v2.2
+    single: withPointsCost ; One To Many
 
 One to Many
 ...............................................................................
@@ -154,7 +154,7 @@ One to Many
    :end-before: -- q3
 
 .. index::
-    single: withPointsCost - Proposed ; Many To One - Proposed on v2.2
+    single: withPointsCost ; Many To One
 
 Many to One
 ...............................................................................
@@ -175,7 +175,7 @@ Many to One
    :end-before: -- q4
 
 .. index::
-    single: withPointsCost - Proposed ; Many To Many - Proposed on v2.2
+    single: withPointsCost ; Many To Many
 
 Many to Many
 ...............................................................................
@@ -197,7 +197,7 @@ Many to Many
    :end-before: -- q5
 
 .. index::
-    single: withPointsCost - Proposed ; Combinations -- Proposed on v3.2
+    single: withPointsCost ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/withPoints/pgr_withPointsCostMatrix.rst
+++ b/doc/withPoints/pgr_withPointsCostMatrix.rst
@@ -8,24 +8,24 @@
    ****************************************************************************
 
 .. index::
-   single: withPoints Family ; pgr_withPointsCostMatrix - Proposed
-   single: With Points Category ; pgr_withPointsCostMatrix - Proposed
-   single: Cost Matrix Category ; pgr_withPointsCostMatrix - Proposed
-   single: withPointsCostMatrix - proposed on v2.0
+   single: withPoints Family ; pgr_withPointsCostMatrix
+   single: With Points Category ; pgr_withPointsCostMatrix
+   single: Cost Matrix Category ; pgr_withPointsCostMatrix
+   single: withPointsCostMatrix
 
 |
 
-``pgr_withPointsCostMatrix`` - proposed
+``pgr_withPointsCostMatrix``
 ===============================================================================
 
 ``pgr_withPointsCostMatrix`` - Calculates a cost matrix using
 :doc:`pgr_withPoints`.
 
-.. include:: proposed.rst
-   :start-after: warning-begin
-   :end-before: end-warning
-
 .. rubric:: Availability
+
+* Version 4.0.0
+
+  * **Official** function.
 
 * Version 2.2.0
 
@@ -48,8 +48,6 @@ Using Dijkstra algorithm, calculate and return a cost matrix.
 
 Signatures
 -------------------------------------------------------------------------------
-
-.. rubric:: Summary
 
 .. admonition:: \ \
    :class: signatures

--- a/doc/withPoints/pgr_withPointsCostMatrix.rst
+++ b/doc/withPoints/pgr_withPointsCostMatrix.rst
@@ -25,7 +25,7 @@
 
 * Version 4.0.0
 
-  * **Official** function.
+  * Function promoted to official.
 
 * Version 2.2.0
 

--- a/doc/withPoints/pgr_withPointsDD.rst
+++ b/doc/withPoints/pgr_withPointsDD.rst
@@ -8,23 +8,23 @@
    ****************************************************************************
 
 .. index::
-   single: withPoints Family ; pgr_withPointsDD - Proposed
-   single: With Points Category ; pgr_withPointsDD - Proposed
-   single: Driving Distance Category ; pgr_withPointsDD - Proposed
-   single: withPointsDD - Proposed
+   single: withPoints Family ; pgr_withPointsDD
+   single: With Points Category ; pgr_withPointsDD
+   single: Driving Distance Category ; pgr_withPointsDD
+   single: withPointsDD
 
 |
 
-``pgr_withPointsDD`` - Proposed
+``pgr_withPointsDD``
 ===============================================================================
 
 ``pgr_withPointsDD`` - Returns the driving **distance** from a starting point.
 
-.. include:: proposed.rst
-   :start-after: warning-begin
-   :end-before: end-warning
-
 .. rubric:: Availability
+
+.. rubric:: Version 4.0.0
+
+* **Official** function.
 
 .. rubric:: Version 3.6.0
 
@@ -84,7 +84,7 @@ Signatures
    | OR EMPTY SET
 
 .. index::
-    single: withPointsDD - Proposed ; Single Vertex - Proposed on v2.2
+    single: withPointsDD ; Single Vertex
 
 Single vertex
 ...............................................................................
@@ -106,7 +106,7 @@ Single vertex
    :end-before: -- q3
 
 .. index::
-    single: withPointsDD - Proposed ; Multiple Vertices - Proposed on v2.2
+    single: withPointsDD ; Multiple Vertices
 
 Multiple vertices
 ...............................................................................

--- a/doc/withPoints/pgr_withPointsDD.rst
+++ b/doc/withPoints/pgr_withPointsDD.rst
@@ -24,7 +24,7 @@
 
 .. rubric:: Version 4.0.0
 
-* **Official** function.
+* Function promoted to official.
 
 .. rubric:: Version 3.6.0
 

--- a/doc/withPoints/pgr_withPointsKSP.rst
+++ b/doc/withPoints/pgr_withPointsKSP.rst
@@ -22,7 +22,7 @@
 
 .. rubric:: Version 4.0.0
 
-* **Official** function.
+* Function promoted to official.
 
 .. rubric:: Version 3.6.0
 

--- a/doc/withPoints/pgr_withPointsKSP.rst
+++ b/doc/withPoints/pgr_withPointsKSP.rst
@@ -15,14 +15,14 @@
 
 |
 
-pgr_withPointsKSP - Proposed
+``pgr_withPointsKSP``
 ===============================================================================
 
 ``pgr_withPointsKSP`` — Yen's algorithm for K shortest paths using Dijkstra.
 
-.. include:: proposed.rst
-   :start-after: warning-begin
-   :end-before: end-warning
+.. rubric:: Version 4.0.0
+
+* **Official** function.
 
 .. rubric:: Version 3.6.0
 
@@ -74,7 +74,7 @@ Signatures
    | OR EMPTY SET
 
 .. index::
-    single: withPointsKSP ; One to One - Proposed on v2.2
+    single: withPointsKSP ; One to One
 
 One to One
 ...............................................................................
@@ -100,7 +100,7 @@ One to One
    :end-before: --q2
 
 .. index::
-    single: withPointsKSP ; One to Many - Proposed on v3.6
+    single: withPointsKSP ; One to Many
 
 One to Many
 ...............................................................................
@@ -122,7 +122,7 @@ One to Many
    :end-before: --q3
 
 .. index::
-    single: withPointsKSP ; Many to One - Proposed on v3.6
+    single: withPointsKSP ; Many to One
 
 Many to One
 ...............................................................................
@@ -144,7 +144,7 @@ Many to One
    :end-before: --q4
 
 .. index::
-    single: withPointsKSP ; Many to Many - Proposed on v3.6
+    single: withPointsKSP ; Many to Many
 
 Many to Many
 ...............................................................................
@@ -166,7 +166,7 @@ Many to Many
    :end-before: --q5
 
 .. index::
-    single: withPointsKSP ; Combinations - Proposed on v3.6
+    single: withPointsKSP ; Combinations
 
 Combinations
 ...............................................................................

--- a/doc/withPoints/pgr_withPointsVia.rst
+++ b/doc/withPoints/pgr_withPointsVia.rst
@@ -15,17 +15,17 @@
 
 |
 
-``pgr_withPointsVia`` - Proposed
+``pgr_withPointsVia``
 ===============================================================================
 
 ``pgr_withPointsVia`` - Route that goes through a list of vertices and/or
 points.
 
-.. include:: proposed.rst
-   :start-after: warning-begin
-   :end-before: end-warning
-
 .. rubric:: Availability
+
+* Version 4.0.0
+
+  * **Official** function.
 
 * Version 3.4.0
 
@@ -57,7 +57,7 @@ Signatures
 -------------------------------------------------------------------------------
 
 .. index::
-    single: withPointsVia ; One Via - Proposed on v3.4
+    single: withPointsVia ; One Via
 
 One Via
 ...............................................................................

--- a/doc/withPoints/pgr_withPointsVia.rst
+++ b/doc/withPoints/pgr_withPointsVia.rst
@@ -25,7 +25,7 @@ points.
 
 * Version 4.0.0
 
-  * **Official** function.
+  * Function promoted to official.
 
 * Version 3.4.0
 

--- a/sql/driving_distance/withPointsDD.sql
+++ b/sql/driving_distance/withPointsDD.sql
@@ -94,7 +94,6 @@ ROWS 1000;
 
 COMMENT ON FUNCTION pgr_withPointsDD(TEXT, TEXT, BIGINT, FLOAT, CHAR, BOOLEAN, BOOLEAN)
 IS 'pgr_withPointsDD(Single Vertex)
-- PROPOSED
 - Parameters:
     - Edges SQL with columns: id, source, target, cost [,reverse_cost]
     - Points SQL with columns: [pid], edge_id, fraction[,side]
@@ -111,7 +110,6 @@ IS 'pgr_withPointsDD(Single Vertex)
 
 COMMENT ON FUNCTION pgr_withPointsDD(TEXT, TEXT, ANYARRAY, FLOAT, CHAR, BOOLEAN, BOOLEAN, BOOLEAN)
 IS 'pgr_withPointsDD(Multiple Vertices)
-- PROPOSED
 - Parameters:
     - Edges SQL with columns: id, source, target, cost [,reverse_cost]
     - Points SQL with columns: [pid], edge_id, fraction[,side]

--- a/sql/ksp/withPointsKSP.sql
+++ b/sql/ksp/withPointsKSP.sql
@@ -188,7 +188,6 @@ ROWS 1000;
 
 COMMENT ON FUNCTION pgr_withPointsKSP(TEXT, TEXT, BIGINT, BIGINT, INTEGER, CHAR, BOOLEAN, BOOLEAN, BOOLEAN)
 IS 'pgr_withPointsKSP
-- PROPOSED
 - Parameters:
     - Edges SQL with columns: id, source, target, cost [,reverse_cost]
     - Points SQL with columns: [pid], edge_id, fraction[,side]
@@ -205,7 +204,6 @@ IS 'pgr_withPointsKSP
 
 COMMENT ON FUNCTION pgr_withPointsKSP(TEXT, TEXT, BIGINT, ANYARRAY, INTEGER, CHAR, BOOLEAN, BOOLEAN, BOOLEAN)
 IS 'pgr_withPointsKSP
-- PROPOSED
 - Parameters:
     - Edges SQL with columns: id, source, target, cost [,reverse_cost]
     - Points SQL with columns: [pid], edge_id, fraction[,side]
@@ -222,7 +220,6 @@ IS 'pgr_withPointsKSP
 
 COMMENT ON FUNCTION pgr_withPointsKSP(TEXT, TEXT, ANYARRAY, BIGINT, INTEGER, CHAR, BOOLEAN, BOOLEAN, BOOLEAN)
 IS 'pgr_withPointsKSP
-- PROPOSED
 - Parameters:
     - Edges SQL with columns: id, source, target, cost [,reverse_cost]
     - Points SQL with columns: [pid], edge_id, fraction[,side]
@@ -239,7 +236,6 @@ IS 'pgr_withPointsKSP
 
 COMMENT ON FUNCTION pgr_withPointsKSP(TEXT, TEXT, ANYARRAY, ANYARRAY, INTEGER, CHAR, BOOLEAN, BOOLEAN, BOOLEAN)
 IS 'pgr_withPointsKSP
-- PROPOSED
 - Parameters:
     - Edges SQL with columns: id, source, target, cost [,reverse_cost]
     - Points SQL with columns: [pid], edge_id, fraction[,side]
@@ -256,7 +252,6 @@ IS 'pgr_withPointsKSP
 
 COMMENT ON FUNCTION pgr_withPointsKSP(TEXT, TEXT, TEXT, INTEGER, CHAR, BOOLEAN, BOOLEAN, BOOLEAN)
 IS 'pgr_withPointsKSP
-- PROPOSED
 - Parameters:
     - Edges SQL with columns: id, source, target, cost [,reverse_cost]
     - Points SQL with columns: [pid], edge_id, fraction[,side]

--- a/sql/trsp/trsp.sql
+++ b/sql/trsp/trsp.sql
@@ -191,7 +191,6 @@ ROWS 1000;
 
 COMMENT ON FUNCTION pgr_trsp(TEXT, TEXT, BIGINT, BIGINT, BOOLEAN)
 IS 'pgr_trsp(one to one)
-- PROPOSED
 - Parameters
   - Edges SQL with columns: id, source, target, cost [,reverse_cost]
   - Restrictions SQL with columns: cost, path
@@ -205,7 +204,6 @@ IS 'pgr_trsp(one to one)
 
 COMMENT ON FUNCTION pgr_trsp(TEXT, TEXT, BIGINT, ANYARRAY, BOOLEAN)
 IS 'pgr_trsp(one to many)
-- PROPOSED
 - Parameters
   - Edges SQL with columns: id, source, target, cost [,reverse_cost]
   - Restrictions SQL with columns: cost, path
@@ -219,7 +217,6 @@ IS 'pgr_trsp(one to many)
 
 COMMENT ON FUNCTION pgr_trsp(TEXT, TEXT, ANYARRAY, BIGINT, BOOLEAN)
 IS 'pgr_trsp(many to one)
-- PROPOSED
 - Parameters
   - Edges SQL with columns: id, source, target, cost [,reverse_cost]
   - Restrictions SQL with columns: cost, path
@@ -233,7 +230,6 @@ IS 'pgr_trsp(many to one)
 
 COMMENT ON FUNCTION pgr_trsp(TEXT, TEXT, ANYARRAY, ANYARRAY, BOOLEAN)
 IS 'pgr_trsp(many to many)
-- PROPOSED
 - Parameters
   - Edges SQL with columns: id, source, target, cost [,reverse_cost]
   - Restrictions SQL with columns: cost, path
@@ -247,7 +243,6 @@ IS 'pgr_trsp(many to many)
 
 COMMENT ON FUNCTION pgr_trsp(TEXT, TEXT, TEXT, BOOLEAN)
 IS 'pgr_trsp(combinations)
-- PROPOSED
 - Parameters
   - Edges SQL with columns: id, source, target, cost [,reverse_cost]
   - Restrictions SQL with columns: cost, path

--- a/sql/trsp/trspVia.sql
+++ b/sql/trsp/trspVia.sql
@@ -58,7 +58,6 @@ ROWS 1000;
 
 COMMENT ON FUNCTION pgr_trspVia(TEXT, TEXT, ANYARRAY, BOOLEAN, BOOLEAN, BOOLEAN)
 IS 'pgr_trspVia
-- PROPOSED
 - Parameters:
   - Edges SQL with columns: id, source, target, cost [,reverse_cost]
   - Restrictions SQL with columns: cost, path

--- a/sql/trsp/trspVia_withPoints.sql
+++ b/sql/trsp/trspVia_withPoints.sql
@@ -66,7 +66,6 @@ ROWS 1000;
 
 COMMENT ON FUNCTION pgr_trspVia_withPoints(TEXT, TEXT, TEXT, ANYARRAY, BOOLEAN, BOOLEAN, BOOLEAN, CHAR, BOOLEAN)
 IS 'pgr_trspVia_withPoints
-- PROPOSED
 - Parameters:
   - Edges SQL with columns: id, source, target, cost [,reverse_cost]
   - Restrictions SQL with columns: cost, path

--- a/sql/trsp/trsp_withPoints.sql
+++ b/sql/trsp/trsp_withPoints.sql
@@ -199,7 +199,6 @@ ROWS 1000;
 -- COMMENTS
 COMMENT ON FUNCTION pgr_trsp_withPoints(TEXT, TEXT, TEXT, BIGINT, BIGINT, BOOLEAN, CHAR, BOOLEAN)
 IS 'pgr_trsp_withPoints (One to One)
-- PROPOSED
 - Parameters:
   - Edges SQL with columns: id, source, target, cost [,reverse_cost]
   - Restrictions SQL with columns: id, cost, path
@@ -217,7 +216,6 @@ IS 'pgr_trsp_withPoints (One to One)
 
 COMMENT ON FUNCTION pgr_trsp_withPoints(TEXT, TEXT, TEXT, BIGINT, ANYARRAY, BOOLEAN, CHAR, BOOLEAN)
 IS 'pgr_trsp_withPoints(One to Many)
-- PROPOSED
 - Parameters:
   - Edges SQL with columns: id, source, target, cost [,reverse_cost]
   - Restrictions SQL with columns: id, cost, path
@@ -234,7 +232,6 @@ IS 'pgr_trsp_withPoints(One to Many)
 
 COMMENT ON FUNCTION pgr_trsp_withPoints(TEXT, TEXT, TEXT, ANYARRAY, BIGINT, BOOLEAN, CHAR, BOOLEAN)
 IS 'pgr_trsp_withPoints(Many to One)
-- PROPOSED
 - Parameters:
   - Edges SQL with columns: id, source, target, cost [,reverse_cost]
   - Restrictions SQL with columns: id, cost, path
@@ -251,7 +248,6 @@ IS 'pgr_trsp_withPoints(Many to One)
 
 COMMENT ON FUNCTION pgr_trsp_withPoints(TEXT, TEXT, TEXT, ANYARRAY, ANYARRAY, BOOLEAN, CHAR, BOOLEAN)
 IS 'pgr_trsp_withPoints(Many to Many)
-- PROPOSED
 - Parameters:
   - Edges SQL with columns: id, source, target, cost [,reverse_cost]
   - Restrictions SQL with columns: id, cost, path

--- a/sql/withPoints/withPoints.sql
+++ b/sql/withPoints/withPoints.sql
@@ -185,7 +185,6 @@ ROWS 1000;
 
 COMMENT ON FUNCTION pgr_withPoints(TEXT, TEXT, BIGINT, BIGINT, BOOLEAN, CHAR, BOOLEAN)
 IS 'pgr_withPoints (One to One)
-- PROPOSED
 - Parameters:
     - Edges SQL with columns: id, source, target, cost [,reverse_cost]
     - Points SQL with columns: [pid], edge_id, fraction[,side]
@@ -202,7 +201,6 @@ IS 'pgr_withPoints (One to One)
 
 COMMENT ON FUNCTION pgr_withPoints(TEXT, TEXT, BIGINT, ANYARRAY, BOOLEAN, CHAR, BOOLEAN)
 IS 'pgr_withPoints (One to Many)
-- PROPOSED
 - Parameters:
     - Edges SQL with columns: id, source, target, cost [,reverse_cost]
     - Points SQL with columns: [pid], edge_id, fraction[,side]
@@ -219,7 +217,6 @@ IS 'pgr_withPoints (One to Many)
 
 COMMENT ON FUNCTION pgr_withPoints(TEXT, TEXT, ANYARRAY, BIGINT, BOOLEAN, CHAR, BOOLEAN)
 IS 'pgr_withPoints (Many to One)
-- PROPOSED
 - Parameters:
     - Edges SQL with columns: id, source, target, cost [,reverse_cost]
     - Points SQL with columns: [pid], edge_id, fraction[,side]
@@ -236,7 +233,6 @@ IS 'pgr_withPoints (Many to One)
 
 COMMENT ON FUNCTION pgr_withPoints(TEXT, TEXT, ANYARRAY, ANYARRAY, BOOLEAN, CHAR, BOOLEAN)
 IS 'pgr_withPoints (Many to Many)
-- PROPOSED
 - Parameters:
     - Edges SQL with columns: id, source, target, cost [,reverse_cost]
     - Points SQL with columns: [pid], edge_id, fraction[,side]

--- a/sql/withPoints/withPointsCost.sql
+++ b/sql/withPoints/withPointsCost.sql
@@ -157,7 +157,6 @@ ROWS 1000;
 
 COMMENT ON FUNCTION pgr_withPointsCost(TEXT, TEXT, BIGINT, BIGINT, BOOLEAN, CHAR)
 IS 'pgr_withPointsCost (One to One)
-- PROPOSED
 - Parameters:
     - Edges SQL with columns: id, source, target, cost [,reverse_cost]
     - Points SQL with columns: [pid], edge_id, fraction[,side]
@@ -173,7 +172,6 @@ IS 'pgr_withPointsCost (One to One)
 
 COMMENT ON FUNCTION pgr_withPointsCost(TEXT, TEXT, BIGINT, ANYARRAY, BOOLEAN, CHAR)
 IS 'pgr_withPointsCost (One to Many)
-- PROPOSED
 - Parameters:
     - Edges SQL with columns: id, source, target, cost [,reverse_cost]
     - Points SQL with columns: [pid], edge_id, fraction[,side]
@@ -189,7 +187,6 @@ IS 'pgr_withPointsCost (One to Many)
 
 COMMENT ON FUNCTION pgr_withPointsCost(TEXT, TEXT, ANYARRAY, BIGINT, BOOLEAN, CHAR)
 IS 'pgr_withPointsCost (Many to One)
-- PROPOSED
 - Parameters:
     - Edges SQL with columns: id, source, target, cost [,reverse_cost]
     - Points SQL with columns: [pid], edge_id, fraction[,side]

--- a/sql/withPoints/withPointsCostMatrix.sql
+++ b/sql/withPoints/withPointsCostMatrix.sql
@@ -27,16 +27,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 
----------------------
----------------------
--- costMatrix
----------------------
----------------------
-
 ---------------------------
 -- pgr_withPointsCostMatrix
 ---------------------------
-
 
 --v2.6
 CREATE FUNCTION pgr_withPointsCostMatrix(
@@ -63,7 +56,6 @@ ROWS 1000;
 
 COMMENT ON FUNCTION pgr_withPointsCostMatrix(TEXT, TEXT, ANYARRAY, BOOLEAN, CHAR)
 IS'pgr_withPointsCostMatrix
-- PROPOSED
 - Parameters:
     - Edges SQL with columns: id, source, target, cost [,reverse_cost]
     - Points SQL with columns: [pid], edge_id, fraction[,side]

--- a/sql/withPoints/withPointsVia.sql
+++ b/sql/withPoints/withPointsVia.sql
@@ -64,7 +64,6 @@ ROWS 1000;
 
 COMMENT ON FUNCTION pgr_withPointsVia(TEXT, TEXT, ANYARRAY, BOOLEAN, BOOLEAN, BOOLEAN, CHAR, BOOLEAN)
 IS 'pgr_withPointsVia
-- PROPOSED
 - Parameters:
   - Edges SQL with columns: id, source, target, cost [,reverse_cost]
   - Points SQL with columns: [pid], edge_id, fraction [,side]


### PR DESCRIPTION
Fixes #2700 #2701 #2718 
 .

Changes proposed in this pull request:
- Modification on documentation about official functions
- Remove `PROPOSED` keyword on sql files of the official functions


@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes for pgRouting 4.0.0

- **New Features**
  - Promoted multiple functions to official status, including `pgr_trsp`, `pgr_withPoints`, and related variants
  - Added support for combination signatures in various routing functions
  - Enhanced parameter flexibility for routing functions

- **Improvements**
  - Updated function signatures to support array inputs for vertices
  - Added new routing scenarios for one-to-many, many-to-one, and many-to-many configurations
  - Improved documentation for function parameters and usage

- **Deprecated Functions**
  - Removed several deprecated functions, including `pgr_trspviaedges` and `pgr_trspviavertices`

- **Documentation**
  - Clarified function statuses and promoted previously proposed functions to official

<!-- end of auto-generated comment: release notes by coderabbit.ai -->