### PR TITLE
Porting form 2725

### DIFF
--- a/docqueries/ordering/topologicalSort.result
+++ b/docqueries/ordering/topologicalSort.result
@@ -62,7 +62,6 @@ SELECT * FROM pgr_topologicalsort(
 SELECT * FROM pgr_topologicalsort(
   $$SELECT id, source, target, cost, reverse_cost FROM edges$$);
 ERROR:  Graph is not DAG
-HINT:
 CONTEXT:  SQL function "pgr_topologicalsort" statement 1
 /* -- q4 */
 ROLLBACK;

--- a/include/c_common/e_report.h
+++ b/include/c_common/e_report.h
@@ -41,7 +41,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  * ~~~~{.c}
  * std::ostringstream log;
  * log << "the message";
- * *log_msg = pgr_msg(log.str().c_str());
+ * *log_msg = to_pg_msg(log.str());
  * ~~~~
  *
  *

--- a/include/cpp_common/alloc.hpp
+++ b/include/cpp_common/alloc.hpp
@@ -33,6 +33,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 #include <string>
+#include <sstream>
 
 extern "C" {
 
@@ -86,8 +87,8 @@ pgr_free(T* ptr) {
     return nullptr;
 }
 
-char *
-pgr_msg(const std::string &msg);
+char* to_pg_msg(const std::string&);
+char* to_pg_msg(const std::ostringstream&);
 
 }  // namespace pgrouting
 

--- a/src/allpairs/floydWarshall_driver.cpp
+++ b/src/allpairs/floydWarshall_driver.cpp
@@ -49,7 +49,7 @@ pgr_do_floydWarshall(
         size_t *return_count,
         char ** log_msg,
         char ** err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -85,35 +85,33 @@ pgr_do_floydWarshall(
 
         if (*return_count == 0) {
             err <<  "No result generated, report this error\n";
-            *err_msg = pgr_msg(err.str().c_str());
+            *err_msg = to_pg_msg(err);
             *return_tuples = NULL;
             *return_count = 0;
             return;
         }
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
+        *log_msg = to_pg_msg(log);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/allpairs/johnson_driver.cpp
+++ b/src/allpairs/johnson_driver.cpp
@@ -48,7 +48,7 @@ pgr_do_johnson(
         size_t *return_count,
         char ** log_msg,
         char ** err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -84,35 +84,33 @@ pgr_do_johnson(
 
         if (*return_count == 0) {
             err << "No result generated, report this error\n";
-            *err_msg = pgr_msg(err.str().c_str());
+            *err_msg = to_pg_msg(err);
             *return_tuples = NULL;
             *return_count = 0;
             return;
         }
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
+        *log_msg = to_pg_msg(log);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/alpha_shape/alphaShape_driver.cpp
+++ b/src/alpha_shape/alphaShape_driver.cpp
@@ -73,7 +73,7 @@ pgr_do_alphaShape(
         char **notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -180,7 +180,7 @@ pgr_do_alphaShape(
             *return_tuples = pgr_alloc(*return_count, (*return_tuples));
             std::stringstream ss;
             ss << "MULTIPOLYGON EMPTY";
-            (*return_tuples)[0].geom = pgr_msg(ss.str().c_str());
+            (*return_tuples)[0].geom = to_pg_msg(ss.str());
         } else {
             *return_count = results.size();
             *return_tuples = pgr_alloc(*return_count, (*return_tuples));
@@ -188,38 +188,34 @@ pgr_do_alphaShape(
             for (const auto &r : results) {
                 std::stringstream ss;
                 ss << bg::wkt(r);
-                (*return_tuples)[row].geom = pgr_msg(ss.str().c_str());
+                (*return_tuples)[row].geom = to_pg_msg(ss.str());
                 ++row;
             }
         }
 
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/astar/astar_driver.cpp
+++ b/src/astar/astar_driver.cpp
@@ -61,7 +61,7 @@ void pgr_do_astar(
         char** log_msg, char** notice_msg, char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -85,8 +85,8 @@ void pgr_do_astar(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -96,8 +96,8 @@ void pgr_do_astar(
         hint = nullptr;
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = pgr_msg(edges_sql);
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = to_pg_msg(edges_sql);
             return;
         }
 
@@ -128,39 +128,35 @@ void pgr_do_astar(
             (*return_tuples) = nullptr;
             (*return_count) = 0;
             notice << "No paths found\n";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/bdAstar/bdAstar_driver.cpp
+++ b/src/bdAstar/bdAstar_driver.cpp
@@ -62,7 +62,7 @@ void pgr_do_bdAstar(
         char** log_msg, char** notice_msg, char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -83,8 +83,8 @@ void pgr_do_bdAstar(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -92,8 +92,8 @@ void pgr_do_bdAstar(
         auto edges = pgrouting::pgget::get_edges_xy(std::string(edges_sql), true);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -118,39 +118,35 @@ void pgr_do_bdAstar(
             (*return_tuples) = nullptr;
             (*return_count) = 0;
             notice << "No paths found\n";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/bdDijkstra/bdDijkstra_driver.cpp
+++ b/src/bdDijkstra/bdDijkstra_driver.cpp
@@ -95,7 +95,7 @@ pgr_do_bdDijkstra(
         char **err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -116,8 +116,8 @@ pgr_do_bdDijkstra(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -127,8 +127,8 @@ pgr_do_bdDijkstra(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -151,39 +151,35 @@ pgr_do_bdDijkstra(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/bellman_ford/bellman_ford_driver.cpp
+++ b/src/bellman_ford/bellman_ford_driver.cpp
@@ -79,7 +79,7 @@ pgr_do_bellman_ford(
                 char ** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
     using pgrouting::pgget::get_edges;
@@ -103,8 +103,8 @@ pgr_do_bellman_ford(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -112,8 +112,8 @@ pgr_do_bellman_ford(
         auto edges = get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -136,39 +136,35 @@ pgr_do_bellman_ford(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/bellman_ford/bellman_ford_neg_driver.cpp
+++ b/src/bellman_ford/bellman_ford_neg_driver.cpp
@@ -81,7 +81,7 @@ pgr_do_bellman_ford_neg(
                 char ** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
     using pgrouting::pgget::get_edges;
@@ -105,8 +105,8 @@ pgr_do_bellman_ford_neg(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -117,8 +117,8 @@ pgr_do_bellman_ford_neg(
         auto neg_edges = get_edges(std::string(neg_edges_sql), true, false);
 
         if (edges.size() + neg_edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -143,39 +143,35 @@ pgr_do_bellman_ford_neg(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/bellman_ford/edwardMoore_driver.cpp
+++ b/src/bellman_ford/edwardMoore_driver.cpp
@@ -79,7 +79,7 @@ pgr_do_edwardMoore(
         char ** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
     using pgrouting::pgget::get_edges;
@@ -103,8 +103,8 @@ pgr_do_edwardMoore(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -112,8 +112,8 @@ pgr_do_edwardMoore(
         auto edges = get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -136,39 +136,35 @@ pgr_do_edwardMoore(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/breadthFirstSearch/binaryBreadthFirstSearch_driver.cpp
+++ b/src/breadthFirstSearch/binaryBreadthFirstSearch_driver.cpp
@@ -136,7 +136,7 @@ pgr_do_binaryBreadthFirstSearch(
         char ** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
     using pgrouting::pgget::get_edges;
@@ -162,8 +162,8 @@ pgr_do_binaryBreadthFirstSearch(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -172,8 +172,8 @@ pgr_do_binaryBreadthFirstSearch(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
 
@@ -184,7 +184,7 @@ pgr_do_binaryBreadthFirstSearch(
 
             if (!(costCheck(digraph))) {
                 err << c_err_msg;
-                *err_msg = pgr_msg(err.str().c_str());
+                *err_msg = to_pg_msg(err);
                 return;
             }
             paths = binaryBreadthFirstSearch(digraph, combinations);
@@ -195,7 +195,7 @@ pgr_do_binaryBreadthFirstSearch(
 
             if (!(costCheck(undigraph))) {
                 err << c_err_msg;
-                *err_msg = pgr_msg(err.str().c_str());
+                *err_msg = to_pg_msg(err);
                 return;
             }
 
@@ -210,7 +210,7 @@ pgr_do_binaryBreadthFirstSearch(
             (*return_count) = 0;
             notice <<
                 "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -218,32 +218,28 @@ pgr_do_binaryBreadthFirstSearch(
         log << "\nConverting a set of paths into the tuples";
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/breadthFirstSearch/breadthFirstSearch_driver.cpp
+++ b/src/breadthFirstSearch/breadthFirstSearch_driver.cpp
@@ -67,7 +67,7 @@ pgr_do_breadthFirstSearch(
                 char ** notice_msg,
                 char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intSet;
 
@@ -91,8 +91,8 @@ pgr_do_breadthFirstSearch(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -117,7 +117,7 @@ pgr_do_breadthFirstSearch(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No traversal found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -127,32 +127,28 @@ pgr_do_breadthFirstSearch(
             *((*return_tuples) + i) = results[i];
         }
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/chinese/chinesePostman_driver.cpp
+++ b/src/chinese/chinesePostman_driver.cpp
@@ -52,7 +52,7 @@ pgr_do_directedChPP(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -71,8 +71,8 @@ pgr_do_directedChPP(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -101,7 +101,7 @@ pgr_do_directedChPP(
             (*return_count) = 0;
             notice <<
                 "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -112,33 +112,29 @@ pgr_do_directedChPP(
         }
         *return_count = count;
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }
 

--- a/src/circuits/hawickCircuits_driver.cpp
+++ b/src/circuits/hawickCircuits_driver.cpp
@@ -70,7 +70,7 @@ pgr_do_hawickCircuits(
         char ** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -88,8 +88,8 @@ pgr_do_hawickCircuits(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -107,7 +107,7 @@ pgr_do_hawickCircuits(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No Circuit found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -118,32 +118,28 @@ pgr_do_hawickCircuits(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/coloring/bipartite_driver.cpp
+++ b/src/coloring/bipartite_driver.cpp
@@ -53,7 +53,7 @@ pgr_do_bipartite(
         char **notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -74,8 +74,8 @@ pgr_do_bipartite(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -92,12 +92,8 @@ pgr_do_bipartite(
         if (count == 0) {
             (*return_tuples) = NULL;
             (*return_count) = 0;
-            *log_msg = log.str().empty()?
-                       *log_msg :
-                       pgr_msg(log.str().c_str());
-            *notice_msg = notice.str().empty()?
-                          *notice_msg :
-                          pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(log);
+            *notice_msg = to_pg_msg(notice);
             return;
         }
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
@@ -107,32 +103,28 @@ pgr_do_bipartite(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-                   *log_msg :
-                   pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-                      *notice_msg :
-                      pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/coloring/edgeColoring_driver.cpp
+++ b/src/coloring/edgeColoring_driver.cpp
@@ -47,7 +47,7 @@ void pgr_do_edgeColoring(
     char **notice_msg,
     char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -65,8 +65,8 @@ void pgr_do_edgeColoring(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -84,7 +84,7 @@ void pgr_do_edgeColoring(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No results found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -95,28 +95,28 @@ void pgr_do_edgeColoring(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty() ? *log_msg : pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty() ? *notice_msg : pgr_msg(notice.str().c_str());
+        *log_msg = log.str().empty() ? *log_msg : to_pg_msg(log);
+        *notice_msg = notice.str().empty() ? *notice_msg : to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/coloring/sequentialVertexColoring_driver.cpp
+++ b/src/coloring/sequentialVertexColoring_driver.cpp
@@ -65,7 +65,7 @@ pgr_do_sequentialVertexColoring(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -83,8 +83,8 @@ pgr_do_sequentialVertexColoring(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -103,7 +103,7 @@ pgr_do_sequentialVertexColoring(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No traversal found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -114,32 +114,28 @@ pgr_do_sequentialVertexColoring(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/common/alloc.cpp
+++ b/src/common/alloc.cpp
@@ -31,13 +31,19 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 namespace pgrouting {
 
-char *
-pgr_msg(const std::string &msg) {
-    char* duplicate = NULL;
+char*
+to_pg_msg(const std::string &msg) {
+    if (msg.empty()) return nullptr;
+    char* duplicate = nullptr;
     duplicate = pgr_alloc(msg.size() + 1, duplicate);
     memcpy(duplicate, msg.c_str(), msg.size());
     duplicate[msg.size()] = '\0';
     return duplicate;
+}
+
+char*
+to_pg_msg(const std::ostringstream &msg) {
+    return to_pg_msg(msg.str());
 }
 
 }  // namespace pgrouting

--- a/src/common/e_report.c
+++ b/src/common/e_report.c
@@ -44,7 +44,7 @@ pgr_throw_error(char *err, char *hint) {
  * ~~~~{.c}
  * std::ostringstream log;
  * log << "the message";
- * *log_msg = to_pg_msg(log.str().c_str());
+ * *log_msg = to_pg_msg(log);
  * ~~~~
  *
  * Then on the C side

--- a/src/components/articulationPoints_driver.cpp
+++ b/src/components/articulationPoints_driver.cpp
@@ -52,7 +52,7 @@ pgr_do_articulationPoints(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_edges;
 
@@ -71,8 +71,8 @@ pgr_do_articulationPoints(
         hint = edges_sql;
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -100,33 +100,29 @@ pgr_do_articulationPoints(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }
 

--- a/src/components/biconnectedComponents_driver.cpp
+++ b/src/components/biconnectedComponents_driver.cpp
@@ -53,7 +53,7 @@ pgr_do_biconnectedComponents(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_edges;
 
@@ -72,8 +72,8 @@ pgr_do_biconnectedComponents(
         hint = edges_sql;
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -99,33 +99,29 @@ pgr_do_biconnectedComponents(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }
 

--- a/src/components/bridges_driver.cpp
+++ b/src/components/bridges_driver.cpp
@@ -51,7 +51,7 @@ pgr_do_bridges(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_edges;
 
@@ -70,8 +70,8 @@ pgr_do_bridges(
         hint = edges_sql;
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -98,33 +98,29 @@ pgr_do_bridges(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }
 

--- a/src/components/connectedComponents_driver.cpp
+++ b/src/components/connectedComponents_driver.cpp
@@ -52,7 +52,7 @@ pgr_do_connectedComponents(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_edges;
 
@@ -71,8 +71,8 @@ pgr_do_connectedComponents(
         hint = edges_sql;
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -97,33 +97,29 @@ pgr_do_connectedComponents(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }
 

--- a/src/components/makeConnected_driver.cpp
+++ b/src/components/makeConnected_driver.cpp
@@ -51,7 +51,7 @@ pgr_do_makeConnected(
                 char ** notice_msg,
                 char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_edges;
 
@@ -73,8 +73,8 @@ pgr_do_makeConnected(
         hint = edges_sql;
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -93,7 +93,7 @@ pgr_do_makeConnected(
             (*return_count) = 0;
             notice <<
                 "No Vertices";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -105,32 +105,28 @@ pgr_do_makeConnected(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/components/strongComponents_driver.cpp
+++ b/src/components/strongComponents_driver.cpp
@@ -53,7 +53,7 @@ pgr_do_strongComponents(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_edges;
 
@@ -72,8 +72,8 @@ pgr_do_strongComponents(
         hint = edges_sql;
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -98,33 +98,29 @@ pgr_do_strongComponents(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }
 

--- a/src/contraction/contractGraph_driver.cpp
+++ b/src/contraction/contractGraph_driver.cpp
@@ -184,7 +184,7 @@ pgr_do_contractGraph(
         char **notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
     using pgrouting::pgget::get_edges;
@@ -205,8 +205,8 @@ pgr_do_contractGraph(
         hint = edges_sql;
         auto edges = get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -216,9 +216,9 @@ pgr_do_contractGraph(
 
         for (const auto kind : ordering) {
             if (!pgrouting::contraction::is_valid_contraction(static_cast<int>(kind))) {
-                *err_msg = pgr_msg("Invalid contraction type found");
+                *err_msg = to_pg_msg("Invalid contraction type found");
                 log << "Contraction type " << kind << " not valid";
-                *log_msg = pgr_msg(log.str().c_str());
+                *log_msg = to_pg_msg(log);
                 return;
             }
         }
@@ -249,32 +249,28 @@ pgr_do_contractGraph(
         }
 
         pgassert(err.str().empty());
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/cpp_common/trsp_pgget.cpp
+++ b/src/cpp_common/trsp_pgget.cpp
@@ -85,7 +85,7 @@ pgr_get_edges(
         bool normal,
         bool ignore_id,
         char **err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::Column_info_t;
     try {
@@ -100,11 +100,11 @@ pgr_get_edges(
     } catch (const std::string &ex) {
         (*rows) = pgr_free(*rows);
         (*total_rows) = 0;
-        *err_msg = pgr_msg(ex.c_str());
+        *err_msg = to_pg_msg(ex);
     } catch(...) {
         (*rows) = pgr_free(*rows);
         (*total_rows) = 0;
-        *err_msg = pgr_msg("Caught unknown exception!");
+        *err_msg = to_pg_msg("Caught unknown exception!");
     }
 }
 

--- a/src/dagShortestPath/dagShortestPath_driver.cpp
+++ b/src/dagShortestPath/dagShortestPath_driver.cpp
@@ -77,7 +77,7 @@ pgr_do_dagShortestPath(
         char **err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
     using pgrouting::pgget::get_edges;
@@ -100,8 +100,8 @@ pgr_do_dagShortestPath(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -111,8 +111,8 @@ pgr_do_dagShortestPath(
         auto edges = get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -134,39 +134,35 @@ pgr_do_dagShortestPath(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/dijkstra/dijkstraVia_driver.cpp
+++ b/src/dijkstra/dijkstraVia_driver.cpp
@@ -103,7 +103,7 @@ pgr_do_dijkstraVia(
         char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
     using pgrouting::pgget::get_edges;
@@ -128,8 +128,8 @@ pgr_do_dijkstraVia(
         auto edges = get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -164,7 +164,7 @@ pgr_do_dijkstraVia(
             (*return_count) = 0;
             notice <<
                 "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -174,32 +174,28 @@ pgr_do_dijkstraVia(
         (*return_count) = (get_route(return_tuples, paths));
         (*return_tuples)[count - 1].edge = -2;
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/dijkstra/dijkstra_driver.cpp
+++ b/src/dijkstra/dijkstra_driver.cpp
@@ -122,7 +122,7 @@ pgr_do_dijkstra(
         char **err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
     using pgrouting::pgget::get_edges;
@@ -144,8 +144,8 @@ pgr_do_dijkstra(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -155,8 +155,8 @@ pgr_do_dijkstra(
         auto edges = get_edges(std::string(edges_sql), normal, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -182,39 +182,35 @@ pgr_do_dijkstra(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/dominator/lengauerTarjanDominatorTree_driver.cpp
+++ b/src/dominator/lengauerTarjanDominatorTree_driver.cpp
@@ -56,7 +56,7 @@ pgr_do_LTDTree(
         char **err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -74,8 +74,8 @@ pgr_do_LTDTree(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -97,12 +97,8 @@ pgr_do_LTDTree(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No result found";
-            *log_msg = log.str().empty()?
-                       *log_msg :
-                       pgr_msg(log.str().c_str());
-            *notice_msg = notice.str().empty()?
-                          *notice_msg :
-                          pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(log);
+            *notice_msg = to_pg_msg(notice);
             return;
         }
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
@@ -112,32 +108,28 @@ pgr_do_LTDTree(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-                   *log_msg :
-                   pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-                      *notice_msg :
-                      pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/driving_distance/driving_distance_driver.cpp
+++ b/src/driving_distance/driving_distance_driver.cpp
@@ -56,7 +56,7 @@ pgr_do_drivingDistance(
         char **err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::algorithm::drivingDistance;
     using pgrouting::pgget::get_intSet;
@@ -80,8 +80,8 @@ pgr_do_drivingDistance(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -103,7 +103,7 @@ pgr_do_drivingDistance(
 
         if (count == 0) {
             log << "\nNo return values were found";
-            *notice_msg = pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg(log);
             return;
         }
 
@@ -124,32 +124,28 @@ pgr_do_drivingDistance(
         }
         (*return_count) = count;
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch( ... ) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/driving_distance/driving_distance_withPoints_driver.cpp
+++ b/src/driving_distance/driving_distance_withPoints_driver.cpp
@@ -67,7 +67,7 @@ pgr_do_withPointsDD(
         char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intSet;
     using pgrouting::utilities::get_combinations;
@@ -99,8 +99,8 @@ pgr_do_withPointsDD(
         auto edges = get_edges(std::string(edges_sql), true, false);
 
         if (edges.size() + edges_of_points.size() == 0) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -114,8 +114,8 @@ pgr_do_withPointsDD(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str().c_str());
-            *err_msg = pgr_msg(err.str().c_str());
+            *log_msg = to_pg_msg(log);
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -148,7 +148,7 @@ pgr_do_withPointsDD(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -176,32 +176,28 @@ pgr_do_withPointsDD(
         std::stable_sort((*return_tuples), (*return_tuples) + count,
                 [](const MST_rt &l, const MST_rt &r) {return l.from_v < r.from_v;});
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/ksp/ksp_driver.cpp
+++ b/src/ksp/ksp_driver.cpp
@@ -64,7 +64,7 @@ void pgr_do_ksp(
         char **err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
     using pgrouting::yen::Pgr_ksp;
@@ -92,8 +92,8 @@ void pgr_do_ksp(
         }
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -101,8 +101,8 @@ void pgr_do_ksp(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -126,7 +126,7 @@ void pgr_do_ksp(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -139,32 +139,28 @@ void pgr_do_ksp(
         }
         *return_count = count;
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/ksp/turnRestrictedPath_driver.cpp
+++ b/src/ksp/turnRestrictedPath_driver.cpp
@@ -99,7 +99,7 @@ pgr_do_turnRestrictedPath(
         char ** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::yen::Pgr_turnRestrictedPath;
     using pgrouting::trsp::Rule;
@@ -123,8 +123,8 @@ pgr_do_turnRestrictedPath(
         auto edges = get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -205,33 +205,29 @@ pgr_do_turnRestrictedPath(
 
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
         pgassert(!log.str().empty());
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/ksp/withPoints_ksp_driver.cpp
+++ b/src/ksp/withPoints_ksp_driver.cpp
@@ -70,7 +70,7 @@ pgr_do_withPointsKsp(
         char ** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::yen::Pgr_ksp;
     using pgrouting::utilities::get_combinations;
@@ -99,8 +99,8 @@ pgr_do_withPointsKsp(
         }
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -116,8 +116,8 @@ pgr_do_withPointsKsp(
         auto edges = get_edges(std::string(edges_sql), true, false);
 
         if (edges.size() + edges_of_points.size() == 0) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -130,8 +130,8 @@ pgr_do_withPointsKsp(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str().c_str());
-            *err_msg = pgr_msg(err.str().c_str());
+            *log_msg = to_pg_msg(log);
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -163,7 +163,7 @@ pgr_do_withPointsKsp(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -180,37 +180,33 @@ pgr_do_withPointsKsp(
         if (count != sequence) {
             (*return_count) = 0;
             notice << "Something went wrong";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
         (*return_count) = sequence;
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/lineGraph/lineGraphFull_driver.cpp
+++ b/src/lineGraph/lineGraphFull_driver.cpp
@@ -75,7 +75,7 @@ pgr_do_lineGraphFull(
         char ** log_msg,
         char ** notice_msg,
         char ** err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -93,8 +93,8 @@ pgr_do_lineGraphFull(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -128,36 +128,32 @@ pgr_do_lineGraphFull(
             (*return_count) = sequence;
         }
 #if 1
-        log << line.log.str().c_str() << "\n\n\n";
+        log << line.log.str() << "\n\n\n";
         log << line << "\n";
 #endif
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/lineGraph/lineGraph_driver.cpp
+++ b/src/lineGraph/lineGraph_driver.cpp
@@ -65,7 +65,7 @@ pgr_do_lineGraph(
         char ** log_msg,
         char ** notice_msg,
         char ** err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -84,8 +84,8 @@ pgr_do_lineGraph(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -106,7 +106,7 @@ pgr_do_lineGraph(
         if (count == 0) {
             (*return_tuples) = NULL;
             (*return_count) = 0;
-            *log_msg = pgr_msg(log.str().c_str());
+            *log_msg = to_pg_msg(log);
             return;
         }
 
@@ -122,28 +122,28 @@ pgr_do_lineGraph(
         (*return_count) = sequence;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?  *log_msg : pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?  *notice_msg : pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/max_flow/edge_disjoint_paths_driver.cpp
+++ b/src/max_flow/edge_disjoint_paths_driver.cpp
@@ -83,7 +83,7 @@ pgr_do_edge_disjoint_paths(
     char** notice_msg,
     char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -104,8 +104,8 @@ pgr_do_edge_disjoint_paths(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -114,8 +114,8 @@ pgr_do_edge_disjoint_paths(
         hint = nullptr;
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = pgr_msg(edges_sql);
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = to_pg_msg(edges_sql);
             return;
         }
 
@@ -184,32 +184,28 @@ pgr_do_edge_disjoint_paths(
         *return_count = paths.size();
 
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/max_flow/max_flow_driver.cpp
+++ b/src/max_flow/max_flow_driver.cpp
@@ -58,7 +58,7 @@ pgr_do_max_flow(
         char** notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -79,8 +79,8 @@ pgr_do_max_flow(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -95,7 +95,7 @@ pgr_do_max_flow(
         vertices.insert(targets.begin(), targets.end());
 
         if (vertices.size() != (sources.size() + targets.size())) {
-            *err_msg = pgr_msg("A source found as sink");
+            *err_msg = to_pg_msg("A source found as sink");
             return;
         }
 
@@ -104,7 +104,7 @@ pgr_do_max_flow(
         hint = nullptr;
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
+            *notice_msg = to_pg_msg("No edges found");
             *log_msg = edges_sql;
             return;
         }
@@ -123,7 +123,7 @@ pgr_do_max_flow(
             max_flow = digraph.boykov_kolmogorov();
         } else {
             log << "Unspecified algorithm!\n";
-            *err_msg = pgr_msg(log.str().c_str());
+            *err_msg = to_pg_msg(log);
             (*return_tuples) = NULL;
             (*return_count) = 0;
             return;
@@ -145,32 +145,28 @@ pgr_do_max_flow(
         *return_count = flow_edges.size();
 
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/max_flow/maximum_cardinality_matching_driver.cpp
+++ b/src/max_flow/maximum_cardinality_matching_driver.cpp
@@ -58,7 +58,7 @@ pgr_do_maximum_cardinality_matching(
     char** notice_msg,
     char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -71,8 +71,8 @@ pgr_do_maximum_cardinality_matching(
         auto edges = pgrouting::pgget::get_basic_edges(std::string(edges_sql));
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -86,32 +86,28 @@ pgr_do_maximum_cardinality_matching(
         }
         *return_count = matched_vertices.size();
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/max_flow/minCostMaxFlow_driver.cpp
+++ b/src/max_flow/minCostMaxFlow_driver.cpp
@@ -59,7 +59,7 @@ pgr_do_minCostMaxFlow(
         char **notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -80,8 +80,8 @@ pgr_do_minCostMaxFlow(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -96,7 +96,7 @@ pgr_do_minCostMaxFlow(
         vertices.insert(targets.begin(), targets.end());
 
         if (vertices.size() != (sources.size() + targets.size())) {
-            *err_msg = pgr_msg("A source found as sink");
+            *err_msg = to_pg_msg("A source found as sink");
             return;
         }
 
@@ -104,8 +104,8 @@ pgr_do_minCostMaxFlow(
         auto edges = pgrouting::pgget::get_costFlow_edges(std::string(edges_sql));
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -140,32 +140,28 @@ pgr_do_minCostMaxFlow(
         *return_count = flow_edges.size();
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/metrics/betweennessCentrality_driver.cpp
+++ b/src/metrics/betweennessCentrality_driver.cpp
@@ -48,7 +48,7 @@ pgr_do_betweennessCentrality(
         size_t *return_count,
         char ** log_msg,
         char ** err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -87,35 +87,33 @@ pgr_do_betweennessCentrality(
 
         if (*return_count == 0) {
             err <<  "No result generated, report this error\n";
-            *err_msg = pgr_msg(err.str().c_str());
+            *err_msg = to_pg_msg(err);
             *return_tuples = NULL;
             *return_count = 0;
             return;
         }
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
+        *log_msg = to_pg_msg(log);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
        (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/mincut/stoerWagner_driver.cpp
+++ b/src/mincut/stoerWagner_driver.cpp
@@ -61,7 +61,7 @@ pgr_do_stoerWagner(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -79,8 +79,8 @@ pgr_do_stoerWagner(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -109,32 +109,28 @@ pgr_do_stoerWagner(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/ordering/cuthillMckeeOrdering_driver.cpp
+++ b/src/ordering/cuthillMckeeOrdering_driver.cpp
@@ -79,7 +79,7 @@ void pgr_do_cuthillMckeeOrdering(
     char **notice_msg,
     char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -97,8 +97,8 @@ void pgr_do_cuthillMckeeOrdering(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -114,7 +114,7 @@ void pgr_do_cuthillMckeeOrdering(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No results found";
-            *log_msg = pgr_msg(log.str().c_str());
+            *log_msg = to_pg_msg(log);
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
@@ -126,30 +126,30 @@ void pgr_do_cuthillMckeeOrdering(
         pgassert(*err_msg == NULL);
         *log_msg = log.str().empty() ?
         *log_msg :
-        pgr_msg(log.str().c_str());
+        to_pg_msg(log);
         *notice_msg = notice.str().empty() ?
         *notice_msg :
-        pgr_msg(notice.str().c_str());
+        to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/pickDeliver/pickDeliverEuclidean_driver.cpp
+++ b/src/pickDeliver/pickDeliverEuclidean_driver.cpp
@@ -61,7 +61,7 @@ pgr_do_pickDeliverEuclidean(
         char **notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -76,16 +76,16 @@ pgr_do_pickDeliverEuclidean(
         hint = customers_sql;
         auto orders = pgrouting::pgget::get_orders(std::string(customers_sql), false);
         if (orders.size() == 0) {
-            *notice_msg = pgr_msg("Insufficient data found on inner query");
-            *log_msg = hint? pgr_msg(hint) : nullptr;
+            *notice_msg = to_pg_msg("Insufficient data found on inner query");
+            *log_msg = hint? to_pg_msg(hint) : nullptr;
             return;
         }
 
         hint = vehicles_sql;
         auto vehicles = pgrouting::pgget::get_vehicles(std::string(vehicles_sql), false);
         if (vehicles.size() == 0) {
-            *notice_msg = pgr_msg("Insufficient data found on inner query");
-            *log_msg = hint? pgr_msg(hint) : nullptr;
+            *notice_msg = to_pg_msg("Insufficient data found on inner query");
+            *log_msg = hint? to_pg_msg(hint) : nullptr;
             return;
         }
 
@@ -141,8 +141,8 @@ pgr_do_pickDeliverEuclidean(
             log.clear();
             log << pd_problem.msg.get_error();
             log << pd_problem.msg.get_log();
-            *log_msg = pgr_msg(log.str().c_str());
-            *err_msg = pgr_msg(err.str().c_str());
+            *log_msg = to_pg_msg(log);
+            *err_msg = to_pg_msg(err);
             return;
         }
         log << pd_problem.msg.get_log();
@@ -179,40 +179,36 @@ pgr_do_pickDeliverEuclidean(
         log << pd_problem.msg.get_log();
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            nullptr :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            nullptr :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (std::exception& except) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;
         err << ex.first;
         log.str("");
         log.clear();
         log << ex.second;
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         if (*return_tuples) free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/planar/boyerMyrvold_driver.cpp
+++ b/src/planar/boyerMyrvold_driver.cpp
@@ -53,7 +53,7 @@ pgr_do_boyerMyrvold(
                 char ** notice_msg,
                 char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_edges;
 
@@ -97,7 +97,7 @@ pgr_do_boyerMyrvold(
             (*return_count) = 0;
             notice <<
                 "No Vertices";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -108,32 +108,28 @@ pgr_do_boyerMyrvold(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/planar/isPlanar_driver.cpp
+++ b/src/planar/isPlanar_driver.cpp
@@ -50,7 +50,7 @@ pgr_do_isPlanar(
                 char ** notice_msg,
                 char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_edges;
 
@@ -79,28 +79,24 @@ pgr_do_isPlanar(
         result = fn_isPlanar.isPlanar(undigraph);
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
         return result;
     } catch (AssertFailedException &except) {
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
     return false;
 }

--- a/src/spanningTree/kruskal_driver.cpp
+++ b/src/spanningTree/kruskal_driver.cpp
@@ -58,7 +58,7 @@ pgr_do_kruskal(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
 
@@ -92,8 +92,8 @@ pgr_do_kruskal(
 
         if (edges.empty()) {
             results = pgrouting::details::get_no_edge_graph_result(roots);
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = pgr_msg(edges_sql);
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = to_pg_msg(edges_sql);
         } else {
             if (suffix == "") {
                 results = kruskal.kruskal(undigraph);
@@ -105,7 +105,7 @@ pgr_do_kruskal(
                 results = kruskal.kruskalDD(undigraph, roots, distance);
             } else {
                 err << "Unknown Kruskal function";
-                *err_msg = pgr_msg(err.str().c_str());
+                *err_msg = to_pg_msg(err);
                 return;
             }
         }
@@ -119,32 +119,28 @@ pgr_do_kruskal(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/spanningTree/mst_common.cpp
+++ b/src/spanningTree/mst_common.cpp
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 int
 get_order(char * fn_suffix, char ** err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     std::ostringstream err;
     try {
         pgassert(!(*err_msg));
@@ -45,10 +45,10 @@ get_order(char * fn_suffix, char ** err_msg) {
         if (suffix == "BFS") return 2;
         if (suffix == "DD") return 1;
         err << "Unknown function suffix" << suffix;
-        *err_msg = pgr_msg(err.str().c_str());
+        *err_msg = to_pg_msg(err);
     } catch (std::exception &except) {
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
+        *err_msg = to_pg_msg(err);
     }
     return -1;
 }
@@ -56,7 +56,7 @@ get_order(char * fn_suffix, char ** err_msg) {
 
 char *
 get_name(int fn_id, char * fn_suffix, char ** err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     std::ostringstream err;
     try {
         pgassert(!(*err_msg));
@@ -68,15 +68,15 @@ get_name(int fn_id, char * fn_suffix, char ** err_msg) {
                     break;
             default : name = "unknown";
                       err << "Unknown function name";
-                      *err_msg = pgr_msg(err.str().c_str());
+                      *err_msg = to_pg_msg(err);
         }
         std::string suffix(fn_suffix);
         name += suffix;
-        char * full_name = pgr_msg(name.c_str());
+        char * full_name = to_pg_msg(name.c_str());
         return full_name;
     } catch (std::exception &except) {
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
+        *err_msg = to_pg_msg(err);
     }
     return nullptr;
 }

--- a/src/spanningTree/prim_driver.cpp
+++ b/src/spanningTree/prim_driver.cpp
@@ -60,7 +60,7 @@ pgr_do_prim(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
 
@@ -94,8 +94,8 @@ pgr_do_prim(
 
         if (edges.empty()) {
             results = pgrouting::details::get_no_edge_graph_result(roots);
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = pgr_msg(edges_sql);
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = to_pg_msg(edges_sql);
         } else {
             if (suffix == "") {
                 results = prim.prim(undigraph);
@@ -107,7 +107,7 @@ pgr_do_prim(
                 results = prim.primDD(undigraph, roots, distance);
             } else {
                 err << "Unknown Prim function";
-                *err_msg = pgr_msg(err.str().c_str());
+                *err_msg = to_pg_msg(err);
                 return;
             }
         }
@@ -121,32 +121,28 @@ pgr_do_prim(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/spanningTree/randomSpanningTree_driver.cpp
+++ b/src/spanningTree/randomSpanningTree_driver.cpp
@@ -61,7 +61,7 @@ pgr_do_randomSpanningTree(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -81,8 +81,8 @@ pgr_do_randomSpanningTree(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -123,32 +123,28 @@ pgr_do_randomSpanningTree(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/topologicalSort/topologicalSort_driver.cpp
+++ b/src/topologicalSort/topologicalSort_driver.cpp
@@ -66,7 +66,7 @@ pgr_do_topologicalSort(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -84,8 +84,8 @@ pgr_do_topologicalSort(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -113,32 +113,28 @@ pgr_do_topologicalSort(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/transitiveClosure/transitiveClosure_driver.cpp
+++ b/src/transitiveClosure/transitiveClosure_driver.cpp
@@ -102,7 +102,7 @@ pgr_do_transitiveClosure(
         char **log_msg,
         char **notice_msg,
         char **err_msg) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -120,8 +120,8 @@ pgr_do_transitiveClosure(
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -134,32 +134,28 @@ pgr_do_transitiveClosure(
                 return_tuples,
                 return_count);
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/traversal/depthFirstSearch_driver.cpp
+++ b/src/traversal/depthFirstSearch_driver.cpp
@@ -94,7 +94,7 @@ pgr_do_depthFirstSearch(
         char ** notice_msg,
         char ** err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
 
@@ -119,8 +119,8 @@ pgr_do_depthFirstSearch(
 
         if (edges.empty()) {
             results = pgrouting::details::get_no_edge_graph_result(roots);
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = pgr_msg(edges_sql);
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = to_pg_msg(edges_sql);
         } else {
             if (directed) {
                 pgrouting::DirectedGraph digraph;
@@ -149,7 +149,7 @@ pgr_do_depthFirstSearch(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No traversal found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -160,32 +160,28 @@ pgr_do_depthFirstSearch(
         (*return_count) = count;
 
         pgassert(*err_msg == NULL);
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/trsp/trspVia_driver.cpp
+++ b/src/trsp/trspVia_driver.cpp
@@ -148,7 +148,7 @@ pgr_do_trspVia(
         char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
 
@@ -171,8 +171,8 @@ pgr_do_trspVia(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = pgr_msg(edges_sql);
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = to_pg_msg(edges_sql);
             return;
         }
         hint = nullptr;
@@ -207,7 +207,7 @@ pgr_do_trspVia(
 
         if (count == 0) {
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -257,32 +257,28 @@ pgr_do_trspVia(
         (*return_count) = (get_route(return_tuples, paths));
         (*return_tuples)[count - 1].edge = -2;
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/trsp/trspVia_withPoints_driver.cpp
+++ b/src/trsp/trspVia_withPoints_driver.cpp
@@ -151,7 +151,7 @@ pgr_do_trspVia_withPoints(
         char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
 
@@ -179,8 +179,8 @@ pgr_do_trspVia_withPoints(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.size() + edges_of_points.size() == 0) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
 
@@ -199,8 +199,8 @@ pgr_do_trspVia_withPoints(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str().c_str());
-            *err_msg = pgr_msg(err.str().c_str());
+            *log_msg = to_pg_msg(log);
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -240,7 +240,7 @@ pgr_do_trspVia_withPoints(
 
         if (count == 0) {
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -287,32 +287,28 @@ pgr_do_trspVia_withPoints(
         (*return_count) = (get_route(return_tuples, paths));
         (*return_tuples)[count - 1].edge = -2;
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/trsp/trsp_driver.cpp
+++ b/src/trsp/trsp_driver.cpp
@@ -111,7 +111,7 @@ pgr_do_trsp(
         char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -132,8 +132,8 @@ pgr_do_trsp(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -142,8 +142,8 @@ pgr_do_trsp(
         hint = nullptr;
 
         if (edges.empty()) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = pgr_msg(edges_sql);
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = to_pg_msg(edges_sql);
             return;
         }
 
@@ -172,7 +172,7 @@ pgr_do_trsp(
 
         if (count == 0) {
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -222,32 +222,28 @@ pgr_do_trsp(
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = collapse_paths(return_tuples, paths);
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/trsp/trsp_withPoints_driver.cpp
+++ b/src/trsp/trsp_withPoints_driver.cpp
@@ -96,7 +96,7 @@ pgr_do_trsp_withPoints(
         char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -117,8 +117,8 @@ pgr_do_trsp_withPoints(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -132,8 +132,8 @@ pgr_do_trsp_withPoints(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.size() + edges_of_points.size() == 0) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
 
@@ -155,8 +155,8 @@ pgr_do_trsp_withPoints(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str().c_str());
-            *err_msg = pgr_msg(err.str().c_str());
+            *log_msg = to_pg_msg(log);
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -194,7 +194,7 @@ pgr_do_trsp_withPoints(
 
         if (count == 0) {
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -255,32 +255,28 @@ pgr_do_trsp_withPoints(
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = collapse_paths(return_tuples, paths);
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/tsp/TSP_driver.cpp
+++ b/src/tsp/TSP_driver.cpp
@@ -58,7 +58,7 @@ pgr_do_tsp(
         char **notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -71,8 +71,8 @@ pgr_do_tsp(
         auto distances = pgrouting::pgget::get_matrixRows(std::string(matrix_sql));
 
         if (distances.size() == 0) {
-            *notice_msg = pgr_msg("Insufficient data found on inner query");
-            *log_msg = hint? pgr_msg(hint) : nullptr;
+            *notice_msg = to_pg_msg("Insufficient data found on inner query");
+            *log_msg = hint? to_pg_msg(hint) : nullptr;
             return;
         }
         hint = nullptr;
@@ -81,13 +81,13 @@ pgr_do_tsp(
 
         if (start_vid != 0 && !fn_tsp.has_vertex(start_vid)) {
             err << "Parameter 'start_id' do not exist on the data";
-            *err_msg = pgr_msg(err.str().c_str());
+            *err_msg = to_pg_msg(err);
             return;
         }
 
         if (end_vid != 0 && !fn_tsp.has_vertex(end_vid)) {
             err << "Parameter 'end_id' do not exist on the data";
-            *err_msg = pgr_msg(err.str().c_str());
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -107,36 +107,32 @@ pgr_do_tsp(
             }
         }
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;
-        *err_msg = pgr_msg(ex.first.c_str());
-        *log_msg = pgr_msg(ex.second.c_str());
+        *err_msg = to_pg_msg(ex.first.c_str());
+        *log_msg = to_pg_msg(ex.second.c_str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/tsp/euclideanTSP_driver.cpp
+++ b/src/tsp/euclideanTSP_driver.cpp
@@ -55,7 +55,7 @@ pgr_do_euclideanTSP(
         char **notice_msg,
         char **err_msg) {
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
 
     std::ostringstream log;
@@ -68,8 +68,8 @@ pgr_do_euclideanTSP(
         auto coordinates = pgrouting::pgget::get_coordinates(std::string(coordinates_sql));
 
         if (coordinates.size() == 0) {
-            *notice_msg = pgr_msg("No coordinates found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No coordinates found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -78,13 +78,13 @@ pgr_do_euclideanTSP(
 
         if (start_vid != 0 && !fn_tsp.has_vertex(start_vid)) {
             err << "Parameter 'start_id' do not exist on the data";
-            *err_msg = pgr_msg(err.str().c_str());
+            *err_msg = to_pg_msg(err);
             return;
         }
 
         if (end_vid != 0 && !fn_tsp.has_vertex(end_vid)) {
             err << "Parameter 'end_id' do not exist on the data";
-            *err_msg = pgr_msg(err.str().c_str());
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -104,36 +104,32 @@ pgr_do_euclideanTSP(
             }
         }
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::pair<std::string, std::string>& ex) {
         (*return_count) = 0;
-        *err_msg = pgr_msg(ex.first.c_str());
-        *log_msg = pgr_msg(ex.second.c_str());
+        *err_msg = to_pg_msg(ex.first.c_str());
+        *log_msg = to_pg_msg(ex.second.c_str());
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/withPoints/get_new_queries.cpp
+++ b/src/withPoints/get_new_queries.cpp
@@ -47,7 +47,7 @@ get_new_queries(
         char *points_sql,
         char **edges_of_points_query,
         char **edges_no_points_query) {
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     std::ostringstream edges_of_points_sql;
     std::ostringstream edges_no_points_sql;
 
@@ -55,7 +55,7 @@ get_new_queries(
         << " edges AS (" << edges_sql << "), "
         << " points AS (" << points_sql << ")"
         << " SELECT DISTINCT edges.* FROM edges JOIN points ON (id = edge_id)";
-    *edges_of_points_query = pgr_msg(edges_of_points_sql.str().c_str());
+    *edges_of_points_query = to_pg_msg(edges_of_points_sql.str());
 
     edges_no_points_sql << "WITH "
         << " edges AS (" << edges_sql << "), "
@@ -63,6 +63,6 @@ get_new_queries(
         << " SELECT edges.*"
         << " FROM edges"
         << " WHERE NOT EXISTS (SELECT edge_id FROM points WHERE id = edge_id)";
-    *edges_no_points_query = pgr_msg(edges_no_points_sql.str().c_str());
+    *edges_no_points_query = to_pg_msg(edges_no_points_sql.str());
 }
 

--- a/src/withPoints/withPointsVia_driver.cpp
+++ b/src/withPoints/withPointsVia_driver.cpp
@@ -111,7 +111,7 @@ pgr_do_withPointsVia(
         char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
 
@@ -141,8 +141,8 @@ pgr_do_withPointsVia(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, false);
 
         if (edges.size() + edges_of_points.size() == 0) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -159,8 +159,8 @@ pgr_do_withPointsVia(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str().c_str());
-            *err_msg = pgr_msg(err.str().c_str());
+            *log_msg = to_pg_msg(log);
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -203,7 +203,7 @@ pgr_do_withPointsVia(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
@@ -211,32 +211,28 @@ pgr_do_withPointsVia(
         (*return_count) = (get_route(return_tuples, paths));
         (*return_tuples)[count - 1].edge = -2;
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }

--- a/src/withPoints/withPoints_driver.cpp
+++ b/src/withPoints/withPoints_driver.cpp
@@ -98,7 +98,7 @@ pgr_do_withPoints(
         char** err_msg) {
     using pgrouting::Path;
     using pgrouting::pgr_alloc;
-    using pgrouting::pgr_msg;
+    using pgrouting::to_pg_msg;
     using pgrouting::pgr_free;
     using pgrouting::utilities::get_combinations;
 
@@ -121,8 +121,8 @@ pgr_do_withPoints(
         hint = nullptr;
 
         if (combinations.empty() && combinations_sql) {
-            *notice_msg = pgr_msg("No (source, target) pairs found");
-            *log_msg = pgr_msg(combinations_sql);
+            *notice_msg = to_pg_msg("No (source, target) pairs found");
+            *log_msg = to_pg_msg(combinations_sql);
             return;
         }
 
@@ -137,8 +137,8 @@ pgr_do_withPoints(
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), normal, false);
 
         if (edges.size() + edges_of_points.size() == 0) {
-            *notice_msg = pgr_msg("No edges found");
-            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            *notice_msg = to_pg_msg("No edges found");
+            *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;
         }
         hint = nullptr;
@@ -154,8 +154,8 @@ pgr_do_withPoints(
         if (pg_graph.has_error()) {
             log << pg_graph.get_log();
             err << pg_graph.get_error();
-            *log_msg = pgr_msg(log.str().c_str());
-            *err_msg = pgr_msg(err.str().c_str());
+            *log_msg = to_pg_msg(log);
+            *err_msg = to_pg_msg(err);
             return;
         }
 
@@ -205,39 +205,35 @@ pgr_do_withPoints(
             (*return_tuples) = NULL;
             (*return_count) = 0;
             notice << "No paths found";
-            *log_msg = pgr_msg(notice.str().c_str());
+            *log_msg = to_pg_msg(notice);
             return;
         }
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
         (*return_count) = (collapse_paths(return_tuples, paths));
 
-        *log_msg = log.str().empty()?
-            *log_msg :
-            pgr_msg(log.str().c_str());
-        *notice_msg = notice.str().empty()?
-            *notice_msg :
-            pgr_msg(notice.str().c_str());
+        *log_msg = to_pg_msg(log);
+        *notice_msg = to_pg_msg(notice);
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch (const std::string &ex) {
-        *err_msg = pgr_msg(ex.c_str());
-        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(ex);
+        *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
     } catch (std::exception &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << except.what();
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     } catch(...) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;
         err << "Caught unknown exception!";
-        *err_msg = pgr_msg(err.str().c_str());
-        *log_msg = pgr_msg(log.str().c_str());
+        *err_msg = to_pg_msg(err);
+        *log_msg = to_pg_msg(log);
     }
 }


### PR DESCRIPTION
Proting changes from #2725 

(C++/performance) Removing passing c_str() to a function that takes std::string as argument
* - rename pgr_msg -> to_pg_msg
* -Adding overload of to_pg_msg
* - Using the new functions
* (docqueries) empty hint is not shown anymore

(cherry picked from commit bf1d91e0113d73f23b2439c5e10c30b701db1559)

@pgRouting/admins
