### PR TITLE
(C++/performance) Removing passing c_str() to a function that takes s…

### DIFF
--- a/docqueries/ordering/topologicalSort.result
+++ b/docqueries/ordering/topologicalSort.result
@@ -62,7 +62,6 @@ SELECT * FROM pgr_topologicalsort(
 SELECT * FROM pgr_topologicalsort(
   $$SELECT id, source, target, cost, reverse_cost FROM edges$$);
 ERROR:  Graph is not DAG
-HINT:
 CONTEXT:  SQL function "pgr_topologicalsort" statement 1
 /* -- q4 */
 ROLLBACK;

--- a/include/c_common/e_report.h
+++ b/include/c_common/e_report.h
@@ -41,7 +41,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  * ~~~~{.c}
  * std::ostringstream log;
  * log << "the message";
- * *log_msg = pgr_msg(log.str().c_str());
+ * *log_msg = pgr_msg(log.str());
  * ~~~~
  *
  *

--- a/include/c_common/e_report.h
+++ b/include/c_common/e_report.h
@@ -41,7 +41,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  * ~~~~{.c}
  * std::ostringstream log;
  * log << "the message";
- * *log_msg = pgr_msg(log.str());
+ * *log_msg = to_pg_msg(log.str());
  * ~~~~
  *
  *

--- a/include/cpp_common/alloc.hpp
+++ b/include/cpp_common/alloc.hpp
@@ -33,6 +33,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 #include <string>
+#include <sstream>
 
 extern "C" {
 
@@ -86,8 +87,8 @@ pgr_free(T* ptr) {
     return nullptr;
 }
 
-char *
-to_pg_msg(const std::string &msg);
+char* to_pg_msg(const std::string&);
+char* to_pg_msg(const std::ostringstream&);
 
 }  // namespace pgrouting
 

--- a/include/cpp_common/alloc.hpp
+++ b/include/cpp_common/alloc.hpp
@@ -87,7 +87,7 @@ pgr_free(T* ptr) {
 }
 
 char *
-pgr_msg(const std::string &msg);
+to_pg_msg(const std::string &msg);
 
 }  // namespace pgrouting
 

