### PR TITLE
Make sure `CMP0148` exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,9 @@ if(POLICY CMP0167)
     cmake_policy(SET CMP0167 OLD)
 endif()
 
-cmake_policy(SET CMP0148 OLD)
+if(POLICY CMP0148)
+    cmake_policy(SET CMP0148 OLD)
+endif()
 
 #---------------------------------------------
 # Setting kind of build


### PR DESCRIPTION
Might help building on pre-3.27 CMake like in Debian 12. Not tested.

Reported by @df7cb on Matrix.

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CMake configuration to improve policy handling robustness
	- Enhanced compatibility with different CMake environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->