--- a/src/allpairs/floydWarshall_driver.cpp
+++ b/src/allpairs/floydWarshall_driver.cpp
@@ -101,7 +101,7 @@ pgr_do_floydWarshall(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/allpairs/floydWarshall_driver.cpp
+++ b/src/allpairs/floydWarshall_driver.cpp
@@ -49,7 +49,7 @@ pgr_do_floydWarshall(
         size_t *return_count,
         char ** log_msg,
         char ** err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -85,7 +85,7 @@ pgr_do_floydWarshall(
 
         if (*return_count == 0) {
             err <<  "No result generated, report this error\n";
-            *err_msg = pgr_msg(err.str());
+            *err_msg = to_pg_msg(err.str());
             *return_tuples = NULL;
             *return_count = 0;
             return;
@@ -93,27 +93,27 @@ pgr_do_floydWarshall(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/allpairs/floydWarshall_driver.cpp
+++ b/src/allpairs/floydWarshall_driver.cpp
@@ -85,35 +85,33 @@ pgr_do_floydWarshall(
 
         if (*return_count == 0) {
             err <<  "No result generated, report this error\n";
-            *err_msg = to_pg_msg(err.str());
+            *err_msg = to_pg_msg(err);
             *return_tuples = NULL;
             *return_count = 0;
             return;
         }
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
+        *log_msg = to_pg_msg(log);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/allpairs/floydWarshall_driver.cpp
+++ b/src/allpairs/floydWarshall_driver.cpp
@@ -85,7 +85,7 @@ pgr_do_floydWarshall(
 
         if (*return_count == 0) {
             err <<  "No result generated, report this error\n";
-            *err_msg = pgr_msg(err.str().c_str());
+            *err_msg = pgr_msg(err.str());
             *return_tuples = NULL;
             *return_count = 0;
             return;
@@ -93,27 +93,27 @@ pgr_do_floydWarshall(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/allpairs/johnson_driver.cpp
+++ b/src/allpairs/johnson_driver.cpp
@@ -48,7 +48,7 @@ pgr_do_johnson(
         size_t *return_count,
         char ** log_msg,
         char ** err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -84,7 +84,7 @@ pgr_do_johnson(
 
         if (*return_count == 0) {
             err << "No result generated, report this error\n";
-            *err_msg = pgr_msg(err.str());
+            *err_msg = to_pg_msg(err.str());
             *return_tuples = NULL;
             *return_count = 0;
             return;
@@ -92,27 +92,27 @@ pgr_do_johnson(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/allpairs/johnson_driver.cpp
+++ b/src/allpairs/johnson_driver.cpp
@@ -100,7 +100,7 @@ pgr_do_johnson(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/allpairs/johnson_driver.cpp
+++ b/src/allpairs/johnson_driver.cpp
@@ -84,7 +84,7 @@ pgr_do_johnson(
 
         if (*return_count == 0) {
             err << "No result generated, report this error\n";
-            *err_msg = pgr_msg(err.str().c_str());
+            *err_msg = pgr_msg(err.str());
             *return_tuples = NULL;
             *return_count = 0;
             return;
@@ -92,27 +92,27 @@ pgr_do_johnson(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/allpairs/johnson_driver.cpp
+++ b/src/allpairs/johnson_driver.cpp
@@ -84,35 +84,33 @@ pgr_do_johnson(
 
         if (*return_count == 0) {
             err << "No result generated, report this error\n";
-            *err_msg = to_pg_msg(err.str());
+            *err_msg = to_pg_msg(err);
             *return_tuples = NULL;
             *return_count = 0;
             return;
         }
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
+        *log_msg = to_pg_msg(log);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/alpha_shape/alphaShape_driver.cpp
+++ b/src/alpha_shape/alphaShape_driver.cpp
@@ -207,7 +207,7 @@ pgr_do_alphaShape(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/alpha_shape/alphaShape_driver.cpp
+++ b/src/alpha_shape/alphaShape_driver.cpp
@@ -194,32 +194,28 @@ pgr_do_alphaShape(
         }
 
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/alpha_shape/alphaShape_driver.cpp
+++ b/src/alpha_shape/alphaShape_driver.cpp
@@ -180,7 +180,7 @@ pgr_do_alphaShape(
             *return_tuples = pgr_alloc(*return_count, (*return_tuples));
             std::stringstream ss;
             ss << "MULTIPOLYGON EMPTY";
-            (*return_tuples)[0].geom = pgr_msg(ss.str().c_str());
+            (*return_tuples)[0].geom = pgr_msg(ss.str());
         } else {
             *return_count = results.size();
             *return_tuples = pgr_alloc(*return_count, (*return_tuples));
@@ -188,7 +188,7 @@ pgr_do_alphaShape(
             for (const auto &r : results) {
                 std::stringstream ss;
                 ss << bg::wkt(r);
-                (*return_tuples)[row].geom = pgr_msg(ss.str().c_str());
+                (*return_tuples)[row].geom = pgr_msg(ss.str());
                 ++row;
             }
         }
@@ -196,30 +196,30 @@ pgr_do_alphaShape(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/alpha_shape/alphaShape_driver.cpp
+++ b/src/alpha_shape/alphaShape_driver.cpp
@@ -73,7 +73,7 @@ pgr_do_alphaShape(
         char **notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -180,7 +180,7 @@ pgr_do_alphaShape(
             *return_tuples = pgr_alloc(*return_count, (*return_tuples));
             std::stringstream ss;
             ss << "MULTIPOLYGON EMPTY";
-            (*return_tuples)[0].geom = pgr_msg(ss.str());
+            (*return_tuples)[0].geom = to_pg_msg(ss.str());
         } else {
             *return_count = results.size();
             *return_tuples = pgr_alloc(*return_count, (*return_tuples));
@@ -188,7 +188,7 @@ pgr_do_alphaShape(
             for (const auto &r : results) {
                 std::stringstream ss;
                 ss << bg::wkt(r);
-                (*return_tuples)[row].geom = pgr_msg(ss.str());
+                (*return_tuples)[row].geom = to_pg_msg(ss.str());
                 ++row;
             }
         }
@@ -196,30 +196,30 @@ pgr_do_alphaShape(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/astar/astar_driver.cpp
+++ b/src/astar/astar_driver.cpp
@@ -148,7 +148,7 @@ void pgr_do_astar(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/astar/astar_driver.cpp
+++ b/src/astar/astar_driver.cpp
@@ -128,7 +128,7 @@ void pgr_do_astar(
             (*return_tuples) = nullptr;
             (*return_count) = 0;
             notice << "No paths found\n";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -137,30 +137,30 @@ void pgr_do_astar(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/astar/astar_driver.cpp
+++ b/src/astar/astar_driver.cpp
@@ -61,7 +61,7 @@ void pgr_do_astar(
         char** log_msg, char** notice_msg, char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -85,8 +85,8 @@ void pgr_do_astar(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -96,8 +96,8 @@ void pgr_do_astar(
         hint = nullptr;
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = pgr_msg(edges_sql);
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = to_pg_msg(edges_sql);
             return;
         }
 
@@ -128,7 +128,7 @@ void pgr_do_astar(
             (*return_tuples) = nullptr;
             (*return_count) = 0;
             notice << "No paths found\n";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -137,30 +137,30 @@ void pgr_do_astar(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/astar/astar_driver.cpp
+++ b/src/astar/astar_driver.cpp
@@ -128,39 +128,35 @@ void pgr_do_astar(
             (*return_tuples) = nullptr;
             (*return_count) = 0;
             notice << "No paths found\n";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/bdAstar/bdAstar_driver.cpp
+++ b/src/bdAstar/bdAstar_driver.cpp
@@ -138,7 +138,7 @@ void pgr_do_bdAstar(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/bdAstar/bdAstar_driver.cpp
+++ b/src/bdAstar/bdAstar_driver.cpp
@@ -62,7 +62,7 @@ void pgr_do_bdAstar(
         char** log_msg, char** notice_msg, char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -83,8 +83,8 @@ void pgr_do_bdAstar(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -92,8 +92,8 @@ void pgr_do_bdAstar(
         auto edges = pgrouting::pgget::get_edges_xy(std::string(edges_sql), true);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -118,7 +118,7 @@ void pgr_do_bdAstar(
             (*return_tuples) = nullptr;
             (*return_count) = 0;
             notice << "No paths found\n";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -127,30 +127,30 @@ void pgr_do_bdAstar(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/bdAstar/bdAstar_driver.cpp
+++ b/src/bdAstar/bdAstar_driver.cpp
@@ -93,7 +93,7 @@ void pgr_do_bdAstar(
 
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -118,7 +118,7 @@ void pgr_do_bdAstar(
             (*return_tuples) = nullptr;
             (*return_count) = 0;
             notice << "No paths found\n";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -127,30 +127,30 @@ void pgr_do_bdAstar(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/bdAstar/bdAstar_driver.cpp
+++ b/src/bdAstar/bdAstar_driver.cpp
@@ -93,7 +93,7 @@ void pgr_do_bdAstar(
 
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -118,39 +118,35 @@ void pgr_do_bdAstar(
             (*return_tuples) = nullptr;
             (*return_count) = 0;
             notice << "No paths found\n";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/bdDijkstra/bdDijkstra_driver.cpp
+++ b/src/bdDijkstra/bdDijkstra_driver.cpp
@@ -95,7 +95,7 @@ pgr_do_bdDijkstra(
         char **err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -116,8 +116,8 @@ pgr_do_bdDijkstra(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -127,8 +127,8 @@ pgr_do_bdDijkstra(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -151,7 +151,7 @@ pgr_do_bdDijkstra(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -160,30 +160,30 @@ pgr_do_bdDijkstra(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/bdDijkstra/bdDijkstra_driver.cpp
+++ b/src/bdDijkstra/bdDijkstra_driver.cpp
@@ -128,7 +128,7 @@ pgr_do_bdDijkstra(
 
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -151,39 +151,35 @@ pgr_do_bdDijkstra(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/bdDijkstra/bdDijkstra_driver.cpp
+++ b/src/bdDijkstra/bdDijkstra_driver.cpp
@@ -171,7 +171,7 @@ pgr_do_bdDijkstra(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/bdDijkstra/bdDijkstra_driver.cpp
+++ b/src/bdDijkstra/bdDijkstra_driver.cpp
@@ -128,7 +128,7 @@ pgr_do_bdDijkstra(
 
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -151,7 +151,7 @@ pgr_do_bdDijkstra(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -160,30 +160,30 @@ pgr_do_bdDijkstra(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/bellman_ford/bellman_ford_driver.cpp
+++ b/src/bellman_ford/bellman_ford_driver.cpp
@@ -156,7 +156,7 @@ pgr_do_bellman_ford(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/bellman_ford/bellman_ford_driver.cpp
+++ b/src/bellman_ford/bellman_ford_driver.cpp
@@ -79,7 +79,7 @@ pgr_do_bellman_ford(
                 char ** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
     using pgrouting::pgget::get_edges;
@@ -103,8 +103,8 @@ pgr_do_bellman_ford(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -112,8 +112,8 @@ pgr_do_bellman_ford(
         auto edges = get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -136,7 +136,7 @@ pgr_do_bellman_ford(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -145,30 +145,30 @@ pgr_do_bellman_ford(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/bellman_ford/bellman_ford_driver.cpp
+++ b/src/bellman_ford/bellman_ford_driver.cpp
@@ -113,7 +113,7 @@ pgr_do_bellman_ford(
 
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -136,39 +136,35 @@ pgr_do_bellman_ford(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/bellman_ford/bellman_ford_driver.cpp
+++ b/src/bellman_ford/bellman_ford_driver.cpp
@@ -113,7 +113,7 @@ pgr_do_bellman_ford(
 
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -136,7 +136,7 @@ pgr_do_bellman_ford(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -145,30 +145,30 @@ pgr_do_bellman_ford(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/bellman_ford/bellman_ford_neg_driver.cpp
+++ b/src/bellman_ford/bellman_ford_neg_driver.cpp
@@ -118,7 +118,7 @@ pgr_do_bellman_ford_neg(
 
         if (edges.size() + neg_edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -143,39 +143,35 @@ pgr_do_bellman_ford_neg(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/bellman_ford/bellman_ford_neg_driver.cpp
+++ b/src/bellman_ford/bellman_ford_neg_driver.cpp
@@ -81,7 +81,7 @@ pgr_do_bellman_ford_neg(
                 char ** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
     using pgrouting::pgget::get_edges;
@@ -105,8 +105,8 @@ pgr_do_bellman_ford_neg(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -117,8 +117,8 @@ pgr_do_bellman_ford_neg(
         auto neg_edges = get_edges(std::string(neg_edges_sql), true, false);
 
         if (edges.size() + neg_edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -143,7 +143,7 @@ pgr_do_bellman_ford_neg(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -152,30 +152,30 @@ pgr_do_bellman_ford_neg(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/bellman_ford/bellman_ford_neg_driver.cpp
+++ b/src/bellman_ford/bellman_ford_neg_driver.cpp
@@ -163,7 +163,7 @@ pgr_do_bellman_ford_neg(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/bellman_ford/bellman_ford_neg_driver.cpp
+++ b/src/bellman_ford/bellman_ford_neg_driver.cpp
@@ -118,7 +118,7 @@ pgr_do_bellman_ford_neg(
 
         if (edges.size() + neg_edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -143,7 +143,7 @@ pgr_do_bellman_ford_neg(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -152,30 +152,30 @@ pgr_do_bellman_ford_neg(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/bellman_ford/edwardMoore_driver.cpp
+++ b/src/bellman_ford/edwardMoore_driver.cpp
@@ -113,7 +113,7 @@ pgr_do_edwardMoore(
 
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -136,7 +136,7 @@ pgr_do_edwardMoore(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -145,30 +145,30 @@ pgr_do_edwardMoore(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/bellman_ford/edwardMoore_driver.cpp
+++ b/src/bellman_ford/edwardMoore_driver.cpp
@@ -79,7 +79,7 @@ pgr_do_edwardMoore(
         char ** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
     using pgrouting::pgget::get_edges;
@@ -103,8 +103,8 @@ pgr_do_edwardMoore(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -112,8 +112,8 @@ pgr_do_edwardMoore(
         auto edges = get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -136,7 +136,7 @@ pgr_do_edwardMoore(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -145,30 +145,30 @@ pgr_do_edwardMoore(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/bellman_ford/edwardMoore_driver.cpp
+++ b/src/bellman_ford/edwardMoore_driver.cpp
@@ -156,7 +156,7 @@ pgr_do_edwardMoore(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/bellman_ford/edwardMoore_driver.cpp
+++ b/src/bellman_ford/edwardMoore_driver.cpp
@@ -113,7 +113,7 @@ pgr_do_edwardMoore(
 
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -136,39 +136,35 @@ pgr_do_edwardMoore(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/breadthFirstSearch/binaryBreadthFirstSearch_driver.cpp
+++ b/src/breadthFirstSearch/binaryBreadthFirstSearch_driver.cpp
@@ -136,7 +136,7 @@ pgr_do_binaryBreadthFirstSearch(
         char ** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
     using pgrouting::pgget::get_edges;
@@ -162,8 +162,8 @@ pgr_do_binaryBreadthFirstSearch(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -172,8 +172,8 @@ pgr_do_binaryBreadthFirstSearch(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
 
@@ -184,7 +184,7 @@ pgr_do_binaryBreadthFirstSearch(
 
             if (!(costCheck(digraph))) {
                 err << c_err_msg;
-                *err_msg = pgr_msg(err.str());
+                *err_msg = to_pg_msg(err.str());
                 return;
             }
             paths = binaryBreadthFirstSearch(digraph, combinations);
@@ -195,7 +195,7 @@ pgr_do_binaryBreadthFirstSearch(
 
             if (!(costCheck(undigraph))) {
                 err << c_err_msg;
-                *err_msg = pgr_msg(err.str());
+                *err_msg = to_pg_msg(err.str());
                 return;
             }
 
@@ -210,7 +210,7 @@ pgr_do_binaryBreadthFirstSearch(
             (*return_count) = 0;
             notice <<
                 "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -220,30 +220,30 @@ pgr_do_binaryBreadthFirstSearch(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/breadthFirstSearch/binaryBreadthFirstSearch_driver.cpp
+++ b/src/breadthFirstSearch/binaryBreadthFirstSearch_driver.cpp
@@ -231,7 +231,7 @@ pgr_do_binaryBreadthFirstSearch(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/breadthFirstSearch/binaryBreadthFirstSearch_driver.cpp
+++ b/src/breadthFirstSearch/binaryBreadthFirstSearch_driver.cpp
@@ -173,7 +173,7 @@ pgr_do_binaryBreadthFirstSearch(
 
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
 
@@ -184,7 +184,7 @@ pgr_do_binaryBreadthFirstSearch(
 
             if (!(costCheck(digraph))) {
                 err << c_err_msg;
-                *err_msg = pgr_msg(err.str().c_str());
+                *err_msg = pgr_msg(err.str());
                 return;
             }
             paths = binaryBreadthFirstSearch(digraph, combinations);
@@ -195,7 +195,7 @@ pgr_do_binaryBreadthFirstSearch(
 
             if (!(costCheck(undigraph))) {
                 err << c_err_msg;
-                *err_msg = pgr_msg(err.str().c_str());
+                *err_msg = pgr_msg(err.str());
                 return;
             }
 
@@ -210,7 +210,7 @@ pgr_do_binaryBreadthFirstSearch(
             (*return_count) = 0;
             notice <<
                 "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -220,30 +220,30 @@ pgr_do_binaryBreadthFirstSearch(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/breadthFirstSearch/binaryBreadthFirstSearch_driver.cpp
+++ b/src/breadthFirstSearch/binaryBreadthFirstSearch_driver.cpp
@@ -173,7 +173,7 @@ pgr_do_binaryBreadthFirstSearch(
 
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
 
@@ -184,7 +184,7 @@ pgr_do_binaryBreadthFirstSearch(
 
             if (!(costCheck(digraph))) {
                 err << c_err_msg;
-                *err_msg = to_pg_msg(err.str());
+                *err_msg = to_pg_msg(err);
                 return;
             }
             paths = binaryBreadthFirstSearch(digraph, combinations);
@@ -195,7 +195,7 @@ pgr_do_binaryBreadthFirstSearch(
 
             if (!(costCheck(undigraph))) {
                 err << c_err_msg;
-                *err_msg = to_pg_msg(err.str());
+                *err_msg = to_pg_msg(err);
                 return;
             }
 
@@ -210,7 +210,7 @@ pgr_do_binaryBreadthFirstSearch(
             (*return_count) = 0;
             notice <<
                 "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -218,32 +218,28 @@ pgr_do_binaryBreadthFirstSearch(
         log << "\nConverting a set of paths into the tuples";
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/breadthFirstSearch/breadthFirstSearch_driver.cpp
+++ b/src/breadthFirstSearch/breadthFirstSearch_driver.cpp
@@ -140,7 +140,7 @@ pgr_do_breadthFirstSearch(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/breadthFirstSearch/breadthFirstSearch_driver.cpp
+++ b/src/breadthFirstSearch/breadthFirstSearch_driver.cpp
@@ -67,7 +67,7 @@ pgr_do_breadthFirstSearch(
                 char ** notice_msg,
                 char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intSet;
 
@@ -91,8 +91,8 @@ pgr_do_breadthFirstSearch(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -117,7 +117,7 @@ pgr_do_breadthFirstSearch(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No traversal found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -129,30 +129,30 @@ pgr_do_breadthFirstSearch(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/breadthFirstSearch/breadthFirstSearch_driver.cpp
+++ b/src/breadthFirstSearch/breadthFirstSearch_driver.cpp
@@ -92,7 +92,7 @@ pgr_do_breadthFirstSearch(
 
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -117,7 +117,7 @@ pgr_do_breadthFirstSearch(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No traversal found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -127,32 +127,28 @@ pgr_do_breadthFirstSearch(
             *((*return_tuples) + i) = results[i];
         }
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/breadthFirstSearch/breadthFirstSearch_driver.cpp
+++ b/src/breadthFirstSearch/breadthFirstSearch_driver.cpp
@@ -92,7 +92,7 @@ pgr_do_breadthFirstSearch(
 
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -117,7 +117,7 @@ pgr_do_breadthFirstSearch(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No traversal found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -129,30 +129,30 @@ pgr_do_breadthFirstSearch(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/chinese/chinesePostman_driver.cpp
+++ b/src/chinese/chinesePostman_driver.cpp
@@ -125,7 +125,7 @@ pgr_do_directedChPP(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/chinese/chinesePostman_driver.cpp
+++ b/src/chinese/chinesePostman_driver.cpp
@@ -72,7 +72,7 @@ pgr_do_directedChPP(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -101,7 +101,7 @@ pgr_do_directedChPP(
             (*return_count) = 0;
             notice <<
                 "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -114,31 +114,31 @@ pgr_do_directedChPP(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }
 

--- a/src/chinese/chinesePostman_driver.cpp
+++ b/src/chinese/chinesePostman_driver.cpp
@@ -72,7 +72,7 @@ pgr_do_directedChPP(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -101,7 +101,7 @@ pgr_do_directedChPP(
             (*return_count) = 0;
             notice <<
                 "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -112,33 +112,29 @@ pgr_do_directedChPP(
         }
         *return_count = count;
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }
 

--- a/src/chinese/chinesePostman_driver.cpp
+++ b/src/chinese/chinesePostman_driver.cpp
@@ -52,7 +52,7 @@ pgr_do_directedChPP(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -71,8 +71,8 @@ pgr_do_directedChPP(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -101,7 +101,7 @@ pgr_do_directedChPP(
             (*return_count) = 0;
             notice <<
                 "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -114,31 +114,31 @@ pgr_do_directedChPP(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }
 

--- a/src/circuits/hawickCircuits_driver.cpp
+++ b/src/circuits/hawickCircuits_driver.cpp
@@ -131,7 +131,7 @@ pgr_do_hawickCircuits(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/circuits/hawickCircuits_driver.cpp
+++ b/src/circuits/hawickCircuits_driver.cpp
@@ -89,7 +89,7 @@ pgr_do_hawickCircuits(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -107,7 +107,7 @@ pgr_do_hawickCircuits(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No Circuit found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -118,32 +118,28 @@ pgr_do_hawickCircuits(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/circuits/hawickCircuits_driver.cpp
+++ b/src/circuits/hawickCircuits_driver.cpp
@@ -70,7 +70,7 @@ pgr_do_hawickCircuits(
         char ** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -88,8 +88,8 @@ pgr_do_hawickCircuits(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -107,7 +107,7 @@ pgr_do_hawickCircuits(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No Circuit found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -120,30 +120,30 @@ pgr_do_hawickCircuits(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/circuits/hawickCircuits_driver.cpp
+++ b/src/circuits/hawickCircuits_driver.cpp
@@ -89,7 +89,7 @@ pgr_do_hawickCircuits(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -107,7 +107,7 @@ pgr_do_hawickCircuits(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No Circuit found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -120,30 +120,30 @@ pgr_do_hawickCircuits(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/coloring/bipartite_driver.cpp
+++ b/src/coloring/bipartite_driver.cpp
@@ -75,7 +75,7 @@ pgr_do_bipartite(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -92,12 +92,8 @@ pgr_do_bipartite(
         if (count == 0) {
             (*return_tuples) = NULL;
             (*return_count) = 0;
-            *log_msg = log.str().empty()?
-                       *log_msg :
-                       to_pg_msg(log.str());
-            *notice_msg = notice.str().empty()?
-                          *notice_msg :
-                          to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(log);
+            *notice_msg = to_pg_msg(notice);
             return;
         }
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
@@ -107,32 +103,28 @@ pgr_do_bipartite(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-                   *log_msg :
-                   to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-                      *notice_msg :
-                      to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/coloring/bipartite_driver.cpp
+++ b/src/coloring/bipartite_driver.cpp
@@ -75,7 +75,7 @@ pgr_do_bipartite(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -94,10 +94,10 @@ pgr_do_bipartite(
             (*return_count) = 0;
             *log_msg = log.str().empty()?
                        *log_msg :
-                       pgr_msg(log.str().c_str());
+                       pgr_msg(log.str());
             *notice_msg = notice.str().empty()?
                           *notice_msg :
-                          pgr_msg(notice.str().c_str());
+                          pgr_msg(notice.str());
             return;
         }
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
@@ -109,30 +109,30 @@ pgr_do_bipartite(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
                    *log_msg :
-                   pgr_msg(log.str().c_str());
+                   pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
                       *notice_msg :
-                      pgr_msg(notice.str().c_str());
+                      pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/coloring/bipartite_driver.cpp
+++ b/src/coloring/bipartite_driver.cpp
@@ -120,7 +120,7 @@ pgr_do_bipartite(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/coloring/bipartite_driver.cpp
+++ b/src/coloring/bipartite_driver.cpp
@@ -53,7 +53,7 @@ pgr_do_bipartite(
         char **notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -74,8 +74,8 @@ pgr_do_bipartite(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -94,10 +94,10 @@ pgr_do_bipartite(
             (*return_count) = 0;
             *log_msg = log.str().empty()?
                        *log_msg :
-                       pgr_msg(log.str());
+                       to_pg_msg(log.str());
             *notice_msg = notice.str().empty()?
                           *notice_msg :
-                          pgr_msg(notice.str());
+                          to_pg_msg(notice.str());
             return;
         }
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
@@ -109,30 +109,30 @@ pgr_do_bipartite(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
                    *log_msg :
-                   pgr_msg(log.str());
+                   to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
                       *notice_msg :
-                      pgr_msg(notice.str());
+                      to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/coloring/edgeColoring_driver.cpp
+++ b/src/coloring/edgeColoring_driver.cpp
@@ -47,7 +47,7 @@ void pgr_do_edgeColoring(
     char **notice_msg,
     char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -65,8 +65,8 @@ void pgr_do_edgeColoring(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -84,7 +84,7 @@ void pgr_do_edgeColoring(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No results found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -95,28 +95,28 @@ void pgr_do_edgeColoring(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty() ? *log_msg : pgr_msg(log.str());
-        *notice_msg = notice.str().empty() ? *notice_msg : pgr_msg(notice.str());
+        *log_msg = log.str().empty() ? *log_msg : to_pg_msg(log.str());
+        *notice_msg = notice.str().empty() ? *notice_msg : to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/coloring/edgeColoring_driver.cpp
+++ b/src/coloring/edgeColoring_driver.cpp
@@ -66,7 +66,7 @@ void pgr_do_edgeColoring(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -84,7 +84,7 @@ void pgr_do_edgeColoring(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No results found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -95,28 +95,28 @@ void pgr_do_edgeColoring(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty() ? *log_msg : pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty() ? *notice_msg : pgr_msg(notice.str().c_str());
+        *log_msg = log.str().empty() ? *log_msg : pgr_msg(log.str());
+        *notice_msg = notice.str().empty() ? *notice_msg : pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/coloring/edgeColoring_driver.cpp
+++ b/src/coloring/edgeColoring_driver.cpp
@@ -104,7 +104,7 @@ void pgr_do_edgeColoring(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/coloring/edgeColoring_driver.cpp
+++ b/src/coloring/edgeColoring_driver.cpp
@@ -66,7 +66,7 @@ void pgr_do_edgeColoring(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -84,7 +84,7 @@ void pgr_do_edgeColoring(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No results found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -95,28 +95,28 @@ void pgr_do_edgeColoring(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty() ? *log_msg : to_pg_msg(log.str());
-        *notice_msg = notice.str().empty() ? *notice_msg : to_pg_msg(notice.str());
+        *log_msg = log.str().empty() ? *log_msg : to_pg_msg(log);
+        *notice_msg = notice.str().empty() ? *notice_msg : to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/coloring/sequentialVertexColoring_driver.cpp
+++ b/src/coloring/sequentialVertexColoring_driver.cpp
@@ -84,7 +84,7 @@ pgr_do_sequentialVertexColoring(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -103,7 +103,7 @@ pgr_do_sequentialVertexColoring(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No traversal found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -116,30 +116,30 @@ pgr_do_sequentialVertexColoring(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/coloring/sequentialVertexColoring_driver.cpp
+++ b/src/coloring/sequentialVertexColoring_driver.cpp
@@ -65,7 +65,7 @@ pgr_do_sequentialVertexColoring(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -83,8 +83,8 @@ pgr_do_sequentialVertexColoring(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -103,7 +103,7 @@ pgr_do_sequentialVertexColoring(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No traversal found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -116,30 +116,30 @@ pgr_do_sequentialVertexColoring(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/coloring/sequentialVertexColoring_driver.cpp
+++ b/src/coloring/sequentialVertexColoring_driver.cpp
@@ -84,7 +84,7 @@ pgr_do_sequentialVertexColoring(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -103,7 +103,7 @@ pgr_do_sequentialVertexColoring(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No traversal found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -114,32 +114,28 @@ pgr_do_sequentialVertexColoring(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/coloring/sequentialVertexColoring_driver.cpp
+++ b/src/coloring/sequentialVertexColoring_driver.cpp
@@ -127,7 +127,7 @@ pgr_do_sequentialVertexColoring(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/common/alloc.cpp
+++ b/src/common/alloc.cpp
@@ -31,13 +31,19 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 namespace pgrouting {
 
-char *
+char*
 to_pg_msg(const std::string &msg) {
-    char* duplicate = NULL;
+    if (msg.empty()) return nullptr;
+    char* duplicate = nullptr;
     duplicate = pgr_alloc(msg.size() + 1, duplicate);
     memcpy(duplicate, msg.c_str(), msg.size());
     duplicate[msg.size()] = '\0';
     return duplicate;
+}
+
+char*
+to_pg_msg(const std::ostringstream &msg) {
+    return to_pg_msg(msg.str());
 }
 
 }  // namespace pgrouting

--- a/src/common/alloc.cpp
+++ b/src/common/alloc.cpp
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 namespace pgrouting {
 
 char *
-pgr_msg(const std::string &msg) {
+to_pg_msg(const std::string &msg) {
     char* duplicate = NULL;
     duplicate = pgr_alloc(msg.size() + 1, duplicate);
     memcpy(duplicate, msg.c_str(), msg.size());

--- a/src/common/e_report.c
+++ b/src/common/e_report.c
@@ -44,7 +44,7 @@ pgr_throw_error(char *err, char *hint) {
  * ~~~~{.c}
  * std::ostringstream log;
  * log << "the message";
- * *log_msg = to_pg_msg(log.str().c_str());
+ * *log_msg = to_pg_msg(log.str());
  * ~~~~
  *
  * Then on the C side

--- a/src/common/e_report.c
+++ b/src/common/e_report.c
@@ -44,7 +44,7 @@ pgr_throw_error(char *err, char *hint) {
  * ~~~~{.c}
  * std::ostringstream log;
  * log << "the message";
- * *log_msg = to_pg_msg(log.str());
+ * *log_msg = to_pg_msg(log);
  * ~~~~
  *
  * Then on the C side

--- a/src/components/articulationPoints_driver.cpp
+++ b/src/components/articulationPoints_driver.cpp
@@ -52,7 +52,7 @@ pgr_do_articulationPoints(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_edges;
 
@@ -71,8 +71,8 @@ pgr_do_articulationPoints(
         hint = edges_sql;
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -102,31 +102,31 @@ pgr_do_articulationPoints(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }
 

--- a/src/components/articulationPoints_driver.cpp
+++ b/src/components/articulationPoints_driver.cpp
@@ -72,7 +72,7 @@ pgr_do_articulationPoints(
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -102,31 +102,31 @@ pgr_do_articulationPoints(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }
 

--- a/src/components/articulationPoints_driver.cpp
+++ b/src/components/articulationPoints_driver.cpp
@@ -113,7 +113,7 @@ pgr_do_articulationPoints(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/components/articulationPoints_driver.cpp
+++ b/src/components/articulationPoints_driver.cpp
@@ -72,7 +72,7 @@ pgr_do_articulationPoints(
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -100,33 +100,29 @@ pgr_do_articulationPoints(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }
 

--- a/src/components/biconnectedComponents_driver.cpp
+++ b/src/components/biconnectedComponents_driver.cpp
@@ -73,7 +73,7 @@ pgr_do_biconnectedComponents(
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -99,33 +99,29 @@ pgr_do_biconnectedComponents(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }
 

--- a/src/components/biconnectedComponents_driver.cpp
+++ b/src/components/biconnectedComponents_driver.cpp
@@ -73,7 +73,7 @@ pgr_do_biconnectedComponents(
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -101,31 +101,31 @@ pgr_do_biconnectedComponents(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }
 

--- a/src/components/biconnectedComponents_driver.cpp
+++ b/src/components/biconnectedComponents_driver.cpp
@@ -112,7 +112,7 @@ pgr_do_biconnectedComponents(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/components/biconnectedComponents_driver.cpp
+++ b/src/components/biconnectedComponents_driver.cpp
@@ -53,7 +53,7 @@ pgr_do_biconnectedComponents(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_edges;
 
@@ -72,8 +72,8 @@ pgr_do_biconnectedComponents(
         hint = edges_sql;
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -101,31 +101,31 @@ pgr_do_biconnectedComponents(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }
 

--- a/src/components/bridges_driver.cpp
+++ b/src/components/bridges_driver.cpp
@@ -71,7 +71,7 @@ pgr_do_bridges(
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -100,31 +100,31 @@ pgr_do_bridges(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }
 

--- a/src/components/bridges_driver.cpp
+++ b/src/components/bridges_driver.cpp
@@ -51,7 +51,7 @@ pgr_do_bridges(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_edges;
 
@@ -70,8 +70,8 @@ pgr_do_bridges(
         hint = edges_sql;
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -100,31 +100,31 @@ pgr_do_bridges(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }
 

--- a/src/components/bridges_driver.cpp
+++ b/src/components/bridges_driver.cpp
@@ -71,7 +71,7 @@ pgr_do_bridges(
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -98,33 +98,29 @@ pgr_do_bridges(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }
 

--- a/src/components/bridges_driver.cpp
+++ b/src/components/bridges_driver.cpp
@@ -111,7 +111,7 @@ pgr_do_bridges(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/components/connectedComponents_driver.cpp
+++ b/src/components/connectedComponents_driver.cpp
@@ -52,7 +52,7 @@ pgr_do_connectedComponents(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_edges;
 
@@ -71,8 +71,8 @@ pgr_do_connectedComponents(
         hint = edges_sql;
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -99,31 +99,31 @@ pgr_do_connectedComponents(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }
 

--- a/src/components/connectedComponents_driver.cpp
+++ b/src/components/connectedComponents_driver.cpp
@@ -72,7 +72,7 @@ pgr_do_connectedComponents(
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -97,33 +97,29 @@ pgr_do_connectedComponents(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }
 

--- a/src/components/connectedComponents_driver.cpp
+++ b/src/components/connectedComponents_driver.cpp
@@ -110,7 +110,7 @@ pgr_do_connectedComponents(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/components/connectedComponents_driver.cpp
+++ b/src/components/connectedComponents_driver.cpp
@@ -72,7 +72,7 @@ pgr_do_connectedComponents(
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -99,31 +99,31 @@ pgr_do_connectedComponents(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }
 

--- a/src/components/makeConnected_driver.cpp
+++ b/src/components/makeConnected_driver.cpp
@@ -118,7 +118,7 @@ pgr_do_makeConnected(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/components/makeConnected_driver.cpp
+++ b/src/components/makeConnected_driver.cpp
@@ -51,7 +51,7 @@ pgr_do_makeConnected(
                 char ** notice_msg,
                 char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_edges;
 
@@ -73,8 +73,8 @@ pgr_do_makeConnected(
         hint = edges_sql;
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -93,7 +93,7 @@ pgr_do_makeConnected(
             (*return_count) = 0;
             notice <<
                 "No Vertices";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -107,30 +107,30 @@ pgr_do_makeConnected(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/components/makeConnected_driver.cpp
+++ b/src/components/makeConnected_driver.cpp
@@ -74,7 +74,7 @@ pgr_do_makeConnected(
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -93,7 +93,7 @@ pgr_do_makeConnected(
             (*return_count) = 0;
             notice <<
                 "No Vertices";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -107,30 +107,30 @@ pgr_do_makeConnected(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/components/makeConnected_driver.cpp
+++ b/src/components/makeConnected_driver.cpp
@@ -74,7 +74,7 @@ pgr_do_makeConnected(
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -93,7 +93,7 @@ pgr_do_makeConnected(
             (*return_count) = 0;
             notice <<
                 "No Vertices";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -105,32 +105,28 @@ pgr_do_makeConnected(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/components/strongComponents_driver.cpp
+++ b/src/components/strongComponents_driver.cpp
@@ -53,7 +53,7 @@ pgr_do_strongComponents(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_edges;
 
@@ -72,8 +72,8 @@ pgr_do_strongComponents(
         hint = edges_sql;
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -100,31 +100,31 @@ pgr_do_strongComponents(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }
 

--- a/src/components/strongComponents_driver.cpp
+++ b/src/components/strongComponents_driver.cpp
@@ -73,7 +73,7 @@ pgr_do_strongComponents(
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -98,33 +98,29 @@ pgr_do_strongComponents(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }
 

--- a/src/components/strongComponents_driver.cpp
+++ b/src/components/strongComponents_driver.cpp
@@ -111,7 +111,7 @@ pgr_do_strongComponents(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/components/strongComponents_driver.cpp
+++ b/src/components/strongComponents_driver.cpp
@@ -73,7 +73,7 @@ pgr_do_strongComponents(
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -100,31 +100,31 @@ pgr_do_strongComponents(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }
 

--- a/src/contraction/contractGraph_driver.cpp
+++ b/src/contraction/contractGraph_driver.cpp
@@ -262,7 +262,7 @@ pgr_do_contractGraph(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/contraction/contractGraph_driver.cpp
+++ b/src/contraction/contractGraph_driver.cpp
@@ -206,7 +206,7 @@ pgr_do_contractGraph(
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -218,7 +218,7 @@ pgr_do_contractGraph(
             if (!pgrouting::contraction::is_valid_contraction(static_cast<int>(kind))) {
                 *err_msg = pgr_msg("Invalid contraction type found");
                 log << "Contraction type " << kind << " not valid";
-                *log_msg = pgr_msg(log.str().c_str());
+                *log_msg = pgr_msg(log.str());
                 return;
             }
         }
@@ -251,30 +251,30 @@ pgr_do_contractGraph(
         pgassert(err.str().empty());
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/contraction/contractGraph_driver.cpp
+++ b/src/contraction/contractGraph_driver.cpp
@@ -184,7 +184,7 @@ pgr_do_contractGraph(
         char **notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
     using pgrouting::pgget::get_edges;
@@ -205,8 +205,8 @@ pgr_do_contractGraph(
         hint = edges_sql;
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -216,9 +216,9 @@ pgr_do_contractGraph(
 
         for (const auto kind : ordering) {
             if (!pgrouting::contraction::is_valid_contraction(static_cast<int>(kind))) {
-                *err_msg = pgr_msg("Invalid contraction type found");
+                *err_msg = to_pg_msg("Invalid contraction type found");
                 log << "Contraction type " << kind << " not valid";
-                *log_msg = pgr_msg(log.str());
+                *log_msg = to_pg_msg(log.str());
                 return;
             }
         }
@@ -251,30 +251,30 @@ pgr_do_contractGraph(
         pgassert(err.str().empty());
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/contraction/contractGraph_driver.cpp
+++ b/src/contraction/contractGraph_driver.cpp
@@ -206,7 +206,7 @@ pgr_do_contractGraph(
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -218,7 +218,7 @@ pgr_do_contractGraph(
             if (!pgrouting::contraction::is_valid_contraction(static_cast<int>(kind))) {
                 *err_msg = to_pg_msg("Invalid contraction type found");
                 log << "Contraction type " << kind << " not valid";
-                *log_msg = to_pg_msg(log.str());
+                *log_msg = to_pg_msg(log);
                 return;
             }
         }
@@ -249,32 +249,28 @@ pgr_do_contractGraph(
         }
 
         pgassert(err.str().empty());
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/cpp_common/trsp_pgget.cpp
+++ b/src/cpp_common/trsp_pgget.cpp
@@ -85,7 +85,7 @@ pgr_get_edges(
         bool normal,
         bool ignore_id,
         char **err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::Column_info_t;
     try {
@@ -100,11 +100,11 @@ pgr_get_edges(
     } catch (const std::string &ex) {
         (*rows) = pgr_free(*rows);
         (*total_rows) = 0;
-        *err_msg = pgr_msg(ex);
+        *err_msg = to_pg_msg(ex);
     } catch(...) {
         (*rows) = pgr_free(*rows);
         (*total_rows) = 0;
-        *err_msg = pgr_msg("Caught unknown exception!");
+        *err_msg = to_pg_msg("Caught unknown exception!");
     }
 }
 

--- a/src/cpp_common/trsp_pgget.cpp
+++ b/src/cpp_common/trsp_pgget.cpp
@@ -100,7 +100,7 @@ pgr_get_edges(
     } catch (const std::string &ex) {
         (*rows) = pgr_free(*rows);
         (*total_rows) = 0;
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
     } catch(...) {
         (*rows) = pgr_free(*rows);
         (*total_rows) = 0;

--- a/src/dagShortestPath/dagShortestPath_driver.cpp
+++ b/src/dagShortestPath/dagShortestPath_driver.cpp
@@ -77,7 +77,7 @@ pgr_do_dagShortestPath(
         char **err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
     using pgrouting::pgget::get_edges;
@@ -100,8 +100,8 @@ pgr_do_dagShortestPath(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -111,8 +111,8 @@ pgr_do_dagShortestPath(
         auto edges = get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -134,7 +134,7 @@ pgr_do_dagShortestPath(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -143,30 +143,30 @@ pgr_do_dagShortestPath(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/dagShortestPath/dagShortestPath_driver.cpp
+++ b/src/dagShortestPath/dagShortestPath_driver.cpp
@@ -154,7 +154,7 @@ pgr_do_dagShortestPath(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/dagShortestPath/dagShortestPath_driver.cpp
+++ b/src/dagShortestPath/dagShortestPath_driver.cpp
@@ -112,7 +112,7 @@ pgr_do_dagShortestPath(
 
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -134,39 +134,35 @@ pgr_do_dagShortestPath(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/dagShortestPath/dagShortestPath_driver.cpp
+++ b/src/dagShortestPath/dagShortestPath_driver.cpp
@@ -112,7 +112,7 @@ pgr_do_dagShortestPath(
 
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -134,7 +134,7 @@ pgr_do_dagShortestPath(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -143,30 +143,30 @@ pgr_do_dagShortestPath(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/dijkstra/dijkstraVia_driver.cpp
+++ b/src/dijkstra/dijkstraVia_driver.cpp
@@ -187,7 +187,7 @@ pgr_do_dijkstraVia(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/dijkstra/dijkstraVia_driver.cpp
+++ b/src/dijkstra/dijkstraVia_driver.cpp
@@ -103,7 +103,7 @@ pgr_do_dijkstraVia(
         char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
     using pgrouting::pgget::get_edges;
@@ -128,8 +128,8 @@ pgr_do_dijkstraVia(
         auto edges = get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -164,7 +164,7 @@ pgr_do_dijkstraVia(
             (*return_count) = 0;
             notice <<
                 "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -176,30 +176,30 @@ pgr_do_dijkstraVia(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/dijkstra/dijkstraVia_driver.cpp
+++ b/src/dijkstra/dijkstraVia_driver.cpp
@@ -129,7 +129,7 @@ pgr_do_dijkstraVia(
 
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -164,7 +164,7 @@ pgr_do_dijkstraVia(
             (*return_count) = 0;
             notice <<
                 "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -176,30 +176,30 @@ pgr_do_dijkstraVia(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/dijkstra/dijkstraVia_driver.cpp
+++ b/src/dijkstra/dijkstraVia_driver.cpp
@@ -129,7 +129,7 @@ pgr_do_dijkstraVia(
 
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -164,7 +164,7 @@ pgr_do_dijkstraVia(
             (*return_count) = 0;
             notice <<
                 "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -174,32 +174,28 @@ pgr_do_dijkstraVia(
         (*return_count) = (get_route(return_tuples, paths));
         (*return_tuples)[count - 1].edge = -2;
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/dijkstra/dijkstra_driver.cpp
+++ b/src/dijkstra/dijkstra_driver.cpp
@@ -122,7 +122,7 @@ pgr_do_dijkstra(
         char **err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
     using pgrouting::pgget::get_edges;
@@ -144,8 +144,8 @@ pgr_do_dijkstra(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -155,8 +155,8 @@ pgr_do_dijkstra(
         auto edges = get_edges(std::string(edges_sql), normal, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -182,7 +182,7 @@ pgr_do_dijkstra(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -191,30 +191,30 @@ pgr_do_dijkstra(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/dijkstra/dijkstra_driver.cpp
+++ b/src/dijkstra/dijkstra_driver.cpp
@@ -202,7 +202,7 @@ pgr_do_dijkstra(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/dijkstra/dijkstra_driver.cpp
+++ b/src/dijkstra/dijkstra_driver.cpp
@@ -156,7 +156,7 @@ pgr_do_dijkstra(
 
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -182,7 +182,7 @@ pgr_do_dijkstra(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -191,30 +191,30 @@ pgr_do_dijkstra(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/dijkstra/dijkstra_driver.cpp
+++ b/src/dijkstra/dijkstra_driver.cpp
@@ -156,7 +156,7 @@ pgr_do_dijkstra(
 
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -182,39 +182,35 @@ pgr_do_dijkstra(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/dominator/lengauerTarjanDominatorTree_driver.cpp
+++ b/src/dominator/lengauerTarjanDominatorTree_driver.cpp
@@ -75,7 +75,7 @@ pgr_do_LTDTree(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -97,12 +97,8 @@ pgr_do_LTDTree(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No result found";
-            *log_msg = log.str().empty()?
-                       *log_msg :
-                       to_pg_msg(log.str());
-            *notice_msg = notice.str().empty()?
-                          *notice_msg :
-                          to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(log);
+            *notice_msg = to_pg_msg(notice);
             return;
         }
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
@@ -112,32 +108,28 @@ pgr_do_LTDTree(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-                   *log_msg :
-                   to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-                      *notice_msg :
-                      to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/dominator/lengauerTarjanDominatorTree_driver.cpp
+++ b/src/dominator/lengauerTarjanDominatorTree_driver.cpp
@@ -56,7 +56,7 @@ pgr_do_LTDTree(
         char **err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -74,8 +74,8 @@ pgr_do_LTDTree(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -99,10 +99,10 @@ pgr_do_LTDTree(
             notice << "No result found";
             *log_msg = log.str().empty()?
                        *log_msg :
-                       pgr_msg(log.str());
+                       to_pg_msg(log.str());
             *notice_msg = notice.str().empty()?
                           *notice_msg :
-                          pgr_msg(notice.str());
+                          to_pg_msg(notice.str());
             return;
         }
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
@@ -114,30 +114,30 @@ pgr_do_LTDTree(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
                    *log_msg :
-                   pgr_msg(log.str());
+                   to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
                       *notice_msg :
-                      pgr_msg(notice.str());
+                      to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/dominator/lengauerTarjanDominatorTree_driver.cpp
+++ b/src/dominator/lengauerTarjanDominatorTree_driver.cpp
@@ -75,7 +75,7 @@ pgr_do_LTDTree(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -99,10 +99,10 @@ pgr_do_LTDTree(
             notice << "No result found";
             *log_msg = log.str().empty()?
                        *log_msg :
-                       pgr_msg(log.str().c_str());
+                       pgr_msg(log.str());
             *notice_msg = notice.str().empty()?
                           *notice_msg :
-                          pgr_msg(notice.str().c_str());
+                          pgr_msg(notice.str());
             return;
         }
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
@@ -114,30 +114,30 @@ pgr_do_LTDTree(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
                    *log_msg :
-                   pgr_msg(log.str().c_str());
+                   pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
                       *notice_msg :
-                      pgr_msg(notice.str().c_str());
+                      pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/dominator/lengauerTarjanDominatorTree_driver.cpp
+++ b/src/dominator/lengauerTarjanDominatorTree_driver.cpp
@@ -125,7 +125,7 @@ pgr_do_LTDTree(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/driving_distance/driving_distance_driver.cpp
+++ b/src/driving_distance/driving_distance_driver.cpp
@@ -137,7 +137,7 @@ pgr_do_drivingDistance(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/driving_distance/driving_distance_driver.cpp
+++ b/src/driving_distance/driving_distance_driver.cpp
@@ -56,7 +56,7 @@ pgr_do_drivingDistance(
         char **err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::algorithm::drivingDistance;
     using pgrouting::pgget::get_intSet;
@@ -80,8 +80,8 @@ pgr_do_drivingDistance(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -103,7 +103,7 @@ pgr_do_drivingDistance(
 
         if (count == 0) {
             log << "\nNo return values were found";
-            *notice_msg = pgr_msg(log.str());
+            *notice_msg = to_pg_msg(log.str());
             return;
         }
 
@@ -126,30 +126,30 @@ pgr_do_drivingDistance(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch( ... ) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/driving_distance/driving_distance_driver.cpp
+++ b/src/driving_distance/driving_distance_driver.cpp
@@ -81,7 +81,7 @@ pgr_do_drivingDistance(
 
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -103,7 +103,7 @@ pgr_do_drivingDistance(
 
         if (count == 0) {
             log << "\nNo return values were found";
-            *notice_msg = to_pg_msg(log.str());
+            *notice_msg = to_pg_msg(log);
             return;
         }
 
@@ -124,32 +124,28 @@ pgr_do_drivingDistance(
         }
         (*return_count) = count;
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch( ... ) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/driving_distance/driving_distance_driver.cpp
+++ b/src/driving_distance/driving_distance_driver.cpp
@@ -81,7 +81,7 @@ pgr_do_drivingDistance(
 
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -103,7 +103,7 @@ pgr_do_drivingDistance(
 
         if (count == 0) {
             log << "\nNo return values were found";
-            *notice_msg = pgr_msg(log.str().c_str());
+            *notice_msg = pgr_msg(log.str());
             return;
         }
 
@@ -126,30 +126,30 @@ pgr_do_drivingDistance(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch( ... ) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/driving_distance/driving_distance_withPoints_driver.cpp
+++ b/src/driving_distance/driving_distance_withPoints_driver.cpp
@@ -100,7 +100,7 @@ pgr_do_withPointsDD(
 
         if (edges.size() + edges_of_points.size() == 0) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -114,8 +114,8 @@ pgr_do_withPointsDD(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str().c_str());
-            *err_msg = pgr_msg(err.str().c_str());
+            *log_msg = pgr_msg(log.str());
+            *err_msg = pgr_msg(err.str());
             return;
         }
 
@@ -148,7 +148,7 @@ pgr_do_withPointsDD(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -178,30 +178,30 @@ pgr_do_withPointsDD(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/driving_distance/driving_distance_withPoints_driver.cpp
+++ b/src/driving_distance/driving_distance_withPoints_driver.cpp
@@ -100,7 +100,7 @@ pgr_do_withPointsDD(
 
         if (edges.size() + edges_of_points.size() == 0) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -114,8 +114,8 @@ pgr_do_withPointsDD(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = to_pg_msg(log.str());
-            *err_msg = to_pg_msg(err.str());
+            *log_msg = to_pg_msg(log);
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -148,7 +148,7 @@ pgr_do_withPointsDD(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -176,32 +176,28 @@ pgr_do_withPointsDD(
         std::stable_sort((*return_tuples), (*return_tuples) + count,
                 [](const MST_rt &l, const MST_rt &r) {return l.from_v < r.from_v;});
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/driving_distance/driving_distance_withPoints_driver.cpp
+++ b/src/driving_distance/driving_distance_withPoints_driver.cpp
@@ -67,7 +67,7 @@ pgr_do_withPointsDD(
         char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intSet;
     using pgrouting::utilities::get_combinations;
@@ -99,8 +99,8 @@ pgr_do_withPointsDD(
         auto edges = get_edges(std::string(edges_sql), true, false);
 
         if (edges.size() + edges_of_points.size() == 0) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -114,8 +114,8 @@ pgr_do_withPointsDD(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str());
-            *err_msg = pgr_msg(err.str());
+            *log_msg = to_pg_msg(log.str());
+            *err_msg = to_pg_msg(err.str());
             return;
         }
 
@@ -148,7 +148,7 @@ pgr_do_withPointsDD(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -178,30 +178,30 @@ pgr_do_withPointsDD(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/driving_distance/driving_distance_withPoints_driver.cpp
+++ b/src/driving_distance/driving_distance_withPoints_driver.cpp
@@ -189,7 +189,7 @@ pgr_do_withPointsDD(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/ksp/ksp_driver.cpp
+++ b/src/ksp/ksp_driver.cpp
@@ -64,7 +64,7 @@ void pgr_do_ksp(
         char **err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
     using pgrouting::yen::Pgr_ksp;
@@ -92,8 +92,8 @@ void pgr_do_ksp(
         }
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -101,8 +101,8 @@ void pgr_do_ksp(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -126,7 +126,7 @@ void pgr_do_ksp(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -141,30 +141,30 @@ void pgr_do_ksp(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/ksp/ksp_driver.cpp
+++ b/src/ksp/ksp_driver.cpp
@@ -152,7 +152,7 @@ void pgr_do_ksp(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/ksp/ksp_driver.cpp
+++ b/src/ksp/ksp_driver.cpp
@@ -102,7 +102,7 @@ void pgr_do_ksp(
 
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -126,7 +126,7 @@ void pgr_do_ksp(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -141,30 +141,30 @@ void pgr_do_ksp(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/ksp/ksp_driver.cpp
+++ b/src/ksp/ksp_driver.cpp
@@ -102,7 +102,7 @@ void pgr_do_ksp(
 
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -126,7 +126,7 @@ void pgr_do_ksp(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -139,32 +139,28 @@ void pgr_do_ksp(
         }
         *return_count = count;
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/ksp/turnRestrictedPath_driver.cpp
+++ b/src/ksp/turnRestrictedPath_driver.cpp
@@ -124,7 +124,7 @@ pgr_do_turnRestrictedPath(
 
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -205,33 +205,29 @@ pgr_do_turnRestrictedPath(
 
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
         pgassert(!log.str().empty());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/ksp/turnRestrictedPath_driver.cpp
+++ b/src/ksp/turnRestrictedPath_driver.cpp
@@ -99,7 +99,7 @@ pgr_do_turnRestrictedPath(
         char ** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::yen::Pgr_turnRestrictedPath;
     using pgrouting::trsp::Rule;
@@ -123,8 +123,8 @@ pgr_do_turnRestrictedPath(
         auto edges = get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -207,31 +207,31 @@ pgr_do_turnRestrictedPath(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
         pgassert(!log.str().empty());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/ksp/turnRestrictedPath_driver.cpp
+++ b/src/ksp/turnRestrictedPath_driver.cpp
@@ -124,7 +124,7 @@ pgr_do_turnRestrictedPath(
 
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -207,31 +207,31 @@ pgr_do_turnRestrictedPath(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
         pgassert(!log.str().empty());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/ksp/turnRestrictedPath_driver.cpp
+++ b/src/ksp/turnRestrictedPath_driver.cpp
@@ -225,7 +225,7 @@ pgr_do_turnRestrictedPath(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/ksp/withPoints_ksp_driver.cpp
+++ b/src/ksp/withPoints_ksp_driver.cpp
@@ -70,7 +70,7 @@ pgr_do_withPointsKsp(
         char ** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::yen::Pgr_ksp;
     using pgrouting::utilities::get_combinations;
@@ -99,8 +99,8 @@ pgr_do_withPointsKsp(
         }
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -116,8 +116,8 @@ pgr_do_withPointsKsp(
         auto edges = get_edges(std::string(edges_sql), true, false);
 
         if (edges.size() + edges_of_points.size() == 0) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -130,8 +130,8 @@ pgr_do_withPointsKsp(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str());
-            *err_msg = pgr_msg(err.str());
+            *log_msg = to_pg_msg(log.str());
+            *err_msg = to_pg_msg(err.str());
             return;
         }
 
@@ -163,7 +163,7 @@ pgr_do_withPointsKsp(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -180,37 +180,37 @@ pgr_do_withPointsKsp(
         if (count != sequence) {
             (*return_count) = 0;
             notice << "Something went wrong";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
         (*return_count) = sequence;
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/ksp/withPoints_ksp_driver.cpp
+++ b/src/ksp/withPoints_ksp_driver.cpp
@@ -198,7 +198,7 @@ pgr_do_withPointsKsp(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/ksp/withPoints_ksp_driver.cpp
+++ b/src/ksp/withPoints_ksp_driver.cpp
@@ -117,7 +117,7 @@ pgr_do_withPointsKsp(
 
         if (edges.size() + edges_of_points.size() == 0) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -130,8 +130,8 @@ pgr_do_withPointsKsp(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str().c_str());
-            *err_msg = pgr_msg(err.str().c_str());
+            *log_msg = pgr_msg(log.str());
+            *err_msg = pgr_msg(err.str());
             return;
         }
 
@@ -163,7 +163,7 @@ pgr_do_withPointsKsp(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -180,37 +180,37 @@ pgr_do_withPointsKsp(
         if (count != sequence) {
             (*return_count) = 0;
             notice << "Something went wrong";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
         (*return_count) = sequence;
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/ksp/withPoints_ksp_driver.cpp
+++ b/src/ksp/withPoints_ksp_driver.cpp
@@ -117,7 +117,7 @@ pgr_do_withPointsKsp(
 
         if (edges.size() + edges_of_points.size() == 0) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -130,8 +130,8 @@ pgr_do_withPointsKsp(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = to_pg_msg(log.str());
-            *err_msg = to_pg_msg(err.str());
+            *log_msg = to_pg_msg(log);
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -163,7 +163,7 @@ pgr_do_withPointsKsp(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -180,37 +180,33 @@ pgr_do_withPointsKsp(
         if (count != sequence) {
             (*return_count) = 0;
             notice << "Something went wrong";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
         (*return_count) = sequence;
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/lineGraph/lineGraphFull_driver.cpp
+++ b/src/lineGraph/lineGraphFull_driver.cpp
@@ -145,7 +145,7 @@ pgr_do_lineGraphFull(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/lineGraph/lineGraphFull_driver.cpp
+++ b/src/lineGraph/lineGraphFull_driver.cpp
@@ -75,7 +75,7 @@ pgr_do_lineGraphFull(
         char ** log_msg,
         char ** notice_msg,
         char ** err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -93,8 +93,8 @@ pgr_do_lineGraphFull(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -134,30 +134,30 @@ pgr_do_lineGraphFull(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/lineGraph/lineGraphFull_driver.cpp
+++ b/src/lineGraph/lineGraphFull_driver.cpp
@@ -94,7 +94,7 @@ pgr_do_lineGraphFull(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -128,36 +128,36 @@ pgr_do_lineGraphFull(
             (*return_count) = sequence;
         }
 #if 1
-        log << line.log.str().c_str() << "\n\n\n";
+        log << line.log.str() << "\n\n\n";
         log << line << "\n";
 #endif
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/lineGraph/lineGraphFull_driver.cpp
+++ b/src/lineGraph/lineGraphFull_driver.cpp
@@ -94,7 +94,7 @@ pgr_do_lineGraphFull(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -132,32 +132,28 @@ pgr_do_lineGraphFull(
         log << line << "\n";
 #endif
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/lineGraph/lineGraph_driver.cpp
+++ b/src/lineGraph/lineGraph_driver.cpp
@@ -65,7 +65,7 @@ pgr_do_lineGraph(
         char ** log_msg,
         char ** notice_msg,
         char ** err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -84,8 +84,8 @@ pgr_do_lineGraph(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -106,7 +106,7 @@ pgr_do_lineGraph(
         if (count == 0) {
             (*return_tuples) = NULL;
             (*return_count) = 0;
-            *log_msg = pgr_msg(log.str());
+            *log_msg = to_pg_msg(log.str());
             return;
         }
 
@@ -122,28 +122,28 @@ pgr_do_lineGraph(
         (*return_count) = sequence;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?  *log_msg : pgr_msg(log.str());
-        *notice_msg = notice.str().empty()?  *notice_msg : pgr_msg(notice.str());
+        *log_msg = log.str().empty()?  *log_msg : to_pg_msg(log.str());
+        *notice_msg = notice.str().empty()?  *notice_msg : to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/lineGraph/lineGraph_driver.cpp
+++ b/src/lineGraph/lineGraph_driver.cpp
@@ -85,7 +85,7 @@ pgr_do_lineGraph(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -106,7 +106,7 @@ pgr_do_lineGraph(
         if (count == 0) {
             (*return_tuples) = NULL;
             (*return_count) = 0;
-            *log_msg = to_pg_msg(log.str());
+            *log_msg = to_pg_msg(log);
             return;
         }
 
@@ -122,28 +122,28 @@ pgr_do_lineGraph(
         (*return_count) = sequence;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?  *log_msg : to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?  *notice_msg : to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/lineGraph/lineGraph_driver.cpp
+++ b/src/lineGraph/lineGraph_driver.cpp
@@ -85,7 +85,7 @@ pgr_do_lineGraph(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -106,7 +106,7 @@ pgr_do_lineGraph(
         if (count == 0) {
             (*return_tuples) = NULL;
             (*return_count) = 0;
-            *log_msg = pgr_msg(log.str().c_str());
+            *log_msg = pgr_msg(log.str());
             return;
         }
 
@@ -122,28 +122,28 @@ pgr_do_lineGraph(
         (*return_count) = sequence;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?  *log_msg : pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?  *notice_msg : pgr_msg(notice.str().c_str());
+        *log_msg = log.str().empty()?  *log_msg : pgr_msg(log.str());
+        *notice_msg = notice.str().empty()?  *notice_msg : pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/lineGraph/lineGraph_driver.cpp
+++ b/src/lineGraph/lineGraph_driver.cpp
@@ -131,7 +131,7 @@ pgr_do_lineGraph(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/max_flow/edge_disjoint_paths_driver.cpp
+++ b/src/max_flow/edge_disjoint_paths_driver.cpp
@@ -184,32 +184,28 @@ pgr_do_edge_disjoint_paths(
         *return_count = paths.size();
 
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/max_flow/edge_disjoint_paths_driver.cpp
+++ b/src/max_flow/edge_disjoint_paths_driver.cpp
@@ -203,7 +203,7 @@ pgr_do_edge_disjoint_paths(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/max_flow/edge_disjoint_paths_driver.cpp
+++ b/src/max_flow/edge_disjoint_paths_driver.cpp
@@ -186,30 +186,30 @@ pgr_do_edge_disjoint_paths(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/max_flow/edge_disjoint_paths_driver.cpp
+++ b/src/max_flow/edge_disjoint_paths_driver.cpp
@@ -83,7 +83,7 @@ pgr_do_edge_disjoint_paths(
     char** notice_msg,
     char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -104,8 +104,8 @@ pgr_do_edge_disjoint_paths(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -114,8 +114,8 @@ pgr_do_edge_disjoint_paths(
         hint = nullptr;
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = pgr_msg(edges_sql);
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = to_pg_msg(edges_sql);
             return;
         }
 
@@ -186,30 +186,30 @@ pgr_do_edge_disjoint_paths(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/max_flow/max_flow_driver.cpp
+++ b/src/max_flow/max_flow_driver.cpp
@@ -164,7 +164,7 @@ pgr_do_max_flow(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/max_flow/max_flow_driver.cpp
+++ b/src/max_flow/max_flow_driver.cpp
@@ -58,7 +58,7 @@ pgr_do_max_flow(
         char** notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -79,8 +79,8 @@ pgr_do_max_flow(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -95,7 +95,7 @@ pgr_do_max_flow(
         vertices.insert(targets.begin(), targets.end());
 
         if (vertices.size() != (sources.size() + targets.size())) {
-            *err_msg = pgr_msg("A source found as sink");
+            *err_msg = to_pg_msg("A source found as sink");
             return;
         }
 
@@ -104,7 +104,7 @@ pgr_do_max_flow(
         hint = nullptr;
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
+            *notice_msg = to_pg_msg("No edges found");
             *log_msg = edges_sql;
             return;
         }
@@ -123,7 +123,7 @@ pgr_do_max_flow(
             max_flow = digraph.boykov_kolmogorov();
         } else {
             log << "Unspecified algorithm!\n";
-            *err_msg = pgr_msg(log.str());
+            *err_msg = to_pg_msg(log.str());
             (*return_tuples) = NULL;
             (*return_count) = 0;
             return;
@@ -147,30 +147,30 @@ pgr_do_max_flow(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/max_flow/max_flow_driver.cpp
+++ b/src/max_flow/max_flow_driver.cpp
@@ -123,7 +123,7 @@ pgr_do_max_flow(
             max_flow = digraph.boykov_kolmogorov();
         } else {
             log << "Unspecified algorithm!\n";
-            *err_msg = to_pg_msg(log.str());
+            *err_msg = to_pg_msg(log);
             (*return_tuples) = NULL;
             (*return_count) = 0;
             return;
@@ -145,32 +145,28 @@ pgr_do_max_flow(
         *return_count = flow_edges.size();
 
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/max_flow/max_flow_driver.cpp
+++ b/src/max_flow/max_flow_driver.cpp
@@ -123,7 +123,7 @@ pgr_do_max_flow(
             max_flow = digraph.boykov_kolmogorov();
         } else {
             log << "Unspecified algorithm!\n";
-            *err_msg = pgr_msg(log.str().c_str());
+            *err_msg = pgr_msg(log.str());
             (*return_tuples) = NULL;
             (*return_count) = 0;
             return;
@@ -147,30 +147,30 @@ pgr_do_max_flow(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/max_flow/maximum_cardinality_matching_driver.cpp
+++ b/src/max_flow/maximum_cardinality_matching_driver.cpp
@@ -99,7 +99,7 @@ pgr_do_maximum_cardinality_matching(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/max_flow/maximum_cardinality_matching_driver.cpp
+++ b/src/max_flow/maximum_cardinality_matching_driver.cpp
@@ -72,7 +72,7 @@ pgr_do_maximum_cardinality_matching(
 
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -86,32 +86,28 @@ pgr_do_maximum_cardinality_matching(
         }
         *return_count = matched_vertices.size();
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/max_flow/maximum_cardinality_matching_driver.cpp
+++ b/src/max_flow/maximum_cardinality_matching_driver.cpp
@@ -72,7 +72,7 @@ pgr_do_maximum_cardinality_matching(
 
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -88,30 +88,30 @@ pgr_do_maximum_cardinality_matching(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/max_flow/maximum_cardinality_matching_driver.cpp
+++ b/src/max_flow/maximum_cardinality_matching_driver.cpp
@@ -58,7 +58,7 @@ pgr_do_maximum_cardinality_matching(
     char** notice_msg,
     char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -71,8 +71,8 @@ pgr_do_maximum_cardinality_matching(
         auto edges = pgrouting::pgget::get_basic_edges(std::string(edges_sql));
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -88,30 +88,30 @@ pgr_do_maximum_cardinality_matching(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/max_flow/minCostMaxFlow_driver.cpp
+++ b/src/max_flow/minCostMaxFlow_driver.cpp
@@ -105,7 +105,7 @@ pgr_do_minCostMaxFlow(
 
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -140,32 +140,28 @@ pgr_do_minCostMaxFlow(
         *return_count = flow_edges.size();
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/max_flow/minCostMaxFlow_driver.cpp
+++ b/src/max_flow/minCostMaxFlow_driver.cpp
@@ -153,7 +153,7 @@ pgr_do_minCostMaxFlow(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/max_flow/minCostMaxFlow_driver.cpp
+++ b/src/max_flow/minCostMaxFlow_driver.cpp
@@ -105,7 +105,7 @@ pgr_do_minCostMaxFlow(
 
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -142,30 +142,30 @@ pgr_do_minCostMaxFlow(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/max_flow/minCostMaxFlow_driver.cpp
+++ b/src/max_flow/minCostMaxFlow_driver.cpp
@@ -59,7 +59,7 @@ pgr_do_minCostMaxFlow(
         char **notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -80,8 +80,8 @@ pgr_do_minCostMaxFlow(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -96,7 +96,7 @@ pgr_do_minCostMaxFlow(
         vertices.insert(targets.begin(), targets.end());
 
         if (vertices.size() != (sources.size() + targets.size())) {
-            *err_msg = pgr_msg("A source found as sink");
+            *err_msg = to_pg_msg("A source found as sink");
             return;
         }
 
@@ -104,8 +104,8 @@ pgr_do_minCostMaxFlow(
         auto edges = pgrouting::pgget::get_costFlow_edges(std::string(edges_sql));
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -142,30 +142,30 @@ pgr_do_minCostMaxFlow(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/metrics/betweennessCentrality_driver.cpp
+++ b/src/metrics/betweennessCentrality_driver.cpp
@@ -87,35 +87,33 @@ pgr_do_betweennessCentrality(
 
         if (*return_count == 0) {
             err <<  "No result generated, report this error\n";
-            *err_msg = to_pg_msg(err.str());
+            *err_msg = to_pg_msg(err);
             *return_tuples = NULL;
             *return_count = 0;
             return;
         }
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
+        *log_msg = to_pg_msg(log);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
        (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/metrics/betweennessCentrality_driver.cpp
+++ b/src/metrics/betweennessCentrality_driver.cpp
@@ -48,7 +48,7 @@ pgr_do_betweennessCentrality(
         size_t *return_count,
         char ** log_msg,
         char ** err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -87,7 +87,7 @@ pgr_do_betweennessCentrality(
 
         if (*return_count == 0) {
             err <<  "No result generated, report this error\n";
-            *err_msg = pgr_msg(err.str());
+            *err_msg = to_pg_msg(err.str());
             *return_tuples = NULL;
             *return_count = 0;
             return;
@@ -95,27 +95,27 @@ pgr_do_betweennessCentrality(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
        (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/metrics/betweennessCentrality_driver.cpp
+++ b/src/metrics/betweennessCentrality_driver.cpp
@@ -87,7 +87,7 @@ pgr_do_betweennessCentrality(
 
         if (*return_count == 0) {
             err <<  "No result generated, report this error\n";
-            *err_msg = pgr_msg(err.str().c_str());
+            *err_msg = pgr_msg(err.str());
             *return_tuples = NULL;
             *return_count = 0;
             return;
@@ -95,27 +95,27 @@ pgr_do_betweennessCentrality(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
        (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/metrics/betweennessCentrality_driver.cpp
+++ b/src/metrics/betweennessCentrality_driver.cpp
@@ -103,7 +103,7 @@ pgr_do_betweennessCentrality(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/mincut/stoerWagner_driver.cpp
+++ b/src/mincut/stoerWagner_driver.cpp
@@ -61,7 +61,7 @@ pgr_do_stoerWagner(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -79,8 +79,8 @@ pgr_do_stoerWagner(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -111,30 +111,30 @@ pgr_do_stoerWagner(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/mincut/stoerWagner_driver.cpp
+++ b/src/mincut/stoerWagner_driver.cpp
@@ -80,7 +80,7 @@ pgr_do_stoerWagner(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -111,30 +111,30 @@ pgr_do_stoerWagner(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/mincut/stoerWagner_driver.cpp
+++ b/src/mincut/stoerWagner_driver.cpp
@@ -80,7 +80,7 @@ pgr_do_stoerWagner(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -109,32 +109,28 @@ pgr_do_stoerWagner(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/mincut/stoerWagner_driver.cpp
+++ b/src/mincut/stoerWagner_driver.cpp
@@ -122,7 +122,7 @@ pgr_do_stoerWagner(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/ordering/cuthillMckeeOrdering_driver.cpp
+++ b/src/ordering/cuthillMckeeOrdering_driver.cpp
@@ -98,7 +98,7 @@ void pgr_do_cuthillMckeeOrdering(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -114,7 +114,7 @@ void pgr_do_cuthillMckeeOrdering(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No results found";
-            *log_msg = to_pg_msg(log.str());
+            *log_msg = to_pg_msg(log);
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
@@ -126,30 +126,30 @@ void pgr_do_cuthillMckeeOrdering(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty() ?
         *log_msg :
-        to_pg_msg(log.str());
+        to_pg_msg(log);
         *notice_msg = notice.str().empty() ?
         *notice_msg :
-        to_pg_msg(notice.str());
+        to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/ordering/cuthillMckeeOrdering_driver.cpp
+++ b/src/ordering/cuthillMckeeOrdering_driver.cpp
@@ -79,7 +79,7 @@ void pgr_do_cuthillMckeeOrdering(
     char **notice_msg,
     char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -97,8 +97,8 @@ void pgr_do_cuthillMckeeOrdering(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -114,7 +114,7 @@ void pgr_do_cuthillMckeeOrdering(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No results found";
-            *log_msg = pgr_msg(log.str());
+            *log_msg = to_pg_msg(log.str());
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
@@ -126,30 +126,30 @@ void pgr_do_cuthillMckeeOrdering(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty() ?
         *log_msg :
-        pgr_msg(log.str());
+        to_pg_msg(log.str());
         *notice_msg = notice.str().empty() ?
         *notice_msg :
-        pgr_msg(notice.str());
+        to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/ordering/cuthillMckeeOrdering_driver.cpp
+++ b/src/ordering/cuthillMckeeOrdering_driver.cpp
@@ -98,7 +98,7 @@ void pgr_do_cuthillMckeeOrdering(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -114,7 +114,7 @@ void pgr_do_cuthillMckeeOrdering(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No results found";
-            *log_msg = pgr_msg(log.str().c_str());
+            *log_msg = pgr_msg(log.str());
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
@@ -126,30 +126,30 @@ void pgr_do_cuthillMckeeOrdering(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty() ?
         *log_msg :
-        pgr_msg(log.str().c_str());
+        pgr_msg(log.str());
         *notice_msg = notice.str().empty() ?
         *notice_msg :
-        pgr_msg(notice.str().c_str());
+        pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/ordering/cuthillMckeeOrdering_driver.cpp
+++ b/src/ordering/cuthillMckeeOrdering_driver.cpp
@@ -137,7 +137,7 @@ void pgr_do_cuthillMckeeOrdering(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/pickDeliver/pickDeliverEuclidean_driver.cpp
+++ b/src/pickDeliver/pickDeliverEuclidean_driver.cpp
@@ -141,8 +141,8 @@ pgr_do_pickDeliverEuclidean(
             log.clear();
             log << pd_problem.msg.get_error();
             log << pd_problem.msg.get_log();
-            *log_msg = pgr_msg(log.str().c_str());
-            *err_msg = pgr_msg(err.str().c_str());
+            *log_msg = pgr_msg(log.str());
+            *err_msg = pgr_msg(err.str());
             return;
         }
         log << pd_problem.msg.get_log();
@@ -181,38 +181,38 @@ pgr_do_pickDeliverEuclidean(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             nullptr :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             nullptr :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (std::exception& except) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;
         err << ex.first;
         log.str("");
         log.clear();
         log << ex.second;
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/pickDeliver/pickDeliverEuclidean_driver.cpp
+++ b/src/pickDeliver/pickDeliverEuclidean_driver.cpp
@@ -141,8 +141,8 @@ pgr_do_pickDeliverEuclidean(
             log.clear();
             log << pd_problem.msg.get_error();
             log << pd_problem.msg.get_log();
-            *log_msg = to_pg_msg(log.str());
-            *err_msg = to_pg_msg(err.str());
+            *log_msg = to_pg_msg(log);
+            *err_msg = to_pg_msg(err);
             return;
         }
         log << pd_problem.msg.get_log();
@@ -179,40 +179,36 @@ pgr_do_pickDeliverEuclidean(
         log << pd_problem.msg.get_log();
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            nullptr :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            nullptr :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (std::exception& except) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;
         err << ex.first;
         log.str("");
         log.clear();
         log << ex.second;
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/pickDeliver/pickDeliverEuclidean_driver.cpp
+++ b/src/pickDeliver/pickDeliverEuclidean_driver.cpp
@@ -61,7 +61,7 @@ pgr_do_pickDeliverEuclidean(
         char **notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -76,16 +76,16 @@ pgr_do_pickDeliverEuclidean(
         hint = customers_sql;
         auto orders = pgrouting::pgget::get_orders(std::string(customers_sql), false);
         if (orders.size() == 0) {
-            *notice_msg = pgr_msg("Insufficient data found on inner query");
-            *log_msg = hint? pgr_msg(hint) : nullptr;
+            *notice_msg = to_pg_msg("Insufficient data found on inner query");
+            *log_msg = hint? to_pg_msg(hint) : nullptr;
             return;
         }
 
         hint = vehicles_sql;
         auto vehicles = pgrouting::pgget::get_vehicles(std::string(vehicles_sql), false);
         if (vehicles.size() == 0) {
-            *notice_msg = pgr_msg("Insufficient data found on inner query");
-            *log_msg = hint? pgr_msg(hint) : nullptr;
+            *notice_msg = to_pg_msg("Insufficient data found on inner query");
+            *log_msg = hint? to_pg_msg(hint) : nullptr;
             return;
         }
 
@@ -141,8 +141,8 @@ pgr_do_pickDeliverEuclidean(
             log.clear();
             log << pd_problem.msg.get_error();
             log << pd_problem.msg.get_log();
-            *log_msg = pgr_msg(log.str());
-            *err_msg = pgr_msg(err.str());
+            *log_msg = to_pg_msg(log.str());
+            *err_msg = to_pg_msg(err.str());
             return;
         }
         log << pd_problem.msg.get_log();
@@ -181,38 +181,38 @@ pgr_do_pickDeliverEuclidean(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             nullptr :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             nullptr :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (std::exception& except) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;
         err << ex.first;
         log.str("");
         log.clear();
         log << ex.second;
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/pickDeliver/pickDeliverEuclidean_driver.cpp
+++ b/src/pickDeliver/pickDeliverEuclidean_driver.cpp
@@ -198,7 +198,7 @@ pgr_do_pickDeliverEuclidean(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;

--- a/src/pickDeliver/pickDeliver_driver.cpp
+++ b/src/pickDeliver/pickDeliver_driver.cpp
@@ -66,7 +66,7 @@ pgr_do_pickDeliver(
         char **notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -84,16 +84,16 @@ pgr_do_pickDeliver(
         hint = customers_sql;
         auto orders = pgrouting::pgget::get_orders(std::string(customers_sql), true);
         if (orders.size() == 0) {
-            *notice_msg = pgr_msg("Insufficient data found on inner query");
-            *log_msg = hint? pgr_msg(hint) : nullptr;
+            *notice_msg = to_pg_msg("Insufficient data found on inner query");
+            *log_msg = hint? to_pg_msg(hint) : nullptr;
             return;
         }
 
         hint = vehicles_sql;
         auto vehicles = pgrouting::pgget::get_vehicles(std::string(vehicles_sql), true);
         if (vehicles.size() == 0) {
-            *notice_msg = pgr_msg("Insufficient data found on inner query");
-            *log_msg = hint? pgr_msg(hint) : nullptr;
+            *notice_msg = to_pg_msg("Insufficient data found on inner query");
+            *log_msg = hint? to_pg_msg(hint) : nullptr;
             return;
         }
 
@@ -101,8 +101,8 @@ pgr_do_pickDeliver(
         auto data_costs = pgrouting::pgget::get_matrixRows(std::string(matrix_sql));
 
         if (data_costs.size() == 0) {
-            *notice_msg = pgr_msg("Insufficient data found on inner query");
-            *log_msg = hint? pgr_msg(hint) : nullptr;
+            *notice_msg = to_pg_msg("Insufficient data found on inner query");
+            *log_msg = hint? to_pg_msg(hint) : nullptr;
             return;
         }
         hint = nullptr;
@@ -121,7 +121,7 @@ pgr_do_pickDeliver(
             for (const auto &v : vehicles) {
                 if (v.start_node_id != depot_node && v.end_node_id != depot_node) {
                     err << "All vehicles must depart & arrive to same node";
-                    *err_msg = pgr_msg(err.str());
+                    *err_msg = to_pg_msg(err.str());
                     return;
                 }
             }
@@ -132,7 +132,7 @@ pgr_do_pickDeliver(
             for (const auto &o : orders) {
                 if (o.pick_node_id != depot_node) {
                     err << "All orders must be picked at depot";
-                    *err_msg = pgr_msg(err.str());
+                    *err_msg = to_pg_msg(err.str());
                     return;
                 }
             }
@@ -140,7 +140,7 @@ pgr_do_pickDeliver(
 
         if (!cost_matrix.has_no_infinity()) {
             err << "An Infinity value was found on the Matrix";
-            *err_msg = pgr_msg(err.str());
+            *err_msg = to_pg_msg(err.str());
             return;
         }
 
@@ -156,8 +156,8 @@ pgr_do_pickDeliver(
         err << pd_problem.msg.get_error();
         if (!err.str().empty()) {
             log << pd_problem.msg.get_log();
-            *log_msg = pgr_msg(log.str());
-            *err_msg = pgr_msg(err.str());
+            *log_msg = to_pg_msg(log.str());
+            *err_msg = to_pg_msg(err.str());
             return;
         }
         log << pd_problem.msg.get_log();
@@ -200,46 +200,46 @@ pgr_do_pickDeliver(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             nullptr :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             nullptr :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (std::exception& except) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;
         err << ex.first;
         log.str("");
         log.clear();
         log << ex.second;
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::pair<std::string, int64_t>& ex) {
         (*return_count) = 0;
         err << ex.first;
         log.str("");
         log.clear();
         log << "Node missing on matrix: id =  " << ex.second;
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/pickDeliver/pickDeliver_driver.cpp
+++ b/src/pickDeliver/pickDeliver_driver.cpp
@@ -217,7 +217,7 @@ pgr_do_pickDeliver(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;

--- a/src/pickDeliver/pickDeliver_driver.cpp
+++ b/src/pickDeliver/pickDeliver_driver.cpp
@@ -121,7 +121,7 @@ pgr_do_pickDeliver(
             for (const auto &v : vehicles) {
                 if (v.start_node_id != depot_node && v.end_node_id != depot_node) {
                     err << "All vehicles must depart & arrive to same node";
-                    *err_msg = pgr_msg(err.str().c_str());
+                    *err_msg = pgr_msg(err.str());
                     return;
                 }
             }
@@ -132,7 +132,7 @@ pgr_do_pickDeliver(
             for (const auto &o : orders) {
                 if (o.pick_node_id != depot_node) {
                     err << "All orders must be picked at depot";
-                    *err_msg = pgr_msg(err.str().c_str());
+                    *err_msg = pgr_msg(err.str());
                     return;
                 }
             }
@@ -140,7 +140,7 @@ pgr_do_pickDeliver(
 
         if (!cost_matrix.has_no_infinity()) {
             err << "An Infinity value was found on the Matrix";
-            *err_msg = pgr_msg(err.str().c_str());
+            *err_msg = pgr_msg(err.str());
             return;
         }
 
@@ -156,8 +156,8 @@ pgr_do_pickDeliver(
         err << pd_problem.msg.get_error();
         if (!err.str().empty()) {
             log << pd_problem.msg.get_log();
-            *log_msg = pgr_msg(log.str().c_str());
-            *err_msg = pgr_msg(err.str().c_str());
+            *log_msg = pgr_msg(log.str());
+            *err_msg = pgr_msg(err.str());
             return;
         }
         log << pd_problem.msg.get_log();
@@ -200,46 +200,46 @@ pgr_do_pickDeliver(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             nullptr :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             nullptr :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (std::exception& except) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;
         err << ex.first;
         log.str("");
         log.clear();
         log << ex.second;
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::pair<std::string, int64_t>& ex) {
         (*return_count) = 0;
         err << ex.first;
         log.str("");
         log.clear();
         log << "Node missing on matrix: id =  " << ex.second;
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/pickDeliver/pickDeliver_driver.cpp
+++ b/src/pickDeliver/pickDeliver_driver.cpp
@@ -121,7 +121,7 @@ pgr_do_pickDeliver(
             for (const auto &v : vehicles) {
                 if (v.start_node_id != depot_node && v.end_node_id != depot_node) {
                     err << "All vehicles must depart & arrive to same node";
-                    *err_msg = to_pg_msg(err.str());
+                    *err_msg = to_pg_msg(err);
                     return;
                 }
             }
@@ -132,7 +132,7 @@ pgr_do_pickDeliver(
             for (const auto &o : orders) {
                 if (o.pick_node_id != depot_node) {
                     err << "All orders must be picked at depot";
-                    *err_msg = to_pg_msg(err.str());
+                    *err_msg = to_pg_msg(err);
                     return;
                 }
             }
@@ -140,7 +140,7 @@ pgr_do_pickDeliver(
 
         if (!cost_matrix.has_no_infinity()) {
             err << "An Infinity value was found on the Matrix";
-            *err_msg = to_pg_msg(err.str());
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -156,8 +156,8 @@ pgr_do_pickDeliver(
         err << pd_problem.msg.get_error();
         if (!err.str().empty()) {
             log << pd_problem.msg.get_log();
-            *log_msg = to_pg_msg(log.str());
-            *err_msg = to_pg_msg(err.str());
+            *log_msg = to_pg_msg(log);
+            *err_msg = to_pg_msg(err);
             return;
         }
         log << pd_problem.msg.get_log();
@@ -198,48 +198,44 @@ pgr_do_pickDeliver(
         (*return_count) = solution.size();
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            nullptr :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            nullptr :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (std::exception& except) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;
         err << ex.first;
         log.str("");
         log.clear();
         log << ex.second;
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::pair<std::string, int64_t>& ex) {
         (*return_count) = 0;
         err << ex.first;
         log.str("");
         log.clear();
         log << "Node missing on matrix: id =  " << ex.second;
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/planar/boyerMyrvold_driver.cpp
+++ b/src/planar/boyerMyrvold_driver.cpp
@@ -97,7 +97,7 @@ pgr_do_boyerMyrvold(
             (*return_count) = 0;
             notice <<
                 "No Vertices";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -108,32 +108,28 @@ pgr_do_boyerMyrvold(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/planar/boyerMyrvold_driver.cpp
+++ b/src/planar/boyerMyrvold_driver.cpp
@@ -53,7 +53,7 @@ pgr_do_boyerMyrvold(
                 char ** notice_msg,
                 char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_edges;
 
@@ -97,7 +97,7 @@ pgr_do_boyerMyrvold(
             (*return_count) = 0;
             notice <<
                 "No Vertices";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -110,30 +110,30 @@ pgr_do_boyerMyrvold(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/planar/boyerMyrvold_driver.cpp
+++ b/src/planar/boyerMyrvold_driver.cpp
@@ -97,7 +97,7 @@ pgr_do_boyerMyrvold(
             (*return_count) = 0;
             notice <<
                 "No Vertices";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -110,30 +110,30 @@ pgr_do_boyerMyrvold(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/planar/boyerMyrvold_driver.cpp
+++ b/src/planar/boyerMyrvold_driver.cpp
@@ -121,7 +121,7 @@ pgr_do_boyerMyrvold(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/planar/isPlanar_driver.cpp
+++ b/src/planar/isPlanar_driver.cpp
@@ -79,28 +79,24 @@ pgr_do_isPlanar(
         result = fn_isPlanar.isPlanar(undigraph);
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
         return result;
     } catch (AssertFailedException &except) {
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
     return false;
 }

--- a/src/planar/isPlanar_driver.cpp
+++ b/src/planar/isPlanar_driver.cpp
@@ -91,7 +91,7 @@ pgr_do_isPlanar(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         err << except.what();

--- a/src/planar/isPlanar_driver.cpp
+++ b/src/planar/isPlanar_driver.cpp
@@ -50,7 +50,7 @@ pgr_do_isPlanar(
                 char ** notice_msg,
                 char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_edges;
 
@@ -81,26 +81,26 @@ pgr_do_isPlanar(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
         return result;
     } catch (AssertFailedException &except) {
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
     return false;
 }

--- a/src/planar/isPlanar_driver.cpp
+++ b/src/planar/isPlanar_driver.cpp
@@ -81,26 +81,26 @@ pgr_do_isPlanar(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
         return result;
     } catch (AssertFailedException &except) {
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
     return false;
 }

--- a/src/spanningTree/kruskal_driver.cpp
+++ b/src/spanningTree/kruskal_driver.cpp
@@ -105,7 +105,7 @@ pgr_do_kruskal(
                 results = kruskal.kruskalDD(undigraph, roots, distance);
             } else {
                 err << "Unknown Kruskal function";
-                *err_msg = pgr_msg(err.str().c_str());
+                *err_msg = pgr_msg(err.str());
                 return;
             }
         }
@@ -121,30 +121,30 @@ pgr_do_kruskal(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/spanningTree/kruskal_driver.cpp
+++ b/src/spanningTree/kruskal_driver.cpp
@@ -58,7 +58,7 @@ pgr_do_kruskal(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
 
@@ -92,8 +92,8 @@ pgr_do_kruskal(
 
         if (edges.empty()) {
             results = pgrouting::details::get_no_edge_graph_result(roots);
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = pgr_msg(edges_sql);
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = to_pg_msg(edges_sql);
         } else {
             if (suffix == "") {
                 results = kruskal.kruskal(undigraph);
@@ -105,7 +105,7 @@ pgr_do_kruskal(
                 results = kruskal.kruskalDD(undigraph, roots, distance);
             } else {
                 err << "Unknown Kruskal function";
-                *err_msg = pgr_msg(err.str());
+                *err_msg = to_pg_msg(err.str());
                 return;
             }
         }
@@ -121,30 +121,30 @@ pgr_do_kruskal(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/spanningTree/kruskal_driver.cpp
+++ b/src/spanningTree/kruskal_driver.cpp
@@ -105,7 +105,7 @@ pgr_do_kruskal(
                 results = kruskal.kruskalDD(undigraph, roots, distance);
             } else {
                 err << "Unknown Kruskal function";
-                *err_msg = to_pg_msg(err.str());
+                *err_msg = to_pg_msg(err);
                 return;
             }
         }
@@ -119,32 +119,28 @@ pgr_do_kruskal(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/spanningTree/kruskal_driver.cpp
+++ b/src/spanningTree/kruskal_driver.cpp
@@ -132,7 +132,7 @@ pgr_do_kruskal(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/spanningTree/mst_common.cpp
+++ b/src/spanningTree/mst_common.cpp
@@ -45,10 +45,10 @@ get_order(char * fn_suffix, char ** err_msg) {
         if (suffix == "BFS") return 2;
         if (suffix == "DD") return 1;
         err << "Unknown function suffix" << suffix;
-        *err_msg = pgr_msg(err.str().c_str());
+        *err_msg = pgr_msg(err.str());
     } catch (std::exception &except) {
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
+        *err_msg = pgr_msg(err.str());
     }
     return -1;
 }
@@ -68,7 +68,7 @@ get_name(int fn_id, char * fn_suffix, char ** err_msg) {
                     break;
             default : name = "unknown";
                       err << "Unknown function name";
-                      *err_msg = pgr_msg(err.str().c_str());
+                      *err_msg = pgr_msg(err.str());
         }
         std::string suffix(fn_suffix);
         name += suffix;
@@ -76,7 +76,7 @@ get_name(int fn_id, char * fn_suffix, char ** err_msg) {
         return full_name;
     } catch (std::exception &except) {
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
+        *err_msg = pgr_msg(err.str());
     }
     return nullptr;
 }

--- a/src/spanningTree/mst_common.cpp
+++ b/src/spanningTree/mst_common.cpp
@@ -45,10 +45,10 @@ get_order(char * fn_suffix, char ** err_msg) {
         if (suffix == "BFS") return 2;
         if (suffix == "DD") return 1;
         err << "Unknown function suffix" << suffix;
-        *err_msg = to_pg_msg(err.str());
+        *err_msg = to_pg_msg(err);
     } catch (std::exception &except) {
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
+        *err_msg = to_pg_msg(err);
     }
     return -1;
 }
@@ -68,7 +68,7 @@ get_name(int fn_id, char * fn_suffix, char ** err_msg) {
                     break;
             default : name = "unknown";
                       err << "Unknown function name";
-                      *err_msg = to_pg_msg(err.str());
+                      *err_msg = to_pg_msg(err);
         }
         std::string suffix(fn_suffix);
         name += suffix;
@@ -76,7 +76,7 @@ get_name(int fn_id, char * fn_suffix, char ** err_msg) {
         return full_name;
     } catch (std::exception &except) {
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
+        *err_msg = to_pg_msg(err);
     }
     return nullptr;
 }

--- a/src/spanningTree/mst_common.cpp
+++ b/src/spanningTree/mst_common.cpp
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 int
 get_order(char * fn_suffix, char ** err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     std::ostringstream err;
     try {
         pgassert(!(*err_msg));
@@ -45,10 +45,10 @@ get_order(char * fn_suffix, char ** err_msg) {
         if (suffix == "BFS") return 2;
         if (suffix == "DD") return 1;
         err << "Unknown function suffix" << suffix;
-        *err_msg = pgr_msg(err.str());
+        *err_msg = to_pg_msg(err.str());
     } catch (std::exception &except) {
         err << except.what();
-        *err_msg = pgr_msg(err.str());
+        *err_msg = to_pg_msg(err.str());
     }
     return -1;
 }
@@ -56,7 +56,7 @@ get_order(char * fn_suffix, char ** err_msg) {
 
 char *
 get_name(int fn_id, char * fn_suffix, char ** err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     std::ostringstream err;
     try {
         pgassert(!(*err_msg));
@@ -68,15 +68,15 @@ get_name(int fn_id, char * fn_suffix, char ** err_msg) {
                     break;
             default : name = "unknown";
                       err << "Unknown function name";
-                      *err_msg = pgr_msg(err.str());
+                      *err_msg = to_pg_msg(err.str());
         }
         std::string suffix(fn_suffix);
         name += suffix;
-        char * full_name = pgr_msg(name.c_str());
+        char * full_name = to_pg_msg(name.c_str());
         return full_name;
     } catch (std::exception &except) {
         err << except.what();
-        *err_msg = pgr_msg(err.str());
+        *err_msg = to_pg_msg(err.str());
     }
     return nullptr;
 }

--- a/src/spanningTree/prim_driver.cpp
+++ b/src/spanningTree/prim_driver.cpp
@@ -107,7 +107,7 @@ pgr_do_prim(
                 results = prim.primDD(undigraph, roots, distance);
             } else {
                 err << "Unknown Prim function";
-                *err_msg = to_pg_msg(err.str());
+                *err_msg = to_pg_msg(err);
                 return;
             }
         }
@@ -121,32 +121,28 @@ pgr_do_prim(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/spanningTree/prim_driver.cpp
+++ b/src/spanningTree/prim_driver.cpp
@@ -134,7 +134,7 @@ pgr_do_prim(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/spanningTree/prim_driver.cpp
+++ b/src/spanningTree/prim_driver.cpp
@@ -60,7 +60,7 @@ pgr_do_prim(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
 
@@ -94,8 +94,8 @@ pgr_do_prim(
 
         if (edges.empty()) {
             results = pgrouting::details::get_no_edge_graph_result(roots);
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = pgr_msg(edges_sql);
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = to_pg_msg(edges_sql);
         } else {
             if (suffix == "") {
                 results = prim.prim(undigraph);
@@ -107,7 +107,7 @@ pgr_do_prim(
                 results = prim.primDD(undigraph, roots, distance);
             } else {
                 err << "Unknown Prim function";
-                *err_msg = pgr_msg(err.str());
+                *err_msg = to_pg_msg(err.str());
                 return;
             }
         }
@@ -123,30 +123,30 @@ pgr_do_prim(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/spanningTree/prim_driver.cpp
+++ b/src/spanningTree/prim_driver.cpp
@@ -107,7 +107,7 @@ pgr_do_prim(
                 results = prim.primDD(undigraph, roots, distance);
             } else {
                 err << "Unknown Prim function";
-                *err_msg = pgr_msg(err.str().c_str());
+                *err_msg = pgr_msg(err.str());
                 return;
             }
         }
@@ -123,30 +123,30 @@ pgr_do_prim(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/spanningTree/randomSpanningTree_driver.cpp
+++ b/src/spanningTree/randomSpanningTree_driver.cpp
@@ -82,7 +82,7 @@ pgr_do_randomSpanningTree(
 
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -125,30 +125,30 @@ pgr_do_randomSpanningTree(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/spanningTree/randomSpanningTree_driver.cpp
+++ b/src/spanningTree/randomSpanningTree_driver.cpp
@@ -61,7 +61,7 @@ pgr_do_randomSpanningTree(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -81,8 +81,8 @@ pgr_do_randomSpanningTree(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -125,30 +125,30 @@ pgr_do_randomSpanningTree(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/spanningTree/randomSpanningTree_driver.cpp
+++ b/src/spanningTree/randomSpanningTree_driver.cpp
@@ -82,7 +82,7 @@ pgr_do_randomSpanningTree(
 
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -123,32 +123,28 @@ pgr_do_randomSpanningTree(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/spanningTree/randomSpanningTree_driver.cpp
+++ b/src/spanningTree/randomSpanningTree_driver.cpp
@@ -136,7 +136,7 @@ pgr_do_randomSpanningTree(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/topologicalSort/topologicalSort_driver.cpp
+++ b/src/topologicalSort/topologicalSort_driver.cpp
@@ -66,7 +66,7 @@ pgr_do_topologicalSort(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -84,8 +84,8 @@ pgr_do_topologicalSort(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -115,30 +115,30 @@ pgr_do_topologicalSort(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/topologicalSort/topologicalSort_driver.cpp
+++ b/src/topologicalSort/topologicalSort_driver.cpp
@@ -85,7 +85,7 @@ pgr_do_topologicalSort(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -113,32 +113,28 @@ pgr_do_topologicalSort(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/topologicalSort/topologicalSort_driver.cpp
+++ b/src/topologicalSort/topologicalSort_driver.cpp
@@ -85,7 +85,7 @@ pgr_do_topologicalSort(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -115,30 +115,30 @@ pgr_do_topologicalSort(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/topologicalSort/topologicalSort_driver.cpp
+++ b/src/topologicalSort/topologicalSort_driver.cpp
@@ -126,7 +126,7 @@ pgr_do_topologicalSort(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/transitiveClosure/transitiveClosure_driver.cpp
+++ b/src/transitiveClosure/transitiveClosure_driver.cpp
@@ -102,7 +102,7 @@ pgr_do_transitiveClosure(
         char **log_msg,
         char **notice_msg,
         char **err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -120,8 +120,8 @@ pgr_do_transitiveClosure(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -136,30 +136,30 @@ pgr_do_transitiveClosure(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/transitiveClosure/transitiveClosure_driver.cpp
+++ b/src/transitiveClosure/transitiveClosure_driver.cpp
@@ -121,7 +121,7 @@ pgr_do_transitiveClosure(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -136,30 +136,30 @@ pgr_do_transitiveClosure(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/transitiveClosure/transitiveClosure_driver.cpp
+++ b/src/transitiveClosure/transitiveClosure_driver.cpp
@@ -147,7 +147,7 @@ pgr_do_transitiveClosure(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/transitiveClosure/transitiveClosure_driver.cpp
+++ b/src/transitiveClosure/transitiveClosure_driver.cpp
@@ -121,7 +121,7 @@ pgr_do_transitiveClosure(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -134,32 +134,28 @@ pgr_do_transitiveClosure(
                 return_tuples,
                 return_count);
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/traversal/depthFirstSearch_driver.cpp
+++ b/src/traversal/depthFirstSearch_driver.cpp
@@ -149,7 +149,7 @@ pgr_do_depthFirstSearch(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No traversal found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -160,32 +160,28 @@ pgr_do_depthFirstSearch(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/traversal/depthFirstSearch_driver.cpp
+++ b/src/traversal/depthFirstSearch_driver.cpp
@@ -94,7 +94,7 @@ pgr_do_depthFirstSearch(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
 
@@ -119,8 +119,8 @@ pgr_do_depthFirstSearch(
 
         if (edges.empty()) {
             results = pgrouting::details::get_no_edge_graph_result(roots);
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = pgr_msg(edges_sql);
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = to_pg_msg(edges_sql);
         } else {
             if (directed) {
                 pgrouting::DirectedGraph digraph;
@@ -149,7 +149,7 @@ pgr_do_depthFirstSearch(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No traversal found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -162,30 +162,30 @@ pgr_do_depthFirstSearch(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/traversal/depthFirstSearch_driver.cpp
+++ b/src/traversal/depthFirstSearch_driver.cpp
@@ -149,7 +149,7 @@ pgr_do_depthFirstSearch(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No traversal found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -162,30 +162,30 @@ pgr_do_depthFirstSearch(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/traversal/depthFirstSearch_driver.cpp
+++ b/src/traversal/depthFirstSearch_driver.cpp
@@ -173,7 +173,7 @@ pgr_do_depthFirstSearch(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/trsp/trspVia_driver.cpp
+++ b/src/trsp/trspVia_driver.cpp
@@ -148,7 +148,7 @@ pgr_do_trspVia(
         char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
 
@@ -171,8 +171,8 @@ pgr_do_trspVia(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = pgr_msg(edges_sql);
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = to_pg_msg(edges_sql);
             return;
         }
         hint = nullptr;
@@ -207,7 +207,7 @@ pgr_do_trspVia(
 
         if (count == 0) {
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -259,30 +259,30 @@ pgr_do_trspVia(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/trsp/trspVia_driver.cpp
+++ b/src/trsp/trspVia_driver.cpp
@@ -207,7 +207,7 @@ pgr_do_trspVia(
 
         if (count == 0) {
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -259,30 +259,30 @@ pgr_do_trspVia(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/trsp/trspVia_driver.cpp
+++ b/src/trsp/trspVia_driver.cpp
@@ -207,7 +207,7 @@ pgr_do_trspVia(
 
         if (count == 0) {
             notice << "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -257,32 +257,28 @@ pgr_do_trspVia(
         (*return_count) = (get_route(return_tuples, paths));
         (*return_tuples)[count - 1].edge = -2;
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/trsp/trspVia_driver.cpp
+++ b/src/trsp/trspVia_driver.cpp
@@ -270,7 +270,7 @@ pgr_do_trspVia(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/trsp/trspVia_withPoints_driver.cpp
+++ b/src/trsp/trspVia_withPoints_driver.cpp
@@ -151,7 +151,7 @@ pgr_do_trspVia_withPoints(
         char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
 
@@ -179,8 +179,8 @@ pgr_do_trspVia_withPoints(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.size() + edges_of_points.size() == 0) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
 
@@ -199,8 +199,8 @@ pgr_do_trspVia_withPoints(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str());
-            *err_msg = pgr_msg(err.str());
+            *log_msg = to_pg_msg(log.str());
+            *err_msg = to_pg_msg(err.str());
             return;
         }
 
@@ -240,7 +240,7 @@ pgr_do_trspVia_withPoints(
 
         if (count == 0) {
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -289,30 +289,30 @@ pgr_do_trspVia_withPoints(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/trsp/trspVia_withPoints_driver.cpp
+++ b/src/trsp/trspVia_withPoints_driver.cpp
@@ -180,7 +180,7 @@ pgr_do_trspVia_withPoints(
 
         if (edges.size() + edges_of_points.size() == 0) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
 
@@ -199,8 +199,8 @@ pgr_do_trspVia_withPoints(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str().c_str());
-            *err_msg = pgr_msg(err.str().c_str());
+            *log_msg = pgr_msg(log.str());
+            *err_msg = pgr_msg(err.str());
             return;
         }
 
@@ -240,7 +240,7 @@ pgr_do_trspVia_withPoints(
 
         if (count == 0) {
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -289,30 +289,30 @@ pgr_do_trspVia_withPoints(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/trsp/trspVia_withPoints_driver.cpp
+++ b/src/trsp/trspVia_withPoints_driver.cpp
@@ -180,7 +180,7 @@ pgr_do_trspVia_withPoints(
 
         if (edges.size() + edges_of_points.size() == 0) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
 
@@ -199,8 +199,8 @@ pgr_do_trspVia_withPoints(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = to_pg_msg(log.str());
-            *err_msg = to_pg_msg(err.str());
+            *log_msg = to_pg_msg(log);
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -240,7 +240,7 @@ pgr_do_trspVia_withPoints(
 
         if (count == 0) {
             notice << "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -287,32 +287,28 @@ pgr_do_trspVia_withPoints(
         (*return_count) = (get_route(return_tuples, paths));
         (*return_tuples)[count - 1].edge = -2;
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/trsp/trspVia_withPoints_driver.cpp
+++ b/src/trsp/trspVia_withPoints_driver.cpp
@@ -300,7 +300,7 @@ pgr_do_trspVia_withPoints(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/trsp/trsp_driver.cpp
+++ b/src/trsp/trsp_driver.cpp
@@ -111,7 +111,7 @@ pgr_do_trsp(
         char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -132,8 +132,8 @@ pgr_do_trsp(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -142,8 +142,8 @@ pgr_do_trsp(
         hint = nullptr;
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = pgr_msg(edges_sql);
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = to_pg_msg(edges_sql);
             return;
         }
 
@@ -172,7 +172,7 @@ pgr_do_trsp(
 
         if (count == 0) {
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -224,30 +224,30 @@ pgr_do_trsp(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/trsp/trsp_driver.cpp
+++ b/src/trsp/trsp_driver.cpp
@@ -172,7 +172,7 @@ pgr_do_trsp(
 
         if (count == 0) {
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -224,30 +224,30 @@ pgr_do_trsp(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/trsp/trsp_driver.cpp
+++ b/src/trsp/trsp_driver.cpp
@@ -172,7 +172,7 @@ pgr_do_trsp(
 
         if (count == 0) {
             notice << "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -222,32 +222,28 @@ pgr_do_trsp(
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = collapse_paths(return_tuples, paths);
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/trsp/trsp_driver.cpp
+++ b/src/trsp/trsp_driver.cpp
@@ -241,7 +241,7 @@ pgr_do_trsp(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/trsp/trsp_withPoints_driver.cpp
+++ b/src/trsp/trsp_withPoints_driver.cpp
@@ -133,7 +133,7 @@ pgr_do_trsp_withPoints(
 
         if (edges.size() + edges_of_points.size() == 0) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
 
@@ -155,8 +155,8 @@ pgr_do_trsp_withPoints(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str().c_str());
-            *err_msg = pgr_msg(err.str().c_str());
+            *log_msg = pgr_msg(log.str());
+            *err_msg = pgr_msg(err.str());
             return;
         }
 
@@ -194,7 +194,7 @@ pgr_do_trsp_withPoints(
 
         if (count == 0) {
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -257,30 +257,30 @@ pgr_do_trsp_withPoints(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/trsp/trsp_withPoints_driver.cpp
+++ b/src/trsp/trsp_withPoints_driver.cpp
@@ -133,7 +133,7 @@ pgr_do_trsp_withPoints(
 
         if (edges.size() + edges_of_points.size() == 0) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
 
@@ -155,8 +155,8 @@ pgr_do_trsp_withPoints(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = to_pg_msg(log.str());
-            *err_msg = to_pg_msg(err.str());
+            *log_msg = to_pg_msg(log);
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -194,7 +194,7 @@ pgr_do_trsp_withPoints(
 
         if (count == 0) {
             notice << "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -255,32 +255,28 @@ pgr_do_trsp_withPoints(
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = collapse_paths(return_tuples, paths);
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/trsp/trsp_withPoints_driver.cpp
+++ b/src/trsp/trsp_withPoints_driver.cpp
@@ -274,7 +274,7 @@ pgr_do_trsp_withPoints(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/trsp/trsp_withPoints_driver.cpp
+++ b/src/trsp/trsp_withPoints_driver.cpp
@@ -96,7 +96,7 @@ pgr_do_trsp_withPoints(
         char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -117,8 +117,8 @@ pgr_do_trsp_withPoints(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -132,8 +132,8 @@ pgr_do_trsp_withPoints(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.size() + edges_of_points.size() == 0) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
 
@@ -155,8 +155,8 @@ pgr_do_trsp_withPoints(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str());
-            *err_msg = pgr_msg(err.str());
+            *log_msg = to_pg_msg(log.str());
+            *err_msg = to_pg_msg(err.str());
             return;
         }
 
@@ -194,7 +194,7 @@ pgr_do_trsp_withPoints(
 
         if (count == 0) {
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -257,30 +257,30 @@ pgr_do_trsp_withPoints(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/tsp/TSP_driver.cpp
+++ b/src/tsp/TSP_driver.cpp
@@ -58,7 +58,7 @@ pgr_do_tsp(
         char **notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -71,8 +71,8 @@ pgr_do_tsp(
         auto distances = pgrouting::pgget::get_matrixRows(std::string(matrix_sql));
 
         if (distances.size() == 0) {
-            *notice_msg = pgr_msg("Insufficient data found on inner query");
-            *log_msg = hint? pgr_msg(hint) : nullptr;
+            *notice_msg = to_pg_msg("Insufficient data found on inner query");
+            *log_msg = hint? to_pg_msg(hint) : nullptr;
             return;
         }
         hint = nullptr;
@@ -81,13 +81,13 @@ pgr_do_tsp(
 
         if (start_vid != 0 && !fn_tsp.has_vertex(start_vid)) {
             err << "Parameter 'start_id' do not exist on the data";
-            *err_msg = pgr_msg(err.str());
+            *err_msg = to_pg_msg(err.str());
             return;
         }
 
         if (end_vid != 0 && !fn_tsp.has_vertex(end_vid)) {
             err << "Parameter 'end_id' do not exist on the data";
-            *err_msg = pgr_msg(err.str());
+            *err_msg = to_pg_msg(err.str());
             return;
         }
 
@@ -109,34 +109,34 @@ pgr_do_tsp(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;
-        *err_msg = pgr_msg(ex.first.c_str());
-        *log_msg = pgr_msg(ex.second.c_str());
+        *err_msg = to_pg_msg(ex.first.c_str());
+        *log_msg = to_pg_msg(ex.second.c_str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/tsp/TSP_driver.cpp
+++ b/src/tsp/TSP_driver.cpp
@@ -81,13 +81,13 @@ pgr_do_tsp(
 
         if (start_vid != 0 && !fn_tsp.has_vertex(start_vid)) {
             err << "Parameter 'start_id' do not exist on the data";
-            *err_msg = to_pg_msg(err.str());
+            *err_msg = to_pg_msg(err);
             return;
         }
 
         if (end_vid != 0 && !fn_tsp.has_vertex(end_vid)) {
             err << "Parameter 'end_id' do not exist on the data";
-            *err_msg = to_pg_msg(err.str());
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -107,36 +107,32 @@ pgr_do_tsp(
             }
         }
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;
         *err_msg = to_pg_msg(ex.first.c_str());
         *log_msg = to_pg_msg(ex.second.c_str());
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/tsp/TSP_driver.cpp
+++ b/src/tsp/TSP_driver.cpp
@@ -81,13 +81,13 @@ pgr_do_tsp(
 
         if (start_vid != 0 && !fn_tsp.has_vertex(start_vid)) {
             err << "Parameter 'start_id' do not exist on the data";
-            *err_msg = pgr_msg(err.str().c_str());
+            *err_msg = pgr_msg(err.str());
             return;
         }
 
         if (end_vid != 0 && !fn_tsp.has_vertex(end_vid)) {
             err << "Parameter 'end_id' do not exist on the data";
-            *err_msg = pgr_msg(err.str().c_str());
+            *err_msg = pgr_msg(err.str());
             return;
         }
 
@@ -109,34 +109,34 @@ pgr_do_tsp(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;
         *err_msg = pgr_msg(ex.first.c_str());
         *log_msg = pgr_msg(ex.second.c_str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/tsp/TSP_driver.cpp
+++ b/src/tsp/TSP_driver.cpp
@@ -124,7 +124,7 @@ pgr_do_tsp(
         *err_msg = pgr_msg(ex.first.c_str());
         *log_msg = pgr_msg(ex.second.c_str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/tsp/euclideanTSP_driver.cpp
+++ b/src/tsp/euclideanTSP_driver.cpp
@@ -121,7 +121,7 @@ pgr_do_euclideanTSP(
         *err_msg = pgr_msg(ex.first.c_str());
         *log_msg = pgr_msg(ex.second.c_str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/tsp/euclideanTSP_driver.cpp
+++ b/src/tsp/euclideanTSP_driver.cpp
@@ -69,7 +69,7 @@ pgr_do_euclideanTSP(
 
         if (coordinates.size() == 0) {
             *notice_msg = to_pg_msg("No coordinates found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -78,13 +78,13 @@ pgr_do_euclideanTSP(
 
         if (start_vid != 0 && !fn_tsp.has_vertex(start_vid)) {
             err << "Parameter 'start_id' do not exist on the data";
-            *err_msg = to_pg_msg(err.str());
+            *err_msg = to_pg_msg(err);
             return;
         }
 
         if (end_vid != 0 && !fn_tsp.has_vertex(end_vid)) {
             err << "Parameter 'end_id' do not exist on the data";
-            *err_msg = to_pg_msg(err.str());
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -104,36 +104,32 @@ pgr_do_euclideanTSP(
             }
         }
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;
         *err_msg = to_pg_msg(ex.first.c_str());
         *log_msg = to_pg_msg(ex.second.c_str());
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/tsp/euclideanTSP_driver.cpp
+++ b/src/tsp/euclideanTSP_driver.cpp
@@ -69,7 +69,7 @@ pgr_do_euclideanTSP(
 
         if (coordinates.size() == 0) {
             *notice_msg = pgr_msg("No coordinates found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -78,13 +78,13 @@ pgr_do_euclideanTSP(
 
         if (start_vid != 0 && !fn_tsp.has_vertex(start_vid)) {
             err << "Parameter 'start_id' do not exist on the data";
-            *err_msg = pgr_msg(err.str().c_str());
+            *err_msg = pgr_msg(err.str());
             return;
         }
 
         if (end_vid != 0 && !fn_tsp.has_vertex(end_vid)) {
             err << "Parameter 'end_id' do not exist on the data";
-            *err_msg = pgr_msg(err.str().c_str());
+            *err_msg = pgr_msg(err.str());
             return;
         }
 
@@ -106,34 +106,34 @@ pgr_do_euclideanTSP(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;
         *err_msg = pgr_msg(ex.first.c_str());
         *log_msg = pgr_msg(ex.second.c_str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/tsp/euclideanTSP_driver.cpp
+++ b/src/tsp/euclideanTSP_driver.cpp
@@ -55,7 +55,7 @@ pgr_do_euclideanTSP(
         char **notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -68,8 +68,8 @@ pgr_do_euclideanTSP(
         auto coordinates = pgrouting::pgget::get_coordinates(std::string(coordinates_sql));
 
         if (coordinates.size() == 0) {
-            *notice_msg = pgr_msg("No coordinates found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No coordinates found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -78,13 +78,13 @@ pgr_do_euclideanTSP(
 
         if (start_vid != 0 && !fn_tsp.has_vertex(start_vid)) {
             err << "Parameter 'start_id' do not exist on the data";
-            *err_msg = pgr_msg(err.str());
+            *err_msg = to_pg_msg(err.str());
             return;
         }
 
         if (end_vid != 0 && !fn_tsp.has_vertex(end_vid)) {
             err << "Parameter 'end_id' do not exist on the data";
-            *err_msg = pgr_msg(err.str());
+            *err_msg = to_pg_msg(err.str());
             return;
         }
 
@@ -106,34 +106,34 @@ pgr_do_euclideanTSP(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;
-        *err_msg = pgr_msg(ex.first.c_str());
-        *log_msg = pgr_msg(ex.second.c_str());
+        *err_msg = to_pg_msg(ex.first.c_str());
+        *log_msg = to_pg_msg(ex.second.c_str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/withPoints/get_new_queries.cpp
+++ b/src/withPoints/get_new_queries.cpp
@@ -47,7 +47,7 @@ get_new_queries(
         char *points_sql,
         char **edges_of_points_query,
         char **edges_no_points_query) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     std::ostringstream edges_of_points_sql;
     std::ostringstream edges_no_points_sql;
 
@@ -55,7 +55,7 @@ get_new_queries(
         << " edges AS (" << edges_sql << "), "
         << " points AS (" << points_sql << ")"
         << " SELECT DISTINCT edges.* FROM edges JOIN points ON (id = edge_id)";
-    *edges_of_points_query = pgr_msg(edges_of_points_sql.str());
+    *edges_of_points_query = to_pg_msg(edges_of_points_sql.str());
 
     edges_no_points_sql << "WITH "
         << " edges AS (" << edges_sql << "), "
@@ -63,6 +63,6 @@ get_new_queries(
         << " SELECT edges.*"
         << " FROM edges"
         << " WHERE NOT EXISTS (SELECT edge_id FROM points WHERE id = edge_id)";
-    *edges_no_points_query = pgr_msg(edges_no_points_sql.str());
+    *edges_no_points_query = to_pg_msg(edges_no_points_sql.str());
 }
 

--- a/src/withPoints/get_new_queries.cpp
+++ b/src/withPoints/get_new_queries.cpp
@@ -55,7 +55,7 @@ get_new_queries(
         << " edges AS (" << edges_sql << "), "
         << " points AS (" << points_sql << ")"
         << " SELECT DISTINCT edges.* FROM edges JOIN points ON (id = edge_id)";
-    *edges_of_points_query = pgr_msg(edges_of_points_sql.str().c_str());
+    *edges_of_points_query = pgr_msg(edges_of_points_sql.str());
 
     edges_no_points_sql << "WITH "
         << " edges AS (" << edges_sql << "), "
@@ -63,6 +63,6 @@ get_new_queries(
         << " SELECT edges.*"
         << " FROM edges"
         << " WHERE NOT EXISTS (SELECT edge_id FROM points WHERE id = edge_id)";
-    *edges_no_points_query = pgr_msg(edges_no_points_sql.str().c_str());
+    *edges_no_points_query = pgr_msg(edges_no_points_sql.str());
 }
 

--- a/src/withPoints/withPointsVia_driver.cpp
+++ b/src/withPoints/withPointsVia_driver.cpp
@@ -142,7 +142,7 @@ pgr_do_withPointsVia(
 
         if (edges.size() + edges_of_points.size() == 0) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -159,8 +159,8 @@ pgr_do_withPointsVia(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = to_pg_msg(log.str());
-            *err_msg = to_pg_msg(err.str());
+            *log_msg = to_pg_msg(log);
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -203,7 +203,7 @@ pgr_do_withPointsVia(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -211,32 +211,28 @@ pgr_do_withPointsVia(
         (*return_count) = (get_route(return_tuples, paths));
         (*return_tuples)[count - 1].edge = -2;
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/withPoints/withPointsVia_driver.cpp
+++ b/src/withPoints/withPointsVia_driver.cpp
@@ -224,7 +224,7 @@ pgr_do_withPointsVia(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/withPoints/withPointsVia_driver.cpp
+++ b/src/withPoints/withPointsVia_driver.cpp
@@ -142,7 +142,7 @@ pgr_do_withPointsVia(
 
         if (edges.size() + edges_of_points.size() == 0) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -159,8 +159,8 @@ pgr_do_withPointsVia(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str().c_str());
-            *err_msg = pgr_msg(err.str().c_str());
+            *log_msg = pgr_msg(log.str());
+            *err_msg = pgr_msg(err.str());
             return;
         }
 
@@ -203,7 +203,7 @@ pgr_do_withPointsVia(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -213,30 +213,30 @@ pgr_do_withPointsVia(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/withPoints/withPointsVia_driver.cpp
+++ b/src/withPoints/withPointsVia_driver.cpp
@@ -111,7 +111,7 @@ pgr_do_withPointsVia(
         char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
 
@@ -141,8 +141,8 @@ pgr_do_withPointsVia(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.size() + edges_of_points.size() == 0) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -159,8 +159,8 @@ pgr_do_withPointsVia(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str());
-            *err_msg = pgr_msg(err.str());
+            *log_msg = to_pg_msg(log.str());
+            *err_msg = to_pg_msg(err.str());
             return;
         }
 
@@ -203,7 +203,7 @@ pgr_do_withPointsVia(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -213,30 +213,30 @@ pgr_do_withPointsVia(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }

--- a/src/withPoints/withPoints_driver.cpp
+++ b/src/withPoints/withPoints_driver.cpp
@@ -225,7 +225,7 @@ pgr_do_withPoints(
         *err_msg = pgr_msg(err.str());
         *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = pgr_msg(ex);
         *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);

--- a/src/withPoints/withPoints_driver.cpp
+++ b/src/withPoints/withPoints_driver.cpp
@@ -138,7 +138,7 @@ pgr_do_withPoints(
 
         if (edges.size() + edges_of_points.size() == 0) {
             *notice_msg = to_pg_msg("No edges found");
-            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -154,8 +154,8 @@ pgr_do_withPoints(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = to_pg_msg(log.str());
-            *err_msg = to_pg_msg(err.str());
+            *log_msg = to_pg_msg(log);
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -205,39 +205,35 @@ pgr_do_withPoints(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = to_pg_msg(notice.str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            to_pg_msg(log.str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            to_pg_msg(notice.str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
         *err_msg = to_pg_msg(ex);
-        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = to_pg_msg(err.str());
-        *log_msg = to_pg_msg(log.str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/withPoints/withPoints_driver.cpp
+++ b/src/withPoints/withPoints_driver.cpp
@@ -138,7 +138,7 @@ pgr_do_withPoints(
 
         if (edges.size() + edges_of_points.size() == 0) {
             *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -154,8 +154,8 @@ pgr_do_withPoints(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str().c_str());
-            *err_msg = pgr_msg(err.str().c_str());
+            *log_msg = pgr_msg(log.str());
+            *err_msg = pgr_msg(err.str());
             return;
         }
 
@@ -205,7 +205,7 @@ pgr_do_withPoints(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = pgr_msg(notice.str());
             return;
         }
 
@@ -214,30 +214,30 @@ pgr_do_withPoints(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str().c_str());
+            pgr_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str().c_str());
+            pgr_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch (const std::string &ex) {
         *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = pgr_msg(err.str());
+        *log_msg = pgr_msg(log.str());
     }
 }

--- a/src/withPoints/withPoints_driver.cpp
+++ b/src/withPoints/withPoints_driver.cpp
@@ -98,7 +98,7 @@ pgr_do_withPoints(
         char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -121,8 +121,8 @@ pgr_do_withPoints(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -137,8 +137,8 @@ pgr_do_withPoints(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), normal, false);
 
         if (edges.size() + edges_of_points.size() == 0) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
             return;
         }
         hint = nullptr;
@@ -154,8 +154,8 @@ pgr_do_withPoints(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str());
-            *err_msg = pgr_msg(err.str());
+            *log_msg = to_pg_msg(log.str());
+            *err_msg = to_pg_msg(err.str());
             return;
         }
 
@@ -205,7 +205,7 @@ pgr_do_withPoints(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str());
+            *log_msg = to_pg_msg(notice.str());
             return;
         }
 
@@ -214,30 +214,30 @@ pgr_do_withPoints(
 
         *log_msg = log.str().empty()?
             *log_msg :
-            pgr_msg(log.str());
+            to_pg_msg(log.str());
         *notice_msg = notice.str().empty()?
             *notice_msg :
-            pgr_msg(notice.str());
+            to_pg_msg(notice.str());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex);
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log.str());
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str());
-        *log_msg = pgr_msg(log.str());
+        *err_msg = to_pg_msg(err.str());
+        *log_msg = to_pg_msg(log.str());
     }
 }


### PR DESCRIPTION
- Fixing issues found with cppcheck

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Code Improvement**
  - Streamlined string handling across multiple driver files.
  - Removed unnecessary `.c_str()` conversions when passing strings to message functions.
  - Enhanced message processing for better memory management and code clarity.

- **Affected Components**
  - Multiple algorithm drivers including Dijkstra, A*, Floyd-Warshall, Bellman-Ford, and others.
  - Logging and error reporting mechanisms.

- **No Functional Changes**
  - Core algorithm implementations remain unchanged.
  - Error handling and control flow preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->