### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/locale/de/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/de/LC_MESSAGES/pgrouting_doc_strings.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-17 00:50+0000\n"
+"POT-Creation-Date: 2025-03-24 14:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -291,9 +291,6 @@ msgstr ""
 msgid ":doc:`pgr_primDFS`"
 msgstr ""
 
-msgid "Proposed"
-msgstr ""
-
 msgid "Proposed functions for next mayor release."
 msgstr ""
 
@@ -361,9 +358,6 @@ msgid ""
 "functionality to the new signatures or replacement functions."
 msgstr ""
 
-msgid "Experimental"
-msgstr ""
-
 msgid "Possible server crash"
 msgstr ""
 
@@ -406,7 +400,7 @@ msgstr ""
 msgid "Documentation examples might need to be automatically generated."
 msgstr ""
 
-msgid "Might need a lot of feedback from the comunity."
+msgid "Might need a lot of feedback from the community."
 msgstr ""
 
 msgid "Might depend on a proposed function of pgRouting"
@@ -652,8 +646,8 @@ msgid "References"
 msgstr ""
 
 msgid ""
-"`Boost's metric appro's metric approximation <https://www.boost.org/libs/"
-"graph/doc/metric_tsp_approx.html>`__"
+"`Boost: metric TSP approx <https://www.boost.org/libs/graph/doc/"
+"metric_tsp_approx.html>`__"
 msgstr ""
 
 msgid "`University of Waterloo TSP <https://www.math.uwaterloo.ca/tsp/>`__"
@@ -664,7 +658,7 @@ msgid ""
 "Traveling_salesman_problem>`__"
 msgstr ""
 
-msgid "Vehicle Routing Functions - Category (Experimental)"
+msgid "Vehicle Routing Functions - Category"
 msgstr ""
 
 msgid "Pickup and delivery problem"
@@ -1613,7 +1607,7 @@ msgstr ""
 msgid "https://en.wikipedia.org/wiki/Vehicle_routing_problem"
 msgstr ""
 
-msgid "The queries use the :doc:`sampledata` network."
+msgid ":doc:`sampledata`"
 msgstr ""
 
 msgid "A* - Family of functions"
@@ -1775,7 +1769,8 @@ msgstr ""
 msgid ":doc:`bdAstar-family`"
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/astar_search.html"
+msgid ""
+"`Boost: A* search <https://www.boost.org/libs/graph/doc/astar_search.html>`__"
 msgstr ""
 
 msgid "https://en.wikipedia.org/wiki/A*_search_algorithm"
@@ -2579,13 +2574,10 @@ msgid ""
 "ending vertex:"
 msgstr ""
 
-msgid "It is expected to terminate faster than pgr_astar"
+msgid "It is expected to terminate faster than pgr_aStar"
 msgstr ""
 
 msgid ":doc:`aStar-family`"
-msgstr ""
-
-msgid "Previous versions of this page"
 msgstr ""
 
 msgid "Bidirectional Dijkstra - Family of functions"
@@ -2729,27 +2721,7 @@ msgid "Identifier of the color of the edge."
 msgstr ""
 
 msgid ""
-"`Boost: Sequential Vertex Coloring algorithm documentation <https://www."
-"boost.org/libs/graph/doc/sequential_vertex_coloring.html>`__"
-msgstr ""
-
-msgid ""
-"`Wikipedia: Graph coloring <https://en.wikipedia.org/wiki/Graph_coloring>`__"
-msgstr ""
-
-msgid ""
-"`Boost: is_bipartite <https://www.boost.org/libs/graph/doc/is_bipartite."
-"html>`__"
-msgstr ""
-
-msgid ""
-"`Wikipedia: bipartite graph <https://en.wikipedia.org/wiki/"
-"Bipartite_graph>`__"
-msgstr ""
-
-msgid ""
-"`Boost: Edge Coloring Algorithm documentation <https://www.boost.org/libs/"
-"graph/doc/edge_coloring.html>`__"
+"`Boost: <https://www.boost.org/libs/graph/doc/table_of_contents.html>`__"
 msgstr ""
 
 msgid "Components - Family of functions"
@@ -2785,6 +2757,9 @@ msgstr ""
 msgid ":doc:`pgr_contraction`"
 msgstr ""
 
+msgid ":doc:`pgr_contractionDeadEnd`"
+msgstr ""
+
 msgid ""
 "In large graphs, like the road graphs, or electric networks, graph "
 "contraction can be used to speed up some graph algorithms. Contraction "
@@ -2813,491 +2788,6 @@ msgstr ""
 msgid ""
 "Decide the order of the contraction algorithms and set the maximum number of "
 "times they are to be executed."
-msgstr ""
-
-msgid "Contraction of the leaf nodes of the graph."
-msgstr ""
-
-msgid "Dead end"
-msgstr ""
-
-msgid "A node is considered a **dead end** node when"
-msgstr ""
-
-msgid "On undirected graphs:"
-msgstr ""
-
-msgid "The number of adjacent vertices is 1."
-msgstr ""
-
-msgid "On directed graphs:"
-msgstr ""
-
-msgid "There are no outgoing edges and has at least one incoming edge."
-msgstr ""
-
-msgid "There are no incoming edges and has at least one outgoing edge."
-msgstr ""
-
-msgid ""
-"When the conditions are true then the `Operation: Dead End Contraction`_ can "
-"be done."
-msgstr ""
-
-msgid "Dead end vertex on undirected graph"
-msgstr ""
-
-msgid "The green nodes are `dead end`_ nodes"
-msgstr ""
-
-msgid "The blue nodes have an unlimited number of edges."
-msgstr ""
-
-msgid "Node"
-msgstr ""
-
-msgid "Adjecent nodes"
-msgstr ""
-
-msgid "Number of adjacent nodes"
-msgstr ""
-
-msgid ":math:`a`"
-msgstr ""
-
-msgid ":math:`\\{u\\}`"
-msgstr ""
-
-msgid ":math:`b`"
-msgstr ""
-
-msgid ":math:`\\{v\\}`"
-msgstr ""
-
-msgid "Dead end vertex on directed graph"
-msgstr ""
-
-msgid ""
-"The blue nodes have an unlimited number of incoming and/or outgoing edges."
-msgstr ""
-
-msgid "Number of incoming edges"
-msgstr ""
-
-msgid "Number of outgoing edges"
-msgstr ""
-
-msgid ":math:`c`"
-msgstr ""
-
-msgid ":math:`\\{v, w\\}`"
-msgstr ""
-
-msgid "2"
-msgstr ""
-
-msgid ":math:`d`"
-msgstr ""
-
-msgid ":math:`\\{x\\}`"
-msgstr ""
-
-msgid ":math:`e`"
-msgstr ""
-
-msgid ":math:`\\{x, y\\}`"
-msgstr ""
-
-msgid ""
-"From above, nodes :math:`\\{a, b, d\\}` are dead ends because the number of "
-"adjacent vertices is 1. No further checks are needed for those nodes."
-msgstr ""
-
-msgid ""
-"On the following table, nodes :math:`\\{c, e\\}` because the even that the "
-"number of adjacent vertices is not 1 for"
-msgstr ""
-
-msgid "Operation: Dead End Contraction"
-msgstr ""
-
-msgid ""
-"The dead end contraction will stop until there are no more dead end nodes. "
-"For example from the following graph where :math:`w` is the `dead end`_ node:"
-msgstr ""
-
-msgid ""
-"After contracting :math:`w`, node :math:`v` is now a `dead end`_ node and is "
-"contracted:"
-msgstr ""
-
-msgid ""
-"After contracting :math:`v`, stop. Node :math:`u` has the information of "
-"nodes that were contrcted."
-msgstr ""
-
-msgid "Node :math:`u` has the information of nodes that were contracted."
-msgstr ""
-
-msgid "In the algorithm, linear contraction is represented by 2."
-msgstr ""
-
-msgid "Linear"
-msgstr ""
-
-msgid ""
-"In case of an undirected graph, a node is considered a `linear` node when"
-msgstr ""
-
-msgid "The number of adjacent vertices is 2."
-msgstr ""
-
-msgid "In case of a directed graph, a node is considered a `linear` node when"
-msgstr ""
-
-msgid "Linearity is symmetrical"
-msgstr ""
-
-msgid "Linear vertex on undirected graph"
-msgstr ""
-
-msgid "The green nodes are `linear`_ nodes"
-msgstr ""
-
-msgid "The blue nodes have an unlimited number of incoming and outgoing edges."
-msgstr ""
-
-msgid "Undirected"
-msgstr ""
-
-msgid ":math:`v`"
-msgstr ""
-
-msgid ":math:`\\{u, w\\}`"
-msgstr ""
-
-msgid "Linear vertex on directed graph"
-msgstr ""
-
-msgid "The white node is not linear because the linearity is not symetrical."
-msgstr ""
-
-msgid "It is possible to go :math:`y \\rightarrow c \\rightarrow z`"
-msgstr ""
-
-msgid "It's not possible to go :math:`z \\rightarrow c \\rightarrow y`"
-msgstr ""
-
-msgid "Is symmetrical?"
-msgstr ""
-
-msgid ":math:`\\{u, v\\}`"
-msgstr ""
-
-msgid "yes"
-msgstr ""
-
-msgid ":math:`\\{w, x\\}`"
-msgstr ""
-
-msgid ":math:`\\{y, z\\}`"
-msgstr ""
-
-msgid "no"
-msgstr ""
-
-msgid "Operation: Linear Contraction"
-msgstr ""
-
-msgid ""
-"The linear contraction will stop when there are no more linear nodes. For "
-"example from the following graph where :math:`v` and :math:`w` are `linear`_ "
-"nodes:"
-msgstr ""
-
-msgid "Contracting :math:`w`,"
-msgstr ""
-
-msgid "The vertex :math:`w` is removed from the graph"
-msgstr ""
-
-msgid ""
-"The edges :math:`v \\rightarrow w` and :math:`w \\rightarrow z` are removed "
-"from the graph."
-msgstr ""
-
-msgid ""
-"A new edge :math:`v \\rightarrow z` is inserted represented with red color."
-msgstr ""
-
-msgid "Contracting :math:`v`:"
-msgstr ""
-
-msgid "The vertex :math:`v` is removed from the graph"
-msgstr ""
-
-msgid ""
-"The edges :math:`u \\rightarrow v` and :math:`v \\rightarrow z` are removed "
-"from the graph."
-msgstr ""
-
-msgid ""
-"A new edge :math:`u \\rightarrow z` is inserted represented with red color."
-msgstr ""
-
-msgid ""
-"Edge :math:`u \\rightarrow z` has the information of nodes that were "
-"contracted."
-msgstr ""
-
-msgid "The cycle"
-msgstr ""
-
-msgid ""
-"Contracting a graph, can be done with more than one operation. The order of "
-"the operations affect the resulting contracted graph, after applying one "
-"operation, the set of vertices that can be contracted by another operation "
-"changes."
-msgstr ""
-
-msgid ""
-"This implementation, cycles ``max_cycles`` times through "
-"``operations_order`` ."
-msgstr ""
-
-msgid "Contracting sample data"
-msgstr ""
-
-msgid ""
-"In this section, building and using a contracted graph will be shown by "
-"example."
-msgstr ""
-
-msgid "The :doc:`sampledata` for an undirected graph is used"
-msgstr ""
-
-msgid "a dead end operation first followed by a linear operation."
-msgstr ""
-
-msgid "Construction of the graph in the database"
-msgstr ""
-
-msgid "Original Data"
-msgstr ""
-
-msgid ""
-"The following query shows the original data involved in the contraction "
-"operation."
-msgstr ""
-
-msgid "The original graph:"
-msgstr ""
-
-msgid "Contraction results"
-msgstr ""
-
-msgid ""
-"The results do not represent the contracted graph. They represent the "
-"changes done to the graph after applying the contraction algorithm."
-msgstr ""
-
-msgid ""
-"Observe that vertices, for example, :math:`6` do not appear in the results "
-"because it was not affected by the contraction algorithm."
-msgstr ""
-
-msgid "After doing the dead end contraction operation:"
-msgstr ""
-
-msgid "After doing the linear contraction operation to the graph above:"
-msgstr ""
-
-msgid "The process to create the contraction graph on the database:"
-msgstr ""
-
-msgid "Add additional columns"
-msgstr ""
-
-msgid ""
-"Adding extra columns to the ``edge_table`` and ``edge_table_vertices_pgr`` "
-"tables, where:"
-msgstr ""
-
-msgid "``contracted_vertices``"
-msgstr ""
-
-msgid "The vertices set belonging to the vertex/edge"
-msgstr ""
-
-msgid "``is_contracted``"
-msgstr ""
-
-msgid "On the vertex table"
-msgstr ""
-
-msgid ""
-"when ``true`` the vertex is contracted, its not part of the contracted graph."
-msgstr ""
-
-msgid ""
-"when ``false`` the vertex is not contracted, its part of the contracted "
-"graph."
-msgstr ""
-
-msgid "``is_new``"
-msgstr ""
-
-msgid "On the edge table"
-msgstr ""
-
-msgid ""
-"when ``true`` the edge was generated by the contraction algorithm. its part "
-"of the contracted graph."
-msgstr ""
-
-msgid ""
-"when ``false`` the edge is an original edge, might be or not part of the "
-"contracted graph."
-msgstr ""
-
-msgid "Store contraction information"
-msgstr ""
-
-msgid "Store the `contraction results`_ in a table"
-msgstr ""
-
-msgid "The vertex table update"
-msgstr ""
-
-msgid ""
-"Use ``is_contracted`` column to indicate the vertices that are contracted."
-msgstr ""
-
-msgid ""
-"Fill ``contracted_vertices`` with the information from the results tha "
-"belong to the vertices."
-msgstr ""
-
-msgid "The modified vertices table:"
-msgstr ""
-
-msgid "The edge table update"
-msgstr ""
-
-msgid "Insert the new edges generated by pgr_contraction."
-msgstr ""
-
-msgid "The modified ``edge_table``."
-msgstr ""
-
-msgid "The contracted graph"
-msgstr ""
-
-msgid "Vertices that belong to the contracted graph."
-msgstr ""
-
-msgid "Edges that belong to the contracted graph."
-msgstr ""
-
-msgid "Contracted graph"
-msgstr ""
-
-msgid "Using the contracted graph"
-msgstr ""
-
-msgid "Using the contracted graph with ``pgr_dijkstra``"
-msgstr ""
-
-msgid ""
-"There are three cases when calculating the shortest path between a given "
-"source and target in a contracted graph:"
-msgstr ""
-
-msgid "Case 1: Both source and target belong to the contracted graph."
-msgstr ""
-
-msgid "Case 2: Source and/or target belong to an edge subgraph."
-msgstr ""
-
-msgid "Case 3: Source and/or target belong to a vertex."
-msgstr ""
-
-msgid ""
-"Using the `Edges that belong to the contracted graph.`_ on lines 11 to 20."
-msgstr ""
-
-msgid "Case 1"
-msgstr ""
-
-msgid ""
-"When both source and target belong to the contracted graph, a path is found."
-msgstr ""
-
-msgid "Case 2"
-msgstr ""
-
-msgid ""
-"When source and/or target belong to an edge subgraph then a path is not "
-"found."
-msgstr ""
-
-msgid ""
-"In this case, the contracted graph do not have an edge connecting with node :"
-"math:`4`."
-msgstr ""
-
-msgid "Case 3"
-msgstr ""
-
-msgid "When source and/or target belong to a vertex then a path is not found."
-msgstr ""
-
-msgid ""
-"In this case, the contracted graph do not have an edge connecting with node :"
-"math:`7` and of node :math:`4` of the second case."
-msgstr ""
-
-msgid "Refining the above function to include nodes that belong to an edge."
-msgstr ""
-
-msgid "The vertices that need to be expanded are calculated on lines 11 to 17."
-msgstr ""
-
-msgid ""
-"Adding to the contracted graph that additional section on lines 26 to 28."
-msgstr ""
-
-msgid ""
-"When source and/or target belong to an edge subgraph, now, a path is found."
-msgstr ""
-
-msgid "The routing graph now has an edge connecting with node :math:`4`."
-msgstr ""
-
-msgid ""
-"In this case, the contracted graph do not have an edge connecting with node :"
-"math:`7`."
-msgstr ""
-
-msgid "The vertices that need to be expanded are calculated on lines 19 to 24."
-msgstr ""
-
-msgid ""
-"Adding to the contracted graph that additional section on lines 38 to 40."
-msgstr ""
-
-msgid ""
-"The code change do not affect this case so when source and/or target belong "
-"to an edge subgraph, a path is still found."
-msgstr ""
-
-msgid "When source and/or target belong to a vertex, now, a path is found."
-msgstr ""
-
-msgid "Now, the routing graph has an edge connecting with node :math:`7`."
-msgstr ""
-
-msgid ":doc:`sampledata`"
 msgstr ""
 
 msgid ""
@@ -3376,9 +2866,6 @@ msgid ":doc:`pgr_bdAstarCostMatrix`"
 msgstr ""
 
 msgid ":doc:`pgr_bdDijkstraCostMatrix`"
-msgstr ""
-
-msgid "proposed"
 msgstr ""
 
 msgid ":doc:`pgr_withPointsCostMatrix`"
@@ -3557,7 +3044,7 @@ msgid ""
 "paths."
 msgstr ""
 
-msgid ":doc:`pgr_dijkstraVia` - Get a route of a seuence of vertices."
+msgid ":doc:`pgr_dijkstraVia` - Get a route of a sequence of vertices."
 msgstr ""
 
 msgid ":doc:`pgr_dijkstraNear` - Get the route to the nearest vertex."
@@ -3642,7 +3129,7 @@ msgstr ""
 msgid "Directed graph"
 msgstr ""
 
-msgid "The weighted directed graph, :math:`G_d(V,E)`, is definied by:"
+msgid "The weighted directed graph, :math:`G_d(V,E)`, is defined by:"
 msgstr ""
 
 msgid "the set of vertices :math:`V`"
@@ -3667,7 +3154,7 @@ msgstr ""
 msgid "Undirected graph"
 msgstr ""
 
-msgid "The weighted undirected graph, :math:`G_u(V,E)`, is definied by:"
+msgid "The weighted undirected graph, :math:`G_u(V,E)`, is defined by:"
 msgstr ""
 
 msgid ":math:`V = source \\cup target \\cup {start_v{vid}} \\cup  {end_{vid}}`"
@@ -3782,7 +3269,7 @@ msgstr ""
 msgid ":doc:`pgr_kruskalDD` - Driving Distance based on Kruskal's algorithm"
 msgstr ""
 
-msgid "Post pocessing"
+msgid "Post processing"
 msgstr ""
 
 msgid ":doc:`pgr_alphaShape` - Alpha shape computation"
@@ -3904,6 +3391,11 @@ msgid ""
 "an undirected graph."
 msgstr ""
 
+msgid ""
+":doc:`pgr_topologicalSort` - Linear ordering of the vertices for directed "
+"acyclic graph."
+msgstr ""
+
 msgid ":doc:`metrics-family`"
 msgstr ""
 
@@ -3921,7 +3413,7 @@ msgstr ""
 msgid ":doc:`VRP-category`"
 msgstr ""
 
-msgid "Unclassified"
+msgid "Shortest Path Category"
 msgstr ""
 
 msgid ":doc:`pgr_bellmanFord`"
@@ -3933,19 +3425,22 @@ msgstr ""
 msgid ":doc:`pgr_edwardMoore`"
 msgstr ""
 
+msgid "Planar Family"
+msgstr ""
+
 msgid ":doc:`pgr_isPlanar`"
+msgstr ""
+
+msgid "Miscellaneous Algorithms"
+msgstr ""
+
+msgid ":doc:`pgr_lengauerTarjanDominatorTree`"
 msgstr ""
 
 msgid ":doc:`pgr_stoerWagner`"
 msgstr ""
 
-msgid ":doc:`pgr_topologicalSort`"
-msgstr ""
-
 msgid ":doc:`pgr_transitiveClosure`"
-msgstr ""
-
-msgid ":doc:`pgr_lengauerTarjanDominatorTree`"
 msgstr ""
 
 msgid ":doc:`pgr_hawickCircuits`"
@@ -4001,7 +3496,7 @@ msgid ""
 "returned."
 msgstr ""
 
-msgid "There is no flow when source has the same vaule as target."
+msgid "There is no flow when source has the same value as target."
 msgstr ""
 
 msgid "Any duplicated values in source or target are ignored."
@@ -4291,6 +3786,11 @@ msgstr ""
 msgid ":doc:`pgr_kruskalDD`"
 msgstr ""
 
+msgid ""
+":doc:`pgr_degree` - Returns a set of vertices and corresponding count of "
+"incident edges to the vertex."
+msgstr ""
+
 msgid ":doc:`prim-family`"
 msgstr ""
 
@@ -4336,7 +3836,18 @@ msgstr ""
 msgid ":doc:`pgr_nodeNetwork` - to create nodes to a not noded edge table."
 msgstr ""
 
+msgid ""
+":doc:`pgr_extractVertices` - Extracts vertex information based on the edge "
+"table information."
+msgstr ""
+
 msgid ":doc:`pgr_trsp` - Turn Restriction Shortest Path (TRSP)"
+msgstr ""
+
+msgid "Utilities family"
+msgstr ""
+
+msgid ":doc:`pgr_findCloseEdges`"
 msgstr ""
 
 msgid "Functions by categories"
@@ -4354,7 +3865,7 @@ msgstr ""
 msgid ":doc:`KSP-category`"
 msgstr ""
 
-msgid ":doc:`spanningTree-family`"
+msgid ":doc:`spanningTree-category`"
 msgstr ""
 
 msgid ":doc:`BFS-category`"
@@ -4375,115 +3886,183 @@ msgstr ""
 msgid ":doc:`release_notes`"
 msgstr ""
 
-msgid "pgRouting 3.7.0 Release Notes"
+msgid "pgRouting 4.0.0 Release Notes"
 msgstr ""
 
 msgid ""
 "To see all issues & pull requests closed by this release see the `Git closed "
-"milestone for 3.7.0 <https://github.com/pgRouting/pgrouting/issues?"
-"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.0%22>`__"
+"milestone for 4.0.0 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%204.0.0%22>`__"
 msgstr ""
 
-msgid "Support"
+msgid "Functions promoted to official"
 msgstr ""
 
-msgid ""
-"`#2656 <https://github.com/pgRouting/pgrouting/pull/2656>`__ Stop support of "
-"PostgreSQL12 on pgrouting v3.7"
+msgid "pgr_trsp"
 msgstr ""
 
-msgid "Stopping support of PostgreSQL 12"
+msgid "pgr_trspVia"
 msgstr ""
 
-msgid "CI does not test for PostgreSQL 12"
+msgid "pgr_trspVia_withPoints"
 msgstr ""
 
-msgid "New experimental functions"
+msgid "pgr_trsp_withPoints"
 msgstr ""
 
-msgid "Metrics"
+msgid "pgr_withPoints"
 msgstr ""
 
-msgid "pgr_betweennessCentrality"
+msgid "pgr_withPointsCost"
 msgstr ""
 
-msgid "Official functions changes"
+msgid "pgr_withPointsCostMatrix"
 msgstr ""
 
-msgid ""
-"`#2605 <https://github.com/pgRouting/pgrouting/pull/2605>`__ Standarize "
-"spanning tree functions output"
+msgid "pgr_withPointsDD"
 msgstr ""
 
-msgid "Functions:"
+msgid "pgr_withPointsKSP"
 msgstr ""
 
-msgid "``pgr_kruskalDD``"
+msgid "pgr_withPointsVia"
 msgstr ""
 
-msgid "``pgr_kruskalDFS``"
+msgid "Signatures promoted to official"
 msgstr ""
 
-msgid "``pgr_kruskalBFS``"
+msgid "pgr_aStar(Combinations)"
 msgstr ""
 
-msgid "``pgr_primDD``"
+msgid "pgr_aStarCost(Combinations)"
 msgstr ""
 
-msgid "``pgr_primDFS``"
+msgid "pgr_bdAstar(Combinations)"
 msgstr ""
 
-msgid "``pgr_primBFS``"
+msgid "pgr_bdAstarCost(Combinations)"
 msgstr ""
 
-msgid "Standarizing output columns to |result-spantree|"
+msgid "pgr_bdDijkstra(Combinations)"
 msgstr ""
 
-msgid "Added ``pred`` result columns."
+msgid "pgr_bdDijkstraCost(Combinations)"
 msgstr ""
 
-msgid "Experimental promoted to proposed."
+msgid "pgr_dijkstra(Combinations)"
 msgstr ""
 
-msgid ""
-"`#2635 <https://github.com/pgRouting/pgrouting/pull/2635>`__ pgr_LineGraph "
-"ignores directed flag and use negative values for identifiers."
+msgid "pgr_dijkstraCost(Combinations)"
 msgstr ""
 
-msgid "``pgr_lineGraph``"
+msgid "pgr_KSP(All signatures)"
 msgstr ""
 
-msgid "Promoted to **proposed** signature."
+msgid "pgr_boykovKolmogorov(Combinations)"
 msgstr ""
 
-msgid "Works for directed and undirected graphs."
+msgid "pgr_edmondsKarp(Combinations)"
 msgstr ""
 
-msgid "Code enhancement"
+msgid "pgr_maxFlow(Combinations)"
 msgstr ""
 
-msgid ""
-"`#2599 <https://github.com/pgRouting/pgrouting/pull/2599>`__ Driving "
-"distance cleanup"
+msgid "pgr_pushRelabel(Combinations)"
 msgstr ""
 
-msgid ""
-"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ Read postgresql "
-"data on C++"
+msgid "code enhancements:"
+msgstr ""
+
+msgid "Removal of unused C/C++ code"
+msgstr ""
+
+msgid "Removal of SQL deprecated functions"
 msgstr ""
 
 msgid ""
-"`#2614 <https://github.com/pgRouting/pgrouting/pull/2614>`__ Clang tidy does "
-"not work"
+"pgr_trsp(text,integer,double precision,integer,double precision,boolean,"
+"boolean,text)"
+msgstr ""
+
+msgid "pgr_trsp(text,integer,integer,boolean,boolean,text)"
+msgstr ""
+
+msgid ""
+"pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)"
+msgstr ""
+
+msgid "pgr_trspviavertices(text,anyarray,boolean,boolean,text)"
+msgstr ""
+
+msgid "Removal of SQL deprecated internal functions"
+msgstr ""
+
+msgid "_pgr_dijkstranear(text,anyarray,anyarray,bigint,boolean)"
+msgstr ""
+
+msgid "_pgr_dijkstranear(text,anyarray,bigint,bigint,boolean)"
+msgstr ""
+
+msgid "_pgr_dijkstranear(text,bigint,anyarray,bigint,boolean)"
+msgstr ""
+
+msgid "_pgr_dijkstra(text,anyarray,anyarray,boolean,boolean,boolean,bigint)"
+msgstr ""
+
+msgid "_pgr_dijkstra(text,text,boolean,boolean,boolean)"
+msgstr ""
+
+msgid "_pgr_drivingdistance(text,anyarray,double precision,boolean,boolean)"
+msgstr ""
+
+msgid "_pgr_kruskal(text,anyarray,text,bigint,double precision)"
+msgstr ""
+
+msgid "_pgr_prim(text,anyarray,text,bigint,double precision)"
+msgstr ""
+
+msgid ""
+"_pgr_trsp(text,integer,double precision,integer,double precision,boolean,"
+"boolean,text)"
+msgstr ""
+
+msgid "_pgr_trsp(text,text,anyarray,anyarray,boolean)"
+msgstr ""
+
+msgid "_pgr_trsp(text,text,anyarray,bigint,boolean)"
+msgstr ""
+
+msgid "_pgr_trsp(text,text,bigint,anyarray,boolean)"
+msgstr ""
+
+msgid "_pgr_trsp(text,text,bigint,bigint,boolean)"
+msgstr ""
+
+msgid "_pgr_trspviavertices(text,integer[],boolean,boolean,text)"
+msgstr ""
+
+msgid "_pgr_withpointsvia(text,bigint[],double precision[],boolean)"
+msgstr ""
+
+msgid "_trsp(text,text,anyarray,anyarray,boolean)"
+msgstr ""
+
+msgid "_v4trsp(text,text,anyarray,anyarray,boolean)"
+msgstr ""
+
+msgid "_v4trsp(text,text,text,boolean)"
+msgstr ""
+
+msgid "Deprecation of internal C/C++ functions"
+msgstr ""
+
+msgid "Internal C/C++ functions in legacy"
 msgstr ""
 
 msgid "All releases"
 msgstr ""
 
 msgid "Kruskal - Family of functions"
-msgstr ""
-
-msgid "Boost Graph Inside"
 msgstr ""
 
 msgid ""
@@ -4516,12 +4095,6 @@ msgid "Results can be different because of the changes."
 msgstr ""
 
 msgid "All deprecated functions will be removed on next mayor version 4.0.0"
-msgstr ""
-
-msgid "Migration of functions"
-msgstr ""
-
-msgid "Migrating functions"
 msgstr ""
 
 msgid "Migration of ``pgr_aStar``"
@@ -4676,7 +4249,7 @@ msgstr ""
 msgid "If needed add the new columns, for example:"
 msgstr ""
 
-msgid "Migration of ``pgr_drivingdistance``"
+msgid "Migration of ``pgr_drivingDistance``"
 msgstr ""
 
 msgid ""
@@ -4696,10 +4269,10 @@ msgstr ""
 msgid "|result-spantree|"
 msgstr ""
 
-msgid "``pgr_drivingdistance`` (Single vertex)"
+msgid "pgr_drivingDistance(Single vertex)"
 msgstr ""
 
-msgid "``pgr_drivingdistance`` (Multiple vertices)"
+msgid "pgr_drivingDistance(Multiple vertices)"
 msgstr ""
 
 msgid "Output columns were |result-dij-dd|"
@@ -4759,10 +4332,19 @@ msgstr ""
 msgid "|result-bfs|"
 msgstr ""
 
+msgid "``pgr_kruskalDD``"
+msgstr ""
+
 msgid "Single vertex"
 msgstr ""
 
 msgid "Multiple vertices"
+msgstr ""
+
+msgid "``pgr_kruskalDFS``"
+msgstr ""
+
+msgid "``pgr_kruskalBFS``"
 msgstr ""
 
 msgid "Output columns were |result-bfs|"
@@ -4916,6 +4498,15 @@ msgid ""
 "Starting from `v3.7.0 <https://docs.pgrouting.org/3.7/en/migration.html>`__ :"
 "doc:`pgr_primDD`, :doc:`pgr_primBFS` and :doc:`pgr_primDFS` result columns "
 "are being standardized."
+msgstr ""
+
+msgid "``pgr_primDD``"
+msgstr ""
+
+msgid "``pgr_primDFS``"
+msgstr ""
+
+msgid "``pgr_primBFS``"
 msgstr ""
 
 msgid "Prim single vertex"
@@ -5110,7 +4701,124 @@ msgid ""
 "original columns:"
 msgstr ""
 
-msgid "Migration of turn restrictions"
+msgid "Migration of ``pgr_trsp`` (Vertices)"
+msgstr ""
+
+msgid "Signature:"
+msgstr ""
+
+msgid "Deprecated"
+msgstr ""
+
+msgid "`v3.4.0 <https://docs.pgrouting.org/3.4>`__"
+msgstr ""
+
+msgid "Removed"
+msgstr ""
+
+msgid "`v4.0.0 <https://docs.pgrouting.org/4.0>`__"
+msgstr ""
+
+msgid ":doc:`pgr_dijkstra`"
+msgstr ""
+
+msgid ":doc:`pgr_trsp`"
+msgstr ""
+
+msgid "`Migration of restrictions`_"
+msgstr ""
+
+msgid "Use ``pgr_dijkstra`` when there are no restrictions."
+msgstr ""
+
+msgid "Use :doc:`pgr_dijkstra` instead."
+msgstr ""
+
+msgid "To get the original column names:"
+msgstr ""
+
+msgid "``id1`` is the node"
+msgstr ""
+
+msgid "``id2`` is the edge"
+msgstr ""
+
+msgid "Use ``pgr_trsp`` when there are restrictions."
+msgstr ""
+
+msgid "Use :doc:`pgr_trsp` (One to One) instead."
+msgstr ""
+
+msgid "Migration of ``pgr_trsp`` (Edges)"
+msgstr ""
+
+msgid ":doc:`pgr_withPoints`"
+msgstr ""
+
+msgid ":doc:`pgr_trsp_withPoints`"
+msgstr ""
+
+msgid "Use ``pgr_withPoints`` when there are no restrictions."
+msgstr ""
+
+msgid "Use :doc:`pgr_withPoints` (One to One) instead."
+msgstr ""
+
+msgid "Use ``pgr_trsp_withPoints`` when there are restrictions."
+msgstr ""
+
+msgid "Use :doc:`pgr_trsp_withPoints` instead."
+msgstr ""
+
+msgid "Migration of ``pgr_trspViaVertices``"
+msgstr ""
+
+msgid ":doc:`pgr_dijkstraVia`"
+msgstr ""
+
+msgid ":doc:`pgr_trspVia`"
+msgstr ""
+
+msgid "Use ``pgr_dijkstraVia`` when there are no restrictions"
+msgstr ""
+
+msgid "Use :doc:`pgr_dijkstraVia` instead."
+msgstr ""
+
+msgid "``id1`` is the path identifier"
+msgstr ""
+
+msgid "``id2`` is the node"
+msgstr ""
+
+msgid "``id3`` is the edge"
+msgstr ""
+
+msgid "Use ``pgr_trspVia`` when there are restrictions"
+msgstr ""
+
+msgid "Use :doc:`pgr_trspVia` instead."
+msgstr ""
+
+msgid "Migration of ``pgr_trspViaEdges``"
+msgstr ""
+
+msgid ":doc:`pgr_withPointsVia`"
+msgstr ""
+
+msgid ":doc:`pgr_trspVia_withPoints`"
+msgstr ""
+
+msgid "Use ``pgr_withPointsVia`` when there are no restrictions"
+msgstr ""
+
+msgid "Use :doc:`pgr_withPointsVia` instead."
+msgstr ""
+
+msgid "Use ``pgr_trspVia_withPoints`` when there are restrictions"
+msgstr ""
+
+msgid "Use :doc:`pgr_trspVia_withPoints` instead."
 msgstr ""
 
 msgid "Migration of restrictions"
@@ -5256,243 +4964,6 @@ msgid "Will be removed on the next mayor version 4.0.0"
 msgstr ""
 
 msgid "The migrated table contents:"
-msgstr ""
-
-msgid "Migration of ``pgr_trsp`` (Vertices)"
-msgstr ""
-
-msgid ""
-":doc:`pgr_trsp` signatures have changed and many issues have been fixed in "
-"the new signatures. This section will show how to migrate from the old "
-"signatures to the new replacement functions. This also affects the "
-"restrictions."
-msgstr ""
-
-msgid "The integral type of the ``Edges SQL`` can only be ``INTEGER``."
-msgstr ""
-
-msgid "The floating point type of the ``Edges SQL`` can only be ``FLOAT``."
-msgstr ""
-
-msgid "``directed`` flag is compulsory."
-msgstr ""
-
-msgid "Does not autodetect if ``reverse_cost`` column exist."
-msgstr ""
-
-msgid ""
-"User must be careful to match the existence of the column with the value of "
-"``has_rcost`` parameter."
-msgstr ""
-
-msgid "The restrictions inner query is optional."
-msgstr ""
-
-msgid "The output column names are meaningless"
-msgstr ""
-
-msgid "Migrate by using:"
-msgstr ""
-
-msgid ":doc:`pgr_dijkstra` when there are no restrictions,"
-msgstr ""
-
-msgid ":doc:`pgr_trsp` (One to One) when there are restrictions."
-msgstr ""
-
-msgid "Migrating ``pgr_trsp`` (Vertices) using ``pgr_dijkstra``"
-msgstr ""
-
-msgid "The following query does not have restrictions."
-msgstr ""
-
-msgid "A message about deprecation is shown"
-msgstr ""
-
-msgid "Deprecated functions will be removed on the next mayor version 4.0.0"
-msgstr ""
-
-msgid "Use :doc:`pgr_dijkstra` instead."
-msgstr ""
-
-msgid "The types casting has been removed."
-msgstr ""
-
-msgid ":doc:`pgr_dijkstra`:"
-msgstr ""
-
-msgid "Autodetects if ``reverse_cost`` column is in the edges SQL."
-msgstr ""
-
-msgid "Accepts ``ANY-INTEGER`` on integral types"
-msgstr ""
-
-msgid "Accepts ``ANY-NUMERICAL`` on floating point types"
-msgstr ""
-
-msgid "``directed`` flag has a default value of ``true``."
-msgstr ""
-
-msgid "Use the same value that on the original query."
-msgstr ""
-
-msgid "In this example it is ``true`` which is the default value."
-msgstr ""
-
-msgid "The flag has been omitted and the default is been used."
-msgstr ""
-
-msgid ""
-"When the need of using strictly the same (meaningless) names and types of "
-"the function been migrated then:"
-msgstr ""
-
-msgid "``id1`` is the node"
-msgstr ""
-
-msgid "``id2`` is the edge"
-msgstr ""
-
-msgid "Migrating ``pgr_trsp`` (Vertices) using ``pgr_trsp``"
-msgstr ""
-
-msgid "The following query has restrictions."
-msgstr ""
-
-msgid "The restrictions are the last parameter of the function"
-msgstr ""
-
-msgid "Using the old structure of restrictions"
-msgstr ""
-
-msgid "Use :doc:`pgr_trsp` (One to One) instead."
-msgstr ""
-
-msgid "The new structure of restrictions is been used."
-msgstr ""
-
-msgid "It is the second parameter."
-msgstr ""
-
-msgid ":doc:`pgr_trsp`:"
-msgstr ""
-
-msgid "Migration of ``pgr_trsp`` (Edges)"
-msgstr ""
-
-msgid "The integral types of the ``sql`` can only be ``INTEGER``."
-msgstr ""
-
-msgid "The floating point type of the ``sql`` can only be ``FLOAT``."
-msgstr ""
-
-msgid "For these migration guide the following points will be used:"
-msgstr ""
-
-msgid ":doc:`pgr_withPoints` when there are no restrictions,"
-msgstr ""
-
-msgid ":doc:`pgr_trsp_withPoints` (One to One) when there are restrictions."
-msgstr ""
-
-msgid "Migrating ``pgr_trsp`` (Edges) using ``pgr_withPoints``"
-msgstr ""
-
-msgid "Use :doc:`pgr_withPoints` instead."
-msgstr ""
-
-msgid "Do not show details, as the deprecated function does not show details."
-msgstr ""
-
-msgid ":doc:`pgr_withPoints`:"
-msgstr ""
-
-msgid "On the points query do not include the ``side`` column."
-msgstr ""
-
-msgid ""
-"When the need of using strictly the same (meaningless) names and types, and "
-"node values of the function been migrated then:"
-msgstr ""
-
-msgid "Migrating ``pgr_trsp`` (Edges) using ``pgr_trsp_withPoints``"
-msgstr ""
-
-msgid "Use :doc:`pgr_trsp_withPoints` instead."
-msgstr ""
-
-msgid ":doc:`pgr_trsp_withPoints`:"
-msgstr ""
-
-msgid "Migration of ``pgr_trspViaVertices``"
-msgstr ""
-
-msgid "The integral types of the ``Edges SQL`` can only be ``INTEGER``."
-msgstr ""
-
-msgid ":doc:`pgr_dijkstraVia` when there are no restrictions,"
-msgstr ""
-
-msgid ":doc:`pgr_trspVia` when there are restrictions."
-msgstr ""
-
-msgid "Migrating ``pgr_trspViaVertices`` using ``pgr_dijkstraVia``"
-msgstr ""
-
-msgid "Use :doc:`pgr_dijkstraVia` instead."
-msgstr ""
-
-msgid ":doc:`pgr_dijkstraVia`:"
-msgstr ""
-
-msgid "``id1`` is the path identifier"
-msgstr ""
-
-msgid "``id2`` is the node"
-msgstr ""
-
-msgid "``id3`` is the edge"
-msgstr ""
-
-msgid "Migrating ``pgr_trspViaVertices`` using ``pgr_trspVia``"
-msgstr ""
-
-msgid "Use :doc:`pgr_trspVia` instead."
-msgstr ""
-
-msgid ":doc:`pgr_trspVia`:"
-msgstr ""
-
-msgid "Migration of ``pgr_trspViaEdges``"
-msgstr ""
-
-msgid ""
-"And will travel thru the following Via points :math:"
-"`4\\rightarrow3\\rightarrow6`"
-msgstr ""
-
-msgid ":doc:`pgr_withPointsVia` when there are no restrictions,"
-msgstr ""
-
-msgid ":doc:`pgr_trspVia_withPoints` when there are restrictions."
-msgstr ""
-
-msgid "Migrating ``pgr_trspViaEdges`` using ``pgr_withPointsVia``"
-msgstr ""
-
-msgid "Use :doc:`pgr_withPointsVia` instead."
-msgstr ""
-
-msgid ":doc:`pgr_withPointsVia`:"
-msgstr ""
-
-msgid "Migrating ``pgr_trspViaEdges`` using ``pgr_trspVia_withPoints``"
-msgstr ""
-
-msgid "Use :doc:`pgr_trspVia_withPoints` instead."
-msgstr ""
-
-msgid ":doc:`pgr_trspVia_withPoints`:"
 msgstr ""
 
 msgid ":doc:`withPoints-category`"
@@ -5654,9 +5125,6 @@ msgid ""
 msgstr ""
 
 msgid "Graph with ``cost`` and ``reverse_cost``"
-msgstr ""
-
-msgid "The weighted directed graph, :math:`G_d(V,E)`, is defined by:"
 msgstr ""
 
 msgid "``SELECT id, source, target, cost, reverse_cost FROM edges``"
@@ -6313,17 +5781,28 @@ msgstr ""
 msgid "To get the dead ends:"
 msgstr ""
 
-msgid ""
-"That information is correct, for example, when the dead end is on the limit "
-"of the imported graph."
+msgid "A dead end happens when"
 msgstr ""
 
 msgid ""
-"Visually node :math:`4` looks to be as start/ending of 3 edges, but it is "
-"not."
+"The vertex is the limit of a cul-de-sac, a no-through road or a no-exit road."
 msgstr ""
 
-msgid "Is that correct?"
+msgid "The vertex is on the limit of the imported graph."
+msgstr ""
+
+msgid "If a larger graph is imported then the vertex might not be a dead end"
+msgstr ""
+
+msgid ""
+"Node :math:`4`, is a dead end on the query, even that it visually looks like "
+"an end point of 3 edges."
+msgstr ""
+
+msgid "Is node :math:`4` a dead end or not?"
+msgstr ""
+
+msgid "The answer to that question will depend on the application."
 msgstr ""
 
 msgid "Is there such a small curb:"
@@ -6347,9 +5826,12 @@ msgid ""
 "the segment?"
 msgstr ""
 
+msgid "Depending on the answer, modification of the data might be needed."
+msgstr ""
+
 msgid ""
-"When there are many dead ends, to speed up, the :doc:`contraction-family` "
-"functions can be used to divide the problem."
+"When there are many dead ends, to speed up processing, the :doc:`contraction-"
+"family` functions can be used to contract the graph."
 msgstr ""
 
 msgid "Linear edges"
@@ -6359,13 +5841,14 @@ msgid "To get the linear edges:"
 msgstr ""
 
 msgid ""
-"This information is correct, for example, when the application is taking "
-"into account speed bumps, stop signals."
+"These linear vertices are correct, for example, when those the vertices are "
+"speed bumps, stop signals and the application is taking them into account."
 msgstr ""
 
 msgid ""
-"When there are many linear edges, to speed up, the :doc:`contraction-family` "
-"functions can be used to divide the problem."
+"When there are many linear vertices, that need not to be taken into account, "
+"to speed up the processing, the :doc:`contraction-family` functions can be "
+"used to contract the problem."
 msgstr ""
 
 msgid "Function's structure"
@@ -6628,9 +6111,6 @@ msgstr ""
 msgid "Parameters for the Via functions"
 msgstr ""
 
-msgid ":doc:`pgr_dijkstraVia`"
-msgstr ""
-
 msgid "SQL query as described."
 msgstr ""
 
@@ -6668,9 +6148,6 @@ msgid ""
 msgstr ""
 
 msgid "For the TRSP functions"
-msgstr ""
-
-msgid ":doc:`pgr_trsp`"
 msgstr ""
 
 msgid "Array of identifiers of destination vertices."
@@ -6722,9 +6199,6 @@ msgid ""
 msgstr ""
 
 msgid "Used in functions the following:"
-msgstr ""
-
-msgid ":doc:`pgr_withPoints`"
 msgstr ""
 
 msgid ""
@@ -6877,6 +6351,12 @@ msgid ""
 "the routing function and is within the area of the results."
 msgstr ""
 
+msgid "Given this area:"
+msgstr ""
+
+msgid "Calculate a route:"
+msgstr ""
+
 msgid "How to contribute"
 msgstr ""
 
@@ -6904,7 +6384,7 @@ msgid ""
 "parallel-edges-(KSP)>`__"
 msgstr ""
 
-msgid "Adding Functionaity to pgRouting"
+msgid "Adding Functionality to pgRouting"
 msgstr ""
 
 msgid ""
@@ -7011,7 +6491,7 @@ msgid "Upgrading the database"
 msgstr ""
 
 msgid ""
-"To upgrade pgRouting in the database to version 3.7.0 use the following "
+"To upgrade pgRouting in the database to version 4.0.0 use the following "
 "command:"
 msgstr ""
 
@@ -7459,7 +6939,7 @@ msgstr ""
 msgid ":doc:`migration`"
 msgstr ""
 
-msgid "pgr_KSP"
+msgid "``pgr_KSP``"
 msgstr ""
 
 msgid "``pgr_KSP`` — Yen's algorithm for K shortest paths using Dijkstra."
@@ -7468,31 +6948,37 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
+msgid "Version 4.0.0"
+msgstr ""
+
+msgid "All signatures promoted to official."
+msgstr ""
+
 msgid "Version 3.6.0"
 msgstr ""
 
 msgid "Result columns standarized to: |nksp-result|"
 msgstr ""
 
-msgid "``pgr_ksp`` (One to One)"
+msgid "pgr_ksp(One to One)"
 msgstr ""
 
 msgid "Added ``start_vid`` and ``end_vid`` result columns."
 msgstr ""
 
-msgid "New overload functions:"
+msgid "New proposed signatures:"
 msgstr ""
 
-msgid "``pgr_ksp`` (One to Many)"
+msgid "pgr_ksp(One to Many)"
 msgstr ""
 
-msgid "``pgr_ksp`` (Many to One)"
+msgid "pgr_ksp(Many to One)"
 msgstr ""
 
-msgid "``pgr_ksp`` (Many to Many)"
+msgid "pgr_ksp(Many to Many)"
 msgstr ""
 
-msgid "``pgr_ksp`` (Combinations)"
+msgid "pgr_ksp(Combinations)"
 msgstr ""
 
 msgid "Version 2.1.0"
@@ -7507,12 +6993,18 @@ msgstr ""
 msgid "Version 2.0.0"
 msgstr ""
 
-msgid "**Official** function"
+msgid "Official function."
 msgstr ""
 
 msgid ""
 "The K shortest path routing algorithm based on Yen's algorithm. \"K\" is the "
 "number of shortest paths desired."
+msgstr ""
+
+msgid "|Boost| Boost Graph Inside"
+msgstr ""
+
+msgid "Boost Graph Inside"
 msgstr ""
 
 msgid "Signatures"
@@ -7640,7 +7132,7 @@ msgstr ""
 msgid "``pgr_TSP``"
 msgstr ""
 
-msgid "``pgr_TSP`` - Aproximation using *metric* algorithm."
+msgid "``pgr_TSP`` - Approximation using *metric* algorithm."
 msgstr ""
 
 msgid "Availability:"
@@ -7856,7 +7348,12 @@ msgstr ""
 msgid "``pgr_TSPeuclidean``"
 msgstr ""
 
-msgid "``pgr_TSPeuclidean`` - Aproximation using *metric* algorithm."
+msgid "``pgr_TSPeuclidean`` - Approximation using *metric* algorithm."
+msgstr ""
+
+msgid ""
+"Using `Boost: metric TSP approx <https://www.boost.org/libs/graph/doc/"
+"metric_tsp_approx.html>`__"
 msgstr ""
 
 msgid ""
@@ -7872,7 +7369,7 @@ msgstr ""
 msgid "Name change from pgr_eucledianTSP"
 msgstr ""
 
-msgid "New **Official** function"
+msgid "New official function."
 msgstr ""
 
 msgid ""
@@ -7953,56 +7450,49 @@ msgid ""
 "obtained with ``pgr_TSPeuclidean``."
 msgstr ""
 
-msgid ":doc:`sampledata` network."
-msgstr ""
-
 msgid "``pgr_aStar``"
 msgstr ""
 
 msgid "``pgr_aStar`` — Shortest path using the A* algorithm."
 msgstr ""
 
+msgid "Combinations signature promoted to official."
+msgstr ""
+
 msgid "Standarizing output columns to |short-generic-result|"
 msgstr ""
 
-msgid ""
-"``pgr_aStar`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
+msgid "pgr_aStar(One to One) added ``start_vid`` and ``end_vid`` columns."
 msgstr ""
 
-msgid "``pgr_aStar`` (`One to Many`_) added ``end_vid`` column."
+msgid "pgr_aStar(One to Many) added ``end_vid`` column."
 msgstr ""
 
-msgid "``pgr_aStar`` (`Many to One`_) added ``start_vid`` column."
+msgid "pgr_aStar(Many to One) added ``start_vid`` column."
 msgstr ""
 
 msgid "Version 3.2.0"
 msgstr ""
 
-msgid "New **proposed** signature:"
+msgid "New proposed signature:"
 msgstr ""
 
-msgid "``pgr_aStar`` (`Combinations`_)"
+msgid "Function promoted to official."
 msgstr ""
 
 msgid "Version 2.4.0"
 msgstr ""
 
-msgid "New **Proposed** signatures:"
+msgid "pgr_aStar(One to Many)"
 msgstr ""
 
-msgid "``pgr_aStar`` (`One to Many`_)"
+msgid "pgr_aStar(Many to One)"
 msgstr ""
 
-msgid "``pgr_aStar`` (`Many to One`_)"
+msgid "pgr_aStar(Many to Many)"
 msgstr ""
 
-msgid "``pgr_aStar`` (`Many to Many`_)"
-msgstr ""
-
-msgid "Signature change on ``pgr_astar`` (`One to One`_)"
-msgstr ""
-
-msgid "**Official** ``pgr_aStar`` (`One to One`_)"
+msgid "Signature change on pgr_aStar(One to One)"
 msgstr ""
 
 msgid ""
@@ -8076,17 +7566,14 @@ msgstr ""
 msgid "Manually assigned vertex combinations."
 msgstr ""
 
-msgid "pgr_aStarCost"
+msgid "``pgr_aStarCost``"
 msgstr ""
 
 msgid ""
 "``pgr_aStarCost`` - Total cost of the shortest path using the A* algorithm."
 msgstr ""
 
-msgid "``pgr_aStarCost`` (`Combinations`_)"
-msgstr ""
-
-msgid "New **proposed** function"
+msgid "New proposed function."
 msgstr ""
 
 msgid ""
@@ -8206,6 +7693,9 @@ msgstr ""
 msgid "Renamed from version 1.x"
 msgstr ""
 
+msgid "Support"
+msgstr ""
+
 msgid "Returns the polygon part of an alpha shape."
 msgstr ""
 
@@ -8278,7 +7768,7 @@ msgstr ""
 msgid "`ST_ConcaveHull <https://postgis.net/docs/ST_ConcaveHull.html>`__"
 msgstr ""
 
-msgid "pgr_analyzeGraph"
+msgid "``pgr_analyzeGraph``"
 msgstr ""
 
 msgid "``pgr_analyzeGraph`` — Analyzes the network topology."
@@ -8540,9 +8030,6 @@ msgid ""
 "table ``othertable``. (note the use of quote_literal)"
 msgstr ""
 
-msgid "The examples use the :doc:`sampledata` network."
-msgstr ""
-
 msgid ":doc:`pgr_analyzeOneWay`"
 msgstr ""
 
@@ -8552,7 +8039,7 @@ msgstr ""
 msgid ":doc:`pgr_nodeNetwork` to create nodes to a not noded edge table."
 msgstr ""
 
-msgid "pgr_analyzeOneWay"
+msgid "``pgr_analyzeOneWay``"
 msgstr ""
 
 msgid ""
@@ -8704,7 +8191,7 @@ msgstr ""
 msgid "Version 2.5.0"
 msgstr ""
 
-msgid "New **experimental** function"
+msgid "New experimental function."
 msgstr ""
 
 msgid ""
@@ -8736,7 +8223,7 @@ msgid "Nodes in red are the articulation points."
 msgstr ""
 
 msgid ""
-"Boost: `Biconnected components & articulation points <https://www.boost.org/"
+"`Boost: Biconnected components & articulation points <https://www.boost.org/"
 "libs/graph/doc/biconnected_components.html>`__"
 msgstr ""
 
@@ -8751,37 +8238,30 @@ msgstr ""
 msgid "``pgr_bdAstar`` — Shortest path using the bidirectional A* algorithm."
 msgstr ""
 
-msgid ""
-"``pgr_bdAstar`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
+msgid "pgr_bdAstar(One to One) added ``start_vid`` and ``end_vid`` columns."
 msgstr ""
 
-msgid "``pgr_bdAstar`` (`One to Many`_) added ``end_vid`` column."
+msgid "pgr_bdAstar(One to Many) added ``end_vid`` column."
 msgstr ""
 
-msgid "``pgr_bdAstar`` (`Many to One`_) added ``start_vid`` column."
+msgid "pgr_bdAstar(Many to One) added ``start_vid`` column."
 msgstr ""
 
-msgid "``pgr_bdAstar`` (`Combinations`_)"
+msgid "pgr_bdAstar(One to Many)"
 msgstr ""
 
-msgid "``pgr_bdAstar`` (`One to Many`_)"
+msgid "pgr_bdAstar(Many to One)"
 msgstr ""
 
-msgid "``pgr_bdAstar`` (`Many to One`_)"
+msgid "pgr_bdAstar(Many to Many)"
 msgstr ""
 
-msgid "``pgr_bdAstar`` (`Many to Many`_)"
-msgstr ""
-
-msgid "Signature change on ``pgr_bdAstar`` (`One to One`_)"
-msgstr ""
-
-msgid "**Official** ``pgr_bdAstar`` (`One to One`_)"
+msgid "Signature change on pgr_bdAstar(One to One)"
 msgstr ""
 
 msgid ""
-"The results are equivalent to the union of the results of the `pgr_bdAStar(` "
-"`One to One`_ `)` on the:"
+"The results are equivalent to the union of the results of the "
+"pgr_bdAStar(One to One) on the:"
 msgstr ""
 
 msgid "pgr_bdAstar(`Edges SQL`_, **start vid**, **end vid**, [**options**])"
@@ -8799,15 +8279,12 @@ msgstr ""
 msgid "pgr_bdAstar(`Edges SQL`_, `Combinations SQL`_, [**options**])"
 msgstr ""
 
-msgid "pgr_bdAstarCost"
+msgid "``pgr_bdAstarCost``"
 msgstr ""
 
 msgid ""
 "``pgr_bdAstarCost`` - Total cost of the shortest path using the "
 "bidirectional A* algorithm."
-msgstr ""
-
-msgid "``pgr_bdAstarCost`` (`Combinations`_)"
 msgstr ""
 
 msgid ""
@@ -8856,25 +8333,16 @@ msgid ""
 "algorithm."
 msgstr ""
 
-msgid "pgr_bdDijkstra(`Combinations`_)"
+msgid "pgr_bdDijkstra(One to Many)"
 msgstr ""
 
-msgid "New **Proposed** functions:"
+msgid "pgr_bdDijkstra(Many to One)"
 msgstr ""
 
-msgid "``pgr_bdDijkstra`` (`One to Many`_)"
+msgid "pgr_bdDijkstra(Many to Many)"
 msgstr ""
 
-msgid "``pgr_bdDijkstra`` (`Many to One`_)"
-msgstr ""
-
-msgid "``pgr_bdDijkstra`` (`Many to Many`_)"
-msgstr ""
-
-msgid "Signature change on ``pgr_bdDijsktra`` (`One to One`_)"
-msgstr ""
-
-msgid "**Official** ``pgr_bdDijkstra`` (`One to One`_)"
+msgid "Signature change on pgr_bdDijsktra(One to One)"
 msgstr ""
 
 msgid ""
@@ -8928,11 +8396,6 @@ msgstr ""
 msgid "Using a combinations table on an **undirected** graph"
 msgstr ""
 
-msgid ""
-"https://www.cs.princeton.edu/courses/archive/spr06/cos423/Handouts/"
-"EPP%20shortest%20path%20algorithms.pdf"
-msgstr ""
-
 msgid "https://en.wikipedia.org/wiki/Bidirectional_search"
 msgstr ""
 
@@ -8942,9 +8405,6 @@ msgstr ""
 msgid ""
 "``pgr_bdDijkstraCost`` — Returns the shortest path's cost using "
 "Bidirectional Dijkstra algorithm."
-msgstr ""
-
-msgid "``pgr_bdDijkstraCost`` (`Combinations`_)"
 msgstr ""
 
 msgid ""
@@ -9005,25 +8465,10 @@ msgstr ""
 msgid "``pgr_bellmanFord`` — Shortest path using Bellman-Ford algorithm."
 msgstr ""
 
-msgid "New **experimental** signature:"
+msgid "New experimental signature:"
 msgstr ""
 
-msgid "``pgr_bellmanFord`` (`Combinations`_)"
-msgstr ""
-
-msgid "New **experimental** signatures:"
-msgstr ""
-
-msgid "``pgr_bellmanFord`` (`One to One`_)"
-msgstr ""
-
-msgid "``pgr_bellmanFord`` (`One to Many`_)"
-msgstr ""
-
-msgid "``pgr_bellmanFord`` (`Many to One`_)"
-msgstr ""
-
-msgid "``pgr_bellmanFord`` (`Many to Many`_)"
+msgid "pgr_bellmanFord(Combinations)"
 msgstr ""
 
 msgid ""
@@ -9098,21 +8543,23 @@ msgstr ""
 msgid "Using a combinations table on an **undirected** graph."
 msgstr ""
 
+msgid ""
+"`Boost: Bellman Ford <https://www.boost.org/libs/graph/doc/"
+"bellman_ford_shortest.html>`__"
+msgstr ""
+
 msgid "https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm"
 msgstr ""
 
-msgid "``pgr_betweennessCentrality``"
+msgid "``pgr_betweennessCentrality`` - Experimental"
 msgstr ""
 
 msgid ""
-"``pgr_betweennessCentrality`` - Calculates the relative betweeness "
+"``pgr_betweennessCentrality`` - Calculates the relative betweenness "
 "centrality using Brandes Algorithm"
 msgstr ""
 
 msgid "Version 3.7.0"
-msgstr ""
-
-msgid "New **experimental** function:"
 msgstr ""
 
 msgid ""
@@ -9184,11 +8631,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Boost's `betweenness_centrality <https://www.boost.org/doc/libs/1_84_0/libs/"
-"graph/doc/betweenness_centrality.html>`_"
-msgstr ""
-
-msgid "Queries use the :doc:`sampledata` network."
+"`Boost: betweenness centrality <https://www.boost.org/libs/graph/doc/"
+"betweenness_centrality.html>`_"
 msgstr ""
 
 msgid "``pgr_biconnectedComponents``"
@@ -9247,11 +8691,6 @@ msgstr ""
 msgid "Identifier of the edge that belongs to the ``component``."
 msgstr ""
 
-msgid ""
-"Boost: `Biconnected components <https://www.boost.org/libs/graph/doc/"
-"biconnected_components.html>`__"
-msgstr ""
-
 msgid "``pgr_binaryBreadthFirstSearch`` - Experimental"
 msgstr ""
 
@@ -9265,19 +8704,7 @@ msgid ""
 "negative integer, is termed as a 'binary graph'."
 msgstr ""
 
-msgid "pgr_binaryBreadthFirstSearch(`Combinations`_)"
-msgstr ""
-
-msgid "pgr_binaryBreadthFirstSearch(`One to One`_)"
-msgstr ""
-
-msgid "pgr_binaryBreadthFirstSearch(`One to Many`_)"
-msgstr ""
-
-msgid "pgr_binaryBreadthFirstSearch(`Many to One`_)"
-msgstr ""
-
-msgid "pgr_binaryBreadthFirstSearch(`Many to Many`_)"
+msgid "pgr_binaryBreadthFirstSearch(Combinations)"
 msgstr ""
 
 msgid ""
@@ -9339,6 +8766,11 @@ msgid ""
 "math:`1``)"
 msgstr ""
 
+msgid ""
+"`Boost: Breadth First Search <https://www.boost.org/libs/graph/doc/"
+"breadth_first_search.html>`__"
+msgstr ""
+
 msgid "https://cp-algorithms.com/graph/01_bfs.html"
 msgstr ""
 
@@ -9346,15 +8778,12 @@ msgid ""
 "https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm#Specialized_variants"
 msgstr ""
 
-msgid "pgr_bipartite -Experimental"
+msgid "``pgr_bipartite`` - Experimental"
 msgstr ""
 
 msgid ""
 "``pgr_bipartite`` — Disjoint sets of vertices such that no two vertices "
 "within the same set are adjacent."
-msgstr ""
-
-msgid "New **experimental** signature"
 msgstr ""
 
 msgid ""
@@ -9403,6 +8832,16 @@ msgstr ""
 msgid "Edges in blue represent odd length cycle subgraph."
 msgstr ""
 
+msgid ""
+"`Boost: is_bipartite <https://www.boost.org/libs/graph/doc/is_bipartite."
+"html>`__"
+msgstr ""
+
+msgid ""
+"`Wikipedia: bipartite graph <https://en.wikipedia.org/wiki/"
+"Bipartite_graph>`__"
+msgstr ""
+
 msgid "``pgr_boykovKolmogorov``"
 msgstr ""
 
@@ -9412,19 +8851,10 @@ msgid ""
 "algorithm."
 msgstr ""
 
-msgid "New **proposed** signature"
-msgstr ""
-
-msgid "``pgr_boykovKolmogorov`` (`Combinations`_)"
-msgstr ""
-
 msgid "Renamed from ``pgr_maxFlowBoykovKolmogorov``"
 msgstr ""
 
-msgid "**Proposed** function"
-msgstr ""
-
-msgid "New **Experimental** function"
+msgid "Function promoted to proposed."
 msgstr ""
 
 msgid "Running time: Polynomial"
@@ -9466,7 +8896,9 @@ msgid ""
 "math:`\\{5, 6\\}` to vertices :math:`\\{10, 15, 14\\}`."
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html"
+msgid ""
+"`Boost: Boykov Kolmogorov max flow <https://www.boost.org/libs/graph/doc/"
+"boykov_kolmogorov_max_flow.html>`__"
 msgstr ""
 
 msgid "``pgr_breadthFirstSearch`` - Experimental"
@@ -9475,12 +8907,6 @@ msgstr ""
 msgid ""
 "``pgr_breadthFirstSearch`` — Returns the traversal order(s) using Breadth "
 "First Search algorithm."
-msgstr ""
-
-msgid "``pgr_breadthFirstSearch`` (`Single Vertex`_)"
-msgstr ""
-
-msgid "``pgr_breadthFirstSearch`` (`Multiple Vertices`_)"
 msgstr ""
 
 msgid ""
@@ -9548,11 +8974,6 @@ msgid "descending"
 msgstr ""
 
 msgid ""
-"`Boost: Breadth First Search algorithm documentation <https://www.boost.org/"
-"libs/graph/doc/breadth_first_search.html>`__"
-msgstr ""
-
-msgid ""
 "`Wikipedia: Breadth First Search algorithm <https://en.wikipedia.org/wiki/"
 "Breadth-first_search>`__"
 msgstr ""
@@ -9590,7 +9011,9 @@ msgstr ""
 msgid "https://en.wikipedia.org/wiki/Bridge_%28graph_theory%29"
 msgstr ""
 
-msgid "**Supported versions**"
+msgid ""
+"`Boost: Connected components <https://www.boost.org/libs/graph/doc/"
+"connected_components.html>`__"
 msgstr ""
 
 msgid "``pgr_chinesePostman`` - Experimental"
@@ -9648,7 +9071,7 @@ msgstr ""
 msgid "Minimum costs of a circuit path."
 msgstr ""
 
-msgid "pgr_connectedComponents"
+msgid "``pgr_connectedComponents``"
 msgstr ""
 
 msgid ""
@@ -9686,11 +9109,6 @@ msgid "Connecting disconnected components"
 msgstr ""
 
 msgid ""
-"Boost: `Connected components <https://www.boost.org/libs/graph/doc/"
-"connected_components.html>`__"
-msgstr ""
-
-msgid ""
 "wikipedia: `Connected component <https://en.wikipedia.org/wiki/"
 "Connected_component_(graph_theory)>`__"
 msgstr ""
@@ -9701,6 +9119,24 @@ msgstr ""
 msgid ""
 "``pgr_contraction`` — Performs graph contraction and returns the contracted "
 "vertices and edges."
+msgstr ""
+
+msgid "Version 3.8.0"
+msgstr ""
+
+msgid "New signature:"
+msgstr ""
+
+msgid ""
+"Previously compulsory parameter **Contraction order** is now optional with "
+"name ``methods``."
+msgstr ""
+
+msgid "New name and order of optional parameters."
+msgstr ""
+
+msgid ""
+"Deprecated signature pgr_contraction(text,bigint[],integer,bigint[],boolean)"
 msgstr ""
 
 msgid "Name change from ``pgr_contractGraph``"
@@ -9715,57 +9151,63 @@ msgid ""
 "original edges decreasing the total time and space used in graph algorithms."
 msgstr ""
 
-msgid "Does not return the full contracted graph"
+msgid "Does not return the full contracted graph."
 msgstr ""
 
-msgid "Only changes on the graph are returned"
+msgid "Only changes on the graph are returned."
 msgstr ""
 
-msgid "Currnetly there are two types of contraction methods"
+msgid "The returned values include:"
 msgstr ""
 
-msgid "Dead End Contraction"
+msgid "The new edges generated by linear contraction."
 msgstr ""
 
-msgid "Linear Contraction"
-msgstr ""
-
-msgid "The returned values include"
-msgstr ""
-
-msgid "the added edges by linear contraction."
-msgstr ""
-
-msgid "the modified vertices by dead end contraction."
+msgid "The modified vertices generated by dead end contraction."
 msgstr ""
 
 msgid "The returned values are ordered as follows:"
 msgstr ""
 
-msgid "column ``id`` ascending when type is ``v``"
+msgid "column ``id`` ascending when its a modified vertex."
 msgstr ""
 
-msgid "column ``id`` descending when type is ``e``"
+msgid "column ``id`` with negative numbers descending when its a new edge."
 msgstr ""
 
-msgid "The pgr_contraction function has the following signature:"
+msgid ""
+"Currently there are two types of contraction methods included in this "
+"function:"
 msgstr ""
 
-msgid "pgr_contraction(`Edges SQL`_, **contraction order**, [**options**])"
+msgid "Dead End Contraction. See :doc:`pgr_contractionDeadEnd`."
 msgstr ""
 
-msgid "**options:** ``[ max_cycles, forbidden_vertices, directed]``"
+msgid "Linear Contraction. See :doc:`pgr_contractionLinear`."
+msgstr ""
+
+msgid "pgr_contraction(`Edges SQL`_, [**options**])"
+msgstr ""
+
+msgid "**options:** ``[directed, methods, cycles, forbidden]``"
 msgstr ""
 
 msgid "Returns set of |result-contract|"
 msgstr ""
 
-msgid ""
-"Making a dead end and linear contraction in that order on an undirected "
-"graph."
+msgid "Dead end and linear contraction in that order on an undirected graph."
 msgstr ""
 
-msgid "**contraction Order**"
+msgid "Contraction optional parameters"
+msgstr ""
+
+msgid "``methods``"
+msgstr ""
+
+msgid "``INTEGER[]``"
+msgstr ""
+
+msgid "``ARRAY[1,2]``"
 msgstr ""
 
 msgid "Ordered contraction operations."
@@ -9777,24 +9219,25 @@ msgstr ""
 msgid "2 = Linear contraction"
 msgstr ""
 
-msgid "Contraction optional parameters"
-msgstr ""
-
-msgid "``forbidden_vertices``"
-msgstr ""
-
-msgid "**Empty**"
-msgstr ""
-
-msgid "Identifiers of vertices forbidden for contraction."
+msgid "``cycles``"
 msgstr ""
 
 msgid ":math:`1`"
 msgstr ""
 
-msgid ""
-"Number of times the contraction operations on ``contraction_order`` will be "
-"performed."
+msgid "Number of times the contraction methods will be performed."
+msgstr ""
+
+msgid "``forbidden``"
+msgstr ""
+
+msgid "``BIGINT[]``"
+msgstr ""
+
+msgid "``ARRAY[]::BIGINT[]``"
+msgstr ""
+
+msgid "Identifiers of vertices forbidden for contraction."
 msgstr ""
 
 msgid "The function returns a single row. The columns of the row are:"
@@ -9803,19 +9246,19 @@ msgstr ""
 msgid "``type``"
 msgstr ""
 
-msgid "Type of the ``id``."
+msgid "Type of the row."
 msgstr ""
 
 msgid "``v`` when the row is a vertex."
 msgstr ""
 
-msgid "Column ``id`` has a positive value"
+msgid "Column ``id`` has a positive value."
 msgstr ""
 
 msgid "``e`` when the row is an edge."
 msgstr ""
 
-msgid "Column ``id`` has a negative value"
+msgid "Column ``id`` has a negative value."
 msgstr ""
 
 msgid "All numbers on this column are ``DISTINCT``"
@@ -9836,6 +9279,9 @@ msgstr ""
 msgid ""
 "Representing a pseudo `id` as is not incorporated in the set of original "
 "edges."
+msgstr ""
+
+msgid "``contracted_vertices``"
 msgstr ""
 
 msgid "Array of contracted vertex identifiers."
@@ -9864,7 +9310,518 @@ msgstr ""
 msgid "Only linear contraction"
 msgstr ""
 
-msgid "pgr_createTopology"
+msgid "The cycle"
+msgstr ""
+
+msgid ""
+"Contracting a graph can be done with more than one operation. The order of "
+"the operations affect the resulting contracted graph, after applying one "
+"operation, the set of vertices that can be contracted by another operation "
+"changes."
+msgstr ""
+
+msgid "This implementation cycles ``cycles`` times through the ``methods`` ."
+msgstr ""
+
+msgid "Contracting sample data"
+msgstr ""
+
+msgid ""
+"In this section, building and using a contracted graph will be shown by "
+"example."
+msgstr ""
+
+msgid "The :doc:`sampledata` for an undirected graph is used"
+msgstr ""
+
+msgid "a dead end operation first followed by a linear operation."
+msgstr ""
+
+msgid "Construction of the graph in the database"
+msgstr ""
+
+msgid "The original graph:"
+msgstr ""
+
+msgid ""
+"The results do not represent the contracted graph. They represent the "
+"changes that need to be done to the graph after applying the contraction "
+"methods."
+msgstr ""
+
+msgid ""
+"Observe that vertices, for example, :math:`6` do not appear in the results "
+"because it was not affected by the contraction algorithm."
+msgstr ""
+
+msgid "After doing the dead end contraction operation:"
+msgstr ""
+
+msgid "After doing the linear contraction operation to the graph above:"
+msgstr ""
+
+msgid "The process to create the contraction graph on the database:"
+msgstr ""
+
+msgid "Add additional columns"
+msgstr ""
+
+msgid ""
+"Adding extra columns to the edges and vertices tables. In this documentation "
+"the following will be used:"
+msgstr ""
+
+msgid "Column."
+msgstr ""
+
+msgid "The vertices set belonging to the vertex/edge"
+msgstr ""
+
+msgid "``is_contracted``"
+msgstr ""
+
+msgid "On the vertex table"
+msgstr ""
+
+msgid ""
+"when ``true`` the vertex is contracted, its not part of the contracted graph."
+msgstr ""
+
+msgid ""
+"when ``false`` the vertex is not contracted, its part of the contracted "
+"graph."
+msgstr ""
+
+msgid "``is_new``"
+msgstr ""
+
+msgid "On the edge table"
+msgstr ""
+
+msgid ""
+"when ``true`` the edge was generated by the contraction algorithm. its part "
+"of the contracted graph."
+msgstr ""
+
+msgid ""
+"when ``false`` the edge is an original edge, might be or not part of the "
+"contracted graph."
+msgstr ""
+
+msgid "Store contraction information"
+msgstr ""
+
+msgid "Store the contraction results in a table."
+msgstr ""
+
+msgid "Update the edges and vertices tables"
+msgstr ""
+
+msgid ""
+"Use ``is_contracted`` column to indicate the vertices that are contracted."
+msgstr ""
+
+msgid ""
+"Fill ``contracted_vertices`` with the information from the results that "
+"belong to the vertices."
+msgstr ""
+
+msgid "Insert the new edges generated by pgr_contraction."
+msgstr ""
+
+msgid "The contracted graph"
+msgstr ""
+
+msgid "Vertices that belong to the contracted graph."
+msgstr ""
+
+msgid "Edges that belong to the contracted graph."
+msgstr ""
+
+msgid "Visually:"
+msgstr ""
+
+msgid "Using the contracted graph"
+msgstr ""
+
+msgid ""
+"Depending on the final application the graph is to be prepared. In this "
+"example the final application will be to calculate the cost from two "
+"vertices in the original graph by using the contracted graph with "
+"``pgr_dijkstraCost``"
+msgstr ""
+
+msgid ""
+"There are three cases when calculating the shortest path between a given "
+"source and target in a contracted graph:"
+msgstr ""
+
+msgid "Case 1: Both source and target belong to the contracted graph."
+msgstr ""
+
+msgid "Case 2: Source and/or target belong to an edge subgraph."
+msgstr ""
+
+msgid "Case 3: Source and/or target belong to a vertex."
+msgstr ""
+
+msgid "The final application should consider all of those cases."
+msgstr ""
+
+msgid "Create a view (or table) of the contracted graph:"
+msgstr ""
+
+msgid "Create the function that will use the contracted graph."
+msgstr ""
+
+msgid ""
+"Case 2: Source and/or target belong to an edge that has contracted vertices."
+msgstr ""
+
+msgid ""
+"Case 3: Source and/or target belong to a vertex that has been contracted."
+msgstr ""
+
+msgid "``pgr_contractionDeadEnd`` - Proposed"
+msgstr ""
+
+msgid ""
+"``pgr_contractionDeadEnd`` — Performs graph contraction and returns the "
+"contracted vertices and edges."
+msgstr ""
+
+msgid "A node is considered a dead end node when:"
+msgstr ""
+
+msgid "On undirected graphs:"
+msgstr ""
+
+msgid "The number of adjacent vertices is 1."
+msgstr ""
+
+msgid "On directed graphs:"
+msgstr ""
+
+msgid "When there is only one adjacent vertex or"
+msgstr ""
+
+msgid ""
+"When all edges are incoming regardless of the number of adjacent vertices."
+msgstr ""
+
+msgid "pgr_contractionDeadEnd(`Edges SQL`_, [**options**])"
+msgstr ""
+
+msgid "**options:** ``[directed, forbidden_vertices]``"
+msgstr ""
+
+msgid "Dead end contraction on an undirected graph."
+msgstr ""
+
+msgid "The green nodes are dead end nodes."
+msgstr ""
+
+msgid "Node :math:`3` is a dead end node after node :math:`1` is contracted."
+msgstr ""
+
+msgid "``forbidden_vertices``"
+msgstr ""
+
+msgid "``ARRAY[`` |ANY-INTEGER| ``]``"
+msgstr ""
+
+msgid "**Empty**"
+msgstr ""
+
+msgid "Value = ``e`` indicating the row is an edge."
+msgstr ""
+
+msgid "A pseudo `id` of the edge."
+msgstr ""
+
+msgid "Identifier of the source vertex of the current edge."
+msgstr ""
+
+msgid "Identifier of the target vertex of the current edge."
+msgstr ""
+
+msgid "Weight of the current edge."
+msgstr ""
+
+msgid "Dead end vertex on undirected graph"
+msgstr ""
+
+msgid "They have only one adjacent node."
+msgstr ""
+
+msgid "Dead end vertex on directed graph"
+msgstr ""
+
+msgid "The green nodes are dead end nodes"
+msgstr ""
+
+msgid ""
+"The blue nodes have an unlimited number of incoming and/or outgoing edges."
+msgstr ""
+
+msgid "Node"
+msgstr ""
+
+msgid "Adjacent nodes"
+msgstr ""
+
+msgid "Dead end"
+msgstr ""
+
+msgid "Reason"
+msgstr ""
+
+msgid ":math:`6`"
+msgstr ""
+
+msgid ":math:`\\{1\\}`"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
+
+msgid "Has only one adjacent node."
+msgstr ""
+
+msgid ":math:`7`"
+msgstr ""
+
+msgid ":math:`\\{2\\}`"
+msgstr ""
+
+msgid ":math:`8`"
+msgstr ""
+
+msgid ":math:`\\{2, 3\\}`"
+msgstr ""
+
+msgid "Has more than one adjacent node and all edges are incoming."
+msgstr ""
+
+msgid ":math:`\\{4\\}`"
+msgstr ""
+
+msgid ":math:`10`"
+msgstr ""
+
+msgid ":math:`\\{4, 5\\}`"
+msgstr ""
+
+msgid "No"
+msgstr ""
+
+msgid "Has more than one adjacent node and all edges are outgoing."
+msgstr ""
+
+msgid ":math:`1,2,3,4,5`"
+msgstr ""
+
+msgid "Many adjacent nodes."
+msgstr ""
+
+msgid ""
+"Has more than one adjacent node and some edges are incoming and some are "
+"outgoing."
+msgstr ""
+
+msgid ""
+"From above, nodes :math:`\\{6, 7, 9\\}` are dead ends because the total "
+"number of adjacent vertices is one."
+msgstr ""
+
+msgid ""
+"When there are more than one adjacent vertex, all edges need to be all "
+"incoming edges otherwise it is not a dead end."
+msgstr ""
+
+msgid "Step by step dead end contraction"
+msgstr ""
+
+msgid ""
+"The dead end contraction will stop until there are no more dead end nodes. "
+"For example, from the following graph where :math:`3` is the dead end node:"
+msgstr ""
+
+msgid ""
+"After contracting :math:`3`, node :math:`2` is now a dead end node and is "
+"contracted:"
+msgstr ""
+
+msgid ""
+"After contracting :math:`2`, stop. Node :math:`1` has the information of "
+"nodes that were contracted."
+msgstr ""
+
+msgid "Creating the contracted graph"
+msgstr ""
+
+msgid "Steps for the creation of the contracted graph"
+msgstr ""
+
+msgid "Add additional columns."
+msgstr ""
+
+msgid "Save results into a table."
+msgstr ""
+
+msgid "The contracted vertices are not part of the contracted graph."
+msgstr ""
+
+msgid "Using when departure and destination are in the contracted graph"
+msgstr ""
+
+msgid "Using when departure/destination is not in the contracted graph"
+msgstr ""
+
+msgid "Using when departure and destination are not in the contracted graph"
+msgstr ""
+
+msgid "``pgr_contractionLinear`` - Proposed"
+msgstr ""
+
+msgid ""
+"``pgr_contractionLinear`` — Performs graph contraction and returns the "
+"contracted vertices and edges."
+msgstr ""
+
+msgid "pgr_contractionLinear(`Edges SQL`_, [**options**])"
+msgstr ""
+
+msgid "**options:** ``[directed, max_cycles, forbidden_vertices]``"
+msgstr ""
+
+msgid "Linear contraction on an undirected graph."
+msgstr ""
+
+msgid ""
+"The green nodes are linear nodes and will not be part of the contracted "
+"graph."
+msgstr ""
+
+msgid "All edges adjacent will not be part of the contracted graph."
+msgstr ""
+
+msgid "The red lines will be new edges of the contracted graph."
+msgstr ""
+
+msgid "**contraction Order**"
+msgstr ""
+
+msgid ""
+"Number of times the contraction operations on ``contraction_order`` will be "
+"performed."
+msgstr ""
+
+msgid "A node connects two (or more) `linear` edges when"
+msgstr ""
+
+msgid "The number of adjacent vertices is 2."
+msgstr ""
+
+msgid "In case of a directed graph, a node is considered a `linear` node when"
+msgstr ""
+
+msgid "Linearity is symmetrical."
+msgstr ""
+
+msgid "Linearity is not symmetrical"
+msgstr ""
+
+msgid "Graph where linearity is not symmetrical."
+msgstr ""
+
+msgid ""
+"When the graph is processed as a directed graph, linearity is not "
+"symmetrical, therefore the graph can not be contracted."
+msgstr ""
+
+msgid ""
+"When the same graph is processed as an undirected graph, linearity is "
+"symmetrical, therefore the graph can be contracted."
+msgstr ""
+
+msgid "The three edges can be replaced by one undirected edge"
+msgstr ""
+
+msgid "Edge :math:`1 - 3`."
+msgstr ""
+
+msgid "With cost: :math:`4`."
+msgstr ""
+
+msgid "Contracted vertices in the edge: :math:`\\{2\\}`."
+msgstr ""
+
+msgid "Linearity is symmetrical"
+msgstr ""
+
+msgid "Graph where linearity is symmetrical."
+msgstr ""
+
+msgid "The four edges can be replaced by two directed edges."
+msgstr ""
+
+msgid "Edge :math:`3 - 1`."
+msgstr ""
+
+msgid "With cost: :math:`6`."
+msgstr ""
+
+msgid "The four edges can be replaced by one undirected edge."
+msgstr ""
+
+msgid "Step by step linear contraction"
+msgstr ""
+
+msgid ""
+"The linear contraction will stop when there are no more linear edges. For "
+"example from the following graph there are linear edges"
+msgstr ""
+
+msgid "Contracting vertex :math:`3`,"
+msgstr ""
+
+msgid "The vertex :math:`3` is removed from the graph"
+msgstr ""
+
+msgid ""
+"The edges :math:`2 \\rightarrow 3` and :math:`w \\rightarrow z` are removed "
+"from the graph."
+msgstr ""
+
+msgid ""
+"A new edge :math:`2 \\rightarrow 4` is inserted represented with red color."
+msgstr ""
+
+msgid "Contracting vertex :math:`2`:"
+msgstr ""
+
+msgid "The vertex :math:`2` is removed from the graph"
+msgstr ""
+
+msgid ""
+"The edges :math:`1 \\rightarrow 2` and :math:`2 \\rightarrow 3` are removed "
+"from the graph."
+msgstr ""
+
+msgid ""
+"A new edge :math:`1 \\rightarrow 3` is inserted represented with red color."
+msgstr ""
+
+msgid ""
+"Edge :math:`1 \\rightarrow 3` has the information of cost and the nodes that "
+"were contracted."
+msgstr ""
+
+msgid "Create the contracted graph."
+msgstr ""
+
+msgid "``pgr_createTopology``"
 msgstr ""
 
 msgid ""
@@ -10067,10 +10024,7 @@ msgid ""
 "to the rest of the edges."
 msgstr ""
 
-msgid "The example uses the :doc:`sampledata` network."
-msgstr ""
-
-msgid "pgr_createVerticesTable"
+msgid "``pgr_createVerticesTable``"
 msgstr ""
 
 msgid ""
@@ -10286,7 +10240,7 @@ msgid ""
 "Cuthill%E2%80%93McKee_algorithm>`__"
 msgstr ""
 
-msgid "pgr_dagShortestPath - Experimental"
+msgid "``pgr_dagShortestPath`` - Experimental"
 msgstr ""
 
 msgid ""
@@ -10365,10 +10319,15 @@ msgstr ""
 msgid "Making **start_vids** the same as **end_vids**"
 msgstr ""
 
+msgid ""
+"`Boost: DAG shortest paths <https://www.boost.org/libs/graph/doc/"
+"dag_shortest_paths.html>`__"
+msgstr ""
+
 msgid "https://en.wikipedia.org/wiki/Topological_sorting"
 msgstr ""
 
-msgid "``pgr_degree`` -- Proposed"
+msgid "``pgr_degree``"
 msgstr ""
 
 msgid ""
@@ -10376,7 +10335,47 @@ msgid ""
 "edges incident to the vertex."
 msgstr ""
 
-msgid "Calculates the degree of the vertices of an **undirected** graph"
+msgid "Error messages adjustment."
+msgstr ""
+
+msgid "New signature with only Edges SQL."
+msgstr ""
+
+msgid "Calculates the degree of the vertices of an undirected graph"
+msgstr ""
+
+msgid ""
+"The degree (or valency) of a vertex of a graph is the number of edges that "
+"are incident to the vertex."
+msgstr ""
+
+msgid "A loop contributes 2 to a vertex's degree."
+msgstr ""
+
+msgid "A vertex with degree 0 is called an isolated vertex."
+msgstr ""
+
+msgid "Isolated vertex is not part of the result"
+msgstr ""
+
+msgid ""
+"Vertex not participating on the subgraph is considered and isolated vertex."
+msgstr ""
+
+msgid ""
+"There can be a ``dryrun`` execution and the code used to get the answer will "
+"be shown in a PostgreSQL ``NOTICE``."
+msgstr ""
+
+msgid ""
+"The code can be used as base code for the particular application "
+"requirements."
+msgstr ""
+
+msgid "No ordering is performed."
+msgstr ""
+
+msgid "pgr_degree(`Edges SQL`_ , [``dryrun``])"
 msgstr ""
 
 msgid "pgr_degree(`Edges SQL`_ , `Vertex SQL`_, [``dryrun``])"
@@ -10385,14 +10384,30 @@ msgstr ""
 msgid "RETURNS SETOF |result-degree|"
 msgstr ""
 
+msgid "Edges"
+msgstr ""
+
+msgid "example"
+msgstr ""
+
+msgid "Get the degree of the vertices defined on the edges table"
+msgstr ""
+
+msgid "Edges and Vertices"
+msgstr ""
+
 msgid "Extracting the vertex information"
 msgstr ""
 
+msgid "``pgr_degree`` can use :doc:`pgr_extractVertices` embedded in the call."
+msgstr ""
+
 msgid ""
-"pgr_degree can utilize output from `pgr_extractVertices` or can have "
-"`pgr_extractVertices` embedded in the call. For decent size networks, it is "
-"best to prep your vertices table before hand and use that vertices table for "
-"pgr_degree calls."
+"For decent size networks, it is best to prepare your vertices table before "
+"hand and use it on ``pgr_degree`` calls. (See `Using a vertex table`_)"
+msgstr ""
+
+msgid "Calculate the degree of the nodes:"
 msgstr ""
 
 msgid "`Vertex SQL`_"
@@ -10407,13 +10422,16 @@ msgstr ""
 msgid "When true do not process and get in a NOTICE the resulting query."
 msgstr ""
 
+msgid "For the `Edges and Vertices`_ signature:"
+msgstr ""
+
+msgid "For the `Edges`_ signature:"
+msgstr ""
+
 msgid "Vertex SQL"
 msgstr ""
 
 msgid "``in_edges``"
-msgstr ""
-
-msgid "``BIGINT[]``"
 msgstr ""
 
 msgid ""
@@ -10444,7 +10462,45 @@ msgstr ""
 msgid "Number of edges that are incident to the vertex ``id``"
 msgstr ""
 
+msgid "Degree of a loop"
+msgstr ""
+
+msgid "Using the `Edges`_ signature."
+msgstr ""
+
+msgid "Using the `Edges and Vertices`_ signature."
+msgstr ""
+
 msgid "Degree of a sub graph"
+msgstr ""
+
+msgid "For the following is a subgraph of the :doc:`sampledata`:"
+msgstr ""
+
+msgid ":math:`E = \\{(1, 5 \\leftrightarrow 6), (1, 6 \\leftrightarrow 10)\\}`"
+msgstr ""
+
+msgid ":math:`V = \\{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17\\}`"
+msgstr ""
+
+msgid "The vertices not participating on the edge are considered isolated"
+msgstr ""
+
+msgid "their degree is 0 in the subgraph and"
+msgstr ""
+
+msgid "their degree is not shown in the output."
+msgstr ""
+
+msgid "Using a vertex table"
+msgstr ""
+
+msgid ""
+"For decent size networks, it is best to prepare your vertices table before "
+"hand and use it on ``pgr_degree`` calls."
+msgstr ""
+
+msgid "Extract the vertex information and save into a table:"
 msgstr ""
 
 msgid "Dry run execution"
@@ -10460,13 +10516,27 @@ msgid ""
 "backend development needs."
 msgstr ""
 
-msgid "Degree from an existing table"
+msgid "Finding dead ends"
 msgstr ""
 
 msgid ""
-"If you have a vertices table already built using ``pgr_extractVertices`` and "
-"want the degree of the whole graph rather than a subset, you can forgo using "
-"pgr_degree and work with the ``in_edges`` and ``out_edges`` columns directly."
+"If there is a vertices table already built using ``pgr_extractVertices`` and "
+"want the degree of the whole graph rather than a subset, it can be forgo "
+"using ``pgr_degree`` and work with the ``in_edges`` and ``out_edges`` "
+"columns directly."
+msgstr ""
+
+msgid "The degree of a dead end is 1."
+msgstr ""
+
+msgid "Finding linear vertices"
+msgstr ""
+
+msgid "The degree of a linear vertex is 2."
+msgstr ""
+
+msgid ""
+"If there is a vertices table already built using the ``pgr_extractVertices``"
 msgstr ""
 
 msgid ":doc:`pgr_extractVertices`"
@@ -10481,15 +10551,6 @@ msgid ""
 msgstr ""
 
 msgid "Version 3.3.0"
-msgstr ""
-
-msgid "Promoted to **proposed** function"
-msgstr ""
-
-msgid "``pgr_depthFirstSearch`` (`Single Vertex`_)"
-msgstr ""
-
-msgid "``pgr_depthFirstSearch`` (`Multiple Vertices`_)"
 msgstr ""
 
 msgid ""
@@ -10545,13 +10606,13 @@ msgid "Same as `Single vertex`_ but with edges in descending order of ``id``."
 msgstr ""
 
 msgid ""
-"`Boost: Depth First Search algorithm documentation <https://www.boost.org/"
-"libs/graph/doc/depth_first_search.html>`__"
+"`Boost: Depth First Search <https://www.boost.org/libs/graph/doc/"
+"depth_first_search.html>`__"
 msgstr ""
 
 msgid ""
-"`Boost: Undirected DFS algorithm documentation <https://www.boost.org/libs/"
-"graph/doc/undirected_dfs.html>`__"
+"`Boost: Undirected DFS <https://www.boost.org/libs/graph/doc/undirected_dfs."
+"html>`__"
 msgstr ""
 
 msgid ""
@@ -10568,44 +10629,31 @@ msgstr ""
 msgid "Version 3.5.0"
 msgstr ""
 
-msgid ""
-"``pgr_dijkstra`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
+msgid "pgr_dijkstra(One to One) added ``start_vid`` and ``end_vid`` columns."
 msgstr ""
 
-msgid "``pgr_dijkstra`` (`One to Many`_) added ``end_vid`` column."
+msgid "pgr_dijkstra(One to Many) added ``end_vid`` column."
 msgstr ""
 
-msgid "``pgr_dijkstra`` (`Many to One`_) added ``start_vid`` column."
+msgid "pgr_dijkstra(Many to One) added ``start_vid`` column."
 msgstr ""
 
 msgid "Version 3.1.0"
 msgstr ""
 
-msgid "``pgr_dijkstra`` (`Combinations`_)"
-msgstr ""
-
-msgid "**Official** functions"
-msgstr ""
-
 msgid "Version 2.2.0"
 msgstr ""
 
-msgid "New **proposed** functions:"
+msgid "pgr_dijkstra(One to Many)"
 msgstr ""
 
-msgid "``pgr_dijkstra`` (`One to Many`_)"
+msgid "pgr_dijkstra(Many to One)"
 msgstr ""
 
-msgid "``pgr_dijkstra`` (`Many to One`_)"
+msgid "pgr_dijkstra(Many to Many)"
 msgstr ""
 
-msgid "``pgr_dijkstra`` (`Many to Many`_)"
-msgstr ""
-
-msgid "Signature change on ``pgr_dijkstra`` (`One to One`_)"
-msgstr ""
-
-msgid "**Official** ``pgr_dijkstra`` (`One to One`_)"
+msgid "Signature change on pgr_dijkstra(One to One)"
 msgstr ""
 
 msgid "pgr_dijkstra(`Edges SQL`_, **start vid**, **end vid**, [``directed``])"
@@ -10791,6 +10839,11 @@ msgstr ""
 msgid "37) Using `Combinations`_"
 msgstr ""
 
+msgid ""
+"`Boost: Dijkstra shortest paths <https://www.boost.org/libs/graph/doc/"
+"dijkstra_shortest_paths.html>`__"
+msgstr ""
+
 msgid "https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm"
 msgstr ""
 
@@ -10800,9 +10853,6 @@ msgstr ""
 msgid ""
 "``pgr_dijkstraCost`` - Total cost of the shortest path using Dijkstra "
 "algorithm."
-msgstr ""
-
-msgid "``pgr_dijkstraCost`` (`Combinations`_)"
 msgstr ""
 
 msgid ""
@@ -11090,9 +11140,6 @@ msgstr ""
 msgid "When ``false``: ``cap`` limit per ``Start vid`` will be returned"
 msgstr ""
 
-msgid "boost: https://www.boost.org/libs/graph/doc/table_of_contents.html"
-msgstr ""
-
 msgid "Wikipedia: https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm"
 msgstr ""
 
@@ -11259,6 +11306,9 @@ msgid ""
 "``pgr_drivingDistance`` - Returns the driving distance from a start node."
 msgstr ""
 
+msgid "Standarizing output columns to |result-spantree|"
+msgstr ""
+
 msgid "Added ``depth`` and ``start_vid`` result columns."
 msgstr ""
 
@@ -11268,13 +11318,16 @@ msgstr ""
 msgid "Added ``depth`` and ``pred`` result columns."
 msgstr ""
 
-msgid "Signature change pgr_drivingDistance(single vertex)"
+msgid "Signature change:"
 msgstr ""
 
-msgid "New **Official** pgr_drivingDistance(multiple vertices)"
+msgid "pgr_drivingDistance(single vertex)"
 msgstr ""
 
-msgid "Official:: pgr_drivingDistance(single vertex)"
+msgid "New official signature:"
+msgstr ""
+
+msgid "pgr_drivingDistance(multiple vertices)"
 msgstr ""
 
 msgid ""
@@ -11329,7 +11382,7 @@ msgid ""
 "undirected graph"
 msgstr ""
 
-msgid "pgr_edgeColoring - Experimental"
+msgid "``pgr_edgeColoring`` - Experimental"
 msgstr ""
 
 msgid ""
@@ -11403,15 +11456,21 @@ msgstr ""
 msgid "Graph coloring of pgRouting :doc:`sampledata`"
 msgstr ""
 
+msgid ""
+"`Boost: Edge Coloring <https://www.boost.org/libs/graph/doc/edge_coloring."
+"html>`__"
+msgstr ""
+
+msgid ""
+"`Wikipedia: Graph coloring <https://en.wikipedia.org/wiki/Graph_coloring>`__"
+msgstr ""
+
 msgid "``pgr_edgeDisjointPaths``"
 msgstr ""
 
 msgid ""
 "``pgr_edgeDisjointPaths`` — Calculates edge disjoint paths between two "
 "groups of vertices."
-msgstr ""
-
-msgid "New **proposed** function:"
 msgstr ""
 
 msgid "pgr_edgeDisjointPaths(Combinations)"
@@ -11495,9 +11554,6 @@ msgid ""
 "the flow from the sources to the targets using Edmonds Karp Algorithm."
 msgstr ""
 
-msgid "``pgr_edmondsKarp`` (`Combinations`_)"
-msgstr ""
-
 msgid "Renamed from ``pgr_maxFlowEdmondsKarp``"
 msgstr ""
 
@@ -11519,32 +11575,22 @@ msgstr ""
 msgid "pgr_edmondsKarp(`Edges SQL`_, `Combinations SQL`_)"
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/edmonds_karp_max_flow.html"
+msgid ""
+"`Boost: Edmonds Karp max flow <https://www.boost.org/libs/graph/doc/"
+"edmonds_karp_max_flow.html>`__"
 msgstr ""
 
 msgid "https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm"
 msgstr ""
 
-msgid "``pgr_edwardMoore - Experimental``"
+msgid "``pgr_edwardMoore`` - Experimental"
 msgstr ""
 
 msgid ""
 "``pgr_edwardMoore`` — Returns the shortest path using Edward-Moore algorithm."
 msgstr ""
 
-msgid "``pgr_edwardMoore`` (`Combinations`_)"
-msgstr ""
-
-msgid "``pgr_edwardMoore`` (`One to One`_)"
-msgstr ""
-
-msgid "``pgr_edwardMoore`` (`One to Many`_)"
-msgstr ""
-
-msgid "``pgr_edwardMoore`` (`Many to One`_)"
-msgstr ""
-
-msgid "``pgr_edwardMoore`` (`Many to Many`_)"
+msgid "pgr_edwardMoore(Combinations)"
 msgstr ""
 
 msgid ""
@@ -11606,13 +11652,10 @@ msgstr ""
 msgid "https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm"
 msgstr ""
 
-msgid "pgr_extractVertices -- Proposed"
+msgid "``pgr_extractVertices``"
 msgstr ""
 
 msgid "``pgr_extractVertices`` — Extracts the vertices information"
-msgstr ""
-
-msgid "Classified as **proposed** function"
 msgstr ""
 
 msgid ""
@@ -11713,13 +11756,7 @@ msgstr ""
 msgid "``pgr_findCloseEdges`` - Finds the close edges to a point geometry."
 msgstr ""
 
-msgid "New **proposed** signatures:"
-msgstr ""
-
-msgid "``pgr_findCloseEdges`` (`One point`_)"
-msgstr ""
-
-msgid "``pgr_findCloseEdges`` (`Many points`_)"
+msgid "``partial`` option is removed."
 msgstr ""
 
 msgid ""
@@ -11736,7 +11773,7 @@ msgid ""
 "adjustments needed by the application."
 msgstr ""
 
-msgid "``EMTPY SET`` is returned on dryrun executions"
+msgid "``EMPTY SET`` is returned on dryrun executions"
 msgstr ""
 
 msgid ""
@@ -11747,7 +11784,7 @@ msgid ""
 "pgr_findCloseEdges(`Edges SQL`_, **points**, **tolerance**, [**options**])"
 msgstr ""
 
-msgid "**options:** ``[cap, partial, dryrun]``"
+msgid "**options:** ``[cap, dryrun]``"
 msgstr ""
 
 msgid "Returns set of |result-find|"
@@ -11756,52 +11793,16 @@ msgstr ""
 msgid "One point"
 msgstr ""
 
-msgid "Default: ``cap => 1``"
+msgid "Get two close edges to points of interest with :math:`pid = 5`"
 msgstr ""
 
-msgid "Maximum one row answer."
-msgstr ""
-
-msgid "Default: ``partial => true``"
-msgstr ""
-
-msgid "With less calculations as possible."
-msgstr ""
-
-msgid "Default: ``dryrun => false``"
-msgstr ""
-
-msgid "Process query"
-msgstr ""
-
-msgid "Returns"
-msgstr ""
-
-msgid "values on ``edge_id``, ``fraction``, ``side`` columns."
-msgstr ""
-
-msgid "``NULL`` on ``distance``, ``geom``, ``edge`` columns."
+msgid "``cap => 2``"
 msgstr ""
 
 msgid "Many points"
 msgstr ""
 
-msgid ""
-"Find at most :math:`2` edges close to all vertices on the points of interest "
-"table."
-msgstr ""
-
-msgid "One answer per point, as small as possible."
-msgstr ""
-
-msgid ""
-"Columns ``edge_id``, ``fraction``, ``side`` and ``geom`` are returned with "
-"values."
-msgstr ""
-
-msgid ""
-"``geom`` contains the original point geometry to assist on deterpartialing "
-"to which point geometry the row belongs to."
+msgid "For each points of interests, find the closest edge."
 msgstr ""
 
 msgid "**point**"
@@ -11828,17 +11829,6 @@ msgstr ""
 msgid "Limit output rows"
 msgstr ""
 
-msgid "``partial``"
-msgstr ""
-
-msgid ""
-"When ``true`` only columns needed for :doc:`withPoints-category` are "
-"calculated."
-msgstr ""
-
-msgid "When ``false`` all columns are calculated"
-msgstr ""
-
 msgid "When ``false`` calculations are performed."
 msgstr ""
 
@@ -11854,63 +11844,74 @@ msgid "When :math:`cap = 1`, it is the closest edge."
 msgstr ""
 
 msgid ""
-"Value in <0,1> that indicates the relative postition from the first end-"
-"point of the edge."
+"Value in <0,1> that indicates the relative position from the first end-point "
+"of the edge."
 msgstr ""
 
 msgid "Value in ``[r, l]`` indicating if the point is:"
 msgstr ""
 
-msgid "In the right ``r``."
-msgstr ""
-
-msgid "In the left ``l``."
+msgid "At the right ``r`` of the segment."
 msgstr ""
 
 msgid "When the point is on the line it is considered to be on the right."
 msgstr ""
 
+msgid "At the left ``l`` of the segment."
+msgstr ""
+
 msgid "``distance``"
 msgstr ""
 
-msgid "Distance from point to edge."
+msgid "Distance from the point to the edge."
 msgstr ""
 
-msgid "``NULL`` when ``cap = 1`` on the `One point`_ signature"
-msgstr ""
-
-msgid "``POINT`` geometry"
+msgid "Original ``POINT`` geometry."
 msgstr ""
 
 msgid ""
-"`One Point`_: Contains the point on the edge that is ``fraction`` away from "
-"the starting point of the edge."
+"``LINESTRING`` geometry that connects the original **point** to the closest "
+"point of the edge with identifier ``edge_id``"
 msgstr ""
 
-msgid "`Many Points`_: Contains the corresponding **original point**"
+msgid "One point in an edge"
 msgstr ""
 
-msgid ""
-"``LINESTRING`` geometry from the **original point** to the closest point of "
-"the edge with identifier ``edge_id``"
+msgid "The green node is the original point."
 msgstr ""
 
-msgid "One point results"
-msgstr ""
-
-msgid "The green nodes is the **original point**"
+msgid "``geom`` has the value of the original point."
 msgstr ""
 
 msgid ""
-"The geometry ``geom`` is a point on the :math:`sp \\rightarrow ep` edge."
+"The geometry ``edge`` is a line that connects the original point with the "
+"edge :math:`sp \\rightarrow ep` edge."
+msgstr ""
+
+msgid "The point is located at the left of the edge."
+msgstr ""
+
+msgid "One point dry run execution"
+msgstr ""
+
+msgid "Using the query from the previous example:"
+msgstr ""
+
+msgid "Returns ``EMPTY SET``."
+msgstr ""
+
+msgid "``dryrun => true``"
+msgstr ""
+
+msgid "Generates a PostgreSQL ``NOTICE`` with the code used."
 msgstr ""
 
 msgid ""
-"The geometry ``edge`` is a line that connects the **original point** with "
-"``geom``"
+"The generated code can be used as a starting base code for additional "
+"requirements, like taking into consideration the SRID."
 msgstr ""
 
-msgid "Many point results"
+msgid "Many points in an edge"
 msgstr ""
 
 msgid "The green nodes are the **original points**"
@@ -11927,130 +11928,7 @@ msgid ""
 "\\rightarrow ep` edge."
 msgstr ""
 
-msgid "One point examples"
-msgstr ""
-
-msgid "At most two answers"
-msgstr ""
-
-msgid "``cap => 2``"
-msgstr ""
-
-msgid "Maximum two row answer."
-msgstr ""
-
-msgid "Understanding the result"
-msgstr ""
-
-msgid "``NULL`` on ``geom``, ``edge``"
-msgstr ""
-
-msgid "``edge_id`` identifier of the edge close to the **original point**"
-msgstr ""
-
-msgid ""
-"Two edges are withing :math:`0.5` distance units from the **original "
-"point**: :math:`{5, 8}`"
-msgstr ""
-
-msgid "For edge :math:`5`:"
-msgstr ""
-
-msgid ""
-"``fraction``: The closest point from the **original point** is at the :math:"
-"`0.8` fraction of the edge :math:`5`."
-msgstr ""
-
-msgid ""
-"``side``: The **original point** is located to the left side of edge :math:"
-"`5`."
-msgstr ""
-
-msgid ""
-"``distance``: The **original point** is located :math:`0.1` length units "
-"from edge :math:`5`."
-msgstr ""
-
-msgid "For edge :math:`8`:"
-msgstr ""
-
-msgid ""
-"``fraction``: The closest point from the **original point** is at the :math:"
-"`0.89..` fraction of the edge :math:`8`."
-msgstr ""
-
-msgid ""
-"``side``: The **original point** is located to the right side of edge :math:"
-"`8`."
-msgstr ""
-
-msgid ""
-"``distance``: The **original point** is located :math:`0.19..` length units "
-"from edge :math:`8`."
-msgstr ""
-
-msgid "One answer, all columns"
-msgstr ""
-
-msgid "``partial => false``"
-msgstr ""
-
-msgid "Calculate all columns"
-msgstr ""
-
-msgid ""
-"``edge_id`` identifier of the edge **closest** to the **original point**"
-msgstr ""
-
-msgid ""
-"From all edges within :math:`0.5` distance units from the **original "
-"point**: :math:`{5}` is the closest one."
-msgstr ""
-
-msgid ""
-"``geom``: Contains the geometry of the closest point on edge :math:`5` from "
-"the **original point**."
-msgstr ""
-
-msgid ""
-"``edge``: Contains the ``LINESTRING`` geometry of the **original point** to "
-"the closest point on on edge :math:`5` ``geom``"
-msgstr ""
-
-msgid "At most two answers with all columns"
-msgstr ""
-
-msgid "Understanding the result:"
-msgstr ""
-
-msgid ""
-"``geom``: Contains the geometry of the closest point on edge :math:`8` from "
-"the **original point**."
-msgstr ""
-
-msgid ""
-"``edge``: Contains the ``LINESTRING`` geometry of the **original point** to "
-"the closest point on on edge :math:`8` ``geom``"
-msgstr ""
-
-msgid "One point dry run execution"
-msgstr ""
-
-msgid "Returns ``EMPTY SET``."
-msgstr ""
-
-msgid "``partial => true``"
-msgstr ""
-
-msgid "Is ignored"
-msgstr ""
-
-msgid ""
-"Because it is a **dry run** excecution, the code for all calculations are "
-"shown on the PostgreSQL ``NOTICE``."
-msgstr ""
-
-msgid "``dryrun => true``"
+msgid "Many points dry run execution"
 msgstr ""
 
 msgid "Do not process query"
@@ -12058,62 +11936,6 @@ msgstr ""
 
 msgid ""
 "Generate a PostgreSQL ``NOTICE`` with the code used to calculate all columns"
-msgstr ""
-
-msgid "``cap`` and **original point** are used in the code"
-msgstr ""
-
-msgid "Many points examples"
-msgstr ""
-
-msgid "At most two answers per point"
-msgstr ""
-
-msgid "``NULL`` on ``edge``"
-msgstr ""
-
-msgid ""
-"``edge_id`` identifier of the edge close to a **original point** (``geom``)"
-msgstr ""
-
-msgid ""
-"Two edges at most withing :math:`0.5` distance units from each of the "
-"**original points**:"
-msgstr ""
-
-msgid "For ``POINT(1.8 0.4)`` and ``POINT(0.3 1.8)`` only one edge was found."
-msgstr ""
-
-msgid "For the rest of the points two edges were found."
-msgstr ""
-
-msgid "For point ``POINT(2.9 1.8)``"
-msgstr ""
-
-msgid ""
-"Edge :math:`5` is before :math:`8` therefore edge :math:`5` has the shortest "
-"distance to ``POINT(2.9 1.8)``."
-msgstr ""
-
-msgid "One answer per point, all columns"
-msgstr ""
-
-msgid "For the **original point** ``POINT(2.9 1.8)``"
-msgstr ""
-
-msgid "Edge :math:`5` is the closest edge to the **original point**"
-msgstr ""
-
-msgid ""
-"``geom``: Contains the geometry of the **original point** ``POINT(2.9 1.8)``"
-msgstr ""
-
-msgid ""
-"``edge``: Contains the ``LINESTRING`` geometry of the **original point** "
-"(``geom``) to the closest point on on edge."
-msgstr ""
-
-msgid "Many points dry run execution"
 msgstr ""
 
 msgid "Find at most two routes to a given point"
@@ -12150,11 +11972,10 @@ msgstr ""
 msgid "A unique identifier."
 msgstr ""
 
-msgid ""
-"Identifier of the edge nearest edge that allows an arrival to the point."
+msgid "Identifier of the nearest segment."
 msgstr ""
 
-msgid "Is it on the left, right or both sides of the segment ``edge_id``"
+msgid "Is it on the left, right or both sides of the segment ``edge_id``."
 msgstr ""
 
 msgid "Where in the segment is the point located."
@@ -12163,13 +11984,35 @@ msgstr ""
 msgid "The geometry of the points."
 msgstr ""
 
+msgid "The distance between ``geom`` and the segment ``edge_id``."
+msgstr ""
+
+msgid ""
+"A segment that connects the ``geom`` of the point to the closest point on "
+"the segment ``edge_id``."
+msgstr ""
+
 msgid "``newPoint``"
 msgstr ""
 
-msgid "The geometry of the points moved on top of the segment."
+msgid "A point on segment ``edge_id`` that is the closest to ``geom``."
 msgstr ""
 
-msgid "Points of interest fillup"
+msgid "Points of interest fill up"
+msgstr ""
+
+msgid "Inserting the points of interest."
+msgstr ""
+
+msgid "Filling the rest of the table."
+msgstr ""
+
+msgid ""
+"Any other additional modification: In this manual, point :math:`6` can be "
+"reached from both sides."
+msgstr ""
+
+msgid "The points of interest:"
 msgstr ""
 
 msgid "``pgr_floydWarshall``"
@@ -12198,17 +12041,11 @@ msgid ""
 "floyd_warshall_shortest.html>`_"
 msgstr ""
 
-msgid "Queries uses the :doc:`sampledata` network."
-msgstr ""
-
 msgid "``pgr_full_version``"
 msgstr ""
 
 msgid ""
 "``pgr_full_version`` — Get the details of pgRouting version information."
-msgstr ""
-
-msgid "New **official** function"
 msgstr ""
 
 msgid "Get complete details of pgRouting version information"
@@ -12277,15 +12114,12 @@ msgstr ""
 msgid "Git hash of pgRouting build"
 msgstr ""
 
-msgid "``pgr_hawickCircuits - Experimental``"
+msgid "``pgr_hawickCircuits`` - Experimental"
 msgstr ""
 
 msgid ""
-"``pgr_hawickCircuits`` — Returns the list of cirucits using hawick circuits "
+"``pgr_hawickCircuits`` — Returns the list of ciruits using hawick circuits "
 "algorithm."
-msgstr ""
-
-msgid "``pgr_hawickCircuits``"
 msgstr ""
 
 msgid ""
@@ -12410,7 +12244,9 @@ msgid ""
 "blue represent :math:`K_5` subgraph."
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/boyer_myrvold.html"
+msgid ""
+"`Boost: Boyer Myrvold <https://www.boost.org/libs/graph/doc/boyer_myrvold."
+"html>`__"
 msgstr ""
 
 msgid "``pgr_johnson``"
@@ -12463,6 +12299,9 @@ msgstr ""
 msgid ""
 "``pgr_kruskalBFS`` — Kruskal's algorithm for Minimum Spanning Tree with "
 "breadth First Search ordering."
+msgstr ""
+
+msgid "Added ``pred`` result columns."
 msgstr ""
 
 msgid ""
@@ -12540,7 +12379,7 @@ msgstr ""
 msgid "pgr_kruskalDFS(`Edges SQL`_, **root vids**, [``max_depth``])"
 msgstr ""
 
-msgid "pgr_lengauerTarjanDominatorTree -Experimental"
+msgid "``pgr_lengauerTarjanDominatorTree`` - Experimental"
 msgstr ""
 
 msgid ""
@@ -12598,8 +12437,8 @@ msgid "Dominator tree of another component."
 msgstr ""
 
 msgid ""
-"`Boost: Lengauer-Tarjan dominator tree algorithm <https://www.boost.org/libs/"
-"graph/doc/lengauer_tarjan_dominator.htm>`__"
+"`Boost: Lengauer-Tarjan dominator <https://www.boost.org/libs/graph/doc/"
+"lengauer_tarjan_dominator.htm>`__"
 msgstr ""
 
 msgid ""
@@ -12607,12 +12446,15 @@ msgid ""
 "Dominator_(graph_theory)>`__"
 msgstr ""
 
-msgid "pgr_lineGraph - Proposed"
+msgid "``pgr_lineGraph`` - Proposed"
 msgstr ""
 
 msgid ""
 "``pgr_lineGraph`` — Transforms the given graph into its corresponding edge-"
 "based graph."
+msgstr ""
+
+msgid "Works for directed and undirected graphs."
 msgstr ""
 
 msgid ""
@@ -12658,13 +12500,7 @@ msgstr ""
 msgid "Gives a local identifier for the edge"
 msgstr ""
 
-msgid "Identifier of the source vertex of the current edge."
-msgstr ""
-
 msgid "When `negative`: the source is the reverse edge in the original graph."
-msgstr ""
-
-msgid "Identifier of the target vertex of the current edge."
 msgstr ""
 
 msgid "When `negative`: the target is the reverse edge in the original graph."
@@ -12875,8 +12711,7 @@ msgid "Full line graph of subgraph of edges :math:`\\{4, 7, 8, 10\\}`"
 msgstr ""
 
 msgid ""
-"The examples of this section are based on the :doc:`sampledata` network. The "
-"examples include the subgraph including edges 4, 7, 8, and 10 with "
+"The examples include the subgraph including edges 4, 7, 8, and 10 with "
 "``reverse_cost``."
 msgstr ""
 
@@ -13095,15 +12930,15 @@ msgstr ""
 msgid "Returns set of |result-component-make|"
 msgstr ""
 
+msgid "List of edges that are needed to connect the graph."
+msgstr ""
+
 msgid ""
-"Query done on :doc:`sampledata` network gives the list of edges that are "
-"needed to connect the graph."
+"`Boost: make connected <https://www.boost.org/libs/graph/doc/make_connected."
+"html>`__"
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/make_connected.html"
-msgstr ""
-
-msgid "pgr_maxCardinalityMatch"
+msgid "``pgr_maxCardinalityMatch``"
 msgstr ""
 
 msgid ""
@@ -13111,13 +12946,16 @@ msgid ""
 "graph."
 msgstr ""
 
+msgid "pgr_maxCardinalityMatch(text) returns only ``edge`` column."
+msgstr ""
+
 msgid "Deprecated signature"
 msgstr ""
 
-msgid "``pgr_maxCardinalityMatch(text,boolean)``"
+msgid "pgr_maxCardinalityMatch(text,boolean)"
 msgstr ""
 
-msgid "``directed => false`` when used."
+msgid "directed => ``false`` when used."
 msgstr ""
 
 msgid "Renamed from ``pgr_maximumCardinalityMatching``"
@@ -13168,7 +13006,9 @@ msgstr ""
 msgid "Identifier of the edge in the original query."
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/maximum_matching.html"
+msgid ""
+"`Boost: maximum_matching <https://www.boost.org/libs/graph/doc/"
+"maximum_matching.html>`__"
 msgstr ""
 
 msgid "https://en.wikipedia.org/wiki/Matching_%28graph_theory%29"
@@ -13185,17 +13025,14 @@ msgid ""
 "source(s) to the targets(s) using the Push Relabel algorithm."
 msgstr ""
 
-msgid "``pgr_maxFlow`` (`Combinations`_)"
-msgstr ""
-
-msgid "New **Proposed** function"
-msgstr ""
-
 msgid "Calculates the maximum flow from the sources to the targets."
 msgstr ""
 
 msgid ""
 "When the maximum flow is **0** then there is no flow and **0** is returned."
+msgstr ""
+
+msgid "There is no flow when source has the same vaule as target."
 msgstr ""
 
 msgid "Uses the :doc:`pgr_pushRelabel <pgr_pushRelabel>` algorithm."
@@ -13225,7 +13062,9 @@ msgstr ""
 msgid "Maximum flow possible from the source(s) to the target(s)"
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html"
+msgid ""
+"`Boost: push relabel max flow <https://www.boost.org/libs/graph/doc/"
+"push_relabel_max_flow.html>`__"
 msgstr ""
 
 msgid ""
@@ -13240,7 +13079,10 @@ msgid ""
 "of the maximum flow on a graph"
 msgstr ""
 
-msgid "``pgr_maxFlowMinCost`` (`Combinations`_)"
+msgid "pgr_maxFlowMinCost(Combinations)"
+msgstr ""
+
+msgid "|boost| graph inside."
 msgstr ""
 
 msgid "**TODO** check which statement is true:"
@@ -13284,11 +13126,6 @@ msgstr ""
 msgid "Returns set of |result-flow-mincost|"
 msgstr ""
 
-msgid ""
-"https://www.boost.org/libs/graph/doc/"
-"successive_shortest_path_nonnegative_weights.html"
-msgstr ""
-
 msgid "``pgr_maxFlowMinCost_Cost`` - Experimental"
 msgstr ""
 
@@ -13297,7 +13134,7 @@ msgid ""
 "maximum flow on a graph"
 msgstr ""
 
-msgid "``pgr_maxFlowMinCost_Cost`` (`Combinations`_)"
+msgid "pgr_maxFlowMinCost_Cost(Combinations)"
 msgstr ""
 
 msgid "**The cost value of all input edges must be nonnegative.**"
@@ -13330,7 +13167,7 @@ msgstr ""
 msgid "Minimum Cost Maximum Flow possible from the source(s) to the target(s)"
 msgstr ""
 
-msgid "pgr_nodeNetwork"
+msgid "``pgr_nodeNetwork``"
 msgstr ""
 
 msgid "``pgr_nodeNetwork`` - Nodes an network edge table."
@@ -13758,7 +13595,7 @@ msgid ""
 "projectweb/top/pdptw/li-lim-benchmark/"
 msgstr ""
 
-msgid "There are 25 vehciles in the problem all with the same characteristics."
+msgid "There are 25 vehicles in the problem all with the same characteristics."
 msgstr ""
 
 msgid "The original orders"
@@ -13769,7 +13606,7 @@ msgid ""
 "order."
 msgstr ""
 
-msgid "The original data needs to be converted to an appropiate table:"
+msgid "The original data needs to be converted to an appropriate table:"
 msgstr ""
 
 msgid "The query"
@@ -13868,9 +13705,6 @@ msgid ""
 "the flow from the sources to the targets using Push Relabel Algorithm."
 msgstr ""
 
-msgid "``pgr_pushRelabel`` (`Combinations`_)"
-msgstr ""
-
 msgid "Renamed from ``pgr_maxFlowPushRelabel``"
 msgstr ""
 
@@ -13889,15 +13723,12 @@ msgstr ""
 msgid "pgr_pushRelabel(`Edges SQL`_, `Combinations SQL`_)"
 msgstr ""
 
-msgid "pgr_sequentialVertexColoring - Proposed"
+msgid "``pgr_sequentialVertexColoring`` - Proposed"
 msgstr ""
 
 msgid ""
 "``pgr_sequentialVertexColoring`` — Returns the vertex coloring of an "
 "undirected graph, using greedy approach."
-msgstr ""
-
-msgid "Promoted to **proposed** signature"
 msgstr ""
 
 msgid ""
@@ -13942,7 +13773,12 @@ msgstr ""
 msgid "pgr_sequentialVertexColoring(`Edges SQL`_)"
 msgstr ""
 
-msgid "pgr_stoerWagner - Experimental"
+msgid ""
+"`Boost: Sequential Vertex Coloring <https://www.boost.org/libs/graph/doc/"
+"sequential_vertex_coloring.html>`__"
+msgstr ""
+
+msgid "``pgr_stoerWagner`` - Experimental"
 msgstr ""
 
 msgid "``pgr_stoerWagner`` — The min-cut of graph using stoerWagner algorithm."
@@ -14026,6 +13862,11 @@ msgstr ""
 msgid "Using :doc:`pgr_connectedComponents`"
 msgstr ""
 
+msgid ""
+"`Boost: Stoer Wagner min cut <https://www.boost.org/libs/graph/doc/"
+"stoer_wagner_min_cut.html>`__"
+msgstr ""
+
 msgid "https://en.wikipedia.org/wiki/Stoer%E2%80%93Wagner_algorithm"
 msgstr ""
 
@@ -14055,7 +13896,7 @@ msgid "The strong components of the graph"
 msgstr ""
 
 msgid ""
-"Boost: `Strong components <https://www.boost.org/libs/graph/doc/"
+"`Boost: Strong components <https://www.boost.org/libs/graph/doc/"
 "strong_components.html>`__"
 msgstr ""
 
@@ -14120,6 +13961,11 @@ msgstr ""
 msgid "Graph is not a DAG"
 msgstr ""
 
+msgid ""
+"`Boost: topological sort <https://www.boost.org/libs/graph/doc/"
+"topological_sort.html>`__"
+msgstr ""
+
 msgid "``pgr_transitiveClosure`` - Experimental"
 msgstr ""
 
@@ -14175,56 +14021,51 @@ msgstr ""
 msgid "Identifiers of the vertices that are reachable from vertex v."
 msgstr ""
 
+msgid ""
+"`Boost: transitive closure <https://www.boost.org/libs/graph/doc/"
+"transitive_closure.html>`__"
+msgstr ""
+
 msgid "https://en.wikipedia.org/wiki/Transitive_closure"
 msgstr ""
 
-msgid "pgr_trsp - Proposed"
+msgid "``pgr_trsp``"
 msgstr ""
 
 msgid "``pgr_trsp`` - routing vertices with restrictions."
 msgstr ""
 
-msgid "New proposed signatures"
+msgid "pgr_trsp(One to One)"
 msgstr ""
 
-msgid "``pgr_trsp`` (`One to One`_)"
+msgid "pgr_trsp(One to Many)"
 msgstr ""
 
-msgid "``pgr_trsp`` (`One to Many`_)"
+msgid "pgr_trsp(Many to One)"
 msgstr ""
 
-msgid "``pgr_trsp`` (`Many to One`_)"
+msgid "pgr_trsp(Many to Many)"
 msgstr ""
 
-msgid "``pgr_trsp`` (`Many to Many`_)"
-msgstr ""
-
-msgid "``pgr_trsp`` (`Combinations`_)"
+msgid "pgr_trsp(Combinations)"
 msgstr ""
 
 msgid "Deprecated signatures"
 msgstr ""
 
-msgid "``pgr_trsp(text,integer,integer,boolean,boolean,text)``"
+msgid "pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)"
 msgstr ""
 
-msgid "``pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)``"
-msgstr ""
-
-msgid "``pgr_trspViaVertices(text,anyarray,boolean,boolean,text)``"
-msgstr ""
-
-msgid ""
-"``pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)``"
+msgid "pgr_trspViaVertices(text,anyarray,boolean,boolean,text)"
 msgstr ""
 
 msgid "New prototypes"
 msgstr ""
 
-msgid "``pgr_trspViaVertices``"
+msgid "pgr_trspViaVertices"
 msgstr ""
 
-msgid "``pgr_trspViaEdges``"
+msgid "pgr_trspViaEdges"
 msgstr ""
 
 msgid ""
@@ -14297,17 +14138,11 @@ msgid ""
 "`Deprecated documentation <https://docs.pgrouting.org/3.3/en/pgr_trsp.html>`_"
 msgstr ""
 
-msgid "``pgr_trspVia`` - Proposed"
+msgid "``pgr_trspVia``"
 msgstr ""
 
 msgid ""
 "``pgr_trspVia`` Route that goes through a list of vertices with restrictions."
-msgstr ""
-
-msgid "New proposed function:"
-msgstr ""
-
-msgid "``pgr_trspVia`` (`One Via`_)"
 msgstr ""
 
 msgid ""
@@ -14387,15 +14222,12 @@ msgstr ""
 msgid ":doc:`via-category`"
 msgstr ""
 
-msgid "``pgr_trspVia_withPoints`` - Proposed"
+msgid "``pgr_trspVia_withPoints``"
 msgstr ""
 
 msgid ""
 "``pgr_trspVia_withPoints`` - Route that goes through a list of vertices and/"
 "or points with restrictions."
-msgstr ""
-
-msgid "``pgr_trspVia_withPoints`` (`One Via`_)"
 msgstr ""
 
 msgid ""
@@ -14557,28 +14389,10 @@ msgid ""
 "`pgr_trsp` algorithm. In this case a U turn is been done using the same edge."
 msgstr ""
 
-msgid "pgr_trsp_withPoints - Proposed"
+msgid "``pgr_trsp_withPoints``"
 msgstr ""
 
 msgid "``pgr_trsp_withPoints`` Routing Vertex/Point with restrictions."
-msgstr ""
-
-msgid "New proposed signatures:"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`One to One`_)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`One to Many`_)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`Many to One`_)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`Many to Many`_)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`Combinations`_)"
 msgstr ""
 
 msgid ""
@@ -14689,15 +14503,12 @@ msgid ""
 "`1` on an undirected graph, with details."
 msgstr ""
 
-msgid "pgr_turnRestrictedPath - Experimental"
+msgid "``pgr_turnRestrictedPath`` - Experimental"
 msgstr ""
 
 msgid ""
-"``pgr_turnRestrictedPath`` Using Yen's algorithm Vertex -Vertex routing with "
-"restrictions"
-msgstr ""
-
-msgid "New experimental function"
+"``pgr_turnRestrictedPath`` Using Yen's algorithm Vertex - Vertex routing "
+"with restrictions"
 msgstr ""
 
 msgid ""
@@ -14771,7 +14582,7 @@ msgstr ""
 msgid "pgRouting Version for this documentation"
 msgstr ""
 
-msgid "pgr_vrpOneDepot - Experimental"
+msgid "``pgr_vrpOneDepot`` - Experimental"
 msgstr ""
 
 msgid "**No documentation available**"
@@ -14780,7 +14591,7 @@ msgstr ""
 msgid "**TBD**"
 msgstr ""
 
-msgid "``pgr_withPoints`` - Proposed"
+msgid "``pgr_withPoints``"
 msgstr ""
 
 msgid ""
@@ -14923,7 +14734,7 @@ msgstr ""
 msgid "Passes in front or visits with left side driving."
 msgstr ""
 
-msgid "``pgr_withPointsCost`` - Proposed"
+msgid "``pgr_withPointsCost``"
 msgstr ""
 
 msgid ""
@@ -15067,7 +14878,7 @@ msgstr ""
 msgid "Does not matter driving side driving topology"
 msgstr ""
 
-msgid "``pgr_withPointsCostMatrix`` - proposed"
+msgid "``pgr_withPointsCostMatrix``"
 msgstr ""
 
 msgid ""
@@ -15099,7 +14910,7 @@ msgid ""
 "locations on the graph of point `(2.9, 1.8)`."
 msgstr ""
 
-msgid "``pgr_withPointsDD`` - Proposed"
+msgid "``pgr_withPointsDD``"
 msgstr ""
 
 msgid ""
@@ -15112,7 +14923,10 @@ msgid ""
 "unnamed compulsory **driving side**."
 msgstr ""
 
-msgid "``pgr_withPointsDD`` (`Single vertex`)"
+msgid "pgr_withPointsDD(Single vertex)"
+msgstr ""
+
+msgid "pgr_withPointsDD(Multiple vertices)"
 msgstr ""
 
 msgid "Added ``depth``, ``pred`` and ``start_vid`` column."
@@ -15130,13 +14944,12 @@ msgid ""
 msgstr ""
 
 msgid ""
-"``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,"
-"boolean)``"
+"pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)"
 msgstr ""
 
 msgid ""
-"``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
-"boolean,boolean)``"
+"pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
+"boolean,boolean)"
 msgstr ""
 
 msgid ""
@@ -15243,7 +15056,7 @@ msgstr ""
 msgid ":doc:`pgr_alphaShape`"
 msgstr ""
 
-msgid "pgr_withPointsKSP - Proposed"
+msgid "``pgr_withPointsKSP``"
 msgstr ""
 
 msgid ""
@@ -15253,26 +15066,23 @@ msgstr ""
 msgid "Standarizing output columns to |nksp-result|"
 msgstr ""
 
-msgid "``pgr_withPointsKSP`` (One to One)"
+msgid "pgr_withPointsKSP(One to One)"
 msgstr ""
 
-msgid "New overload functions"
+msgid "pgr_withPointsKSP(One to Many)"
 msgstr ""
 
-msgid "``pgr_withPointsKSP`` (One to Many)"
+msgid "pgr_withPointsKSP(Many to One)"
 msgstr ""
 
-msgid "``pgr_withPointsKSP`` (Many to One)"
+msgid "pgr_withPointsKSP(Many to Many)"
 msgstr ""
 
-msgid "``pgr_withPointsKSP`` (Many to Many)"
-msgstr ""
-
-msgid "``pgr_withPointsKSP`` (Combinations)"
+msgid "pgr_withPointsKSP(Combinations)"
 msgstr ""
 
 msgid ""
-"``pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
+"pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
 "boolean)``"
 msgstr ""
 
@@ -15388,15 +15198,12 @@ msgid ""
 "to point :math:`2` with heap paths and details."
 msgstr ""
 
-msgid "``pgr_withPointsVia`` - Proposed"
+msgid "``pgr_withPointsVia``"
 msgstr ""
 
 msgid ""
 "``pgr_withPointsVia`` - Route that goes through a list of vertices and/or "
 "points."
-msgstr ""
-
-msgid "New **proposed** function ``pgr_withPointsVia`` (`One Via`_)"
 msgstr ""
 
 msgid ""
@@ -15481,42 +15288,14 @@ msgstr ""
 msgid ":doc:`pgr_withPointsVia` - Via routing"
 msgstr ""
 
-msgid "These proposed functions do not modify the database."
-msgstr ""
-
-msgid ""
-":doc:`pgr_degree` - Returns a set of vertices and corresponding count of "
-"incidet edges to the vertex."
-msgstr ""
-
-msgid ""
-":doc:`pgr_extractVertices` - Extracts vertex information based on the edge "
-"table information."
-msgstr ""
-
 msgid ""
 ":doc:`pgr_lineGraph` - Transformation algorithm for generating a Line Graph."
-msgstr ""
-
-msgid ":doc:`pgr_withPointsVia`"
-msgstr ""
-
-msgid ":doc:`pgr_trspVia`"
-msgstr ""
-
-msgid ":doc:`pgr_trspVia_withPoints`"
 msgstr ""
 
 msgid ":doc:`withPoints-family` - Functions based on Dijkstra algorithm."
 msgstr ""
 
 msgid "From the :doc:`TRSP-family`:"
-msgstr ""
-
-msgid "Utilities"
-msgstr ""
-
-msgid ":doc:`pgr_findCloseEdges`"
 msgstr ""
 
 msgid "Reference"
@@ -15533,13 +15312,202 @@ msgstr ""
 msgid "Mayors"
 msgstr ""
 
+msgid "pgRouting 4"
+msgstr ""
+
+msgid "Minors 4.x"
+msgstr ""
+
+msgid "pgRouting 4.0"
+msgstr ""
+
 msgid "pgRouting 3"
 msgstr ""
 
 msgid "Minors 3.x"
 msgstr ""
 
+msgid "pgRouting 3.8"
+msgstr ""
+
+msgid "pgRouting 3.8.0 Release Notes"
+msgstr ""
+
+msgid "Promotion to official function of pgRouting."
+msgstr ""
+
+msgid "pgr_extractVertices"
+msgstr ""
+
+msgid "pgr_degree"
+msgstr ""
+
+msgid "pgr_findCloseEdges"
+msgstr ""
+
+msgid "Official functions changes"
+msgstr ""
+
+msgid ""
+"`#2786 <https://github.com/pgRouting/pgrouting/issues/2786>`__: "
+"pgr_contraction"
+msgstr ""
+
+msgid "New proposed functions"
+msgstr ""
+
+msgid "Contraction"
+msgstr ""
+
+msgid ""
+"`#2790 <https://github.com/pgRouting/pgrouting/issues/2790>`__: "
+"pgr_contractionDeadEnd"
+msgstr ""
+
+msgid ""
+"`#2791 <https://github.com/pgRouting/pgrouting/issues/2791>`__: "
+"pgr_contractionLinear"
+msgstr ""
+
 msgid "pgRouting 3.7"
+msgstr ""
+
+msgid "pgRouting 3.7.3 Release Notes"
+msgstr ""
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.3 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.3%22>`__"
+msgstr ""
+
+msgid ""
+"`#2731 <https://github.com/pgRouting/pgrouting/pull/2731>`__ Build Failure "
+"on Ubuntu 22"
+msgstr ""
+
+msgid "pgRouting 3.7.2 Release Notes"
+msgstr ""
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.2 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.2%22>`__"
+msgstr ""
+
+msgid "Build"
+msgstr ""
+
+msgid ""
+"`#2713 <https://github.com/pgRouting/pgrouting/pull/2713>`__ cmake missing "
+"some policies and min version"
+msgstr ""
+
+msgid "Using OLD policies: CMP0148, CMP0144, CMP0167"
+msgstr ""
+
+msgid "Minimum cmake version 3.12"
+msgstr ""
+
+msgid ""
+"`#2707 <https://github.com/pgRouting/pgrouting/pull/2707>`__ Build failure "
+"in pgRouting 3.7.1 on Alpine"
+msgstr ""
+
+msgid ""
+"`#2706 <https://github.com/pgRouting/pgrouting/pull/2706>`__ winnie crashing "
+"on pgr_betweennessCentrality"
+msgstr ""
+
+msgid "pgRouting 3.7.1 Release Notes"
+msgstr ""
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.1 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.1%22>`__"
+msgstr ""
+
+msgid ""
+"`#2680 <https://github.com/pgRouting/pgrouting/pull/2680>`__ fails to "
+"compile under mingw64 gcc 13.2"
+msgstr ""
+
+msgid ""
+"`#2689 <https://github.com/pgRouting/pgrouting/pull/2689>`__ When point is a "
+"vertex, the withPoints family do not return results."
+msgstr ""
+
+msgid "C/C++ code enhancemet"
+msgstr ""
+
+msgid "TRSP family"
+msgstr ""
+
+msgid "pgRouting 3.7.0 Release Notes"
+msgstr ""
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.0 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.0%22>`__"
+msgstr ""
+
+msgid ""
+"`#2656 <https://github.com/pgRouting/pgrouting/pull/2656>`__ Stop support of "
+"PostgreSQL12 on pgrouting v3.7"
+msgstr ""
+
+msgid "Stopping support of PostgreSQL 12"
+msgstr ""
+
+msgid "CI does not test for PostgreSQL 12"
+msgstr ""
+
+msgid "New experimental functions"
+msgstr ""
+
+msgid "Metrics"
+msgstr ""
+
+msgid "pgr_betweennessCentrality"
+msgstr ""
+
+msgid ""
+"`#2605 <https://github.com/pgRouting/pgrouting/pull/2605>`__ Standardize "
+"spanning tree functions output"
+msgstr ""
+
+msgid "Functions:"
+msgstr ""
+
+msgid "Experimental promoted to proposed."
+msgstr ""
+
+msgid ""
+"`#2635 <https://github.com/pgRouting/pgrouting/pull/2635>`__ pgr_LineGraph "
+"ignores directed flag and use negative values for identifiers."
+msgstr ""
+
+msgid "``pgr_lineGraph``"
+msgstr ""
+
+msgid "Code enhancement"
+msgstr ""
+
+msgid ""
+"`#2599 <https://github.com/pgRouting/pgrouting/pull/2599>`__ Driving "
+"distance cleanup"
+msgstr ""
+
+msgid ""
+"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ Read postgresql "
+"data on C++"
+msgstr ""
+
+msgid ""
+"`#2614 <https://github.com/pgRouting/pgrouting/pull/2614>`__ Clang tidy does "
+"not work"
 msgstr ""
 
 msgid "pgRouting 3.6"
@@ -15552,9 +15520,6 @@ msgid ""
 "To see all issues & pull requests closed by this release see the `Git closed "
 "milestone for 3.6.3 <https://github.com/pgRouting/pgrouting/issues?"
 "utf8=%E2%9C%93&q=milestone%3A%22Release%203.6.3%22>`__"
-msgstr ""
-
-msgid "Build"
 msgstr ""
 
 msgid "Explicit minimum requirements:"
@@ -15658,55 +15623,38 @@ msgid ""
 msgstr ""
 
 msgid ""
-"`#2516 <https://github.com/pgRouting/pgrouting/pull/2516>`__ Standarize "
+"`#2516 <https://github.com/pgRouting/pgrouting/pull/2516>`__ Standardize "
 "output pgr_aStar"
 msgstr ""
 
-msgid ""
-"``pgr_aStar`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
-msgstr ""
-
-msgid "``pgr_aStar`` (`One to Many`) added ``end_vid`` column."
-msgstr ""
-
-msgid "``pgr_aStar`` (`Many to One`) added ``start_vid`` column."
+msgid "Standardize output columns to |short-generic-result|"
 msgstr ""
 
 msgid ""
-"`#2523 <https://github.com/pgRouting/pgrouting/pull/2523>`__ Standarize "
+"`#2523 <https://github.com/pgRouting/pgrouting/pull/2523>`__ Standardize "
 "output pgr_bdAstar"
 msgstr ""
 
 msgid ""
-"``pgr_bdAstar`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
-msgstr ""
-
-msgid "``pgr_bdAstar`` (`One to Many`) added ``end_vid`` column."
-msgstr ""
-
-msgid "``pgr_bdAstar`` (`Many to One`) added ``start_vid`` column."
-msgstr ""
-
-msgid ""
-"`#2547 <https://github.com/pgRouting/pgrouting/pull/2547>`__ Standarize "
+"`#2547 <https://github.com/pgRouting/pgrouting/pull/2547>`__ Standardize "
 "output and modifying signature pgr_KSP"
 msgstr ""
 
 msgid ""
-"`#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ Standarize "
-"output pgr_drivingdistance"
+"`#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ Standardize "
+"output pgr_drivingDistance"
 msgstr ""
 
 msgid "Proposed functions changes"
 msgstr ""
 
 msgid ""
-"`#2544 <https://github.com/pgRouting/pgrouting/pull/2544>`__ Standarize "
+"`#2544 <https://github.com/pgRouting/pgrouting/pull/2544>`__ Standardize "
 "output and modifying signature pgr_withPointsDD"
 msgstr ""
 
 msgid ""
-"`#2546 <https://github.com/pgRouting/pgrouting/pull/2546>`__ Standarize "
+"`#2546 <https://github.com/pgRouting/pgrouting/pull/2546>`__ Standardize "
 "output and modifying signature pgr_withPointsKSP"
 msgstr ""
 
@@ -15750,11 +15698,11 @@ msgid ""
 "history links."
 msgstr ""
 
-msgid "..rubric:: SQL standarization"
+msgid "..rubric:: Standardize SQL"
 msgstr ""
 
 msgid ""
-"`#2555 <https://github.com/pgRouting/pgrouting/pull/2555>`__ standarize "
+"`#2555 <https://github.com/pgRouting/pgrouting/pull/2555>`__ Standardize "
 "deprecated messages"
 msgstr ""
 
@@ -15780,9 +15728,6 @@ msgstr ""
 msgid "Changes on the documentation to the following:"
 msgstr ""
 
-msgid "pgr_degree"
-msgstr ""
-
 msgid "pgr_dijkstra"
 msgstr ""
 
@@ -15800,7 +15745,7 @@ msgstr ""
 
 msgid ""
 "`#2565 <https://github.com/pgRouting/pgrouting/issues/2565>`__ "
-"pgr_pgr_lengauerTarjanDominatorTree triggers an assertion"
+"pgr_lengauerTarjanDominatorTree triggers an assertion"
 msgstr ""
 
 msgid "SQL enhancements"
@@ -15838,16 +15783,6 @@ msgid ""
 msgstr ""
 
 msgid "Dijkstra"
-msgstr ""
-
-msgid ""
-"``pgr_dijkstra`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
-msgstr ""
-
-msgid "``pgr_dijkstra`` (`One to Many`) added ``end_vid`` column."
-msgstr ""
-
-msgid "``pgr_dijkstra`` (`Many to One`) added ``start_vid`` column."
 msgstr ""
 
 msgid "pgRouting 3.4"
@@ -15906,13 +15841,13 @@ msgid ""
 "doesn't give all correct shortest path"
 msgstr ""
 
-msgid "New proposed functions"
+msgid "New proposed functions."
 msgstr ""
 
 msgid "With points"
 msgstr ""
 
-msgid "``pgr_withPointsVia`` (One Via)"
+msgid "pgr_withPointsVia(One Via)"
 msgstr ""
 
 msgid "Turn Restrictions"
@@ -15921,82 +15856,67 @@ msgstr ""
 msgid "Via with turn restrictions"
 msgstr ""
 
-msgid "``pgr_trspVia`` (One Via)"
+msgid "pgr_trspVia(One Via)"
 msgstr ""
 
-msgid "``pgr_trspVia_withPoints`` (One Via)"
+msgid "pgr_trspVia_withPoints(One Via)"
 msgstr ""
 
-msgid "``pgr_trsp``"
+msgid "pgr_trsp_withPoints(One to One)"
 msgstr ""
 
-msgid "``pgr_trsp`` (One to One)"
+msgid "pgr_trsp_withPoints(One to Many)"
 msgstr ""
 
-msgid "``pgr_trsp`` (One to Many)"
+msgid "pgr_trsp_withPoints(Many to One)"
 msgstr ""
 
-msgid "``pgr_trsp`` (Many to One)"
+msgid "pgr_trsp_withPoints(Many to Many)"
 msgstr ""
 
-msgid "``pgr_trsp`` (Many to Many)"
-msgstr ""
-
-msgid "``pgr_trsp`` (Combinations)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints``"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (One to One)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (One to Many)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (Many to One)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (Many to Many)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (Combinations)"
+msgid "pgr_trsp_withPoints(Combinations)"
 msgstr ""
 
 msgid "Topology"
 msgstr ""
 
-msgid "``pgr_degree``"
+msgid "Utilities"
 msgstr ""
 
-msgid "``pgr_findCloseEdges`` (One point)"
+msgid "pgr_findCloseEdges(One point)"
 msgstr ""
 
-msgid "``pgr_findCloseEdges`` (Many points)"
+msgid "pgr_findCloseEdges(Many points)"
 msgstr ""
 
 msgid "Ordering"
 msgstr ""
 
-msgid "``pgr_cuthillMckeeOrdering``"
+msgid "pgr_cuthillMckeeOrdering"
+msgstr ""
+
+msgid "Unclassified"
+msgstr ""
+
+msgid "pgr_hawickCircuits"
 msgstr ""
 
 msgid "Flow functions"
 msgstr ""
 
-msgid "``pgr_maxCardinalityMatch(text)``"
+msgid "pgr_maxCardinalityMatch(text)"
 msgstr ""
 
-msgid "Deprecating ``pgr_maxCardinalityMatch(text,boolean)``"
+msgid "Deprecating: pgr_maxCardinalityMatch(text,boolean)"
 msgstr ""
 
 msgid "Deprecated Functions"
 msgstr ""
 
-msgid "``pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)``"
+msgid "pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)"
 msgstr ""
 
-msgid "``pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)``"
+msgid "pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)"
 msgstr ""
 
 msgid "pgRouting 3.3"
@@ -16182,9 +16102,6 @@ msgstr ""
 msgid "pgr_sequentialVertexColoring"
 msgstr ""
 
-msgid "pgr_extractVertices"
-msgstr ""
-
 msgid "Traversal"
 msgstr ""
 
@@ -16258,12 +16175,6 @@ msgstr ""
 msgid "Removing support for Boost v1.53, v1.54 & v1.55"
 msgstr ""
 
-msgid "pgr_bellmanFord(Combinations)"
-msgstr ""
-
-msgid "pgr_binaryBreadthFirstSearch(Combinations)"
-msgstr ""
-
 msgid "pgr_bipartite"
 msgstr ""
 
@@ -16271,9 +16182,6 @@ msgid "pgr_depthFirstSearch"
 msgstr ""
 
 msgid "Dijkstra Near"
-msgstr ""
-
-msgid "pgr_edwardMoore(Combinations)"
 msgstr ""
 
 msgid "pgr_isPlanar"
@@ -16285,49 +16193,13 @@ msgstr ""
 msgid "pgr_makeConnected"
 msgstr ""
 
-msgid "pgr_maxFlowMinCost(Combinations)"
-msgstr ""
-
-msgid "pgr_maxFlowMinCost_Cost(Combinations)"
-msgstr ""
-
 msgid "Astar"
-msgstr ""
-
-msgid "pgr_aStar(Combinations)"
-msgstr ""
-
-msgid "pgr_aStarCost(Combinations)"
 msgstr ""
 
 msgid "Bidirectional Astar"
 msgstr ""
 
-msgid "pgr_bdAstar(Combinations)"
-msgstr ""
-
-msgid "pgr_bdAstarCost(Combinations)"
-msgstr ""
-
 msgid "Bidirectional Dijkstra"
-msgstr ""
-
-msgid "pgr_bdDijkstra(Combinations)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCost(Combinations)"
-msgstr ""
-
-msgid "pgr_boykovKolmogorov(Combinations)"
-msgstr ""
-
-msgid "pgr_edmondsKarp(Combinations)"
-msgstr ""
-
-msgid "pgr_maxFlow(Combinations)"
-msgstr ""
-
-msgid "pgr_pushRelabel(Combinations)"
 msgstr ""
 
 msgid "pgRouting 3.1"
@@ -16564,7 +16436,7 @@ msgid ""
 "information"
 msgstr ""
 
-msgid "New functions"
+msgid "New Functions"
 msgstr ""
 
 msgid "Kruskal family"
@@ -16603,148 +16475,94 @@ msgstr ""
 msgid "aStar Family"
 msgstr ""
 
-msgid "pgr_aStar(one to many)"
+msgid "pgr_aStarCost(One to One)"
 msgstr ""
 
-msgid "pgr_aStar(many to one)"
+msgid "pgr_aStarCost(One to Many)"
 msgstr ""
 
-msgid "pgr_aStar(many to many)"
+msgid "pgr_aStarCost(Many to One)"
 msgstr ""
 
-msgid "pgr_aStarCost(one to one)"
+msgid "pgr_aStarCost(Many to Many)"
 msgstr ""
 
-msgid "pgr_aStarCost(one to many)"
-msgstr ""
-
-msgid "pgr_aStarCost(many to one)"
-msgstr ""
-
-msgid "pgr_aStarCost(many to many)"
-msgstr ""
-
-msgid "pgr_aStarCostMatrix(one to one)"
-msgstr ""
-
-msgid "pgr_aStarCostMatrix(one to many)"
-msgstr ""
-
-msgid "pgr_aStarCostMatrix(many to one)"
-msgstr ""
-
-msgid "pgr_aStarCostMatrix(many to many)"
+msgid "pgr_aStarCostMatrix"
 msgstr ""
 
 msgid "bdAstar Family"
 msgstr ""
 
-msgid "pgr_bdAstar(one to many)"
+msgid "pgr_bdAstarCost(One to One)"
 msgstr ""
 
-msgid "pgr_bdAstar(many to one)"
+msgid "pgr_bdAstarCost(One to Many)"
 msgstr ""
 
-msgid "pgr_bdAstar(many to many)"
+msgid "pgr_bdAstarCost(Many to One)"
 msgstr ""
 
-msgid "pgr_bdAstarCost(one to one)"
+msgid "pgr_bdAstarCost(Many to Many)"
 msgstr ""
 
-msgid "pgr_bdAstarCost(one to many)"
-msgstr ""
-
-msgid "pgr_bdAstarCost(many to one)"
-msgstr ""
-
-msgid "pgr_bdAstarCost(many to many)"
-msgstr ""
-
-msgid "pgr_bdAstarCostMatrix(one to one)"
-msgstr ""
-
-msgid "pgr_bdAstarCostMatrix(one to many)"
-msgstr ""
-
-msgid "pgr_bdAstarCostMatrix(many to one)"
-msgstr ""
-
-msgid "pgr_bdAstarCostMatrix(many to many)"
+msgid "pgr_bdAstarCostMatrix"
 msgstr ""
 
 msgid "bdDijkstra Family"
 msgstr ""
 
-msgid "pgr_bdDijkstra(one to many)"
+msgid "pgr_bdDijkstraCost(One to One)"
 msgstr ""
 
-msgid "pgr_bdDijkstra(many to one)"
+msgid "pgr_bdDijkstraCost(One to Many)"
 msgstr ""
 
-msgid "pgr_bdDijkstra(many to many)"
+msgid "pgr_bdDijkstraCost(Many to One)"
 msgstr ""
 
-msgid "pgr_bdDijkstraCost(one to one)"
+msgid "pgr_bdDijkstraCost(Many to Many)"
 msgstr ""
 
-msgid "pgr_bdDijkstraCost(one to many)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCost(many to one)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCost(many to many)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCostMatrix(one to one)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCostMatrix(one to many)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCostMatrix(many to one)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCostMatrix(many to many)"
+msgid "pgr_bdDijkstraCostMatrix"
 msgstr ""
 
 msgid "Flow Family"
 msgstr ""
 
-msgid "pgr_pushRelabel(one to one)"
+msgid "pgr_pushRelabel(One to One)"
 msgstr ""
 
-msgid "pgr_pushRelabel(one to many)"
+msgid "pgr_pushRelabel(One to Many)"
 msgstr ""
 
-msgid "pgr_pushRelabel(many to one)"
+msgid "pgr_pushRelabel(Many to One)"
 msgstr ""
 
-msgid "pgr_pushRelabel(many to many)"
+msgid "pgr_pushRelabel(Many to Many)"
 msgstr ""
 
-msgid "pgr_edmondsKarp(one to one)"
+msgid "pgr_edmondsKarp(One to One)"
 msgstr ""
 
-msgid "pgr_edmondsKarp(one to many)"
+msgid "pgr_edmondsKarp(One to Many)"
 msgstr ""
 
-msgid "pgr_edmondsKarp(many to one)"
+msgid "pgr_edmondsKarp(Many to One)"
 msgstr ""
 
-msgid "pgr_edmondsKarp(many to many)"
+msgid "pgr_edmondsKarp(Many to Many)"
 msgstr ""
 
-msgid "pgr_boykovKolmogorov (one to one)"
+msgid "pgr_boykovKolmogorov (One to One)"
 msgstr ""
 
-msgid "pgr_boykovKolmogorov (one to many)"
+msgid "pgr_boykovKolmogorov (One to Many)"
 msgstr ""
 
-msgid "pgr_boykovKolmogorov (many to one)"
+msgid "pgr_boykovKolmogorov (Many to One)"
 msgstr ""
 
-msgid "pgr_boykovKolmogorov (many to many)"
+msgid "pgr_boykovKolmogorov (Many to Many)"
 msgstr ""
 
 msgid "pgr_maxCardinalityMatching"
@@ -16753,19 +16571,22 @@ msgstr ""
 msgid "pgr_maxFlow"
 msgstr ""
 
-msgid "pgr_edgeDisjointPaths(one to one)"
+msgid "pgr_edgeDisjointPaths(One to One)"
 msgstr ""
 
-msgid "pgr_edgeDisjointPaths(one to many)"
+msgid "pgr_edgeDisjointPaths(One to Many)"
 msgstr ""
 
-msgid "pgr_edgeDisjointPaths(many to one)"
+msgid "pgr_edgeDisjointPaths(Many to One)"
 msgstr ""
 
-msgid "pgr_edgeDisjointPaths(many to many)"
+msgid "pgr_edgeDisjointPaths(Many to Many)"
 msgstr ""
 
 msgid "Components family"
+msgstr ""
+
+msgid "pgr_connectedComponents"
 msgstr ""
 
 msgid "pgr_strongComponents"
@@ -16954,7 +16775,7 @@ msgstr ""
 msgid "pgr_johnson"
 msgstr ""
 
-msgid "pgr_astar"
+msgid "pgr_aStar"
 msgstr ""
 
 msgid "pgr_bdAstar"
@@ -16973,6 +16794,9 @@ msgid "pgr_dijkstraCost"
 msgstr ""
 
 msgid "pgr_drivingDistance"
+msgstr ""
+
+msgid "pgr_KSP"
 msgstr ""
 
 msgid "pgr_dijkstraVia (proposed)"
@@ -17173,22 +16997,13 @@ msgstr ""
 msgid "Parameter names changed"
 msgstr ""
 
-msgid "The many version results are the union of the one to one version"
+msgid "The many version results are the union of the One to One version"
 msgstr ""
 
 msgid "New Signatures"
 msgstr ""
 
-msgid "pgr_bdAstar(one to one)"
-msgstr ""
-
-msgid "New Proposed functions"
-msgstr ""
-
-msgid "pgr_bdAstarCostMatrix"
-msgstr ""
-
-msgid "pgr_bdDijkstraCostMatrix"
+msgid "pgr_bdAstar(One to One)"
 msgstr ""
 
 msgid "pgr_lineGraph"
@@ -17270,31 +17085,7 @@ msgstr ""
 msgid "pgr_bdDijkstra"
 msgstr ""
 
-msgid "New Proposed Signatures"
-msgstr ""
-
-msgid "pgr_astar(one to many)"
-msgstr ""
-
-msgid "pgr_astar(many to one)"
-msgstr ""
-
-msgid "pgr_astar(many to many)"
-msgstr ""
-
-msgid "pgr_astarCost(one to one)"
-msgstr ""
-
-msgid "pgr_astarCost(one to many)"
-msgstr ""
-
-msgid "pgr_astarCost(many to one)"
-msgstr ""
-
-msgid "pgr_astarCost(many to many)"
-msgstr ""
-
-msgid "pgr_astarCostMatrix"
+msgid "Deprecated signatures."
 msgstr ""
 
 msgid "pgr_bddijkstra - use pgr_bdDijkstra instead"
@@ -17366,52 +17157,43 @@ msgstr ""
 msgid "pgr_TSP"
 msgstr ""
 
-msgid "pgr_aStar"
-msgstr ""
-
-msgid "New Functions"
-msgstr ""
-
 msgid "pgr_eucledianTSP"
 msgstr ""
 
-msgid "pgr_withPointsCostMatrix"
+msgid "pgr_maxFlowPushRelabel(One to One)"
 msgstr ""
 
-msgid "pgr_maxFlowPushRelabel(one to one)"
+msgid "pgr_maxFlowPushRelabel(One to Many)"
 msgstr ""
 
-msgid "pgr_maxFlowPushRelabel(one to many)"
+msgid "pgr_maxFlowPushRelabel(Many to One)"
 msgstr ""
 
-msgid "pgr_maxFlowPushRelabel(many to one)"
+msgid "pgr_maxFlowPushRelabel(Many to Many)"
 msgstr ""
 
-msgid "pgr_maxFlowPushRelabel(many to many)"
+msgid "pgr_maxFlowEdmondsKarp(One to One)"
 msgstr ""
 
-msgid "pgr_maxFlowEdmondsKarp(one to one)"
+msgid "pgr_maxFlowEdmondsKarp(One to Many)"
 msgstr ""
 
-msgid "pgr_maxFlowEdmondsKarp(one to many)"
+msgid "pgr_maxFlowEdmondsKarp(Many to One)"
 msgstr ""
 
-msgid "pgr_maxFlowEdmondsKarp(many to one)"
+msgid "pgr_maxFlowEdmondsKarp(Many to Many)"
 msgstr ""
 
-msgid "pgr_maxFlowEdmondsKarp(many to many)"
+msgid "pgr_maxFlowBoykovKolmogorov (One to One)"
 msgstr ""
 
-msgid "pgr_maxFlowBoykovKolmogorov (one to one)"
+msgid "pgr_maxFlowBoykovKolmogorov (One to Many)"
 msgstr ""
 
-msgid "pgr_maxFlowBoykovKolmogorov (one to many)"
+msgid "pgr_maxFlowBoykovKolmogorov (Many to One)"
 msgstr ""
 
-msgid "pgr_maxFlowBoykovKolmogorov (many to one)"
-msgstr ""
-
-msgid "pgr_maxFlowBoykovKolmogorov (many to many)"
+msgid "pgr_maxFlowBoykovKolmogorov (Many to Many)"
 msgstr ""
 
 msgid "pgr_maximumCardinalityMatching"
@@ -17423,7 +17205,7 @@ msgstr ""
 msgid "pgr_tsp - use pgr_TSP or pgr_eucledianTSP instead"
 msgstr ""
 
-msgid "pgr_astar - use pgr_aStar instead"
+msgid "pgr_aStar - use pgr_aStar instead"
 msgstr ""
 
 msgid "pgr_flip_edges"
@@ -17510,6 +17292,9 @@ msgstr ""
 msgid "Improvements"
 msgstr ""
 
+msgid "pgr_nodeNetwork"
+msgstr ""
+
 msgid "Adding a row_where and outall optional parameters"
 msgstr ""
 
@@ -17522,52 +17307,49 @@ msgstr ""
 msgid "pgr_Johnson"
 msgstr ""
 
-msgid "pgr_dijkstraCost(one to one)"
+msgid "pgr_dijkstraCost(One to One)"
 msgstr ""
 
-msgid "pgr_dijkstraCost(one to many)"
+msgid "pgr_dijkstraCost(One to Many)"
 msgstr ""
 
-msgid "pgr_dijkstraCost(many to one)"
+msgid "pgr_dijkstraCost(Many to One)"
 msgstr ""
 
-msgid "pgr_dijkstraCost(many to many)"
+msgid "pgr_dijkstraCost(Many to Many)"
 msgstr ""
 
 msgid "Proposed Functionality"
 msgstr ""
 
-msgid "pgr_withPoints(one to one)"
+msgid "pgr_withPoints(One to One)"
 msgstr ""
 
-msgid "pgr_withPoints(one to many)"
+msgid "pgr_withPoints(One to Many)"
 msgstr ""
 
-msgid "pgr_withPoints(many to one)"
+msgid "pgr_withPoints(Many to One)"
 msgstr ""
 
-msgid "pgr_withPoints(many to many)"
+msgid "pgr_withPoints(Many to Many)"
 msgstr ""
 
-msgid "pgr_withPointsCost(one to one)"
+msgid "pgr_withPointsCost(One to One)"
 msgstr ""
 
-msgid "pgr_withPointsCost(one to many)"
+msgid "pgr_withPointsCost(One to Many)"
 msgstr ""
 
-msgid "pgr_withPointsCost(many to one)"
+msgid "pgr_withPointsCost(Many to One)"
 msgstr ""
 
-msgid "pgr_withPointsCost(many to many)"
+msgid "pgr_withPointsCost(Many to Many)"
 msgstr ""
 
 msgid "pgr_withPointsDD(single vertex)"
 msgstr ""
 
 msgid "pgr_withPointsDD(multiple vertices)"
-msgstr ""
-
-msgid "pgr_withPointsKSP"
 msgstr ""
 
 msgid "pgr_dijkstraVia"
@@ -17603,25 +17385,10 @@ msgid ""
 "q=is%3Aissue+milestone%3A%22Release+2.1.0%22+is%3Aclosed>`_ on Github."
 msgstr ""
 
-msgid "pgr_dijkstra(one to many)"
-msgstr ""
-
-msgid "pgr_dijkstra(many to one)"
-msgstr ""
-
-msgid "pgr_dijkstra(many to many)"
-msgstr ""
-
-msgid "pgr_drivingDistance(multiple vertices)"
-msgstr ""
-
 msgid "Refactored"
 msgstr ""
 
-msgid "pgr_dijkstra(one to one)"
-msgstr ""
-
-msgid "pgr_drivingDistance(single vertex)"
+msgid "pgr_dijkstra(One to One)"
 msgstr ""
 
 msgid ""
@@ -17960,8 +17727,8 @@ msgstr ""
 
 msgid ""
 "The documentation provides very simple example queries based on a small "
-"sample network that resembles a city. To be able to execute the mayority of "
-"the examples queries, follow the instructions bellow."
+"sample network that resembles a city. To be able to execute the majority of "
+"the examples queries, follow the instructions below."
 msgstr ""
 
 msgid "Main graph"
@@ -17975,7 +17742,8 @@ msgstr ""
 
 msgid ""
 "Information known at this point is the geometry of the edges, cost values, "
-"cpacity values, category values and some locations that are not in the graph."
+"capacity values, category values and some locations that are not in the "
+"graph."
 msgstr ""
 
 msgid ""
@@ -17983,14 +17751,11 @@ msgid ""
 "that everything else is calculated."
 msgstr ""
 
-msgid "Edges"
-msgstr ""
-
 msgid ""
 "The database design for the documentation of pgRouting, keeps in the same "
 "row 2 segments, one in the direction of the geometry and the second in the "
-"oposite direction. Therfore some information has the ``reverse_`` prefix "
-"which corresponds to the segment on the oposite direction of the geometry."
+"opposite direction. Therefore some information has the ``reverse_`` prefix "
+"which corresponds to the segment on the opposite direction of the geometry."
 msgstr ""
 
 msgid "Identifier of the starting vertex of the geometry ``geom``."
@@ -18021,7 +17786,7 @@ msgid ":math:`x` coordinate of the starting vertex of the geometry."
 msgstr ""
 
 msgid ""
-"For convinience it is saved on the table but can be calculated as "
+"For convenience it is saved on the table but can be calculated as "
 "``ST_X(ST_StartPoint(geom))``."
 msgstr ""
 
@@ -18029,7 +17794,7 @@ msgid ":math:`y` coordinate of the ending vertex of the geometry."
 msgstr ""
 
 msgid ""
-"For convinience it is saved on the table but can be calculated as "
+"For convenience it is saved on the table but can be calculated as "
 "``ST_Y(ST_EndPoint(geom))``."
 msgstr ""
 
@@ -18040,8 +17805,8 @@ msgid "Starting on PostgreSQL 12::"
 msgstr ""
 
 msgid ""
-"Optionally indexes on different columns can be created. The recomendation is "
-"to have"
+"Optionally indexes on different columns can be created. The recommendation "
+"is to have"
 msgstr ""
 
 msgid "``id`` indexed."
@@ -18052,7 +17817,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"``geom`` indexed to speed up gemetry processes that might be needed in the "
+"``geom`` indexed to speed up geometry processes that might be needed in the "
 "front end."
 msgstr ""
 
@@ -18121,7 +17886,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"For convinence of this documentations, some combinations will be stored on a "
+"For convenience of this documentation, some combinations will be stored on a "
 "table:"
 msgstr ""
 
@@ -18331,8 +18096,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"pgRouting suplies some functions to create a routing topology and to analyze "
-"the topology."
+"pgRouting supplies some functions to create a routing topology and to "
+"analyze the topology."
 msgstr ""
 
 msgid "Additional functions to create a graph:"
@@ -18352,7 +18117,7 @@ msgstr ""
 msgid "Traversal - Family of functions"
 msgstr ""
 
-msgid "Aditionaly there are 2 categories under this family"
+msgid "Additionally there are 2 categories under this family"
 msgstr ""
 
 msgid "Via - Category"
@@ -18367,7 +18132,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"In other words, find a continuos route that visits all the vertices in the "
+"In other words, find a continuous route that visits all the vertices in the "
 "order given."
 msgstr ""
 

--- a/locale/es/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/es/LC_MESSAGES/pgrouting_doc_strings.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 # Pedro Jose Rios Vergara <jose@georepublic.de>, 2022.
 # Celia Virginia Vergara Castillo <vicky@georepublic.de>, 2022.
-# Celia Virginia Vergara Castillo <vicky@erosion.dev>, 2023, 2024.
+# Celia Virginia Vergara Castillo <vicky@erosion.dev>, 2023, 2024, 2025.
 # DeepL <noreply-mt-deepl@weblate.org>, 2024.
 msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.8\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-24 14:17+0000\n"
-"PO-Revision-Date: 2024-10-10 19:43+0000\n"
-"Last-Translator: DeepL <noreply-mt-deepl@weblate.org>\n"
+"PO-Revision-Date: 2025-03-30 01:13+0000\n"
+"Last-Translator: Celia Virginia Vergara Castillo <vicky@erosion.dev>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
 "pgrouting-develop/es/>\n"
 "Language: es\n"
@@ -428,7 +428,6 @@ msgstr ""
 "Puede ser necesario que los ejemplos de documentación se generen "
 "automáticamente."
 
-#, fuzzy
 msgid "Might need a lot of feedback from the community."
 msgstr "Puede ser necesaria retroalimentación por parte de la comunidad."
 
@@ -3025,9 +3024,8 @@ msgstr "Contraction - Familia de funciones"
 msgid ":doc:`pgr_contraction`"
 msgstr ":doc:`pgr_contraction`"
 
-#, fuzzy
 msgid ":doc:`pgr_contractionDeadEnd`"
-msgstr ":doc:`pgr_contraction`"
+msgstr ":doc:`pgr_contractionDeadEnd`"
 
 msgid ""
 "In large graphs, like the road graphs, or electric networks, graph "
@@ -3365,11 +3363,9 @@ msgstr ""
 ":doc:`pgr_KSP` - Usar el algoritmo Yen con pgr_dijkstra para obtener las K "
 "rutas más cortas."
 
-#, fuzzy
 msgid ":doc:`pgr_dijkstraVia` - Get a route of a sequence of vertices."
 msgstr ""
-":doc:`pgr_dijkstraVia` - Obtenga una ruta a partir de una secuencia de "
-"vértices."
+":doc:`pgr_dijkstraVia` - Obtener una ruta para una secuencia de vértices."
 
 msgid ":doc:`pgr_dijkstraNear` - Get the route to the nearest vertex."
 msgstr ":doc:`pgr_dijkstraNear` - Obtener la ruta al vértice más cercano."
@@ -3494,9 +3490,8 @@ msgstr ""
 msgid "Undirected graph"
 msgstr "Grafo no dirigido"
 
-#, fuzzy
 msgid "The weighted undirected graph, :math:`G_u(V,E)`, is defined by:"
-msgstr "El grafo ponderado no dirigido :math:`G_u(V,E)`, es definido por:"
+msgstr "El grafo ponderado no dirigido, :math:`G_u(V,E)`, es definido por:"
 
 msgid ":math:`V = source \\cup target \\cup {start_v{vid}} \\cup  {end_{vid}}`"
 msgstr ":math:`V = source \\cup target \\cup {start_v{vid}} \\cup {end_{vid}}`"
@@ -3642,7 +3637,6 @@ msgid ":doc:`pgr_kruskalDD` - Driving Distance based on Kruskal's algorithm"
 msgstr ""
 ":doc:`pgr_kruskalDD` - Distancia de Manejo basada en el algoritmo de Kruskal"
 
-#, fuzzy
 msgid "Post processing"
 msgstr "Post procesamiento"
 
@@ -3825,9 +3819,8 @@ msgstr "Familia Planar"
 msgid ":doc:`pgr_isPlanar`"
 msgstr ":doc:`pgr_isPlanar`"
 
-#, fuzzy
 msgid "Miscellaneous Algorithms"
-msgstr "Algoritmos diversos"
+msgstr "Algoritmos Diversos"
 
 msgid ":doc:`pgr_lengauerTarjanDominatorTree`"
 msgstr ":doc:`pgr_lengauerTarjanDominatorTree`"
@@ -3905,7 +3898,6 @@ msgstr ""
 "Cuando el flujo máximo es 0 entonces no hay flujo, se devolverá: **EMPTY "
 "SET**."
 
-#, fuzzy
 msgid "There is no flow when source has the same value as target."
 msgstr "No hay flujo cuando el origen tiene el mismo valor que el destino."
 
@@ -4242,13 +4234,12 @@ msgstr ":doc:`pgr_kruskal`"
 msgid ":doc:`pgr_kruskalDD`"
 msgstr ":doc:`pgr_kruskalDD`"
 
-#, fuzzy
 msgid ""
 ":doc:`pgr_degree` - Returns a set of vertices and corresponding count of "
 "incident edges to the vertex."
 msgstr ""
-"``pgr_degree`` - Para cada vértice de un grafo no dirigido, devuelve el "
-"número de aristas incidentes en el vértice."
+":doc:`pgr_degree` - Regresa un conjunto de vertices y la cantidad de aristas "
+"incidentes al vértice."
 
 msgid ":doc:`prim-family`"
 msgstr ":doc:`prim-family`"
@@ -4315,9 +4306,8 @@ msgstr ""
 msgid ":doc:`pgr_trsp` - Turn Restriction Shortest Path (TRSP)"
 msgstr ":doc:`pgr_trsp` - Camino más corto con restricción de giros (TRSP)"
 
-#, fuzzy
 msgid "Utilities family"
-msgstr "Utilidades"
+msgstr "Utilidades - familia"
 
 msgid ":doc:`pgr_findCloseEdges`"
 msgstr ":doc:`pgr_findCloseEdges`"
@@ -4337,9 +4327,8 @@ msgstr ":doc:`drivingDistance-category`"
 msgid ":doc:`KSP-category`"
 msgstr ":doc:`KSP-category`"
 
-#, fuzzy
 msgid ":doc:`spanningTree-category`"
-msgstr ":doc:`spanningTree-family`"
+msgstr ":doc:`spanningTree-category`"
 
 msgid ":doc:`BFS-category`"
 msgstr ":doc:`BFS-category`"
@@ -6555,11 +6544,8 @@ msgid ""
 "The vertex is the limit of a cul-de-sac, a no-through road or a no-exit road."
 msgstr ""
 
-#, fuzzy
 msgid "The vertex is on the limit of the imported graph."
-msgstr ""
-"En caso de ''true'' se contrae el vértice, no forma parte del grafo "
-"contraído."
+msgstr "El vértice esta en el limite del grafo importado."
 
 msgid "If a larger graph is imported then the vertex might not be a dead end"
 msgstr ""
@@ -6602,18 +6588,16 @@ msgstr ""
 "¿Hay un gran acantilado y desde la vista de las águilas parece que el "
 "callejón sin salida está cerca del segmento?"
 
-#, fuzzy
 msgid "Depending on the answer, modification of the data might be needed."
-msgstr ""
-"Dependiendo de la función, serán necesarias una o mas consultas internas."
+msgstr "Dependiendo de la respuesta, será necesario la modificación de datos."
 
-#, fuzzy
 msgid ""
 "When there are many dead ends, to speed up processing, the :doc:`contraction-"
 "family` functions can be used to contract the graph."
 msgstr ""
-"Cuando hay muchos callejones sin salida, para acelerar, se pueden utilizar "
-"las funciones de :doc:`contraction-family` para dividir el problema."
+"Cuando hay muchos callejones sin salida, para acelerar el procesamiento, se "
+"pueden utilizar las funciones de :doc:`contraction-family` para contraer el "
+"grafo."
 
 msgid "Linear edges"
 msgstr "Bordes lineales"
@@ -6626,14 +6610,14 @@ msgid ""
 "speed bumps, stop signals and the application is taking them into account."
 msgstr ""
 
-#, fuzzy
 msgid ""
 "When there are many linear vertices, that need not to be taken into account, "
 "to speed up the processing, the :doc:`contraction-family` functions can be "
 "used to contract the problem."
 msgstr ""
-"Cuando hay muchas aristas lineales, para acelerar, se pueden utilizar las "
-"funciones :doc:`contraction-family` para dividir el problema."
+"Cuando hay muchas aristas lineales, que no necesitan tomarse en cuenta, para "
+"acelerar el procesamiento se pueden utilizar las funciones :doc:`contraction-"
+"family` para contraer el grafo."
 
 msgid "Function's structure"
 msgstr "Estructura de la función"
@@ -7208,13 +7192,11 @@ msgstr ""
 "En este ejemplo, usar una consulta SQL interna que no incluya algunas "
 "aristas en la función de ruteo y dentro del área de los resultados."
 
-#, fuzzy
 msgid "Given this area:"
-msgstr "Dados los vehículos:"
+msgstr "Dada esta área:"
 
-#, fuzzy
 msgid "Calculate a route:"
-msgstr "Calcular todas las columnas"
+msgstr "Calcular una ruta:"
 
 msgid "How to contribute"
 msgstr "Cómo contribuir"
@@ -7249,9 +7231,8 @@ msgstr ""
 "`Ejemplo <https://github.com/pgRouting/pgrouting/wiki/How-to:-Handle-"
 "parallel-edges-(KSP)>`__"
 
-#, fuzzy
 msgid "Adding Functionality to pgRouting"
-msgstr "Agregar funcionalidad a pgRouting"
+msgstr "Agregando Funcionalidad a pgRouting"
 
 msgid ""
 "Consult the `developer's documentation <https://docs.pgrouting.org/doxy/2.4/"
@@ -8131,9 +8112,8 @@ msgstr "https://en.wikipedia.org/wiki/K_shortest_path_routing"
 msgid "``pgr_TSP``"
 msgstr "``pgr_TSP``"
 
-#, fuzzy
 msgid "``pgr_TSP`` - Approximation using *metric* algorithm."
-msgstr "``pgr_TSP`` - Aproximación usando el algoritmo*metrico*."
+msgstr "``pgr_TSP`` - Aproximación usando el algoritmo *métrico*."
 
 msgid "Availability:"
 msgstr "Disponibilidad:"
@@ -8394,9 +8374,8 @@ msgstr ""
 msgid "``pgr_TSPeuclidean``"
 msgstr "``pgr_TSPeuclidean``"
 
-#, fuzzy
 msgid "``pgr_TSPeuclidean`` - Approximation using *metric* algorithm."
-msgstr "``pgr_TSPeuclidean`` - Aproximación usando el algoritmo *metric*."
+msgstr "``pgr_TSPeuclidean`` - Aproximación usando el algoritmo *métrico*."
 
 msgid ""
 "Using `Boost: metric TSP approx <https://www.boost.org/libs/graph/doc/"
@@ -10563,27 +10542,23 @@ msgstr ""
 "``pgr_contraction`` — Realiza la contracción del grafo y devuelve los "
 "vértices y aristas contraídos.."
 
-#, fuzzy
 msgid "Version 3.8.0"
-msgstr "Versión 3.6.0"
+msgstr "Versión 3.8.0"
 
-#, fuzzy
 msgid "New signature:"
-msgstr "Nueva firma"
+msgstr "Nueva firma:"
 
 msgid ""
 "Previously compulsory parameter **Contraction order** is now optional with "
 "name ``methods``."
 msgstr ""
 
-#, fuzzy
 msgid "New name and order of optional parameters."
-msgstr "Parámetros opcionales de Cercanía"
+msgstr "Nuevo nombre y orden de parámetros opcionales."
 
-#, fuzzy
 msgid ""
 "Deprecated signature pgr_contraction(text,bigint[],integer,bigint[],boolean)"
-msgstr "_pgr_dijkstranear(text,bigint,anyarray,bigint,boolean)"
+msgstr "Firma obsoleta pgr_contraction(text,bigint[],integer,bigint[],boolean)"
 
 msgid "Name change from ``pgr_contractGraph``"
 msgstr "Cambio de nombre de ``pgr_contractGraph``"
@@ -10601,42 +10576,37 @@ msgstr ""
 "secuencia de aristas originales disminuyendo el tiempo total y el espacio "
 "utilizados en los algoritmos de grafo."
 
-#, fuzzy
 msgid "Does not return the full contracted graph."
-msgstr "No devuelve el grafo completo contraído"
+msgstr "No devuelve el grafo contraído completo."
 
-#, fuzzy
 msgid "Only changes on the graph are returned."
-msgstr "Solo se devuelven los cambios en el gráfico"
+msgstr "Solo se devuelven los cambios en el grafo."
 
-#, fuzzy
 msgid "The returned values include:"
-msgstr "Los valores devueltos incluyen"
+msgstr "Los valores devueltos incluyen:"
 
-#, fuzzy
 msgid "The new edges generated by linear contraction."
-msgstr "Inserte las nuevas aristas generadas por pgr_contraction."
+msgstr "Las nuevas aristas generadas por la contracción lineal."
 
-#, fuzzy
 msgid "The modified vertices generated by dead end contraction."
-msgstr "los vértices modificados por contracción sin salida."
+msgstr "Los vértices modificados por contracción sin salida."
 
 msgid "The returned values are ordered as follows:"
 msgstr "Los valores devueltos se ordenan de la siguiente manera:"
 
-#, fuzzy
 msgid "column ``id`` ascending when its a modified vertex."
-msgstr "columna ``id`` ascendente cuando el tipo = ``v``"
+msgstr "columna ``id`` ascendente cuando es un vértice modificado."
 
-#, fuzzy
 msgid "column ``id`` with negative numbers descending when its a new edge."
-msgstr "columna ``id`` descendente cuando el tipo = ``e``"
+msgstr ""
+"columna ``id`` con números negativos descendentes cuando es una nueva arista."
 
-#, fuzzy
 msgid ""
 "Currently there are two types of contraction methods included in this "
 "function:"
-msgstr "Actualmente hay dos tipos de métodos de contracción"
+msgstr ""
+"Actualmente hay dos tipos de métodos de contracción incluidos en esta "
+"función:"
 
 msgid "Dead End Contraction. See :doc:`pgr_contractionDeadEnd`."
 msgstr ""
@@ -10644,19 +10614,15 @@ msgstr ""
 msgid "Linear Contraction. See :doc:`pgr_contractionLinear`."
 msgstr ""
 
-#, fuzzy
 msgid "pgr_contraction(`Edges SQL`_, [**options**])"
-msgstr ""
-"pgr_contraction(`SQL de aristas`_, **orden de contracción**, [**opciones**])"
+msgstr "pgr_contraction(`SQL de aristas`_, [**opciones**])"
 
-#, fuzzy
 msgid "**options:** ``[directed, methods, cycles, forbidden]``"
-msgstr "**opcionales:** ``[directed, details]``"
+msgstr "**opciones:** ``[directed, methods, cycles, forbidden]``"
 
 msgid "Returns set of |result-contract|"
 msgstr "Regresa conjunto de |result-contract|"
 
-#, fuzzy
 msgid "Dead end and linear contraction in that order on an undirected graph."
 msgstr ""
 "Hacer una contracción de callejón sin salida y una contracción lineal en ese "
@@ -10668,13 +10634,11 @@ msgstr "Parámetros opcionales de Contracción"
 msgid "``methods``"
 msgstr ""
 
-#, fuzzy
 msgid "``INTEGER[]``"
-msgstr "``INTEGER``"
+msgstr "``INTEGER[]``"
 
-#, fuzzy
 msgid "``ARRAY[1,2]``"
-msgstr "``ARRAY[BIGINT]``"
+msgstr "``ARRAY[1,2]``"
 
 msgid "Ordered contraction operations."
 msgstr "Operaciones de contracción ordenadas."
@@ -10685,29 +10649,23 @@ msgstr "1 = Contracción sin salida"
 msgid "2 = Linear contraction"
 msgstr "2 - Contracción lineal"
 
-#, fuzzy
 msgid "``cycles``"
-msgstr "``max_cycles``"
+msgstr "``cycles``"
 
 msgid ":math:`1`"
 msgstr ":math:`1`"
 
-#, fuzzy
 msgid "Number of times the contraction methods will be performed."
-msgstr ""
-"Número de veces que se realizarán las operaciones de contracción en el orden "
-"``contraction_order``."
+msgstr "Número de veces que se realizarán las operaciones de contracción."
 
-#, fuzzy
 msgid "``forbidden``"
-msgstr "``forbidden_vertices``"
+msgstr "``forbidden``"
 
 msgid "``BIGINT[]``"
 msgstr "``BIGINT[]``"
 
-#, fuzzy
 msgid "``ARRAY[]::BIGINT[]``"
-msgstr "``ARRAY[BIGINT]``"
+msgstr "``ARRAY[]::BIGINT[]``"
 
 msgid "Identifiers of vertices forbidden for contraction."
 msgstr "Identificadores de vértices prohibidos para contracción."
@@ -10718,23 +10676,20 @@ msgstr "La función devuelve una sola fila. Las columnas de la fila son:"
 msgid "``type``"
 msgstr "``type``"
 
-#, fuzzy
 msgid "Type of the row."
-msgstr "Tipo del ``id``."
+msgstr "Tipo de la fila."
 
 msgid "``v`` when the row is a vertex."
 msgstr "``v`` cuando la fila es un vértice."
 
-#, fuzzy
 msgid "Column ``id`` has a positive value."
-msgstr "Columna ``id`` tiene valor positivo"
+msgstr "Columna ``id`` tiene valor positivo."
 
 msgid "``e`` when the row is an edge."
 msgstr "``e`` cuando la fila es una arista."
 
-#, fuzzy
 msgid "Column ``id`` has a negative value."
-msgstr "Columna ``id`` tiene valor negativo"
+msgstr "Columna ``id`` tiene valor negativo."
 
 msgid "All numbers on this column are ``DISTINCT``"
 msgstr "Todos los números de esta columna son ''DISTINTOS''"
@@ -10796,7 +10751,6 @@ msgstr "Sólo contracción lineal"
 msgid "The cycle"
 msgstr "El ciclo"
 
-#, fuzzy
 msgid ""
 "Contracting a graph can be done with more than one operation. The order of "
 "the operations affect the resulting contracted graph, after applying one "
@@ -10804,15 +10758,13 @@ msgid ""
 "changes."
 msgstr ""
 "Contraer un grafo se puede hacer con más de una operación. El orden de las "
-"operaciones afecta al gráfico contraído resultante; después de aplicar una "
+"operaciones afecta al grafo contraído resultante, después de aplicar una "
 "operación, el conjunto de vértices que se pueden contraer con otra operación "
 "cambia."
 
-#, fuzzy
 msgid "This implementation cycles ``cycles`` times through the ``methods`` ."
 msgstr ""
-"Esta implementación alterna los tiempos `` max_cycles`` a través de `` "
-"operations_order``."
+"Esta implementación cicla `` cycles`` veces a través de los ``methods``."
 
 msgid "Contracting sample data"
 msgstr "Contracción de los datos de muestra"
@@ -10836,14 +10788,14 @@ msgstr "Construcción del grafo en la base de datos"
 msgid "The original graph:"
 msgstr "El grafo original:"
 
-#, fuzzy
 msgid ""
 "The results do not represent the contracted graph. They represent the "
 "changes that need to be done to the graph after applying the contraction "
 "methods."
 msgstr ""
 "Los resultados no representan al grafo contraído. Representan los cambios "
-"realizados en el grafo después de aplicar el algoritmo de contracción."
+"que necesitan hacerse en el grafo después de aplicar los métodos de "
+"contracción."
 
 msgid ""
 "Observe that vertices, for example, :math:`6` do not appear in the results "
@@ -10869,9 +10821,8 @@ msgid ""
 "the following will be used:"
 msgstr ""
 
-#, fuzzy
 msgid "Column."
-msgstr "Columna"
+msgstr "Columna."
 
 msgid "The vertices set belonging to the vertex/edge"
 msgstr "El conjunto de vértices que pertenecen al vértice/arista"
@@ -10917,25 +10868,22 @@ msgstr ""
 msgid "Store contraction information"
 msgstr "Almacenar información de contracción"
 
-#, fuzzy
 msgid "Store the contraction results in a table."
-msgstr "Almacenar los `resultados de la contracción`_ en una tabla"
+msgstr "Almacenar los resultados de la contracción en una tabla."
 
-#, fuzzy
 msgid "Update the edges and vertices tables"
-msgstr "Crear la tabla de vértices"
+msgstr "Actualizar las tablas de aristas y vértices"
 
 msgid ""
 "Use ``is_contracted`` column to indicate the vertices that are contracted."
 msgstr ""
 "Usar la columna ``is_contracted`` para indicar los vértices contraídos."
 
-#, fuzzy
 msgid ""
 "Fill ``contracted_vertices`` with the information from the results that "
 "belong to the vertices."
 msgstr ""
-"Lllena ``contracted_vertices`` con la información de los resultados que "
+"Llenar ``contracted_vertices`` con la información de los resultados que "
 "pertenecen a los vértices."
 
 msgid "Insert the new edges generated by pgr_contraction."
@@ -10950,9 +10898,8 @@ msgstr "Vértices que pertenecen al grafo contraído."
 msgid "Edges that belong to the contracted graph."
 msgstr "Aristas que pertenecen al grafo contraído."
 
-#, fuzzy
 msgid "Visually:"
-msgstr "Resultados visuales"
+msgstr "Visualmente:"
 
 msgid "Using the contracted graph"
 msgstr "Usando el grafo contraído"
@@ -10983,39 +10930,36 @@ msgstr "Caso 3: El origen y/o el destino pertenecen a un vértice."
 msgid "The final application should consider all of those cases."
 msgstr ""
 
-#, fuzzy
 msgid "Create a view (or table) of the contracted graph:"
-msgstr "Vértices que pertenecen al grafo contraído."
+msgstr "Crear una vista (o tabla) del grafo Contraído:"
 
-#, fuzzy
 msgid "Create the function that will use the contracted graph."
-msgstr "Caso 1: Tanto el origen como el destino pertenecen al grafo contraído."
+msgstr "Crear la función que va a utilizar el grafo contraído."
 
-#, fuzzy
 msgid ""
 "Case 2: Source and/or target belong to an edge that has contracted vertices."
-msgstr "Caso 2: El origen y/o el destino pertenecen a un subgrafo de aristas."
+msgstr ""
+"Caso 2: El origen y/o el destino pertenecen a una arista que ha contraído "
+"vertices."
 
-#, fuzzy
 msgid ""
 "Case 3: Source and/or target belong to a vertex that has been contracted."
-msgstr "Caso 3: El origen y/o el destino pertenecen a un vértice."
+msgstr ""
+"Caso 3: El origen y/o el destino pertenecen a un vértice que ha sido "
+"contraído."
 
-#, fuzzy
 msgid "``pgr_contractionDeadEnd`` - Proposed"
-msgstr "``pgr_extractVertices``-- Propuesto"
+msgstr "``pgr_contractionDeadEnd`` - Propuesto"
 
-#, fuzzy
 msgid ""
 "``pgr_contractionDeadEnd`` — Performs graph contraction and returns the "
 "contracted vertices and edges."
 msgstr ""
-"``pgr_contraction`` — Realiza la contracción del grafo y devuelve los "
+"``pgr_contractionDeadEnd`` — Realiza la contracción del grafo y devuelve los "
 "vértices y aristas contraídos.."
 
-#, fuzzy
 msgid "A node is considered a dead end node when:"
-msgstr "Un nodo se considera **sin salida** cuando"
+msgstr "Un nodo se considera sin salida cuando:"
 
 msgid "On undirected graphs:"
 msgstr "En grafos no dirigidos:"
@@ -11026,53 +10970,44 @@ msgstr "El número de vértices adyacentes es 1."
 msgid "On directed graphs:"
 msgstr "En grafos dirigidos:"
 
-#, fuzzy
 msgid "When there is only one adjacent vertex or"
-msgstr "Cuando no hay ruta:"
+msgstr "Cuando hay solo un vértice adyacente o"
 
 msgid ""
 "When all edges are incoming regardless of the number of adjacent vertices."
 msgstr ""
 
-#, fuzzy
 msgid "pgr_contractionDeadEnd(`Edges SQL`_, [**options**])"
-msgstr ""
-"pgr_contraction(`SQL de aristas`_, **orden de contracción**, [**opciones**])"
+msgstr "pgr_contractionDeadEnd(`SQL de aristas`_, [**opciones**])"
 
-#, fuzzy
 msgid "**options:** ``[directed, forbidden_vertices]``"
-msgstr "**opcionales:** ``[directed, details]``"
+msgstr "**opciones:** ``[directed, forbidden]``"
 
-#, fuzzy
 msgid "Dead end contraction on an undirected graph."
-msgstr "Vértice sin salida en un grafo sin dirigir"
+msgstr "Contracción de vértice sin salida en un grafo no dirigido."
 
-#, fuzzy
 msgid "The green nodes are dead end nodes."
-msgstr "Los nodos verdes son nodos `dead end`_"
+msgstr "Los nodos verdes son nodos sin salida."
 
-#, fuzzy
 msgid "Node :math:`3` is a dead end node after node :math:`1` is contracted."
 msgstr ""
-"El nodo :math:`u` tiene la información de los nodos que se contrajeron."
+"El nodo :math:`3` es sin salida después de haberse contraído el nodo "
+":math:`1`."
 
 msgid "``forbidden_vertices``"
 msgstr "``forbidden_vertices``"
 
-#, fuzzy
 msgid "``ARRAY[`` |ANY-INTEGER| ``]``"
-msgstr "``ARRAY[`` **ANY-INTEGER** ``]``"
+msgstr "``ARRAY[`` |ANY-INTEGER| ``]``"
 
 msgid "**Empty**"
 msgstr "**vacío**"
 
-#, fuzzy
 msgid "Value = ``e`` indicating the row is an edge."
-msgstr "``e`` cuando la fila es una arista."
+msgstr "Valor = ``e`` cuando la fila es una arista."
 
-#, fuzzy
 msgid "A pseudo `id` of the edge."
-msgstr "Geometría de la arista."
+msgstr "Un pseudo `identificador` de la arista."
 
 msgid "Identifier of the source vertex of the current edge."
 msgstr "Identificador del vértice de origen de la arista actual."
@@ -11080,9 +11015,8 @@ msgstr "Identificador del vértice de origen de la arista actual."
 msgid "Identifier of the target vertex of the current edge."
 msgstr "Identificador del vértice destino de la arista actual."
 
-#, fuzzy
 msgid "Weight of the current edge."
-msgstr "Identificador del vértice de origen de la arista actual."
+msgstr "Peso de la arista actual."
 
 msgid "Dead end vertex on undirected graph"
 msgstr "Vértice sin salida en un grafo sin dirigir"
@@ -11093,9 +11027,8 @@ msgstr ""
 msgid "Dead end vertex on directed graph"
 msgstr "Vértice sin salida en un grafo dirigido"
 
-#, fuzzy
 msgid "The green nodes are dead end nodes"
-msgstr "Los nodos verdes son nodos `dead end`_"
+msgstr "Los nodos verdes son nodos sin salida"
 
 msgid ""
 "The blue nodes have an unlimited number of incoming and/or outgoing edges."
@@ -11115,176 +11048,138 @@ msgstr "Sin salida"
 msgid "Reason"
 msgstr ""
 
-#, fuzzy
 msgid ":math:`6`"
-msgstr ":math:`a`"
+msgstr ":math:`6`"
 
-#, fuzzy
 msgid ":math:`\\{1\\}`"
-msgstr ":math:`\\{u\\}`"
+msgstr ":math:`\\{1\\}`"
 
-#, fuzzy
 msgid "Yes"
-msgstr "sí"
+msgstr "Si"
 
-#, fuzzy
 msgid "Has only one adjacent node."
-msgstr "Número de vértices adyacentes"
+msgstr "Solo tiene un nodo adyacente."
 
-#, fuzzy
 msgid ":math:`7`"
-msgstr ":math:`a`"
+msgstr ":math:`7`"
 
-#, fuzzy
 msgid ":math:`\\{2\\}`"
-msgstr ":math:`\\{u\\}`"
+msgstr ":math:`\\{2\\}`"
 
-#, fuzzy
 msgid ":math:`8`"
-msgstr ":math:`a`"
+msgstr ":math:`8`"
 
-#, fuzzy
 msgid ":math:`\\{2, 3\\}`"
-msgstr ":math:`\\{v, w\\}`"
+msgstr ":math:`\\{2, 3\\}`"
 
 msgid "Has more than one adjacent node and all edges are incoming."
 msgstr ""
 
-#, fuzzy
 msgid ":math:`\\{4\\}`"
-msgstr ":math:`\\{u\\}`"
+msgstr ":math:`\\{4\\}`"
 
-#, fuzzy
 msgid ":math:`10`"
-msgstr ":math:`1`"
+msgstr ":math:`10`"
 
-#, fuzzy
 msgid ":math:`\\{4, 5\\}`"
-msgstr ":math:`\\{v, w\\}`"
+msgstr ":math:`\\{4, 5\\}`"
 
-#, fuzzy
 msgid "No"
-msgstr "Nodo"
+msgstr "No"
 
 msgid "Has more than one adjacent node and all edges are outgoing."
 msgstr ""
 
-#, fuzzy
 msgid ":math:`1,2,3,4,5`"
-msgstr ":math:`1`"
+msgstr ":math:`1,2,3,4,5`"
 
-#, fuzzy
 msgid "Many adjacent nodes."
-msgstr "Nodos adyacentes"
+msgstr "Muchos nodos adyacentes."
 
 msgid ""
 "Has more than one adjacent node and some edges are incoming and some are "
 "outgoing."
 msgstr ""
 
-#, fuzzy
 msgid ""
 "From above, nodes :math:`\\{6, 7, 9\\}` are dead ends because the total "
 "number of adjacent vertices is one."
 msgstr ""
-"De arriba, nodes :math:`\\{a, b, d\\}` son callejones sin salida por que el "
-"número de vértices adyacentes es 1. No son necesarios los checks para esos "
-"nodos."
+"De arriba, nodes :math:`\\{6, 7, 9\\}` son sin salida por que el número de "
+"vértices adyacentes es 1."
 
 msgid ""
 "When there are more than one adjacent vertex, all edges need to be all "
 "incoming edges otherwise it is not a dead end."
 msgstr ""
 
-#, fuzzy
 msgid "Step by step dead end contraction"
-msgstr "Sólo contracción sin salida"
+msgstr "Paso a paso contracción sin salida"
 
-#, fuzzy
 msgid ""
 "The dead end contraction will stop until there are no more dead end nodes. "
 "For example, from the following graph where :math:`3` is the dead end node:"
 msgstr ""
 "La contracción sin salida se detendrá hasta que no haya más nodos sin "
-"salida. Por ejemplo, del siguiente grafo donde :math:`w` es el nodo `dead "
-"end`_:"
+"salida. Por ejemplo, del siguiente grafo donde :math:`3` es el nodo sin "
+"salida:"
 
-#, fuzzy
 msgid ""
 "After contracting :math:`3`, node :math:`2` is now a dead end node and is "
 "contracted:"
 msgstr ""
-"Después de contraer :math:`w`, el nodo ` :math:`v` es ahora un nodo `dead "
-"end`_ y es contraído:"
+"Después de contraer :math:`3`, el nodo ` :math:`2` es ahora un nodo sin "
+"salida y es contraído:"
 
-#, fuzzy
 msgid ""
 "After contracting :math:`2`, stop. Node :math:`1` has the information of "
 "nodes that were contracted."
 msgstr ""
-"Después de contraer math:`v`, detenerse El nodo math:`u` tiene la "
+"Después de contraer :math:`2`, detener. El nodo :math:`1` tiene la "
 "información de los nodos que se contraen."
 
-#, fuzzy
 msgid "Creating the contracted graph"
-msgstr "Usando el grafo contraído"
+msgstr "Creando el grafo contraído"
 
-#, fuzzy
 msgid "Steps for the creation of the contracted graph"
-msgstr "Aristas que pertenecen al grafo contraído."
+msgstr "Pasos para la creación del grafo contraído"
 
-#, fuzzy
 msgid "Add additional columns."
-msgstr "Añadir columnas adicionales"
+msgstr "Añadir columnas adicionales."
 
-#, fuzzy
 msgid "Save results into a table."
-msgstr "Almacenar los `resultados de la contracción`_ en una tabla"
+msgstr "Almacenar los resultados en una tabla."
 
-#, fuzzy
 msgid "The contracted vertices are not part of the contracted graph."
-msgstr ""
-"En caso de ''true'' se contrae el vértice, no forma parte del grafo "
-"contraído."
+msgstr "Los vértices contraído no forman parte del grafo contraído."
 
-#, fuzzy
 msgid "Using when departure and destination are in the contracted graph"
-msgstr "Caso 1: Tanto el origen como el destino pertenecen al grafo contraído."
+msgstr "Usando cuando la salida como el destino pertenecen al grafo contraído"
 
-#, fuzzy
 msgid "Using when departure/destination is not in the contracted graph"
-msgstr ""
-"En caso de ''true'' se contrae el vértice, no forma parte del grafo "
-"contraído."
+msgstr "Usando cuando la salida /destino no pertenecen al grafo contraído"
 
-#, fuzzy
 msgid "Using when departure and destination are not in the contracted graph"
-msgstr "Caso 1: Tanto el origen como el destino pertenecen al grafo contraído."
+msgstr "Usando cuando la salida y el destino no están en el grafo contraído"
 
-#, fuzzy
 msgid "``pgr_contractionLinear`` - Proposed"
-msgstr "``pgr_dijkstraNear`` - Propuesto"
+msgstr "``pgr_contractionLinear`` - Propuesto"
 
-#, fuzzy
 msgid ""
 "``pgr_contractionLinear`` — Performs graph contraction and returns the "
 "contracted vertices and edges."
 msgstr ""
-"``pgr_contraction`` — Realiza la contracción del grafo y devuelve los "
+"``pgr_contractionLinear`` — Realiza la contracción del grafo y devuelve los "
 "vértices y aristas contraídos.."
 
-#, fuzzy
 msgid "pgr_contractionLinear(`Edges SQL`_, [**options**])"
-msgstr ""
-"pgr_contraction(`SQL de aristas`_, **orden de contracción**, [**opciones**])"
+msgstr "pgr_contractionLinear(`SQL de aristas`_, [**opciones**])"
 
-#, fuzzy
 msgid "**options:** ``[directed, max_cycles, forbidden_vertices]``"
-msgstr "**opcionales:** ``[ max_cycles, forbidden_vertices, directed]``"
+msgstr "**opciones:** ``[directed, forbidden_vertices]``"
 
-#, fuzzy
 msgid "Linear contraction on an undirected graph."
-msgstr "Usando una tabla de combinaciones en un grafo no dirigido."
+msgstr "Contracción lineal en un grafo no dirigido."
 
 #, fuzzy
 msgid ""
@@ -11321,17 +11216,15 @@ msgstr "El número de vértices adyacentes es 2."
 msgid "In case of a directed graph, a node is considered a `linear` node when"
 msgstr "En el caso de un grafo dirigido, un nodo se considera `lineal` cuando"
 
-#, fuzzy
 msgid "Linearity is symmetrical."
-msgstr "La linealidad es simétrica"
+msgstr "La linealidad es simétrica."
 
 #, fuzzy
 msgid "Linearity is not symmetrical"
 msgstr "La linealidad es simétrica"
 
-#, fuzzy
 msgid "Graph where linearity is not symmetrical."
-msgstr "La linealidad es simétrica"
+msgstr "Grafo cuando la linealidad no es simétrica."
 
 msgid ""
 "When the graph is processed as a directed graph, linearity is not "
@@ -11343,17 +11236,14 @@ msgid ""
 "symmetrical, therefore the graph can be contracted."
 msgstr ""
 
-#, fuzzy
 msgid "The three edges can be replaced by one undirected edge"
-msgstr "El gráfico puede dirigido o no."
+msgstr "Las tres aristas pueden ser reemplazadas por una arista no dirigida"
 
-#, fuzzy
 msgid "Edge :math:`1 - 3`."
-msgstr ":math:`1`"
+msgstr "Arista :math:`1 - 3`."
 
-#, fuzzy
 msgid "With cost: :math:`4`."
-msgstr "Con ``cost``"
+msgstr "Con costo: :math:`4`."
 
 #, fuzzy
 msgid "Contracted vertices in the edge: :math:`\\{2\\}`."
@@ -11362,21 +11252,18 @@ msgstr "Para un grafo dirigido con aristas :math:`\\{1, 2, 3, 4\\}`."
 msgid "Linearity is symmetrical"
 msgstr "La linealidad es simétrica"
 
-#, fuzzy
 msgid "Graph where linearity is symmetrical."
-msgstr "La linealidad es simétrica"
+msgstr "Grafo donde la linealidad es simétrica."
 
 #, fuzzy
 msgid "The four edges can be replaced by two directed edges."
 msgstr "El gráfico puede dirigido o no."
 
-#, fuzzy
 msgid "Edge :math:`3 - 1`."
-msgstr ":math:`-1`"
+msgstr "Arista :math:`3 - 1`."
 
-#, fuzzy
 msgid "With cost: :math:`6`."
-msgstr "Con ``cost``"
+msgstr "Con costo: :math:`6`."
 
 #, fuzzy
 msgid "The four edges can be replaced by one undirected edge."
@@ -11386,14 +11273,12 @@ msgstr "El gráfico puede dirigido o no."
 msgid "Step by step linear contraction"
 msgstr "Sólo contracción lineal"
 
-#, fuzzy
 msgid ""
 "The linear contraction will stop when there are no more linear edges. For "
 "example from the following graph there are linear edges"
 msgstr ""
-"La contracción lineal se detendrá hasta que no hayan más nodos lineales. Por "
-"ejemplo, en el siguiente grafo donde ` :math:`v` y :math:`w` son nodos "
-"`lineales`_ :"
+"La contracción lineal se detendrá hasta que no hayan más aristas lineales. "
+"Por ejemplo, en el siguiente grafo hay aristas lineales"
 
 #, fuzzy
 msgid "Contracting vertex :math:`3`,"
@@ -11449,9 +11334,8 @@ msgstr ""
 "El arista :math:`u \\rightarrow z` tiene la información de los nodos que "
 "fueron contraídos."
 
-#, fuzzy
 msgid "Create the contracted graph."
-msgstr "El grafo contraído"
+msgstr "Crear el grafo contraído."
 
 msgid "``pgr_createTopology``"
 msgstr "``pgr_createTopology``"
@@ -12137,9 +12021,8 @@ msgid ""
 "requirements."
 msgstr ""
 
-#, fuzzy
 msgid "No ordering is performed."
-msgstr "No se realiza ningún pedido"
+msgstr "No se realiza ningún ordenamiento."
 
 #, fuzzy
 msgid "pgr_degree(`Edges SQL`_ , [``dryrun``])"
@@ -12158,9 +12041,8 @@ msgstr ""
 msgid "example"
 msgstr "Ejemplo"
 
-#, fuzzy
 msgid "Get the degree of the vertices defined on the edges table"
-msgstr ":math:`m` es el grado máximo de los vértices en el grafo."
+msgstr "Obtener el grado de los vértices definidos en la tabla de aristas"
 
 #, fuzzy
 msgid "Edges and Vertices"
@@ -12177,9 +12059,8 @@ msgid ""
 "hand and use it on ``pgr_degree`` calls. (See `Using a vertex table`_)"
 msgstr ""
 
-#, fuzzy
 msgid "Calculate the degree of the nodes:"
-msgstr "Calcula el grado de los vértices de un grafo **no dirigido**"
+msgstr "Calcula el grado de los vértices:"
 
 msgid "`Vertex SQL`_"
 msgstr "`SQL de vértices`_"
@@ -12244,9 +12125,8 @@ msgstr "Número de aristas incidentes al vértice ``id``"
 msgid "Degree of a loop"
 msgstr "Grado de un subgrafo"
 
-#, fuzzy
 msgid "Using the `Edges`_ signature."
-msgstr "Sobre las firmas obsoletas:"
+msgstr "Usando la firma `Aristas`_."
 
 msgid "Using the `Edges and Vertices`_ signature."
 msgstr ""
@@ -12254,9 +12134,8 @@ msgstr ""
 msgid "Degree of a sub graph"
 msgstr "Grado de un subgrafo"
 
-#, fuzzy
 msgid "For the following is a subgraph of the :doc:`sampledata`:"
-msgstr "Coloración de grafos de pgRouting :doc:`sampledata`"
+msgstr "Para el siguiente sub-grafo de :doc:`sampledata`:"
 
 msgid ":math:`E = \\{(1, 5 \\leftrightarrow 6), (1, 6 \\leftrightarrow 10)\\}`"
 msgstr ""
@@ -12287,9 +12166,8 @@ msgstr ""
 "decente, lo mejor es preparar la tabla de vértices de antemano y utilizar "
 "esa tabla de vértices para las llamadas pgr_degree."
 
-#, fuzzy
 msgid "Extract the vertex information and save into a table:"
-msgstr "Extraer la información del vértice"
+msgstr "Extraer la información del vértice y almacenar en una tabla:"
 
 msgid "Dry run execution"
 msgstr "Ejecución de prueba"
@@ -12324,9 +12202,8 @@ msgstr ""
 "subconjunto, se puede trabajar con las columnas ``in_edges`` y ``out_edges`` "
 "directamente."
 
-#, fuzzy
 msgid "The degree of a dead end is 1."
-msgstr "Los nodos verdes son nodos `dead end`_"
+msgstr "El grado de un sin salida es 1."
 
 #, fuzzy
 msgid "Finding linear vertices"
@@ -13830,9 +13707,8 @@ msgstr ""
 "``pgr_findCloseEdges`` - Encuentra las aristas cercanas a una geometría "
 "puntual."
 
-#, fuzzy
 msgid "``partial`` option is removed."
-msgstr "``n_seq`` se elimina"
+msgstr "Opción ``partial`` se elimina."
 
 msgid ""
 "``pgr_findCloseEdges`` - An utility function that finds the closest edge to "
@@ -13959,9 +13835,8 @@ msgstr "``distancia``"
 msgid "Distance from the point to the edge."
 msgstr "Distancia del punto a la arista."
 
-#, fuzzy
 msgid "Original ``POINT`` geometry."
-msgstr "geometría ``POINT``"
+msgstr "Geometría original ``POINT``."
 
 #, fuzzy
 msgid ""
@@ -13975,13 +13850,11 @@ msgstr ""
 msgid "One point in an edge"
 msgstr "Ejecución en seco de un punto"
 
-#, fuzzy
 msgid "The green node is the original point."
-msgstr "Los nodos verdes son el **punto original**"
+msgstr "El nodo verde es el punto original."
 
-#, fuzzy
 msgid "``geom`` has the value of the original point."
-msgstr "La arista :math:`5` es la más cercana al **punto original**"
+msgstr "``geom`` Tiene el valor del punto original."
 
 #, fuzzy
 msgid ""
@@ -14011,11 +13884,8 @@ msgstr "Devuelve ``CONJUNTO VACÍO``."
 msgid "``dryrun => true``"
 msgstr "``dryrun => true``"
 
-#, fuzzy
 msgid "Generates a PostgreSQL ``NOTICE`` with the code used."
-msgstr ""
-"Generar un ``NOTICE`` de PostgreSQL con el código utilizado para calcular "
-"todas las columnas"
+msgstr "Genera un ``NOTICE`` de PostgreSQL con el código utilizado."
 
 msgid ""
 "The generated code can be used as a starting base code for additional "
@@ -14102,10 +13972,9 @@ msgstr "Un identificador único."
 msgid "Identifier of the nearest segment."
 msgstr "Identificador del vértice."
 
-#, fuzzy
 msgid "Is it on the left, right or both sides of the segment ``edge_id``."
 msgstr ""
-"Está a la izquierda, a la derecha o a ambos lados del segmento ``edge_id``"
+"Está a la izquierda, a la derecha o a ambos lados del segmento ``edge_id``."
 
 msgid "Where in the segment is the point located."
 msgstr "En qué parte del segmento se encuentra el punto."
@@ -14113,17 +13982,15 @@ msgstr "En qué parte del segmento se encuentra el punto."
 msgid "The geometry of the points."
 msgstr "La geometría de los puntos."
 
-#, fuzzy
 msgid "The distance between ``geom`` and the segment ``edge_id``."
-msgstr ""
-"Está a la izquierda, a la derecha o a ambos lados del segmento ``edge_id``"
+msgstr "La distancia entre ``geom`` y el segmento ``edge_id``."
 
-#, fuzzy
 msgid ""
 "A segment that connects the ``geom`` of the point to the closest point on "
 "the segment ``edge_id``."
 msgstr ""
-"Está a la izquierda, a la derecha o a ambos lados del segmento ``edge_id``"
+"Un segmento que conecta la ``geom`` del punto al punto mas cercano al "
+"segmento ``edge_id``."
 
 msgid "``newPoint``"
 msgstr "``newPoint``"
@@ -14135,22 +14002,19 @@ msgstr ""
 msgid "Points of interest fill up"
 msgstr "LLenado de puntos de interés"
 
-#, fuzzy
 msgid "Inserting the points of interest."
-msgstr "Puntos de interés"
+msgstr "Insertando los puntos de interés."
 
-#, fuzzy
 msgid "Filling the rest of the table."
-msgstr "En la tabla de vértices"
+msgstr "Llenando el resto de la tabla."
 
 msgid ""
 "Any other additional modification: In this manual, point :math:`6` can be "
 "reached from both sides."
 msgstr ""
 
-#, fuzzy
 msgid "The points of interest:"
-msgstr "Puntos de interés"
+msgstr "Los puntos de interés:"
 
 msgid "``pgr_floydWarshall``"
 msgstr "``pgr_floydWarshall``"
@@ -16843,7 +16707,7 @@ msgid "Use ``pgr_findCloseEdges`` for points on the fly"
 msgstr ""
 
 msgid "Using :doc:`pgr_findCloseEdges`:"
-msgstr "Usa :doc:`pgr_findCloseEdges`:"
+msgstr "Usando :doc:`pgr_findCloseEdges`:"
 
 msgid ""
 "Visit from vertex :math:`1` to the two locations on the graph of point "
@@ -18083,9 +17947,8 @@ msgstr "pgRouting 3.7"
 msgid "pgRouting 3.8.0 Release Notes"
 msgstr "Notas de la versión de pgRouting 3.7.0"
 
-#, fuzzy
 msgid "Promotion to official function of pgRouting."
-msgstr "Propuesta cambió a oficial en pgRouting"
+msgstr "Promoción a función oficial de pgRouting."
 
 msgid "pgr_extractVertices"
 msgstr "pgr_extractVertices"
@@ -18093,27 +17956,24 @@ msgstr "pgr_extractVertices"
 msgid "pgr_degree"
 msgstr "pgr_degree"
 
-#, fuzzy
 msgid "pgr_findCloseEdges"
-msgstr "``pgr_findCloseEdges``"
+msgstr "pgr_findCloseEdges"
 
 msgid "Official functions changes"
 msgstr "Cambios en las funciones oficiales"
 
-#, fuzzy
 msgid ""
 "`#2786 <https://github.com/pgRouting/pgrouting/issues/2786>`__: "
 "pgr_contraction"
 msgstr ""
-"`#1002 <https://github.com/pgRouting/pgrouting/issues/1002>`__: Problemas de "
-"contracción solucionados:"
+"`#2786 <https://github.com/pgRouting/pgrouting/issues/2786>`__: "
+"pgr_contraction"
 
 msgid "New proposed functions"
 msgstr "Nuevas funciones propuestas"
 
-#, fuzzy
 msgid "Contraction"
-msgstr "Contracción:"
+msgstr "Contracción"
 
 #, fuzzy
 msgid ""
@@ -18123,13 +17983,12 @@ msgstr ""
 "`#2087 <https://github.com/pgRouting/pgrouting/issues/2087>`__: "
 "pgr_extractVertices a propuesto"
 
-#, fuzzy
 msgid ""
 "`#2791 <https://github.com/pgRouting/pgrouting/issues/2791>`__: "
 "pgr_contractionLinear"
 msgstr ""
-"`#1002 <https://github.com/pgRouting/pgrouting/issues/1002>`__: Problemas de "
-"contracción solucionados:"
+"`#2791 <https://github.com/pgRouting/pgrouting/issues/2791>`__: "
+"pgr_contractionLinear"
 
 msgid "pgRouting 3.7"
 msgstr "pgRouting 3.7"
@@ -21054,13 +20913,12 @@ msgid ""
 "when wanting a route from ``source`` to ``target``."
 msgstr ""
 
-#, fuzzy
 msgid ""
 "For convenience of this documentation, some combinations will be stored on a "
 "table:"
 msgstr ""
-"En esta documentación habrá unos 6 puntos de interés fijos y se almacenarán "
-"en una tabla."
+"Por conveniencia de esta documentación, algunas combinaciones se almacenan "
+"en una tabla:"
 
 msgid "Inserting the data:"
 msgstr "Insertar los datos:"

--- a/locale/es/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/es/LC_MESSAGES/pgrouting_doc_strings.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-17 00:50+0000\n"
+"POT-Creation-Date: 2025-03-24 14:17+0000\n"
 "PO-Revision-Date: 2024-10-10 19:43+0000\n"
 "Last-Translator: DeepL <noreply-mt-deepl@weblate.org>\n"
 "Language-Team: Spanish <https://weblate.osgeo.org/projects/pgrouting/"
@@ -313,9 +313,6 @@ msgstr ":doc:`pgr_kruskalDFS`"
 msgid ":doc:`pgr_primDFS`"
 msgstr ":doc:`pgr_primDFS`"
 
-msgid "Proposed"
-msgstr "Propuesto"
-
 msgid "Proposed functions for next mayor release."
 msgstr "Funciones propuestas para la próxima versión mayor."
 
@@ -387,9 +384,6 @@ msgstr ""
 "Leer :doc:`migration` sobre como migrar de la funcionalidad obsoleta de TRSP "
 "a las nuevas firmas o funciones que las reemplazan."
 
-msgid "Experimental"
-msgstr "Experimental"
-
 msgid "Possible server crash"
 msgstr "Posible bloqueo del servidor"
 
@@ -434,7 +428,8 @@ msgstr ""
 "Puede ser necesario que los ejemplos de documentación se generen "
 "automáticamente."
 
-msgid "Might need a lot of feedback from the comunity."
+#, fuzzy
+msgid "Might need a lot of feedback from the community."
 msgstr "Puede ser necesaria retroalimentación por parte de la comunidad."
 
 msgid "Might depend on a proposed function of pgRouting"
@@ -726,11 +721,11 @@ msgid "References"
 msgstr "Referencias"
 
 msgid ""
-"`Boost's metric appro's metric approximation <https://www.boost.org/libs/"
-"graph/doc/metric_tsp_approx.html>`__"
+"`Boost: metric TSP approx <https://www.boost.org/libs/graph/doc/"
+"metric_tsp_approx.html>`__"
 msgstr ""
-"`Algoritmo Métrico de la Librería Boost <https://www.boost.org/libs/graph/"
-"doc/metric_tsp_approx.html>`__"
+"`Boost: aproximación métrica de TSP <https://www.boost.org/libs/graph/doc/"
+"metric_tsp_approx.html>`__"
 
 msgid "`University of Waterloo TSP <https://www.math.uwaterloo.ca/tsp/>`__"
 msgstr "`Universided de Waterloo TSP <https://www.math.uwaterloo.ca/tsp/>`__"
@@ -742,8 +737,8 @@ msgstr ""
 "`Wikipedia: Problema del viajante <https://es.wikipedia.org/wiki/"
 "Problema_del_viajante>`__"
 
-msgid "Vehicle Routing Functions - Category (Experimental)"
-msgstr "Funciones de Ruteo de Vehículos - Categoría (Experimental)"
+msgid "Vehicle Routing Functions - Category"
+msgstr "Funciones de Ruteo de Vehículos - Categoría"
 
 msgid "Pickup and delivery problem"
 msgstr "Problema de recogida y entrega"
@@ -1788,8 +1783,8 @@ msgstr ":math:`1km * 0.0277hr/km = 0.0277hr`"
 msgid "https://en.wikipedia.org/wiki/Vehicle_routing_problem"
 msgstr "https://en.wikipedia.org/wiki/Vehicle_routing_problem"
 
-msgid "The queries use the :doc:`sampledata` network."
-msgstr "Las consultas utilizan la red :doc:`sampledata` ."
+msgid ":doc:`sampledata`"
+msgstr ":doc:`sampledata`"
 
 msgid "A* - Family of functions"
 msgstr "A* - Familia de Funciones"
@@ -1969,8 +1964,11 @@ msgstr ""
 msgid ":doc:`bdAstar-family`"
 msgstr ":doc:`bdAstar-family`"
 
-msgid "https://www.boost.org/libs/graph/doc/astar_search.html"
-msgstr "https://www.boost.org/libs/graph/doc/astar_search.html"
+msgid ""
+"`Boost: A* search <https://www.boost.org/libs/graph/doc/astar_search.html>`__"
+msgstr ""
+"`Boost: Búsqueda A* <https://www.boost.org/libs/graph/doc/astar_search."
+"html>`__"
 
 msgid "https://en.wikipedia.org/wiki/A*_search_algorithm"
 msgstr "https://en.wikipedia.org/wiki/A*_search_algorithm"
@@ -2806,14 +2804,11 @@ msgstr ""
 "Para grandes gráficos donde hay un camino entre el vértice inicial y el "
 "vértice final:"
 
-msgid "It is expected to terminate faster than pgr_astar"
-msgstr "Se espera que termine más rápido que pgr_astar"
+msgid "It is expected to terminate faster than pgr_aStar"
+msgstr "Se espera que termine más rápido que pgr_aStar"
 
 msgid ":doc:`aStar-family`"
 msgstr ":doc:`aStar-family`"
-
-msgid "Previous versions of this page"
-msgstr "Versiones anteriores de esta página"
 
 msgid "Bidirectional Dijkstra - Family of functions"
 msgstr "Bidirectional Dijkstra - Familia de funciones"
@@ -2984,38 +2979,9 @@ msgid "Identifier of the color of the edge."
 msgstr "Identificador del color del segmento."
 
 msgid ""
-"`Boost: Sequential Vertex Coloring algorithm documentation <https://www."
-"boost.org/libs/graph/doc/sequential_vertex_coloring.html>`__"
+"`Boost: <https://www.boost.org/libs/graph/doc/table_of_contents.html>`__"
 msgstr ""
-"`Boost: Documentacion de Algoritmo de Coloración Secuencial de Vertices "
-"<https://www.boost.org/libs/graph/doc/sequential_vertex_coloring.html>`__"
-
-msgid ""
-"`Wikipedia: Graph coloring <https://en.wikipedia.org/wiki/Graph_coloring>`__"
-msgstr ""
-"`Wikipedia: Coloración de grafos <https://en.wikipedia.org/wiki/"
-"Graph_coloring>`__"
-
-msgid ""
-"`Boost: is_bipartite <https://www.boost.org/libs/graph/doc/is_bipartite."
-"html>`__"
-msgstr ""
-"`Boost: es bipartido <https://www.boost.org/libs/graph/doc/is_bipartite."
-"html>`__"
-
-msgid ""
-"`Wikipedia: bipartite graph <https://en.wikipedia.org/wiki/"
-"Bipartite_graph>`__"
-msgstr ""
-"`Wikipedia: grafo bipartito <https://en.wikipedia.org/wiki/"
-"Bipartite_graph>`__"
-
-msgid ""
-"`Boost: Edge Coloring Algorithm documentation <https://www.boost.org/libs/"
-"graph/doc/edge_coloring.html>`__"
-msgstr ""
-"`Boost: Algoritmo de Coloración de Segmentos <https://www.boost.org/libs/"
-"graph/doc/edge_coloring.html>`__"
+"`Boost: <https://www.boost.org/libs/graph/doc/table_of_contents.html>`__"
 
 msgid "Components - Family of functions"
 msgstr "Componentes - Familia de funciones"
@@ -3059,6 +3025,10 @@ msgstr "Contraction - Familia de funciones"
 msgid ":doc:`pgr_contraction`"
 msgstr ":doc:`pgr_contraction`"
 
+#, fuzzy
+msgid ":doc:`pgr_contractionDeadEnd`"
+msgstr ":doc:`pgr_contraction`"
+
 msgid ""
 "In large graphs, like the road graphs, or electric networks, graph "
 "contraction can be used to speed up some graph algorithms. Contraction "
@@ -3098,578 +3068,6 @@ msgid ""
 msgstr ""
 "Decida el orden de los algoritmos de contracción y establezca el número "
 "máximo de veces que se van a ejecutar."
-
-msgid "Contraction of the leaf nodes of the graph."
-msgstr "Contracción de los nodos de hoja del grafo."
-
-msgid "Dead end"
-msgstr "Sin salida"
-
-msgid "A node is considered a **dead end** node when"
-msgstr "Un nodo se considera **sin salida** cuando"
-
-msgid "On undirected graphs:"
-msgstr "En grafos no dirigidos:"
-
-msgid "The number of adjacent vertices is 1."
-msgstr "El número de vértices adyacentes es 1."
-
-msgid "On directed graphs:"
-msgstr "En grafos dirigidos:"
-
-msgid "There are no outgoing edges and has at least one incoming edge."
-msgstr "No hay aristas salientes y tiene al menos una arista entrante."
-
-msgid "There are no incoming edges and has at least one outgoing edge."
-msgstr "No hay aristas entrantes y tiene al menos una arista saliente."
-
-msgid ""
-"When the conditions are true then the `Operation: Dead End Contraction`_ can "
-"be done."
-msgstr ""
-"Cuando las condiciones son verdaderas, se puede hacer la `Operación: "
-"Contracción de callejón sin salida`_."
-
-msgid "Dead end vertex on undirected graph"
-msgstr "Vértice sin salida en un grafo sin dirigir"
-
-msgid "The green nodes are `dead end`_ nodes"
-msgstr "Los nodos verdes son nodos `dead end`_"
-
-msgid "The blue nodes have an unlimited number of edges."
-msgstr "Los nodos azules tienen un número ilimitado de aristas."
-
-msgid "Node"
-msgstr "Nodo"
-
-msgid "Adjecent nodes"
-msgstr "Nodos adyacentes"
-
-msgid "Number of adjacent nodes"
-msgstr "Número de vértices adyacentes"
-
-msgid ":math:`a`"
-msgstr ":math:`a`"
-
-msgid ":math:`\\{u\\}`"
-msgstr ":math:`\\{u\\}`"
-
-msgid ":math:`b`"
-msgstr ":math:`b`"
-
-msgid ":math:`\\{v\\}`"
-msgstr ":math:`\\{v\\}`"
-
-msgid "Dead end vertex on directed graph"
-msgstr "Vértice sin salida en un grafo dirigido"
-
-msgid ""
-"The blue nodes have an unlimited number of incoming and/or outgoing edges."
-msgstr ""
-"Los nodos azules tienen un número ilimitado de aristas entrantes y/o "
-"salientes."
-
-msgid "Number of incoming edges"
-msgstr "Número de aristas entrantes"
-
-msgid "Number of outgoing edges"
-msgstr "Número de aristas salientes"
-
-msgid ":math:`c`"
-msgstr ":math:`c`"
-
-msgid ":math:`\\{v, w\\}`"
-msgstr ":math:`\\{v, w\\}`"
-
-msgid "2"
-msgstr "2"
-
-msgid ":math:`d`"
-msgstr ":math:`d`"
-
-msgid ":math:`\\{x\\}`"
-msgstr ":math:`\\{x\\}`"
-
-msgid ":math:`e`"
-msgstr ":math:`e`"
-
-msgid ":math:`\\{x, y\\}`"
-msgstr ":math:`\\{x, y\\}`"
-
-msgid ""
-"From above, nodes :math:`\\{a, b, d\\}` are dead ends because the number of "
-"adjacent vertices is 1. No further checks are needed for those nodes."
-msgstr ""
-"De arriba, nodes :math:`\\{a, b, d\\}` son callejones sin salida por que el "
-"número de vértices adyacentes es 1. No son necesarios los checks para esos "
-"nodos."
-
-msgid ""
-"On the following table, nodes :math:`\\{c, e\\}` because the even that the "
-"number of adjacent vertices is not 1 for"
-msgstr ""
-"En al siguiente tabla, nodos :math:`\\{c, e\\}` por que el par del numero de "
-"vértices adyacentes no es 1 para"
-
-msgid "Operation: Dead End Contraction"
-msgstr "Operación: Contracción sin salida"
-
-msgid ""
-"The dead end contraction will stop until there are no more dead end nodes. "
-"For example from the following graph where :math:`w` is the `dead end`_ node:"
-msgstr ""
-"La contracción sin salida se detendrá hasta que no haya más nodos sin "
-"salida. Por ejemplo, del siguiente grafo donde :math:`w` es el nodo `dead "
-"end`_:"
-
-msgid ""
-"After contracting :math:`w`, node :math:`v` is now a `dead end`_ node and is "
-"contracted:"
-msgstr ""
-"Después de contraer :math:`w`, el nodo ` :math:`v` es ahora un nodo `dead "
-"end`_ y es contraído:"
-
-msgid ""
-"After contracting :math:`v`, stop. Node :math:`u` has the information of "
-"nodes that were contrcted."
-msgstr ""
-"Después de contraer math:`v`, detenerse El nodo math:`u` tiene la "
-"información de los nodos que se contraen."
-
-msgid "Node :math:`u` has the information of nodes that were contracted."
-msgstr ""
-"El nodo :math:`u` tiene la información de los nodos que se contrajeron."
-
-msgid "In the algorithm, linear contraction is represented by 2."
-msgstr "En el algoritmo, la contracción lineal es representada con un 2."
-
-msgid "Linear"
-msgstr "Lineal"
-
-msgid ""
-"In case of an undirected graph, a node is considered a `linear` node when"
-msgstr ""
-"En el caso de un grafo no dirigido, un nodo se considera un nodo `lineal` "
-"cuando"
-
-msgid "The number of adjacent vertices is 2."
-msgstr "El número de vértices adyacentes es 2."
-
-msgid "In case of a directed graph, a node is considered a `linear` node when"
-msgstr "En el caso de un grafo dirigido, un nodo se considera `lineal` cuando"
-
-msgid "Linearity is symmetrical"
-msgstr "La linealidad es simétrica"
-
-msgid "Linear vertex on undirected graph"
-msgstr "Vértice lineal en grafo no dirigido"
-
-msgid "The green nodes are `linear`_ nodes"
-msgstr "Los nodos verdes son `lineales`_"
-
-msgid "The blue nodes have an unlimited number of incoming and outgoing edges."
-msgstr ""
-"Los nodos azules tienen un número ilimitado de aristas entrantes y salientes."
-
-msgid "Undirected"
-msgstr "No dirigido"
-
-msgid ":math:`v`"
-msgstr ":math:`v`"
-
-msgid ":math:`\\{u, w\\}`"
-msgstr ":math:`\\{u, w\\}`"
-
-msgid "Linear vertex on directed graph"
-msgstr "Vértice lineal en grafo dirigido"
-
-msgid "The white node is not linear because the linearity is not symetrical."
-msgstr "El nodo blanco no es linero por que la linealidad no es simétrica."
-
-msgid "It is possible to go :math:`y \\rightarrow c \\rightarrow z`"
-msgstr "Es posible ir a :math:`y \\rightarrow c \\rightarrow z`"
-
-msgid "It's not possible to go :math:`z \\rightarrow c \\rightarrow y`"
-msgstr "No es posible ir a :math:`z \\rightarrow c \\rightarrow y`"
-
-msgid "Is symmetrical?"
-msgstr "Es simétrico?"
-
-msgid ":math:`\\{u, v\\}`"
-msgstr ":math:`\\{u, v\\}`"
-
-msgid "yes"
-msgstr "sí"
-
-msgid ":math:`\\{w, x\\}`"
-msgstr ":math:`\\{w, x\\}`"
-
-msgid ":math:`\\{y, z\\}`"
-msgstr ":math:`\\{y, z\\}`"
-
-msgid "no"
-msgstr "no"
-
-msgid "Operation: Linear Contraction"
-msgstr "Operación: Contracción Lineal"
-
-msgid ""
-"The linear contraction will stop when there are no more linear nodes. For "
-"example from the following graph where :math:`v` and :math:`w` are `linear`_ "
-"nodes:"
-msgstr ""
-"La contracción lineal se detendrá hasta que no hayan más nodos lineales. Por "
-"ejemplo, en el siguiente grafo donde ` :math:`v` y :math:`w` son nodos "
-"`lineales`_ :"
-
-msgid "Contracting :math:`w`,"
-msgstr "Contrayendo :math:`w`,"
-
-msgid "The vertex :math:`w` is removed from the graph"
-msgstr "El vértice :math:`w` se elimina del grafo"
-
-msgid ""
-"The edges :math:`v \\rightarrow w` and :math:`w \\rightarrow z` are removed "
-"from the graph."
-msgstr ""
-"Los aristas :math:`v \\rightarrow w` y :math:`w \\rightarrow z` fueron "
-"eliminados del grafo."
-
-msgid ""
-"A new edge :math:`v \\rightarrow z` is inserted represented with red color."
-msgstr ""
-"Se inserta un nuevo arista :math:`v \\rightarrow z` y se representa con "
-"color rojo."
-
-msgid "Contracting :math:`v`:"
-msgstr "Contrayendo :math:`v`:"
-
-msgid "The vertex :math:`v` is removed from the graph"
-msgstr "El vértice :math:`v` se elimina del grafo"
-
-msgid ""
-"The edges :math:`u \\rightarrow v` and :math:`v \\rightarrow z` are removed "
-"from the graph."
-msgstr ""
-"Los aristas :math:`u \\rightarrow v` y :math:`v \\rightarrow z` son "
-"removidos del grafo."
-
-msgid ""
-"A new edge :math:`u \\rightarrow z` is inserted represented with red color."
-msgstr ""
-"Se inserta un nuevo arista :math:`u \\rightarrow z` y se representa con "
-"color rojo."
-
-msgid ""
-"Edge :math:`u \\rightarrow z` has the information of nodes that were "
-"contracted."
-msgstr ""
-"El arista :math:`u \\rightarrow z` tiene la información de los nodos que "
-"fueron contraídos."
-
-msgid "The cycle"
-msgstr "El ciclo"
-
-msgid ""
-"Contracting a graph, can be done with more than one operation. The order of "
-"the operations affect the resulting contracted graph, after applying one "
-"operation, the set of vertices that can be contracted by another operation "
-"changes."
-msgstr ""
-"Contraer un grafo se puede hacer con más de una operación. El orden de las "
-"operaciones afecta al gráfico contraído resultante; después de aplicar una "
-"operación, el conjunto de vértices que se pueden contraer con otra operación "
-"cambia."
-
-msgid ""
-"This implementation, cycles ``max_cycles`` times through "
-"``operations_order`` ."
-msgstr ""
-"Esta implementación alterna los tiempos `` max_cycles`` a través de `` "
-"operations_order``."
-
-msgid "Contracting sample data"
-msgstr "Contracción de los datos de muestra"
-
-msgid ""
-"In this section, building and using a contracted graph will be shown by "
-"example."
-msgstr ""
-"En esta sección, la creación y el uso de un grafo contraído se mostrarán en "
-"el ejemplo."
-
-msgid "The :doc:`sampledata` for an undirected graph is used"
-msgstr "Se usa :doc:`sampledata` para un grafo no dirigido"
-
-msgid "a dead end operation first followed by a linear operation."
-msgstr "una operación sin salida primero seguida de una operación lineal."
-
-msgid "Construction of the graph in the database"
-msgstr "Construcción del grafo en la base de datos"
-
-msgid "Original Data"
-msgstr "Datos Originales"
-
-msgid ""
-"The following query shows the original data involved in the contraction "
-"operation."
-msgstr ""
-"La siguiente consulta muestra los datos originales implicados en la "
-"operación de contracción."
-
-msgid "The original graph:"
-msgstr "El grafo original:"
-
-msgid "Contraction results"
-msgstr "Resultados de la Contracción"
-
-msgid ""
-"The results do not represent the contracted graph. They represent the "
-"changes done to the graph after applying the contraction algorithm."
-msgstr ""
-"Los resultados no representan al grafo contraído. Representan los cambios "
-"realizados en el grafo después de aplicar el algoritmo de contracción."
-
-msgid ""
-"Observe that vertices, for example, :math:`6` do not appear in the results "
-"because it was not affected by the contraction algorithm."
-msgstr ""
-"Observe que los vértices, por ejemplo, :math:`6` , no aparecen en los "
-"resultados porque no se vieron afectados por el algoritmo de contracción."
-
-msgid "After doing the dead end contraction operation:"
-msgstr "Después de realizar la operación de contracción sin salida:"
-
-msgid "After doing the linear contraction operation to the graph above:"
-msgstr "Después de hacer la operación de contracción lineal al grafo anterior:"
-
-msgid "The process to create the contraction graph on the database:"
-msgstr "El proceso para crear el grafo de contracción en la base de datos:"
-
-msgid "Add additional columns"
-msgstr "Añadir columnas adicionales"
-
-msgid ""
-"Adding extra columns to the ``edge_table`` and ``edge_table_vertices_pgr`` "
-"tables, where:"
-msgstr ""
-"Agregar de columnas adicionales a las tablas ``edge_table`` y "
-"``edge_table_vertices_pgr`` donde:"
-
-msgid "``contracted_vertices``"
-msgstr "``contracted_vertices``"
-
-msgid "The vertices set belonging to the vertex/edge"
-msgstr "El conjunto de vértices que pertenecen al vértice/arista"
-
-msgid "``is_contracted``"
-msgstr "``is_contracted``"
-
-msgid "On the vertex table"
-msgstr "En la tabla de vértices"
-
-msgid ""
-"when ``true`` the vertex is contracted, its not part of the contracted graph."
-msgstr ""
-"En caso de ''true'' se contrae el vértice, no forma parte del grafo "
-"contraído."
-
-msgid ""
-"when ``false`` the vertex is not contracted, its part of the contracted "
-"graph."
-msgstr ""
-"En caso de ''false'' el vértice no se contrae, su parte del grafo contraído."
-
-msgid "``is_new``"
-msgstr "``is_new``"
-
-msgid "On the edge table"
-msgstr "En la tabla de aristas"
-
-msgid ""
-"when ``true`` the edge was generated by the contraction algorithm. its part "
-"of the contracted graph."
-msgstr ""
-"En caso de `` true``, la arista se generó por el algoritmo de contracción. "
-"Es parte del grafo contraído."
-
-msgid ""
-"when ``false`` the edge is an original edge, might be or not part of the "
-"contracted graph."
-msgstr ""
-"En caso de ``false`` , la arista es una arista original, podría ser o no "
-"parte del grafo contraído."
-
-msgid "Store contraction information"
-msgstr "Almacenar información de contracción"
-
-msgid "Store the `contraction results`_ in a table"
-msgstr "Almacenar los `resultados de la contracción`_ en una tabla"
-
-msgid "The vertex table update"
-msgstr "Actualización de la tabla de vértices"
-
-msgid ""
-"Use ``is_contracted`` column to indicate the vertices that are contracted."
-msgstr ""
-"Usar la columna ``is_contracted`` para indicar los vértices contraídos."
-
-msgid ""
-"Fill ``contracted_vertices`` with the information from the results tha "
-"belong to the vertices."
-msgstr ""
-"Lllena ``contracted_vertices`` con la información de los resultados que "
-"pertenecen a los vértices."
-
-msgid "The modified vertices table:"
-msgstr "La tabla de vértices modificada:"
-
-msgid "The edge table update"
-msgstr "Actialización de la tabla de aristas"
-
-msgid "Insert the new edges generated by pgr_contraction."
-msgstr "Inserte las nuevas aristas generadas por pgr_contraction."
-
-msgid "The modified ``edge_table``."
-msgstr "La modificada ``edge_table``."
-
-msgid "The contracted graph"
-msgstr "El grafo contraído"
-
-msgid "Vertices that belong to the contracted graph."
-msgstr "Vértices que pertenecen al grafo contraído."
-
-msgid "Edges that belong to the contracted graph."
-msgstr "Aristas que pertenecen al grafo contraído."
-
-msgid "Contracted graph"
-msgstr "Grafo contraído"
-
-msgid "Using the contracted graph"
-msgstr "Usando el grafo contraído"
-
-msgid "Using the contracted graph with ``pgr_dijkstra``"
-msgstr "Uso del grafo contraído con ``pgr_dijkstra``"
-
-msgid ""
-"There are three cases when calculating the shortest path between a given "
-"source and target in a contracted graph:"
-msgstr ""
-"Hay tres casos al calcular la ruta más corta entre un origen y un destino "
-"determinados en un grafo contraído:"
-
-msgid "Case 1: Both source and target belong to the contracted graph."
-msgstr "Caso 1: Tanto el origen como el destino pertenecen al grafo contraído."
-
-msgid "Case 2: Source and/or target belong to an edge subgraph."
-msgstr "Caso 2: El origen y/o el destino pertenecen a un subgrafo de aristas."
-
-msgid "Case 3: Source and/or target belong to a vertex."
-msgstr "Caso 3: El origen y/o el destino pertenecen a un vértice."
-
-msgid ""
-"Using the `Edges that belong to the contracted graph.`_ on lines 11 to 20."
-msgstr ""
-"Usando las `Aristas que pertenecen al grafo contraído.`_ en las líneas 11 a "
-"20."
-
-msgid "Case 1"
-msgstr "Caso 1"
-
-msgid ""
-"When both source and target belong to the contracted graph, a path is found."
-msgstr ""
-"Cuando el origen y el destino pertenecen al grafo contraído, se encuentra "
-"ruta."
-
-msgid "Case 2"
-msgstr "Caso 2"
-
-msgid ""
-"When source and/or target belong to an edge subgraph then a path is not "
-"found."
-msgstr ""
-"Cuando el origen y/o el destino pertenecen a un subgrafo de aristas, no se "
-"encuentra una ruta."
-
-msgid ""
-"In this case, the contracted graph do not have an edge connecting with node :"
-"math:`4`."
-msgstr ""
-"En este caso, el grafo contraído no tiene una arista que se conecte con el "
-"nodo :math:`4`."
-
-msgid "Case 3"
-msgstr "Caso 3"
-
-msgid "When source and/or target belong to a vertex then a path is not found."
-msgstr ""
-"Cuando el origen y/o el destino pertenecen a un vértice, no se encuentra "
-"ruta."
-
-msgid ""
-"In this case, the contracted graph do not have an edge connecting with node :"
-"math:`7` and of node :math:`4` of the second case."
-msgstr ""
-"En este caso, el grafo contraído no tiene algún arista que conecte con el "
-"nodo :math:`7` ni con el nodo :math:`4` del segundo caso."
-
-msgid "Refining the above function to include nodes that belong to an edge."
-msgstr ""
-"Refinar la función anterior para incluir nodos que pertenezcan a una arista."
-
-msgid "The vertices that need to be expanded are calculated on lines 11 to 17."
-msgstr "Los vértices que deben ampliarse se calculan en las líneas 11 a 17."
-
-msgid ""
-"Adding to the contracted graph that additional section on lines 26 to 28."
-msgstr ""
-"Añadiendo al grafo contraído esa sección adicional en las líneas 26 a 28."
-
-msgid ""
-"When source and/or target belong to an edge subgraph, now, a path is found."
-msgstr ""
-"Cuando el origen y/o el destino pertenecen a un subgrafo de arista, entonces "
-"se encuentra una ruta."
-
-msgid "The routing graph now has an edge connecting with node :math:`4`."
-msgstr ""
-"El grafo de ruteo ahora tiene un arista que se conecta con el nodo :math:`4`."
-
-msgid ""
-"In this case, the contracted graph do not have an edge connecting with node :"
-"math:`7`."
-msgstr ""
-"En este caso, el grafo contraído no tiene una arista que se conecte con el "
-"nodo :math:`7`."
-
-msgid "The vertices that need to be expanded are calculated on lines 19 to 24."
-msgstr "Los vértices que deben ampliarse se calculan en las líneas 19 a 24."
-
-msgid ""
-"Adding to the contracted graph that additional section on lines 38 to 40."
-msgstr ""
-"Añadiendo al grafo contraído esa sección adicional en las líneas 38 a 40."
-
-msgid ""
-"The code change do not affect this case so when source and/or target belong "
-"to an edge subgraph, a path is still found."
-msgstr ""
-"El cambio de código no afecta a este caso, por lo que cuando el origen o el "
-"destino pertenecen a un subgrafo de aristas, aún se puede encontrar ruta."
-
-msgid "When source and/or target belong to a vertex, now, a path is found."
-msgstr ""
-"Cuando el origen y/o el destino pertenecen a un vértice, entonces se "
-"encuentra ruta."
-
-msgid "Now, the routing graph has an edge connecting with node :math:`7`."
-msgstr ""
-"Ahora, el grafo de ruteo tiene un arista que se conecta con el nodo :math:"
-"`7`."
-
-msgid ":doc:`sampledata`"
-msgstr ":doc:`sampledata`"
 
 msgid ""
 "https://www.cs.cmu.edu/afs/cs/academic/class/15210-f12/www/lectures/"
@@ -3759,9 +3157,6 @@ msgstr ":doc:`pgr_bdAstarCostMatrix`"
 
 msgid ":doc:`pgr_bdDijkstraCostMatrix`"
 msgstr ":doc:`pgr_bdDijkstraCostMatrix`"
-
-msgid "proposed"
-msgstr "propuesta"
 
 msgid ":doc:`pgr_withPointsCostMatrix`"
 msgstr ":doc:`pgr_withPointsCostMatrix`"
@@ -3970,7 +3365,8 @@ msgstr ""
 ":doc:`pgr_KSP` - Usar el algoritmo Yen con pgr_dijkstra para obtener las K "
 "rutas más cortas."
 
-msgid ":doc:`pgr_dijkstraVia` - Get a route of a seuence of vertices."
+#, fuzzy
+msgid ":doc:`pgr_dijkstraVia` - Get a route of a sequence of vertices."
 msgstr ""
 ":doc:`pgr_dijkstraVia` - Obtenga una ruta a partir de una secuencia de "
 "vértices."
@@ -4066,8 +3462,8 @@ msgstr "Los gráficos se definen como sigue:"
 msgid "Directed graph"
 msgstr "Grafo dirigido"
 
-msgid "The weighted directed graph, :math:`G_d(V,E)`, is definied by:"
-msgstr "El gráfico dirigido ponderado, :math:`G_d(V,E)`, se define por:"
+msgid "The weighted directed graph, :math:`G_d(V,E)`, is defined by:"
+msgstr "El ponderado del grafo dirigido, :math:`G_d(V,E)`, se define por:"
 
 msgid "the set of vertices :math:`V`"
 msgstr "el conjunto de vértices :math:`V`"
@@ -4098,7 +3494,8 @@ msgstr ""
 msgid "Undirected graph"
 msgstr "Grafo no dirigido"
 
-msgid "The weighted undirected graph, :math:`G_u(V,E)`, is definied by:"
+#, fuzzy
+msgid "The weighted undirected graph, :math:`G_u(V,E)`, is defined by:"
 msgstr "El grafo ponderado no dirigido :math:`G_u(V,E)`, es definido por:"
 
 msgid ":math:`V = source \\cup target \\cup {start_v{vid}} \\cup  {end_{vid}}`"
@@ -4245,7 +3642,8 @@ msgid ":doc:`pgr_kruskalDD` - Driving Distance based on Kruskal's algorithm"
 msgstr ""
 ":doc:`pgr_kruskalDD` - Distancia de Manejo basada en el algoritmo de Kruskal"
 
-msgid "Post pocessing"
+#, fuzzy
+msgid "Post processing"
 msgstr "Post procesamiento"
 
 msgid ":doc:`pgr_alphaShape` - Alpha shape computation"
@@ -4383,6 +3781,13 @@ msgstr ""
 ":doc:`pgr_cuthillMckeeOrdering` - Ordenamiento Cuthill-McKee de grafo sin no "
 "dirigido."
 
+msgid ""
+":doc:`pgr_topologicalSort` - Linear ordering of the vertices for directed "
+"acyclic graph."
+msgstr ""
+":doc:`pgr_topologicalSort` - Orden lineal de los vértices para grafos "
+"acíclicos dirigidos."
+
 msgid ":doc:`metrics-family`"
 msgstr ":doc:`metrics-family`"
 
@@ -4402,8 +3807,8 @@ msgstr "Categorías"
 msgid ":doc:`VRP-category`"
 msgstr ":doc:`VRP-category`"
 
-msgid "Unclassified"
-msgstr "No clasificado"
+msgid "Shortest Path Category"
+msgstr "Rutas más cortas Categoría"
 
 msgid ":doc:`pgr_bellmanFord`"
 msgstr ":doc:`pgr_bellmanFord`"
@@ -4414,20 +3819,24 @@ msgstr ":doc:`pgr_dagShortestPath`"
 msgid ":doc:`pgr_edwardMoore`"
 msgstr ":doc:`pgr_edwardMoore`"
 
+msgid "Planar Family"
+msgstr "Familia Planar"
+
 msgid ":doc:`pgr_isPlanar`"
 msgstr ":doc:`pgr_isPlanar`"
+
+#, fuzzy
+msgid "Miscellaneous Algorithms"
+msgstr "Algoritmos diversos"
+
+msgid ":doc:`pgr_lengauerTarjanDominatorTree`"
+msgstr ":doc:`pgr_lengauerTarjanDominatorTree`"
 
 msgid ":doc:`pgr_stoerWagner`"
 msgstr ":doc:`pgr_stoerWagner`"
 
-msgid ":doc:`pgr_topologicalSort`"
-msgstr ":doc:`pgr_topologicalSort`"
-
 msgid ":doc:`pgr_transitiveClosure`"
 msgstr ":doc:`pgr_transitiveClosure`"
-
-msgid ":doc:`pgr_lengauerTarjanDominatorTree`"
-msgstr ":doc:`pgr_lengauerTarjanDominatorTree`"
 
 msgid ":doc:`pgr_hawickCircuits`"
 msgstr ":doc:`pgr_hawickCircuits`"
@@ -4496,7 +3905,8 @@ msgstr ""
 "Cuando el flujo máximo es 0 entonces no hay flujo, se devolverá: **EMPTY "
 "SET**."
 
-msgid "There is no flow when source has the same vaule as target."
+#, fuzzy
+msgid "There is no flow when source has the same value as target."
 msgstr "No hay flujo cuando el origen tiene el mismo valor que el destino."
 
 msgid "Any duplicated values in source or target are ignored."
@@ -4832,6 +4242,14 @@ msgstr ":doc:`pgr_kruskal`"
 msgid ":doc:`pgr_kruskalDD`"
 msgstr ":doc:`pgr_kruskalDD`"
 
+#, fuzzy
+msgid ""
+":doc:`pgr_degree` - Returns a set of vertices and corresponding count of "
+"incident edges to the vertex."
+msgstr ""
+"``pgr_degree`` - Para cada vértice de un grafo no dirigido, devuelve el "
+"número de aristas incidentes en el vértice."
+
 msgid ":doc:`prim-family`"
 msgstr ":doc:`prim-family`"
 
@@ -4887,8 +4305,22 @@ msgid ":doc:`pgr_nodeNetwork` - to create nodes to a not noded edge table."
 msgstr ""
 ":doc:`pgr_nodeNetwork` - para crear nodos a una tabla de aristas sin nodos."
 
+msgid ""
+":doc:`pgr_extractVertices` - Extracts vertex information based on the edge "
+"table information."
+msgstr ""
+":doc:`pgr_extractVertices` - Extrae información de vértices basada en la "
+"tabla de aristas."
+
 msgid ":doc:`pgr_trsp` - Turn Restriction Shortest Path (TRSP)"
 msgstr ":doc:`pgr_trsp` - Camino más corto con restricción de giros (TRSP)"
+
+#, fuzzy
+msgid "Utilities family"
+msgstr "Utilidades"
+
+msgid ":doc:`pgr_findCloseEdges`"
+msgstr ":doc:`pgr_findCloseEdges`"
 
 msgid "Functions by categories"
 msgstr "Funciones por categorías"
@@ -4905,7 +4337,8 @@ msgstr ":doc:`drivingDistance-category`"
 msgid ":doc:`KSP-category`"
 msgstr ":doc:`KSP-category`"
 
-msgid ":doc:`spanningTree-family`"
+#, fuzzy
+msgid ":doc:`spanningTree-category`"
 msgstr ":doc:`spanningTree-family`"
 
 msgid ":doc:`BFS-category`"
@@ -4926,131 +4359,192 @@ msgstr ":doc:`experimental`"
 msgid ":doc:`release_notes`"
 msgstr ":doc:`release_notes`"
 
-msgid "pgRouting 3.7.0 Release Notes"
-msgstr "Notas de la versión de pgRouting 3.7.0"
+msgid "pgRouting 4.0.0 Release Notes"
+msgstr "Notas de la versión de pgRouting 4.0.0"
 
 msgid ""
 "To see all issues & pull requests closed by this release see the `Git closed "
-"milestone for 3.7.0 <https://github.com/pgRouting/pgrouting/issues?"
-"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.0%22>`__"
+"milestone for 4.0.0 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%204.0.0%22>`__"
 msgstr ""
 "Para ver todos los problemas y solicitudes de extracción cerrados para ésta "
-"versión, consulte la `meta cerrada 3.7.0 <https://github.com/pgRouting/"
-"pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.0%22>`_"
+"versión, consulte la `meta cerrada 4.0.0 <https://github.com/pgRouting/"
+"pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%204.0.0%22>`__"
 
-msgid "Support"
-msgstr "Soporte"
+msgid "Functions promoted to official"
+msgstr "Funciones promovidas a oficial"
 
-msgid ""
-"`#2656 <https://github.com/pgRouting/pgrouting/pull/2656>`__ Stop support of "
-"PostgreSQL12 on pgrouting v3.7"
-msgstr ""
-"`#2656 <https://github.com/pgRouting/pgrouting/pull/2656>`__ PostgreSQL 12 "
-"no se apya en pgrouting v3.7"
+msgid "pgr_trsp"
+msgstr "pgr_trsp"
 
-msgid "Stopping support of PostgreSQL 12"
-msgstr "PostgreSQL 12 ya no es soportado"
+msgid "pgr_trspVia"
+msgstr "pgr_trspVia"
 
-msgid "CI does not test for PostgreSQL 12"
-msgstr "CI no hace pruebas con PostgreSQL 12"
+msgid "pgr_trspVia_withPoints"
+msgstr "pgr_trspVia_withPoints"
 
-msgid "New experimental functions"
-msgstr "Nuevas funciones experimentales"
+msgid "pgr_trsp_withPoints"
+msgstr "pgr_trsp_withPoints"
 
-msgid "Metrics"
-msgstr "Métricas"
+msgid "pgr_withPoints"
+msgstr "pgr_withPoints"
 
-msgid "pgr_betweennessCentrality"
-msgstr "pgr_betweennessCentrality"
+msgid "pgr_withPointsCost"
+msgstr "pgr_withPointsCost"
 
-msgid "Official functions changes"
-msgstr "Cambios en las funciones oficiales"
+msgid "pgr_withPointsCostMatrix"
+msgstr "pgr_withPointsCostMatrix"
 
-msgid ""
-"`#2605 <https://github.com/pgRouting/pgrouting/pull/2605>`__ Standarize "
-"spanning tree functions output"
-msgstr ""
-"`#2605 <https://github.com/pgRouting/pgrouting/pull/2605>`__ Estandarización "
-"de las salida de las funciones de árbol de expansión"
+msgid "pgr_withPointsDD"
+msgstr "pgr_withPointsDD"
 
-msgid "Functions:"
-msgstr "Funciones:"
+msgid "pgr_withPointsKSP"
+msgstr "pgr_withPointsKSP"
 
-msgid "``pgr_kruskalDD``"
-msgstr "``pgr_kruskalDD``"
+msgid "pgr_withPointsVia"
+msgstr "pgr_withPointsVia"
 
-msgid "``pgr_kruskalDFS``"
-msgstr "``pgr_kruskalDFS``"
+msgid "Signatures promoted to official"
+msgstr "Firmas promovidas a oficial"
 
-msgid "``pgr_kruskalBFS``"
-msgstr "``pgr_kruskalBFS``"
+msgid "pgr_aStar(Combinations)"
+msgstr "pgr_aStar(Combinaciones)"
 
-msgid "``pgr_primDD``"
-msgstr "``pgr_primDD``"
+msgid "pgr_aStarCost(Combinations)"
+msgstr "pgr_aStarCost(Combinaciones)"
 
-msgid "``pgr_primDFS``"
-msgstr "``pgr_primDFS``"
+msgid "pgr_bdAstar(Combinations)"
+msgstr "pgr_bdAstar(Combinaciones)"
 
-msgid "``pgr_primBFS``"
-msgstr "``pgr_primBFS``"
+msgid "pgr_bdAstarCost(Combinations)"
+msgstr "pgr_bdAstarCost(Combinaciones)"
 
-msgid "Standarizing output columns to |result-spantree|"
-msgstr "Estandarización de columnas de resultados a |result-spantree|"
+msgid "pgr_bdDijkstra(Combinations)"
+msgstr "pgr_bdDijkstra(Combinaciones)"
 
-msgid "Added ``pred`` result columns."
-msgstr "Agregado columna de resultados ``pred``."
+msgid "pgr_bdDijkstraCost(Combinations)"
+msgstr "pgr_bdDijkstraCost(Combinaciones)"
 
-msgid "Experimental promoted to proposed."
-msgstr "Experimental promovido a propuesto."
+msgid "pgr_dijkstra(Combinations)"
+msgstr "pgr_dijkstra(Combinaciones)"
 
-msgid ""
-"`#2635 <https://github.com/pgRouting/pgrouting/pull/2635>`__ pgr_LineGraph "
-"ignores directed flag and use negative values for identifiers."
-msgstr ""
-"`#2635 <https://github.com/pgRouting/pgrouting/pull/2635>`__ pgr_LineGraph "
-"ignora la bandera directed y usa valores negatives para identificadores."
+msgid "pgr_dijkstraCost(Combinations)"
+msgstr "pgr_dijkstraCost(Combinaciones)"
 
-msgid "``pgr_lineGraph``"
-msgstr "``pgr_lineGraph``"
+msgid "pgr_KSP(All signatures)"
+msgstr "pgr_KSP(todas las firmas)"
 
-msgid "Promoted to **proposed** signature."
-msgstr "Promovido a firma **propuesta**."
+msgid "pgr_boykovKolmogorov(Combinations)"
+msgstr "pgr_boykovKolmogorov(Combinaciones)"
 
-msgid "Works for directed and undirected graphs."
-msgstr "Funciona para grafos dirigidos y no dirigidos."
+msgid "pgr_edmondsKarp(Combinations)"
+msgstr "pgr_edmondsKarp(Combinaciones)"
 
-msgid "Code enhancement"
-msgstr "Mejora del código"
+msgid "pgr_maxFlow(Combinations)"
+msgstr "pgr_maxFlow(Combinaciones)"
 
-msgid ""
-"`#2599 <https://github.com/pgRouting/pgrouting/pull/2599>`__ Driving "
-"distance cleanup"
-msgstr ""
-"`#2599 <https://github.com/pgRouting/pgrouting/pull/2599>`__ Limpieza de la "
-"distancia de conducción"
+msgid "pgr_pushRelabel(Combinations)"
+msgstr "pgr_pushRelabel(Combinaciones)"
+
+msgid "code enhancements:"
+msgstr "Mejora del código:"
+
+msgid "Removal of unused C/C++ code"
+msgstr "Eliminación de código C/C++ no utilizado"
+
+msgid "Removal of SQL deprecated functions"
+msgstr "Eliminación de funciones obsoletas"
 
 msgid ""
-"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ Read postgresql "
-"data on C++"
+"pgr_trsp(text,integer,double precision,integer,double precision,boolean,"
+"boolean,text)"
 msgstr ""
-"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ Leer datos "
-"postgresql en C++"
+"pgr_trsp(text,integer,double precision,integer,double precision,boolean,"
+"boolean,text)"
+
+msgid "pgr_trsp(text,integer,integer,boolean,boolean,text)"
+msgstr "pgr_trsp(text,integer,integer,boolean,boolean,text)"
 
 msgid ""
-"`#2614 <https://github.com/pgRouting/pgrouting/pull/2614>`__ Clang tidy does "
-"not work"
+"pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)"
 msgstr ""
-"`#2614 <https://github.com/pgRouting/pgrouting/pull/2614>`__ Clang tidy no "
-"funciona"
+"pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)"
+
+msgid "pgr_trspviavertices(text,anyarray,boolean,boolean,text)"
+msgstr "pgr_trspviavertices(text,anyarray,boolean,boolean,text)"
+
+msgid "Removal of SQL deprecated internal functions"
+msgstr "Eliminación de funciones internas SQL obsoletas"
+
+msgid "_pgr_dijkstranear(text,anyarray,anyarray,bigint,boolean)"
+msgstr "_pgr_dijkstranear(text,anyarray,anyarray,bigint,boolean)"
+
+msgid "_pgr_dijkstranear(text,anyarray,bigint,bigint,boolean)"
+msgstr "_pgr_dijkstranear(text,anyarray,bigint,bigint,boolean)"
+
+msgid "_pgr_dijkstranear(text,bigint,anyarray,bigint,boolean)"
+msgstr "_pgr_dijkstranear(text,bigint,anyarray,bigint,boolean)"
+
+msgid "_pgr_dijkstra(text,anyarray,anyarray,boolean,boolean,boolean,bigint)"
+msgstr "_pgr_dijkstra(text,anyarray,anyarray,boolean,boolean,boolean,bigint)"
+
+msgid "_pgr_dijkstra(text,text,boolean,boolean,boolean)"
+msgstr "_pgr_dijkstra(text,text,boolean,boolean,boolean)"
+
+msgid "_pgr_drivingdistance(text,anyarray,double precision,boolean,boolean)"
+msgstr "_pgr_drivingdistance(text,anyarray,double precision,boolean,boolean)"
+
+msgid "_pgr_kruskal(text,anyarray,text,bigint,double precision)"
+msgstr "_pgr_kruskal(text,anyarray,text,bigint,double precision)"
+
+msgid "_pgr_prim(text,anyarray,text,bigint,double precision)"
+msgstr "_pgr_prim(text,anyarray,text,bigint,double precision)"
+
+msgid ""
+"_pgr_trsp(text,integer,double precision,integer,double precision,boolean,"
+"boolean,text)"
+msgstr ""
+"_pgr_trsp(text,integer,double precision,integer,double precision,boolean,"
+"boolean,text)"
+
+msgid "_pgr_trsp(text,text,anyarray,anyarray,boolean)"
+msgstr "_pgr_trsp(text,text,anyarray,anyarray,boolean)"
+
+msgid "_pgr_trsp(text,text,anyarray,bigint,boolean)"
+msgstr "_pgr_trsp(text,text,anyarray,bigint,boolean)"
+
+msgid "_pgr_trsp(text,text,bigint,anyarray,boolean)"
+msgstr "_pgr_trsp(text,text,bigint,anyarray,boolean)"
+
+msgid "_pgr_trsp(text,text,bigint,bigint,boolean)"
+msgstr "_pgr_trsp(text,text,bigint,bigint,boolean)"
+
+msgid "_pgr_trspviavertices(text,integer[],boolean,boolean,text)"
+msgstr "_pgr_trspviavertices(text,integer[],boolean,boolean,text)"
+
+msgid "_pgr_withpointsvia(text,bigint[],double precision[],boolean)"
+msgstr "_pgr_withpointsvia(text,bigint[],double precision[],boolean)"
+
+msgid "_trsp(text,text,anyarray,anyarray,boolean)"
+msgstr "_trsp(text,text,anyarray,anyarray,boolean)"
+
+msgid "_v4trsp(text,text,anyarray,anyarray,boolean)"
+msgstr "_v4trsp(text,text,anyarray,anyarray,boolean)"
+
+msgid "_v4trsp(text,text,text,boolean)"
+msgstr "_v4trsp(text,text,text,boolean)"
+
+msgid "Deprecation of internal C/C++ functions"
+msgstr "Obsolescencia de funciones internas C/C++"
+
+msgid "Internal C/C++ functions in legacy"
+msgstr "Funciones C/C++ internas en legado"
 
 msgid "All releases"
 msgstr "Todas las versiones"
 
 msgid "Kruskal - Family of functions"
 msgstr "Kruskal - Familia de funciones"
-
-msgid "Boost Graph Inside"
-msgstr "Adentro: Boost Graph"
 
 msgid ""
 "Kruskal's algorithm is a greedy minimum spanning tree algorithm that in each "
@@ -5090,12 +4584,6 @@ msgid "All deprecated functions will be removed on next mayor version 4.0.0"
 msgstr ""
 "Todas las funciones obsoletas serán removidas en las siguiente versión mayor "
 "4.0.0"
-
-msgid "Migration of functions"
-msgstr "Migración de funciones"
-
-msgid "Migrating functions"
-msgstr "Migrando funciones"
 
 msgid "Migration of ``pgr_aStar``"
 msgstr "Migración de ``pgr_aStar``"
@@ -5263,7 +4751,7 @@ msgstr "En ``pgr_dijkstra`` (`Muchos a Uno`)"
 msgid "If needed add the new columns, for example:"
 msgstr "Si es necesario, añadir las nuevas columnas, por ejemplo:"
 
-msgid "Migration of ``pgr_drivingdistance``"
+msgid "Migration of ``pgr_drivingDistance``"
 msgstr "Migración de ``pgr_drivingDistance``"
 
 msgid ""
@@ -5285,11 +4773,11 @@ msgstr "a"
 msgid "|result-spantree|"
 msgstr "|result-spantree|"
 
-msgid "``pgr_drivingdistance`` (Single vertex)"
-msgstr "``pgr_drivingDistance`` (Vértice único)"
+msgid "pgr_drivingDistance(Single vertex)"
+msgstr "pgr_drivingDistance(Vértice único)"
 
-msgid "``pgr_drivingdistance`` (Multiple vertices)"
-msgstr "``pgr_drivingDistance`` (Múltiples vértices)"
+msgid "pgr_drivingDistance(Multiple vertices)"
+msgstr "pgr_drivingDistance(Múltiples vértices)"
 
 msgid "Output columns were |result-dij-dd|"
 msgstr "Columnas de resultados eran |old-generic-result|"
@@ -5363,11 +4851,20 @@ msgstr ""
 msgid "|result-bfs|"
 msgstr "|result-bfs|"
 
+msgid "``pgr_kruskalDD``"
+msgstr "``pgr_kruskalDD``"
+
 msgid "Single vertex"
 msgstr "Vértice único"
 
 msgid "Multiple vertices"
 msgstr "Múltiples vértices"
+
+msgid "``pgr_kruskalDFS``"
+msgstr "``pgr_kruskalDFS``"
+
+msgid "``pgr_kruskalBFS``"
+msgstr "``pgr_kruskalBFS``"
 
 msgid "Output columns were |result-bfs|"
 msgstr "Las columnas de salida fueron |result-bfs|"
@@ -5549,6 +5046,15 @@ msgstr ""
 "A partir de `v3.7.0 <https://docs.pgrouting.org/3.7/en/migration.html>`__ se "
 "estandarizan las columnas de resultados :doc:`pgr_primDD`, :doc:"
 "`pgr_primBFS` y :doc:`pgr_primDFS`."
+
+msgid "``pgr_primDD``"
+msgstr "``pgr_primDD``"
+
+msgid "``pgr_primDFS``"
+msgstr "``pgr_primDFS``"
+
+msgid "``pgr_primBFS``"
+msgstr "``pgr_primBFS``"
 
 msgid "Prim single vertex"
 msgstr "Prim vértice único"
@@ -5779,8 +5285,125 @@ msgstr ""
 "Si es necesario, filtrar las columnas adicionales, por ejemplo, para "
 "devolver las columnas originales:"
 
-msgid "Migration of turn restrictions"
-msgstr "Migración de las restricciones de giro"
+msgid "Migration of ``pgr_trsp`` (Vertices)"
+msgstr "Migración de `pgr_trsp`` (Vértices)"
+
+msgid "Signature:"
+msgstr "Firma:"
+
+msgid "Deprecated"
+msgstr "Obsoleto"
+
+msgid "`v3.4.0 <https://docs.pgrouting.org/3.4>`__"
+msgstr "`v3.4.0 <https://docs.pgrouting.org/3.4>`__"
+
+msgid "Removed"
+msgstr "Eliminado"
+
+msgid "`v4.0.0 <https://docs.pgrouting.org/4.0>`__"
+msgstr "`v4.0.0 <https://docs.pgrouting.org/4.0>`__"
+
+msgid ":doc:`pgr_dijkstra`"
+msgstr ":doc:`pgr_dijkstra`"
+
+msgid ":doc:`pgr_trsp`"
+msgstr ":doc:`pgr_trsp`"
+
+msgid "`Migration of restrictions`_"
+msgstr "`Migración de restricciones`_"
+
+msgid "Use ``pgr_dijkstra`` when there are no restrictions."
+msgstr "Usar ``pgr_dijkstra`` cuando no hay restricciones."
+
+msgid "Use :doc:`pgr_dijkstra` instead."
+msgstr "Usa en vez :doc:`pgr_dijkstra`."
+
+msgid "To get the original column names:"
+msgstr "Para obtener los nombres originales de las columnas:"
+
+msgid "``id1`` is the node"
+msgstr "``id1`` es el nodo"
+
+msgid "``id2`` is the edge"
+msgstr "``id2`` es la arista"
+
+msgid "Use ``pgr_trsp`` when there are restrictions."
+msgstr "Usar ``pgr_trspVia`` cuando hay restricciones."
+
+msgid "Use :doc:`pgr_trsp` (One to One) instead."
+msgstr "Utilice en su lugar :doc:`pgr_trsp` (Uno a Uno)."
+
+msgid "Migration of ``pgr_trsp`` (Edges)"
+msgstr "Migración de ``pgr_trsp`` (Aristas)"
+
+msgid ":doc:`pgr_withPoints`"
+msgstr ":doc:`pgr_withPoints`"
+
+msgid ":doc:`pgr_trsp_withPoints`"
+msgstr ":doc:`pgr_trsp_withPoints`"
+
+msgid "Use ``pgr_withPoints`` when there are no restrictions."
+msgstr "Usar ``pgr_withPoints`` cuando no hay restricciones."
+
+msgid "Use :doc:`pgr_withPoints` (One to One) instead."
+msgstr "Utilizar en su lugar :doc:`pgr_withPoints` (Uno a Uno)."
+
+msgid "Use ``pgr_trsp_withPoints`` when there are restrictions."
+msgstr "Usar ``pgr_trsp_withPoints`` cuando hay restricciones."
+
+msgid "Use :doc:`pgr_trsp_withPoints` instead."
+msgstr "Utilizar en su lugar :doc:`pgr_trsp_withPoints`."
+
+msgid "Migration of ``pgr_trspViaVertices``"
+msgstr "Migraciones de ``pgr_trspViaVertices``"
+
+msgid ":doc:`pgr_dijkstraVia`"
+msgstr ":doc:`pgr_dijkstraVia`"
+
+msgid ":doc:`pgr_trspVia`"
+msgstr ":doc:`pgr_trspVia`"
+
+msgid "Use ``pgr_dijkstraVia`` when there are no restrictions"
+msgstr "Usar ``pgr_dijkstraVia`` cuando no hay restricciones"
+
+msgid "Use :doc:`pgr_dijkstraVia` instead."
+msgstr "Usar :doc:`pgr_dijkstraVia` en su lugar."
+
+msgid "``id1`` is the path identifier"
+msgstr "``id1`` es el identificador de camino"
+
+msgid "``id2`` is the node"
+msgstr "``id2`` es el nodo"
+
+msgid "``id3`` is the edge"
+msgstr "``id3`` es la arista"
+
+msgid "Use ``pgr_trspVia`` when there are restrictions"
+msgstr "Usar ``pgr_trspVia`` cuando hay restricciones"
+
+msgid "Use :doc:`pgr_trspVia` instead."
+msgstr "Usar :doc:`pgr_trspVia` en su lugar."
+
+msgid "Migration of ``pgr_trspViaEdges``"
+msgstr "Migración de ``pgr_trspViaEdges``"
+
+msgid ":doc:`pgr_withPointsVia`"
+msgstr ":doc:`pgr_withPointsVia`"
+
+msgid ":doc:`pgr_trspVia_withPoints`"
+msgstr ":doc:`pgr_trspVia_withPoints`"
+
+msgid "Use ``pgr_withPointsVia`` when there are no restrictions"
+msgstr "Usar ``pgr_withPointsVia`` cuando no hay restricciones"
+
+msgid "Use :doc:`pgr_withPointsVia` instead."
+msgstr "Usar :doc:`pgr_withPointsVia` en su lugar."
+
+msgid "Use ``pgr_trspVia_withPoints`` when there are restrictions"
+msgstr "Usar ``pgr_trspVia_withPoints`` cuando hay restricciones"
+
+msgid "Use :doc:`pgr_trspVia_withPoints` instead."
+msgstr "Usar :doc:`pgr_trspVia_withPoints` en su lugar."
 
 msgid "Migration of restrictions"
 msgstr "Migración de restricciones"
@@ -5934,257 +5557,6 @@ msgstr "Se eliminara en la próxima versión mayor 4.0.0"
 
 msgid "The migrated table contents:"
 msgstr "El contenido de la tabla de migración:"
-
-msgid "Migration of ``pgr_trsp`` (Vertices)"
-msgstr "Migración de `pgr_trsp`` (Vértices)"
-
-msgid ""
-":doc:`pgr_trsp` signatures have changed and many issues have been fixed in "
-"the new signatures. This section will show how to migrate from the old "
-"signatures to the new replacement functions. This also affects the "
-"restrictions."
-msgstr ""
-":doc:`pgr_trsp` firmas han cambiando y varios problemas han sido arreglados "
-"en las nuevas firmas. Esta sección enseñara como migrar las viejas firmas a "
-"la nueva función de reemplazo. Esto también afecta las restricciones ."
-
-msgid "The integral type of the ``Edges SQL`` can only be ``INTEGER``."
-msgstr "El tipo integral de ``Edges SQL`` sólo puede ser ``INTEGER``."
-
-msgid "The floating point type of the ``Edges SQL`` can only be ``FLOAT``."
-msgstr "El tipo de punto flotante del ``Edges SQL`` solo puede ser ``FLOAT``."
-
-msgid "``directed`` flag is compulsory."
-msgstr "La bandera ``directed`` es obligatoria."
-
-msgid "Does not autodetect if ``reverse_cost`` column exist."
-msgstr "No auto-detecta si la columna``reverse_cost`` existe."
-
-msgid ""
-"User must be careful to match the existence of the column with the value of "
-"``has_rcost`` parameter."
-msgstr ""
-"El usuario debe de tener cuidado al coincidir la existencia de la columna "
-"con el valor del parámetro ``has_rcost``."
-
-msgid "The restrictions inner query is optional."
-msgstr "Las restricciones de consulta interna son opcionales."
-
-msgid "The output column names are meaningless"
-msgstr "Los nombres de la columna de salida no tienen importancia"
-
-msgid "Migrate by using:"
-msgstr "Migra al user:"
-
-msgid ":doc:`pgr_dijkstra` when there are no restrictions,"
-msgstr ":doc:`pgr_dijkstra` cuando no hay restricciones,"
-
-msgid ":doc:`pgr_trsp` (One to One) when there are restrictions."
-msgstr ":doc:`pgr_trsp` (Uno a Uno) cuando hay restricciones."
-
-msgid "Migrating ``pgr_trsp`` (Vertices) using ``pgr_dijkstra``"
-msgstr "Migrar ``pgr_trsp`` (Vértices) usando ``pgr_dijkstra``"
-
-msgid "The following query does not have restrictions."
-msgstr "La siguiente consulta no tiene restricciones."
-
-msgid "A message about deprecation is shown"
-msgstr "Un mensaje sobre lo obsoleto se enseña"
-
-msgid "Deprecated functions will be removed on the next mayor version 4.0.0"
-msgstr "Funciones obsoletas se eliminaran en la siguiente versión mayor 4.0.0"
-
-msgid "Use :doc:`pgr_dijkstra` instead."
-msgstr "Usa en vez :doc:`pgr_dijkstra`."
-
-msgid "The types casting has been removed."
-msgstr "Se han eliminado la fundición de tipos."
-
-msgid ":doc:`pgr_dijkstra`:"
-msgstr ":doc:`pgr_dijkstra`:"
-
-msgid "Autodetects if ``reverse_cost`` column is in the edges SQL."
-msgstr "Auto-detecta si la columna``reverse_cost`` está en la SQL de aristas."
-
-msgid "Accepts ``ANY-INTEGER`` on integral types"
-msgstr "Acepta ``ANY-INTEGER`` sobre tipos integrales"
-
-msgid "Accepts ``ANY-NUMERICAL`` on floating point types"
-msgstr "Acepta ``ANY-NUMERICAL`` sobre tipos de puntos flotantes"
-
-msgid "``directed`` flag has a default value of ``true``."
-msgstr "La bandera ``directed`` tiene valor de facto de ``true``."
-
-msgid "Use the same value that on the original query."
-msgstr "Usa el mismo valor de la consulta original."
-
-msgid "In this example it is ``true`` which is the default value."
-msgstr "En este ejemplo ``true`` que es el valor de facto."
-
-msgid "The flag has been omitted and the default is been used."
-msgstr "Se ha omitido la bandera y se ha utilizado el valor por defecto."
-
-msgid ""
-"When the need of using strictly the same (meaningless) names and types of "
-"the function been migrated then:"
-msgstr ""
-"Cuando la necesidad de utilizar estrictamente los mismos nombres (sin "
-"importancia) y los tipos de la función han sido migradas entonces:"
-
-msgid "``id1`` is the node"
-msgstr "``id1`` es el nodo"
-
-msgid "``id2`` is the edge"
-msgstr "``id2`` es la arista"
-
-msgid "Migrating ``pgr_trsp`` (Vertices) using ``pgr_trsp``"
-msgstr "Migrando ``pgr_trsp`` (Vértices) usando ``pgr_trsp``"
-
-msgid "The following query has restrictions."
-msgstr "La siguiente consulta tiene restricciones."
-
-msgid "The restrictions are the last parameter of the function"
-msgstr "Las restricciones son el último parámetro de la función"
-
-msgid "Using the old structure of restrictions"
-msgstr "Usando la antigua estructura de restricciones"
-
-msgid "Use :doc:`pgr_trsp` (One to One) instead."
-msgstr "Utilice en su lugar :doc:`pgr_trsp` (Uno a Uno)."
-
-msgid "The new structure of restrictions is been used."
-msgstr "La nueva estructura de restricciones han sido utilizados."
-
-msgid "It is the second parameter."
-msgstr "Es el segundo parámetro."
-
-msgid ":doc:`pgr_trsp`:"
-msgstr ":doc:`pgr_trsp`:"
-
-msgid "Migration of ``pgr_trsp`` (Edges)"
-msgstr "Migración de ``pgr_trsp`` (Aristas)"
-
-msgid "The integral types of the ``sql`` can only be ``INTEGER``."
-msgstr "Los tipos integrales de ``sql`` solo pueden ser ``INTEGER``."
-
-msgid "The floating point type of the ``sql`` can only be ``FLOAT``."
-msgstr "El tipo de punto flotante del ``sql`` solo pueden ser ``FLOAT``."
-
-msgid "For these migration guide the following points will be used:"
-msgstr "Para los siguientes puntos la guía de migración se utilizara:"
-
-msgid ":doc:`pgr_withPoints` when there are no restrictions,"
-msgstr ":doc:`pgr_withPoints` cuando no hay restricciones,"
-
-msgid ":doc:`pgr_trsp_withPoints` (One to One) when there are restrictions."
-msgstr ":doc:`pgr_trsp_withPoints` (Uno a Uno) cuando hay restricciones."
-
-msgid "Migrating ``pgr_trsp`` (Edges) using ``pgr_withPoints``"
-msgstr "Migrando ``pgr_trsp`` (Aristas) usando ``pgr_withPoints``"
-
-msgid "Use :doc:`pgr_withPoints` instead."
-msgstr "Utilizar en su lugar :doc:`pgr_withPoints`."
-
-msgid "Do not show details, as the deprecated function does not show details."
-msgstr "No enseña detalles, pues las funciones obsoletas no enseñan detalles."
-
-msgid ":doc:`pgr_withPoints`:"
-msgstr ":doc:`pgr_withPoints`:"
-
-msgid "On the points query do not include the ``side`` column."
-msgstr "La consulta de puntos con incluye la columna ``side``."
-
-msgid ""
-"When the need of using strictly the same (meaningless) names and types, and "
-"node values of the function been migrated then:"
-msgstr ""
-"Cuando la necesidad de utilizar estrictamente los mismos nombres (sin "
-"importancia) y tipos , y los valores de nodo de la función han sido migradas "
-"entonces:"
-
-msgid "Migrating ``pgr_trsp`` (Edges) using ``pgr_trsp_withPoints``"
-msgstr "Migrando``pgr_trsp`` (Aristas) utilizando ``pgr_trsp_withPoints``"
-
-msgid "Use :doc:`pgr_trsp_withPoints` instead."
-msgstr "Utilizar en su lugar :doc:`pgr_trsp_withPoints`."
-
-msgid ":doc:`pgr_trsp_withPoints`:"
-msgstr ":doc:`pgr_trsp_withPoints`:"
-
-msgid "Migration of ``pgr_trspViaVertices``"
-msgstr "Migraciones de ``pgr_trspViaVertices``"
-
-msgid "The integral types of the ``Edges SQL`` can only be ``INTEGER``."
-msgstr ""
-"Los tipos enteros de las ``Consultas de Aristas`` solo pueden ser "
-"``ENTEROS``."
-
-msgid ":doc:`pgr_dijkstraVia` when there are no restrictions,"
-msgstr ":doc:`pgr_dijkstraVia` cuando no hay restricciones,"
-
-msgid ":doc:`pgr_trspVia` when there are restrictions."
-msgstr ":doc:`pgr_trspVia` cuando hay restricciones."
-
-msgid "Migrating ``pgr_trspViaVertices`` using ``pgr_dijkstraVia``"
-msgstr "Migrando ``pgr_trspViaVertices`` usando ``pgr_dijkstraVia``"
-
-msgid "Use :doc:`pgr_dijkstraVia` instead."
-msgstr "Usar :doc:`pgr_dijkstraVia` en su lugar."
-
-msgid ":doc:`pgr_dijkstraVia`:"
-msgstr ":doc:`pgr_dijkstraVia`:"
-
-msgid "``id1`` is the path identifier"
-msgstr "``id1`` es el identificador de camino"
-
-msgid "``id2`` is the node"
-msgstr "``id2`` es el nodo"
-
-msgid "``id3`` is the edge"
-msgstr "``id3`` es la arista"
-
-msgid "Migrating ``pgr_trspViaVertices`` using ``pgr_trspVia``"
-msgstr "Migrando ``pgr_trspViaVertices`` usando ``pgr_trspVia``"
-
-msgid "Use :doc:`pgr_trspVia` instead."
-msgstr "Usar :doc:`pgr_trspVia` en su lugar."
-
-msgid ":doc:`pgr_trspVia`:"
-msgstr ":doc:`pgr_trspVia`:"
-
-msgid "Migration of ``pgr_trspViaEdges``"
-msgstr "Migración de ``pgr_trspViaEdges``"
-
-msgid ""
-"And will travel thru the following Via points :math:"
-"`4\\rightarrow3\\rightarrow6`"
-msgstr ""
-"Viajará a travez de los siguientes puntos de la vía :math:"
-"`4\\rightarrow3\\rightarrow6`"
-
-msgid ":doc:`pgr_withPointsVia` when there are no restrictions,"
-msgstr ":doc:`pgr_withPointsVia` cuando no hay restricciones,"
-
-msgid ":doc:`pgr_trspVia_withPoints` when there are restrictions."
-msgstr ":doc:`pgr_trspVia_withPoints` cuando hay restricciones."
-
-msgid "Migrating ``pgr_trspViaEdges`` using ``pgr_withPointsVia``"
-msgstr "Migrando ``pgr_trspViaEdges`` usando ``pgr_withPointsVia``"
-
-msgid "Use :doc:`pgr_withPointsVia` instead."
-msgstr "Usar :doc:`pgr_withPointsVia` en su lugar."
-
-msgid ":doc:`pgr_withPointsVia`:"
-msgstr ":doc:`pgr_withPointsVia`:"
-
-msgid "Migrating ``pgr_trspViaEdges`` using ``pgr_trspVia_withPoints``"
-msgstr "Migrando ``pgr_trspViaEdges`` usando ``pgr_trspVia_withPoints``"
-
-msgid "Use :doc:`pgr_trspVia_withPoints` instead."
-msgstr "Usar :doc:`pgr_trspVia_withPoints` en su lugar."
-
-msgid ":doc:`pgr_trspVia_withPoints`:"
-msgstr ":doc:`pgr_trspVia_withPoints`:"
 
 msgid ":doc:`withPoints-category`"
 msgstr ":doc:`withPoints-category`"
@@ -6369,9 +5741,6 @@ msgstr ""
 
 msgid "Graph with ``cost`` and ``reverse_cost``"
 msgstr "Grafo con ``cost`` y ``reverse_cost``"
-
-msgid "The weighted directed graph, :math:`G_d(V,E)`, is defined by:"
-msgstr "El ponderado del grafo dirigido, :math:`G_d(V,E)`, se define por:"
 
 msgid "``SELECT id, source, target, cost, reverse_cost FROM edges``"
 msgstr "``SELECT id, source, target, cost, reverse_cost FROM edges``"
@@ -7179,22 +6548,32 @@ msgstr "Callejones sin salida"
 msgid "To get the dead ends:"
 msgstr "Para obtener los callejones sin salida:"
 
-msgid ""
-"That information is correct, for example, when the dead end is on the limit "
-"of the imported graph."
+msgid "A dead end happens when"
 msgstr ""
-"Esa información es correcta, por ejemplo, cuando el punto muerto está en el "
-"límite del gráfico importado."
 
 msgid ""
-"Visually node :math:`4` looks to be as start/ending of 3 edges, but it is "
-"not."
+"The vertex is the limit of a cul-de-sac, a no-through road or a no-exit road."
 msgstr ""
-"Visualmente el nodo :math:`4` parece ser el inicio/final de 3 aristas, pero "
-"no lo es."
 
-msgid "Is that correct?"
-msgstr "¿Es correcto?"
+#, fuzzy
+msgid "The vertex is on the limit of the imported graph."
+msgstr ""
+"En caso de ''true'' se contrae el vértice, no forma parte del grafo "
+"contraído."
+
+msgid "If a larger graph is imported then the vertex might not be a dead end"
+msgstr ""
+
+msgid ""
+"Node :math:`4`, is a dead end on the query, even that it visually looks like "
+"an end point of 3 edges."
+msgstr ""
+
+msgid "Is node :math:`4` a dead end or not?"
+msgstr ""
+
+msgid "The answer to that question will depend on the application."
+msgstr ""
 
 msgid "Is there such a small curb:"
 msgstr "Hay un bordillo tan pequeño:"
@@ -7223,9 +6602,15 @@ msgstr ""
 "¿Hay un gran acantilado y desde la vista de las águilas parece que el "
 "callejón sin salida está cerca del segmento?"
 
+#, fuzzy
+msgid "Depending on the answer, modification of the data might be needed."
+msgstr ""
+"Dependiendo de la función, serán necesarias una o mas consultas internas."
+
+#, fuzzy
 msgid ""
-"When there are many dead ends, to speed up, the :doc:`contraction-family` "
-"functions can be used to divide the problem."
+"When there are many dead ends, to speed up processing, the :doc:`contraction-"
+"family` functions can be used to contract the graph."
 msgstr ""
 "Cuando hay muchos callejones sin salida, para acelerar, se pueden utilizar "
 "las funciones de :doc:`contraction-family` para dividir el problema."
@@ -7237,15 +6622,15 @@ msgid "To get the linear edges:"
 msgstr "Para obtener las aristas lineales:"
 
 msgid ""
-"This information is correct, for example, when the application is taking "
-"into account speed bumps, stop signals."
+"These linear vertices are correct, for example, when those the vertices are "
+"speed bumps, stop signals and the application is taking them into account."
 msgstr ""
-"Esta información es correcta, por ejemplo, cuando la aplicación tiene en "
-"cuenta los topes o las señales de stop."
 
+#, fuzzy
 msgid ""
-"When there are many linear edges, to speed up, the :doc:`contraction-family` "
-"functions can be used to divide the problem."
+"When there are many linear vertices, that need not to be taken into account, "
+"to speed up the processing, the :doc:`contraction-family` functions can be "
+"used to contract the problem."
 msgstr ""
 "Cuando hay muchas aristas lineales, para acelerar, se pueden utilizar las "
 "funciones :doc:`contraction-family` para dividir el problema."
@@ -7546,9 +6931,6 @@ msgstr ""
 msgid "Parameters for the Via functions"
 msgstr "Párametros para las funciones Via"
 
-msgid ":doc:`pgr_dijkstraVia`"
-msgstr ":doc:`pgr_dijkstraVia`"
-
 msgid "SQL query as described."
 msgstr "Consulta SQL como se describe."
 
@@ -7596,9 +6978,6 @@ msgstr ""
 
 msgid "For the TRSP functions"
 msgstr "Para las funciones de TRSP"
-
-msgid ":doc:`pgr_trsp`"
-msgstr ":doc:`pgr_trsp`"
 
 msgid "Array of identifiers of destination vertices."
 msgstr "Arreglo de identificadores de vértices destino."
@@ -7662,9 +7041,6 @@ msgstr ""
 
 msgid "Used in functions the following:"
 msgstr "Se utiliza en las funciones siguientes:"
-
-msgid ":doc:`pgr_withPoints`"
-msgstr ":doc:`pgr_withPoints`"
 
 msgid ""
 "Returns set of ``(seq, path_seq [, start_pid] [, end_pid], node, edge, cost, "
@@ -7832,6 +7208,14 @@ msgstr ""
 "En este ejemplo, usar una consulta SQL interna que no incluya algunas "
 "aristas en la función de ruteo y dentro del área de los resultados."
 
+#, fuzzy
+msgid "Given this area:"
+msgstr "Dados los vehículos:"
+
+#, fuzzy
+msgid "Calculate a route:"
+msgstr "Calcular todas las columnas"
+
 msgid "How to contribute"
 msgstr "Cómo contribuir"
 
@@ -7865,7 +7249,8 @@ msgstr ""
 "`Ejemplo <https://github.com/pgRouting/pgrouting/wiki/How-to:-Handle-"
 "parallel-edges-(KSP)>`__"
 
-msgid "Adding Functionaity to pgRouting"
+#, fuzzy
+msgid "Adding Functionality to pgRouting"
 msgstr "Agregar funcionalidad a pgRouting"
 
 msgid ""
@@ -7998,10 +7383,10 @@ msgid "Upgrading the database"
 msgstr "Actualización de la base de datos"
 
 msgid ""
-"To upgrade pgRouting in the database to version 3.7.0 use the following "
+"To upgrade pgRouting in the database to version 4.0.0 use the following "
 "command:"
 msgstr ""
-"Para actualizar pgRouting en la base de datos a la versión 3.7.0 utilice el "
+"Para actualizar pgRouting en la base de datos a la versión 4.0.0 utilice el "
 "siguiente comando:"
 
 msgid ""
@@ -8530,8 +7915,8 @@ msgstr "Bibliotecas de código Boost C++ en https://www.boost.org."
 msgid ":doc:`migration`"
 msgstr ":doc:`migration`"
 
-msgid "pgr_KSP"
-msgstr "pgr_KSP"
+msgid "``pgr_KSP``"
+msgstr "``pgr_KSP``"
 
 msgid "``pgr_KSP`` — Yen's algorithm for K shortest paths using Dijkstra."
 msgstr "``pgr_KSP`` — Devuelve las K rutas más cortas usando Dijkstra ."
@@ -8539,32 +7924,38 @@ msgstr "``pgr_KSP`` — Devuelve las K rutas más cortas usando Dijkstra ."
 msgid "Availability"
 msgstr "Disponibilidad"
 
+msgid "Version 4.0.0"
+msgstr "Versión 4.0.0"
+
+msgid "All signatures promoted to official."
+msgstr "Todas las firmas promovidas a oficial."
+
 msgid "Version 3.6.0"
 msgstr "Versión 3.6.0"
 
 msgid "Result columns standarized to: |nksp-result|"
 msgstr "Columnas de resultados estandarizadas a: |nksp-result|"
 
-msgid "``pgr_ksp`` (One to One)"
-msgstr "``pgr_ksp`` (Uno a Uno)"
+msgid "pgr_ksp(One to One)"
+msgstr "pgr_ksp(Uno a Uno)"
 
 msgid "Added ``start_vid`` and ``end_vid`` result columns."
 msgstr "Añadidas las columnas de resultados ``start_vid`` y ``end_vid``."
 
-msgid "New overload functions:"
-msgstr "Nuevas funciones de sobrecarga:"
+msgid "New proposed signatures:"
+msgstr "Nuevas firmas propuestas:"
 
-msgid "``pgr_ksp`` (One to Many)"
-msgstr "``pgr_ksp`` (Uno a muchos)"
+msgid "pgr_ksp(One to Many)"
+msgstr "pgr_ksp(Uno a muchos)"
 
-msgid "``pgr_ksp`` (Many to One)"
-msgstr "``pgr_ksp`` (Muchos a uno)"
+msgid "pgr_ksp(Many to One)"
+msgstr "pgr_ksp(Muchos a uno)"
 
-msgid "``pgr_ksp`` (Many to Many)"
-msgstr "``pgr_ksp`` (Muchos a muchos)"
+msgid "pgr_ksp(Many to Many)"
+msgstr "pgr_ksp(Muchos a muchos)"
 
-msgid "``pgr_ksp`` (Combinations)"
-msgstr "``pgr_ksp`` (Combinaciones)"
+msgid "pgr_ksp(Combinations)"
+msgstr "pgr_ksp(Combinaciones)"
 
 msgid "Version 2.1.0"
 msgstr "Versión 2.1.0"
@@ -8578,8 +7969,8 @@ msgstr "Firma antigua ya no soportada"
 msgid "Version 2.0.0"
 msgstr "Versión 2.0.0"
 
-msgid "**Official** function"
-msgstr "Función **oficial**"
+msgid "Official function."
+msgstr "Función oficial."
 
 msgid ""
 "The K shortest path routing algorithm based on Yen's algorithm. \"K\" is the "
@@ -8587,6 +7978,12 @@ msgid ""
 msgstr ""
 "El algoritmo de ruteo para obtener la ruta más corta K basado en el "
 "algoritmo de Yen . \"K\" es el número de rutas más cortas deseadas."
+
+msgid "|Boost| Boost Graph Inside"
+msgstr "|Boost| Adentro: Boost Graph"
+
+msgid "Boost Graph Inside"
+msgstr "Adentro: Boost Graph"
 
 msgid "Signatures"
 msgstr "Firmas"
@@ -8734,7 +8131,8 @@ msgstr "https://en.wikipedia.org/wiki/K_shortest_path_routing"
 msgid "``pgr_TSP``"
 msgstr "``pgr_TSP``"
 
-msgid "``pgr_TSP`` - Aproximation using *metric* algorithm."
+#, fuzzy
+msgid "``pgr_TSP`` - Approximation using *metric* algorithm."
 msgstr "``pgr_TSP`` - Aproximación usando el algoritmo*metrico*."
 
 msgid "Availability:"
@@ -8996,8 +8394,16 @@ msgstr ""
 msgid "``pgr_TSPeuclidean``"
 msgstr "``pgr_TSPeuclidean``"
 
-msgid "``pgr_TSPeuclidean`` - Aproximation using *metric* algorithm."
+#, fuzzy
+msgid "``pgr_TSPeuclidean`` - Approximation using *metric* algorithm."
 msgstr "``pgr_TSPeuclidean`` - Aproximación usando el algoritmo *metric*."
+
+msgid ""
+"Using `Boost: metric TSP approx <https://www.boost.org/libs/graph/doc/"
+"metric_tsp_approx.html>`__"
+msgstr ""
+"Usando `Boost: Algoritmo de aproximación Métrica de TSP <https://www.boost."
+"org/libs/graph/doc/metric_tsp_approx.html>`__"
 
 msgid ""
 "The Simulated Annealing Algorithm related parameters are ignored: "
@@ -9016,8 +8422,8 @@ msgstr "Versión 3.0.0"
 msgid "Name change from pgr_eucledianTSP"
 msgstr "Cambio de nombre de pgr_eucledianTSP"
 
-msgid "New **Official** function"
-msgstr "Nueva función **Oficial**"
+msgid "New official function."
+msgstr "Nueva función oficial."
 
 msgid ""
 "Any duplicated identifier will be ignored. The coordinates that will be kept"
@@ -9112,59 +8518,51 @@ msgstr ""
 "uwaterloo.ca/tsp/world/witour.html>`__ y la segunda imagen es la solución "
 "obtenida con ``pgr_TSPeuclidean``."
 
-msgid ":doc:`sampledata` network."
-msgstr ":doc:`sampledata` ."
-
 msgid "``pgr_aStar``"
 msgstr "``pgr_aStar``"
 
 msgid "``pgr_aStar`` — Shortest path using the A* algorithm."
 msgstr "``pgr_aStar`` — La ruta más corta utilizando el algoritmo A*."
 
+msgid "Combinations signature promoted to official."
+msgstr "Firmas de combinaciones promovidas a oficial."
+
 msgid "Standarizing output columns to |short-generic-result|"
 msgstr "Estandarización de las columnas de salida a |short-generic-result|"
 
-msgid ""
-"``pgr_aStar`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
+msgid "pgr_aStar(One to One) added ``start_vid`` and ``end_vid`` columns."
 msgstr ""
-"``pgr_aStar`` (`Uno a Uno`_) ha añadido las columnas ``start_vid`` y "
-"``end_vid``."
+"pgr_aStar(Uno a Uno) ha añadido las columnas ``start_vid`` y ``end_vid``."
 
-msgid "``pgr_aStar`` (`One to Many`_) added ``end_vid`` column."
-msgstr "``pgr_aStar`` (`Uno a Muchos`_) ha añadido la columna ``end_vid``."
+msgid "pgr_aStar(One to Many) added ``end_vid`` column."
+msgstr "pgr_aStar(Uno a Muchos) ha añadido la columna ``end_vid``."
 
-msgid "``pgr_aStar`` (`Many to One`_) added ``start_vid`` column."
-msgstr "``pgr_aStar`` (`Muchos a Uno`_) ha añadido la columna ``start_vid``."
+msgid "pgr_aStar(Many to One) added ``start_vid`` column."
+msgstr "pgr_aStar(Muchos a Uno) ha añadido la columna ``start_vid``."
 
 msgid "Version 3.2.0"
 msgstr "Versión 3.2.0"
 
-msgid "New **proposed** signature:"
-msgstr "Nueva firma **propuesta**:"
+msgid "New proposed signature:"
+msgstr "Nuevas firmas propuesta:"
 
-msgid "``pgr_aStar`` (`Combinations`_)"
-msgstr "``pgr_aStar`` (`Combinaciones`_)"
+msgid "Function promoted to official."
+msgstr "Función promovida a oficial."
 
 msgid "Version 2.4.0"
 msgstr "Versión 2.4.0"
 
-msgid "New **Proposed** signatures:"
-msgstr "Nuevas firmas **propuestas**:"
+msgid "pgr_aStar(One to Many)"
+msgstr "pgr_aStar(Uno a Muchos)"
 
-msgid "``pgr_aStar`` (`One to Many`_)"
-msgstr "``pgr_aStar`` (`Uno a Muchos`_)"
+msgid "pgr_aStar(Many to One)"
+msgstr "pgr_aStar(Muchos a Uno)"
 
-msgid "``pgr_aStar`` (`Many to One`_)"
-msgstr "``pgr_aStar`` (`Muchos a Uno`_)"
+msgid "pgr_aStar(Many to Many)"
+msgstr "pgr_aStar(Muchos a Muchos)"
 
-msgid "``pgr_aStar`` (`Many to Many`_)"
-msgstr "``pgr_aStar`` (`Muchos a Muchos`_)"
-
-msgid "Signature change on ``pgr_astar`` (`One to One`_)"
-msgstr "Cambio de firma en ``pgr_astar`` (`Uno a Uno`_)"
-
-msgid "**Official** ``pgr_aStar`` (`One to One`_)"
-msgstr "**Oficial** ``pgr_aStar`` (`Uno a Uno`_)"
+msgid "Signature change on pgr_aStar(One to One)"
+msgstr "Cambio de firma en pgr_aStar(Uno a Uno)"
 
 msgid ""
 "The results are equivalent to the union of the results of the `pgr_aStar(` "
@@ -9256,8 +8654,8 @@ msgstr "Ejemplo 3"
 msgid "Manually assigned vertex combinations."
 msgstr "Manualmente asignar combinaciones de vértices."
 
-msgid "pgr_aStarCost"
-msgstr "pgr_aStarCost"
+msgid "``pgr_aStarCost``"
+msgstr "``pgr_aStarCost``"
 
 msgid ""
 "``pgr_aStarCost`` - Total cost of the shortest path using the A* algorithm."
@@ -9265,11 +8663,8 @@ msgstr ""
 "``pgr_aStarCost`` - Coste total del camino más corto utilizando el algoritmo "
 "A*."
 
-msgid "``pgr_aStarCost`` (`Combinations`_)"
-msgstr "``pgr_aStarCost`` (`Combinaciones`_)"
-
-msgid "New **proposed** function"
-msgstr "Nueva función **propuesta**"
+msgid "New proposed function."
+msgstr "Nueva función propuesta."
 
 msgid ""
 "The ``pgr_aStarCost`` function sumarizes of the cost of the shortest path "
@@ -9403,6 +8798,9 @@ msgstr "Soporte para devolver múltiples anillos exteriores/interiores"
 msgid "Renamed from version 1.x"
 msgstr "Renombrado desde la versión 1.x"
 
+msgid "Support"
+msgstr "Soporte"
+
 msgid "Returns the polygon part of an alpha shape."
 msgstr "Devuelve la parte poligonal de una forma alfa."
 
@@ -9482,8 +8880,8 @@ msgstr ":doc:`pgr_drivingDistance`"
 msgid "`ST_ConcaveHull <https://postgis.net/docs/ST_ConcaveHull.html>`__"
 msgstr "`ST_ConcaveHull <https://postgis.net/docs/ST_ConcaveHull.html>`__"
 
-msgid "pgr_analyzeGraph"
-msgstr "pgr_analyzeGraph"
+msgid "``pgr_analyzeGraph``"
+msgstr "``pgr_analyzeGraph``"
 
 msgid "``pgr_analyzeGraph`` — Analyzes the network topology."
 msgstr "``pgr_analyzeGraph`` — analiza la topología de red."
@@ -9800,9 +9198,6 @@ msgstr ""
 "Seleccionar las filas donde la geometría está cerca de la place='myhouse' de "
 "la tabla ``othertable``. (Nótese el uso de quote_literal)"
 
-msgid "The examples use the :doc:`sampledata` network."
-msgstr "Los ejemplos usan la red de ejemplo :doc:`sampledata`."
-
 msgid ":doc:`pgr_analyzeOneWay`"
 msgstr ":doc:`pgr_analyzeOneWay`"
 
@@ -9812,8 +9207,8 @@ msgstr ":doc:`pgr_createVerticesTable`"
 msgid ":doc:`pgr_nodeNetwork` to create nodes to a not noded edge table."
 msgstr ":doc:`pgr_nodeNetwork` para crear nodos en una tabla sin nodos."
 
-msgid "pgr_analyzeOneWay"
-msgstr "pgr_analyzeOneWay"
+msgid "``pgr_analyzeOneWay``"
+msgstr "``pgr_analyzeOneWay``"
 
 msgid ""
 "``pgr_analyzeOneWay`` — Analyzes oneway Sstreets and identifies flipped "
@@ -10013,8 +9408,8 @@ msgstr "Cambio de columnas de resultados: ``seq`` se elimina"
 msgid "Version 2.5.0"
 msgstr "Versión 2.5.0"
 
-msgid "New **experimental** function"
-msgstr "Nueva función **experimental**"
+msgid "New experimental function."
+msgstr "Nueva función experimental."
 
 msgid ""
 "Those vertices that belong to more than one biconnected component are called "
@@ -10050,11 +9445,11 @@ msgid "Nodes in red are the articulation points."
 msgstr "Nodos en rojo son los puntos de articulación."
 
 msgid ""
-"Boost: `Biconnected components & articulation points <https://www.boost.org/"
+"`Boost: Biconnected components & articulation points <https://www.boost.org/"
 "libs/graph/doc/biconnected_components.html>`__"
 msgstr ""
-"Boost: `Componentes biconectados & y puntos de articulación <https://www."
-"boost.org/libs/graph/doc/biconnected_components.html>`__"
+"`Boost: Componentes biconectados y puntos de articulación <https://www.boost."
+"org/libs/graph/doc/biconnected_components.html>`__"
 
 msgid ""
 "wikipedia: `Biconnected component <https://en.wikipedia.org/wiki/"
@@ -10071,42 +9466,34 @@ msgstr ""
 "``pgr_bdAstar`` — Devuelve la ruta más corta usando el algoritmo "
 "Bidireccional A*."
 
-msgid ""
-"``pgr_bdAstar`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
+msgid "pgr_bdAstar(One to One) added ``start_vid`` and ``end_vid`` columns."
 msgstr ""
-"``pgr_bdAstar`` (`Uno a Uno`_) ha añadido las columnas ``start_vid`` y "
-"``end_vid``."
+"pgr_bdAstar(Uno a Uno) ha añadido las columnas ``start_vid`` y ``end_vid``."
 
-msgid "``pgr_bdAstar`` (`One to Many`_) added ``end_vid`` column."
-msgstr "``pgr_bdAstar`` (`Uno a Muchos`_) ha añadido la columna ``end_vid``."
+msgid "pgr_bdAstar(One to Many) added ``end_vid`` column."
+msgstr "pgr_bdAstar(Uno a Muchos) ha añadido la columna ``end_vid``."
 
-msgid "``pgr_bdAstar`` (`Many to One`_) added ``start_vid`` column."
-msgstr "``pgr_bdAstar`` (`Muchos a Uno`_) ha añadido la columna ``start_vid``."
+msgid "pgr_bdAstar(Many to One) added ``start_vid`` column."
+msgstr "pgr_bdAstar(Muchos a Uno) ha añadido la columna ``start_vid``."
 
-msgid "``pgr_bdAstar`` (`Combinations`_)"
-msgstr "``pgr_bdAstar`` (`Combinaciones`_)"
+msgid "pgr_bdAstar(One to Many)"
+msgstr "pgr_bdAstar(Uno a Muchos)"
 
-msgid "``pgr_bdAstar`` (`One to Many`_)"
-msgstr "``pgr_bdAstar`` (`Uno a Muchos`_)"
+msgid "pgr_bdAstar(Many to One)"
+msgstr "pgr_bdAstar(Muchos a Uno)"
 
-msgid "``pgr_bdAstar`` (`Many to One`_)"
-msgstr "``pgr_bdAstar`` (`Muchos a Uno`_)"
+msgid "pgr_bdAstar(Many to Many)"
+msgstr "pgr_bdAstar(Muchos a Muchos)"
 
-msgid "``pgr_bdAstar`` (`Many to Many`_)"
-msgstr "``pgr_bdAstar`` (`Muchos a Muchos`_)"
-
-msgid "Signature change on ``pgr_bdAstar`` (`One to One`_)"
-msgstr "Cambio de firma en ``pgr_bdAstar`` (`Uno a Uno`_)"
-
-msgid "**Official** ``pgr_bdAstar`` (`One to One`_)"
-msgstr "**Oficial** ``pgr_bdAstar`` (`Uno a Uno`_)"
+msgid "Signature change on pgr_bdAstar(One to One)"
+msgstr "Cambio de firma en pgr_bdAstar(Uno a Uno)"
 
 msgid ""
-"The results are equivalent to the union of the results of the `pgr_bdAStar(` "
-"`One to One`_ `)` on the:"
+"The results are equivalent to the union of the results of the "
+"pgr_bdAStar(One to One) on the:"
 msgstr ""
 "Los resultados son equivalentes a la unión de los resultados de "
-"`pgr_bdAStar(` `Uno a Uno`_ `)` en:"
+"pgr_bdAStar(Uno a Uno) en:"
 
 msgid "pgr_bdAstar(`Edges SQL`_, **start vid**, **end vid**, [**options**])"
 msgstr ""
@@ -10128,8 +9515,8 @@ msgid "pgr_bdAstar(`Edges SQL`_, `Combinations SQL`_, [**options**])"
 msgstr ""
 "pgr_bdAstar(`SQL de aristas`_, `SQL de combinaciones`_, [**opciones**])"
 
-msgid "pgr_bdAstarCost"
-msgstr "pgr_bdAstarCost"
+msgid "``pgr_bdAstarCost``"
+msgstr "``pgr_bdAstarCost``"
 
 msgid ""
 "``pgr_bdAstarCost`` - Total cost of the shortest path using the "
@@ -10137,9 +9524,6 @@ msgid ""
 msgstr ""
 "``pgr_bdAstarCost`` - Coste total del camino más corto utilizando el "
 "algoritmo bidireccional A*."
-
-msgid "``pgr_bdAstarCost`` (`Combinations`_)"
-msgstr "``pgr_bdAstarCost`` (`Combinaciones`_)"
 
 msgid ""
 "The ``pgr_bdAstarCost`` function sumarizes of the cost of the shortest path "
@@ -10198,26 +9582,17 @@ msgstr ""
 "``pgr_bdDijkstra`` - Devuelve el camino más corto utilizando el algoritmo "
 "Bidireccional de Dijkstra."
 
-msgid "pgr_bdDijkstra(`Combinations`_)"
-msgstr "pgr_bdDijkstra(`Combinaciones`_)"
+msgid "pgr_bdDijkstra(One to Many)"
+msgstr "pgr_bdDijkstra(Uno a Muchos)"
 
-msgid "New **Proposed** functions:"
-msgstr "Nuevas funciones **Propuestas**:"
+msgid "pgr_bdDijkstra(Many to One)"
+msgstr "pgr_bdDijkstra(Muchos a Uno)"
 
-msgid "``pgr_bdDijkstra`` (`One to Many`_)"
-msgstr "``pgr_bdDijkstra`` (`Uno a Muchos`_)"
+msgid "pgr_bdDijkstra(Many to Many)"
+msgstr "pgr_bdDijkstra(Muchos a Muchos)"
 
-msgid "``pgr_bdDijkstra`` (`Many to One`_)"
-msgstr "``pgr_bdDijkstra`` (`Muchos a Uno`_)"
-
-msgid "``pgr_bdDijkstra`` (`Many to Many`_)"
-msgstr "``pgr_bdDijkstra`` (`Muchos a Muchos`_)"
-
-msgid "Signature change on ``pgr_bdDijsktra`` (`One to One`_)"
-msgstr "La firma cambió en ``pgr_bdDijsktra`` (`Uno a Uno`_)"
-
-msgid "**Official** ``pgr_bdDijkstra`` (`One to One`_)"
-msgstr "**Oficial** ``pgr_bdDijkstra`` (`Uno a Uno`_)"
+msgid "Signature change on pgr_bdDijsktra(One to One)"
+msgstr "La firma cambió en pgr_bdDijsktra(Uno a Uno)"
 
 msgid ""
 "pgr_bdDijkstra(`Edges SQL`_, **start vid**, **end vid**, [``directed``])"
@@ -10281,13 +9656,6 @@ msgstr ""
 msgid "Using a combinations table on an **undirected** graph"
 msgstr "Usando una tabla de combinaciones en un grafo **no dirigido**"
 
-msgid ""
-"https://www.cs.princeton.edu/courses/archive/spr06/cos423/Handouts/"
-"EPP%20shortest%20path%20algorithms.pdf"
-msgstr ""
-"https://www.cs.princeton.edu/courses/archive/spr06/cos423/Handouts/"
-"EPP%20shortest%20path%20algorithms.pdf"
-
 msgid "https://en.wikipedia.org/wiki/Bidirectional_search"
 msgstr "https://en.wikipedia.org/wiki/Bidirectional_search"
 
@@ -10300,9 +9668,6 @@ msgid ""
 msgstr ""
 "``pgr_bdDijkstraCost`` - Devuelve el coste del camino más corto utilizando "
 "el algoritmo Bidireccional de Dijkstra."
-
-msgid "``pgr_bdDijkstraCost`` (`Combinations`_)"
-msgstr "``pgr_bdDijkstraCost`` (`Combinaciones`_)"
 
 msgid ""
 "The ``pgr_bdDijkstraCost`` function sumarizes of the cost of the shortest "
@@ -10385,26 +9750,11 @@ msgstr ""
 "``pgr_bellmanFord`` - Camino más corto utilizando el algoritmo de Bellman-"
 "Ford."
 
-msgid "New **experimental** signature:"
-msgstr "Nueva firma **experimental**:"
+msgid "New experimental signature:"
+msgstr "Nueva firma experimental:"
 
-msgid "``pgr_bellmanFord`` (`Combinations`_)"
-msgstr "``pgr_bellmanFord`` (`Combinaciones`_)"
-
-msgid "New **experimental** signatures:"
-msgstr "Nuevas firmas **experimental**:"
-
-msgid "``pgr_bellmanFord`` (`One to One`_)"
-msgstr "``pgr_bellmanFord`` (`Uno a Uno`_)"
-
-msgid "``pgr_bellmanFord`` (`One to Many`_)"
-msgstr "``pgr_bellmanFord`` (`Uno a Muchos`_)"
-
-msgid "``pgr_bellmanFord`` (`Many to One`_)"
-msgstr "``pgr_bellmanFord`` (`Muchos a uno`_)"
-
-msgid "``pgr_bellmanFord`` (`Many to Many`_)"
-msgstr "``pgr_bellmanFord`` (`Muchos a Muchos`_)"
+msgid "pgr_bellmanFord(Combinations)"
+msgstr "pgr_bellmanFord(Combinaciones)"
 
 msgid ""
 "Bellman-Ford's algorithm, is named after Richard Bellman and Lester Ford, "
@@ -10508,14 +9858,21 @@ msgstr ""
 msgid "Using a combinations table on an **undirected** graph."
 msgstr "Uso de una tabla de combinaciones en un grafo **no dirigido**."
 
+msgid ""
+"`Boost: Bellman Ford <https://www.boost.org/libs/graph/doc/"
+"bellman_ford_shortest.html>`__"
+msgstr ""
+"`Boost: Bellman Ford <https://www.boost.org/libs/graph/doc/"
+"bellman_ford_shortest.html>`__"
+
 msgid "https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm"
 msgstr "https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm"
 
-msgid "``pgr_betweennessCentrality``"
-msgstr "``pgr_betweennessCentrality``"
+msgid "``pgr_betweennessCentrality`` - Experimental"
+msgstr "``pgr_betweennessCentrality`` - Experimental"
 
 msgid ""
-"``pgr_betweennessCentrality`` - Calculates the relative betweeness "
+"``pgr_betweennessCentrality`` - Calculates the relative betweenness "
 "centrality using Brandes Algorithm"
 msgstr ""
 "``pgr_betweennessCentrality`` - Calcula la centralidad intermedia relativa "
@@ -10523,9 +9880,6 @@ msgstr ""
 
 msgid "Version 3.7.0"
 msgstr "Versión 3.7.0"
-
-msgid "New **experimental** function:"
-msgstr "Nueva función **experimental**:"
 
 msgid ""
 "The Brandes Algorithm takes advantage of the sparse graphs for evaluating "
@@ -10610,14 +9964,11 @@ msgstr ""
 "Puntuación relativa de centralidad entre vértices (estará en el rango [0,1])"
 
 msgid ""
-"Boost's `betweenness_centrality <https://www.boost.org/doc/libs/1_84_0/libs/"
-"graph/doc/betweenness_centrality.html>`_"
+"`Boost: betweenness centrality <https://www.boost.org/libs/graph/doc/"
+"betweenness_centrality.html>`_"
 msgstr ""
-"`Boost: Centralidad de intermediación <https://www.boost.org/doc/libs/1_84_0/"
-"libs/graph/doc/betweenness_centrality.html>`__"
-
-msgid "Queries use the :doc:`sampledata` network."
-msgstr "Las consultas utilizan la red :doc:`sampledata`."
+"`Boost: Centralidad de intermediación <https://www.boost.org/libs/graph/doc/"
+"betweenness_centrality.html>`__"
 
 msgid "``pgr_biconnectedComponents``"
 msgstr "``pgr_biconnectedComponents``"
@@ -10684,13 +10035,6 @@ msgstr "Contiene el identificador mínimo de arista en el componente."
 msgid "Identifier of the edge that belongs to the ``component``."
 msgstr "Identificador de arista que pertenece a ``component``."
 
-msgid ""
-"Boost: `Biconnected components <https://www.boost.org/libs/graph/doc/"
-"biconnected_components.html>`__"
-msgstr ""
-"Boost: `Componentes Biconectados <https://www.boost.org/libs/graph/doc/"
-"biconnected_components.html>`__"
-
 msgid "``pgr_binaryBreadthFirstSearch`` - Experimental"
 msgstr "``pgr_binaryBreadthFirstSearch`` - Experimental"
 
@@ -10708,20 +10052,8 @@ msgstr ""
 "Un grafo cuyos pesos de las aristas pertenece al conjunto {0, X}, donde 'X' "
 "es un entero no negativo, se le llama 'grafo binario'."
 
-msgid "pgr_binaryBreadthFirstSearch(`Combinations`_)"
-msgstr "pgr_binaryBreadthFirstSearch(`Combinaciones`_)"
-
-msgid "pgr_binaryBreadthFirstSearch(`One to One`_)"
-msgstr "pgr_binaryBreadthFirstSearch(`Uno a Uno`_)"
-
-msgid "pgr_binaryBreadthFirstSearch(`One to Many`_)"
-msgstr "pgr_binaryBreadthFirstSearch(`Uno a Muchos`_)"
-
-msgid "pgr_binaryBreadthFirstSearch(`Many to One`_)"
-msgstr "pgr_binaryBreadthFirstSearch(`Muchos a Uno`_)"
-
-msgid "pgr_binaryBreadthFirstSearch(`Many to Many`_)"
-msgstr "pgr_binaryBreadthFirstSearch(`Muchos a Muchos`_)"
+msgid "pgr_binaryBreadthFirstSearch(Combinations)"
+msgstr "pgr_binaryBreadthFirstSearch(Combinaciones)"
 
 msgid ""
 "It is well-known that the shortest paths between a single source and all "
@@ -10812,6 +10144,13 @@ msgstr ""
 "**Nota:** Usando la red de :doc:`sampledata` como todos los pesos son los "
 "mismos (i.e :math:`1``)"
 
+msgid ""
+"`Boost: Breadth First Search <https://www.boost.org/libs/graph/doc/"
+"breadth_first_search.html>`__"
+msgstr ""
+"`Boost: Primera búsqueda en amplitud <https://www.boost.org/libs/graph/doc/"
+"breadth_first_search.html>`__"
+
 msgid "https://cp-algorithms.com/graph/01_bfs.html"
 msgstr "https://cp-algorithms.com/graph/01_bfs.html"
 
@@ -10820,8 +10159,8 @@ msgid ""
 msgstr ""
 "https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm#Specialized_variants"
 
-msgid "pgr_bipartite -Experimental"
-msgstr "pgr_bipartite - Experimental"
+msgid "``pgr_bipartite`` - Experimental"
+msgstr "``pgr_bipartite`` - Experimental"
 
 msgid ""
 "``pgr_bipartite`` — Disjoint sets of vertices such that no two vertices "
@@ -10829,9 +10168,6 @@ msgid ""
 msgstr ""
 "``pgr_bipartite`` — Conjuntos disjuntos tal que ningun par de vertices en el "
 "mismo conjunto son adjacentes."
-
-msgid "New **experimental** signature"
-msgstr "Nueva firma **experimental**"
 
 msgid ""
 "A bipartite graph is a graph with two sets of vertices which are connected "
@@ -10889,6 +10225,20 @@ msgstr ""
 msgid "Edges in blue represent odd length cycle subgraph."
 msgstr "Aristas en azul representan un grafo de ciclo impar."
 
+msgid ""
+"`Boost: is_bipartite <https://www.boost.org/libs/graph/doc/is_bipartite."
+"html>`__"
+msgstr ""
+"`Boost: es bipartido <https://www.boost.org/libs/graph/doc/is_bipartite."
+"html>`__"
+
+msgid ""
+"`Wikipedia: bipartite graph <https://en.wikipedia.org/wiki/"
+"Bipartite_graph>`__"
+msgstr ""
+"`Wikipedia: grafo bipartito <https://en.wikipedia.org/wiki/"
+"Bipartite_graph>`__"
+
 msgid "``pgr_boykovKolmogorov``"
 msgstr "``pgr_boykovKolmogorov``"
 
@@ -10901,20 +10251,11 @@ msgstr ""
 "maximiza el flujo de las fuentes a los objetivos utilizando el algoritmo "
 "Boykov Kolmogorov."
 
-msgid "New **proposed** signature"
-msgstr "Nueva firma **propuesta**"
-
-msgid "``pgr_boykovKolmogorov`` (`Combinations`_)"
-msgstr "``pgr_boykovKolmogorov`` (`Combinaciones`_)"
-
 msgid "Renamed from ``pgr_maxFlowBoykovKolmogorov``"
 msgstr "Renombrado de ``pgr_maxFlowBoykovKolmogorov``"
 
-msgid "**Proposed** function"
-msgstr "Función **propuesta**"
-
-msgid "New **Experimental** function"
-msgstr "Nueva función **Experimental**"
+msgid "Function promoted to proposed."
+msgstr "Función promovida a propuesta."
 
 msgid "Running time: Polynomial"
 msgstr "Tiempo de ejecución: Polinomio"
@@ -10959,8 +10300,12 @@ msgstr ""
 "Usando una tabla de combinaciones, equivalente a calcular el resultado de "
 "los vértices :math:`\\{5, 6\\}` a los vértices :math:`\\{10, 15, 14\\}`."
 
-msgid "https://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html"
-msgstr "https://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html"
+msgid ""
+"`Boost: Boykov Kolmogorov max flow <https://www.boost.org/libs/graph/doc/"
+"boykov_kolmogorov_max_flow.html>`__"
+msgstr ""
+"`Boost: Flujo máximo Boykov Kolmogorov <https://www.boost.org/libs/graph/doc/"
+"boykov_kolmogorov_max_flow.html>`__"
 
 msgid "``pgr_breadthFirstSearch`` - Experimental"
 msgstr "``pgr_breadthFirstSearch`` - Experimental"
@@ -10971,12 +10316,6 @@ msgid ""
 msgstr ""
 "``pgr_breadthFirstSearch`` — Devuelve los orden(es) transversales mediante "
 "el algoritmo Breadth First Search."
-
-msgid "``pgr_breadthFirstSearch`` (`Single Vertex`_)"
-msgstr "``pgr_breadthFirstSearch`` (`Vértice único`_)"
-
-msgid "``pgr_breadthFirstSearch`` (`Multiple Vertices`_)"
-msgstr "``pgr_breadthFirstSearch`` (`Múltiples Vértices`_)"
 
 msgid ""
 "Provides the Breadth First Search traversal order from a root vertex to a "
@@ -11055,13 +10394,6 @@ msgid "descending"
 msgstr "descendente"
 
 msgid ""
-"`Boost: Breadth First Search algorithm documentation <https://www.boost.org/"
-"libs/graph/doc/breadth_first_search.html>`__"
-msgstr ""
-"`Boost: Breadth First Search <https://www.boost.org/libs/graph/doc/"
-"breadth_first_search.html>`__"
-
-msgid ""
 "`Wikipedia: Breadth First Search algorithm <https://en.wikipedia.org/wiki/"
 "Breadth-first_search>`__"
 msgstr ""
@@ -11104,8 +10436,12 @@ msgstr "Identificador del borde que es un puente."
 msgid "https://en.wikipedia.org/wiki/Bridge_%28graph_theory%29"
 msgstr "https://en.wikipedia.org/wiki/Bridge_%28graph_theory%29"
 
-msgid "**Supported versions**"
-msgstr "** Versions soportadas**"
+msgid ""
+"`Boost: Connected components <https://www.boost.org/libs/graph/doc/"
+"connected_components.html>`__"
+msgstr ""
+"`Boost: Componentes conectados <https://www.boost.org/libs/graph/doc/"
+"connected_components.html>`__"
 
 msgid "``pgr_chinesePostman`` - Experimental"
 msgstr "``pgr_chinesePostman`` - Experimental"
@@ -11169,8 +10505,8 @@ msgstr "``pgr_chinesepostmancost``"
 msgid "Minimum costs of a circuit path."
 msgstr "Costes mínimos de una trayectoria de circuito."
 
-msgid "pgr_connectedComponents"
-msgstr "pgr_connectedComponents"
+msgid "``pgr_connectedComponents``"
+msgstr "``pgr_connectedComponents``"
 
 msgid ""
 "``pgr_connectedComponents`` — Connected components of an undirected graph "
@@ -11211,13 +10547,6 @@ msgid "Connecting disconnected components"
 msgstr "Conectando componentes desconectados"
 
 msgid ""
-"Boost: `Connected components <https://www.boost.org/libs/graph/doc/"
-"connected_components.html>`__"
-msgstr ""
-"Boost: `Componente conectado <https://www.boost.org/libs/graph/doc/"
-"connected_components.html>`__"
-
-msgid ""
 "wikipedia: `Connected component <https://en.wikipedia.org/wiki/"
 "Connected_component_(graph_theory)>`__"
 msgstr ""
@@ -11233,6 +10562,28 @@ msgid ""
 msgstr ""
 "``pgr_contraction`` — Realiza la contracción del grafo y devuelve los "
 "vértices y aristas contraídos.."
+
+#, fuzzy
+msgid "Version 3.8.0"
+msgstr "Versión 3.6.0"
+
+#, fuzzy
+msgid "New signature:"
+msgstr "Nueva firma"
+
+msgid ""
+"Previously compulsory parameter **Contraction order** is now optional with "
+"name ``methods``."
+msgstr ""
+
+#, fuzzy
+msgid "New name and order of optional parameters."
+msgstr "Parámetros opcionales de Cercanía"
+
+#, fuzzy
+msgid ""
+"Deprecated signature pgr_contraction(text,bigint[],integer,bigint[],boolean)"
+msgstr "_pgr_dijkstranear(text,bigint,anyarray,bigint,boolean)"
 
 msgid "Name change from ``pgr_contractGraph``"
 msgstr "Cambio de nombre de ``pgr_contractGraph``"
@@ -11250,61 +10601,80 @@ msgstr ""
 "secuencia de aristas originales disminuyendo el tiempo total y el espacio "
 "utilizados en los algoritmos de grafo."
 
-msgid "Does not return the full contracted graph"
+#, fuzzy
+msgid "Does not return the full contracted graph."
 msgstr "No devuelve el grafo completo contraído"
 
-msgid "Only changes on the graph are returned"
+#, fuzzy
+msgid "Only changes on the graph are returned."
 msgstr "Solo se devuelven los cambios en el gráfico"
 
-msgid "Currnetly there are two types of contraction methods"
-msgstr "Actualmente hay dos tipos de métodos de contracción"
-
-msgid "Dead End Contraction"
-msgstr "Contracción Sin Salida"
-
-msgid "Linear Contraction"
-msgstr "Contracción Lineal"
-
-msgid "The returned values include"
+#, fuzzy
+msgid "The returned values include:"
 msgstr "Los valores devueltos incluyen"
 
-msgid "the added edges by linear contraction."
-msgstr "las aristas añadidas por contracción lineal."
+#, fuzzy
+msgid "The new edges generated by linear contraction."
+msgstr "Inserte las nuevas aristas generadas por pgr_contraction."
 
-msgid "the modified vertices by dead end contraction."
+#, fuzzy
+msgid "The modified vertices generated by dead end contraction."
 msgstr "los vértices modificados por contracción sin salida."
 
 msgid "The returned values are ordered as follows:"
 msgstr "Los valores devueltos se ordenan de la siguiente manera:"
 
-msgid "column ``id`` ascending when type is ``v``"
+#, fuzzy
+msgid "column ``id`` ascending when its a modified vertex."
 msgstr "columna ``id`` ascendente cuando el tipo = ``v``"
 
-msgid "column ``id`` descending when type is ``e``"
+#, fuzzy
+msgid "column ``id`` with negative numbers descending when its a new edge."
 msgstr "columna ``id`` descendente cuando el tipo = ``e``"
 
-msgid "The pgr_contraction function has the following signature:"
-msgstr "La función pgr_contraction tiene la siguiente firma:"
+#, fuzzy
+msgid ""
+"Currently there are two types of contraction methods included in this "
+"function:"
+msgstr "Actualmente hay dos tipos de métodos de contracción"
 
-msgid "pgr_contraction(`Edges SQL`_, **contraction order**, [**options**])"
+msgid "Dead End Contraction. See :doc:`pgr_contractionDeadEnd`."
+msgstr ""
+
+msgid "Linear Contraction. See :doc:`pgr_contractionLinear`."
+msgstr ""
+
+#, fuzzy
+msgid "pgr_contraction(`Edges SQL`_, [**options**])"
 msgstr ""
 "pgr_contraction(`SQL de aristas`_, **orden de contracción**, [**opciones**])"
 
-msgid "**options:** ``[ max_cycles, forbidden_vertices, directed]``"
-msgstr "**opcionales:** ``[ max_cycles, forbidden_vertices, directed]``"
+#, fuzzy
+msgid "**options:** ``[directed, methods, cycles, forbidden]``"
+msgstr "**opcionales:** ``[directed, details]``"
 
 msgid "Returns set of |result-contract|"
 msgstr "Regresa conjunto de |result-contract|"
 
-msgid ""
-"Making a dead end and linear contraction in that order on an undirected "
-"graph."
+#, fuzzy
+msgid "Dead end and linear contraction in that order on an undirected graph."
 msgstr ""
 "Hacer una contracción de callejón sin salida y una contracción lineal en ese "
 "orden en un grafo no dirigido."
 
-msgid "**contraction Order**"
-msgstr "**Orden de contracciones**"
+msgid "Contraction optional parameters"
+msgstr "Parámetros opcionales de Contracción"
+
+msgid "``methods``"
+msgstr ""
+
+#, fuzzy
+msgid "``INTEGER[]``"
+msgstr "``INTEGER``"
+
+#, fuzzy
+msgid "``ARRAY[1,2]``"
+msgstr "``ARRAY[BIGINT]``"
 
 msgid "Ordered contraction operations."
 msgstr "Operaciones de contracción ordenadas."
@@ -11315,27 +10685,32 @@ msgstr "1 = Contracción sin salida"
 msgid "2 = Linear contraction"
 msgstr "2 - Contracción lineal"
 
-msgid "Contraction optional parameters"
-msgstr "Parámetros opcionales de Contracción"
-
-msgid "``forbidden_vertices``"
-msgstr "``forbidden_vertices``"
-
-msgid "**Empty**"
-msgstr "**vacío**"
-
-msgid "Identifiers of vertices forbidden for contraction."
-msgstr "Identificadores de vértices prohibidos para contracción."
+#, fuzzy
+msgid "``cycles``"
+msgstr "``max_cycles``"
 
 msgid ":math:`1`"
 msgstr ":math:`1`"
 
-msgid ""
-"Number of times the contraction operations on ``contraction_order`` will be "
-"performed."
+#, fuzzy
+msgid "Number of times the contraction methods will be performed."
 msgstr ""
 "Número de veces que se realizarán las operaciones de contracción en el orden "
 "``contraction_order``."
+
+#, fuzzy
+msgid "``forbidden``"
+msgstr "``forbidden_vertices``"
+
+msgid "``BIGINT[]``"
+msgstr "``BIGINT[]``"
+
+#, fuzzy
+msgid "``ARRAY[]::BIGINT[]``"
+msgstr "``ARRAY[BIGINT]``"
+
+msgid "Identifiers of vertices forbidden for contraction."
+msgstr "Identificadores de vértices prohibidos para contracción."
 
 msgid "The function returns a single row. The columns of the row are:"
 msgstr "La función devuelve una sola fila. Las columnas de la fila son:"
@@ -11343,19 +10718,22 @@ msgstr "La función devuelve una sola fila. Las columnas de la fila son:"
 msgid "``type``"
 msgstr "``type``"
 
-msgid "Type of the ``id``."
+#, fuzzy
+msgid "Type of the row."
 msgstr "Tipo del ``id``."
 
 msgid "``v`` when the row is a vertex."
 msgstr "``v`` cuando la fila es un vértice."
 
-msgid "Column ``id`` has a positive value"
+#, fuzzy
+msgid "Column ``id`` has a positive value."
 msgstr "Columna ``id`` tiene valor positivo"
 
 msgid "``e`` when the row is an edge."
 msgstr "``e`` cuando la fila es una arista."
 
-msgid "Column ``id`` has a negative value"
+#, fuzzy
+msgid "Column ``id`` has a negative value."
 msgstr "Columna ``id`` tiene valor negativo"
 
 msgid "All numbers on this column are ``DISTINCT``"
@@ -11379,6 +10757,9 @@ msgid ""
 msgstr ""
 "Representando un pseudo `id` como no incorporado en el conjunto de aristas "
 "originales."
+
+msgid "``contracted_vertices``"
+msgstr "``contracted_vertices``"
 
 msgid "Array of contracted vertex identifiers."
 msgstr "Arreglo de identificadores de vértices contraídos."
@@ -11412,8 +10793,668 @@ msgstr "Sólo contracción sin salida"
 msgid "Only linear contraction"
 msgstr "Sólo contracción lineal"
 
-msgid "pgr_createTopology"
-msgstr "pgr_createTopology"
+msgid "The cycle"
+msgstr "El ciclo"
+
+#, fuzzy
+msgid ""
+"Contracting a graph can be done with more than one operation. The order of "
+"the operations affect the resulting contracted graph, after applying one "
+"operation, the set of vertices that can be contracted by another operation "
+"changes."
+msgstr ""
+"Contraer un grafo se puede hacer con más de una operación. El orden de las "
+"operaciones afecta al gráfico contraído resultante; después de aplicar una "
+"operación, el conjunto de vértices que se pueden contraer con otra operación "
+"cambia."
+
+#, fuzzy
+msgid "This implementation cycles ``cycles`` times through the ``methods`` ."
+msgstr ""
+"Esta implementación alterna los tiempos `` max_cycles`` a través de `` "
+"operations_order``."
+
+msgid "Contracting sample data"
+msgstr "Contracción de los datos de muestra"
+
+msgid ""
+"In this section, building and using a contracted graph will be shown by "
+"example."
+msgstr ""
+"En esta sección, la creación y el uso de un grafo contraído se mostrarán en "
+"el ejemplo."
+
+msgid "The :doc:`sampledata` for an undirected graph is used"
+msgstr "Se usa :doc:`sampledata` para un grafo no dirigido"
+
+msgid "a dead end operation first followed by a linear operation."
+msgstr "una operación sin salida primero seguida de una operación lineal."
+
+msgid "Construction of the graph in the database"
+msgstr "Construcción del grafo en la base de datos"
+
+msgid "The original graph:"
+msgstr "El grafo original:"
+
+#, fuzzy
+msgid ""
+"The results do not represent the contracted graph. They represent the "
+"changes that need to be done to the graph after applying the contraction "
+"methods."
+msgstr ""
+"Los resultados no representan al grafo contraído. Representan los cambios "
+"realizados en el grafo después de aplicar el algoritmo de contracción."
+
+msgid ""
+"Observe that vertices, for example, :math:`6` do not appear in the results "
+"because it was not affected by the contraction algorithm."
+msgstr ""
+"Observe que los vértices, por ejemplo, :math:`6` , no aparecen en los "
+"resultados porque no se vieron afectados por el algoritmo de contracción."
+
+msgid "After doing the dead end contraction operation:"
+msgstr "Después de realizar la operación de contracción sin salida:"
+
+msgid "After doing the linear contraction operation to the graph above:"
+msgstr "Después de hacer la operación de contracción lineal al grafo anterior:"
+
+msgid "The process to create the contraction graph on the database:"
+msgstr "El proceso para crear el grafo de contracción en la base de datos:"
+
+msgid "Add additional columns"
+msgstr "Añadir columnas adicionales"
+
+msgid ""
+"Adding extra columns to the edges and vertices tables. In this documentation "
+"the following will be used:"
+msgstr ""
+
+#, fuzzy
+msgid "Column."
+msgstr "Columna"
+
+msgid "The vertices set belonging to the vertex/edge"
+msgstr "El conjunto de vértices que pertenecen al vértice/arista"
+
+msgid "``is_contracted``"
+msgstr "``is_contracted``"
+
+msgid "On the vertex table"
+msgstr "En la tabla de vértices"
+
+msgid ""
+"when ``true`` the vertex is contracted, its not part of the contracted graph."
+msgstr ""
+"En caso de ''true'' se contrae el vértice, no forma parte del grafo "
+"contraído."
+
+msgid ""
+"when ``false`` the vertex is not contracted, its part of the contracted "
+"graph."
+msgstr ""
+"En caso de ''false'' el vértice no se contrae, su parte del grafo contraído."
+
+msgid "``is_new``"
+msgstr "``is_new``"
+
+msgid "On the edge table"
+msgstr "En la tabla de aristas"
+
+msgid ""
+"when ``true`` the edge was generated by the contraction algorithm. its part "
+"of the contracted graph."
+msgstr ""
+"En caso de `` true``, la arista se generó por el algoritmo de contracción. "
+"Es parte del grafo contraído."
+
+msgid ""
+"when ``false`` the edge is an original edge, might be or not part of the "
+"contracted graph."
+msgstr ""
+"En caso de ``false`` , la arista es una arista original, podría ser o no "
+"parte del grafo contraído."
+
+msgid "Store contraction information"
+msgstr "Almacenar información de contracción"
+
+#, fuzzy
+msgid "Store the contraction results in a table."
+msgstr "Almacenar los `resultados de la contracción`_ en una tabla"
+
+#, fuzzy
+msgid "Update the edges and vertices tables"
+msgstr "Crear la tabla de vértices"
+
+msgid ""
+"Use ``is_contracted`` column to indicate the vertices that are contracted."
+msgstr ""
+"Usar la columna ``is_contracted`` para indicar los vértices contraídos."
+
+#, fuzzy
+msgid ""
+"Fill ``contracted_vertices`` with the information from the results that "
+"belong to the vertices."
+msgstr ""
+"Lllena ``contracted_vertices`` con la información de los resultados que "
+"pertenecen a los vértices."
+
+msgid "Insert the new edges generated by pgr_contraction."
+msgstr "Inserte las nuevas aristas generadas por pgr_contraction."
+
+msgid "The contracted graph"
+msgstr "El grafo contraído"
+
+msgid "Vertices that belong to the contracted graph."
+msgstr "Vértices que pertenecen al grafo contraído."
+
+msgid "Edges that belong to the contracted graph."
+msgstr "Aristas que pertenecen al grafo contraído."
+
+#, fuzzy
+msgid "Visually:"
+msgstr "Resultados visuales"
+
+msgid "Using the contracted graph"
+msgstr "Usando el grafo contraído"
+
+msgid ""
+"Depending on the final application the graph is to be prepared. In this "
+"example the final application will be to calculate the cost from two "
+"vertices in the original graph by using the contracted graph with "
+"``pgr_dijkstraCost``"
+msgstr ""
+
+msgid ""
+"There are three cases when calculating the shortest path between a given "
+"source and target in a contracted graph:"
+msgstr ""
+"Hay tres casos al calcular la ruta más corta entre un origen y un destino "
+"determinados en un grafo contraído:"
+
+msgid "Case 1: Both source and target belong to the contracted graph."
+msgstr "Caso 1: Tanto el origen como el destino pertenecen al grafo contraído."
+
+msgid "Case 2: Source and/or target belong to an edge subgraph."
+msgstr "Caso 2: El origen y/o el destino pertenecen a un subgrafo de aristas."
+
+msgid "Case 3: Source and/or target belong to a vertex."
+msgstr "Caso 3: El origen y/o el destino pertenecen a un vértice."
+
+msgid "The final application should consider all of those cases."
+msgstr ""
+
+#, fuzzy
+msgid "Create a view (or table) of the contracted graph:"
+msgstr "Vértices que pertenecen al grafo contraído."
+
+#, fuzzy
+msgid "Create the function that will use the contracted graph."
+msgstr "Caso 1: Tanto el origen como el destino pertenecen al grafo contraído."
+
+#, fuzzy
+msgid ""
+"Case 2: Source and/or target belong to an edge that has contracted vertices."
+msgstr "Caso 2: El origen y/o el destino pertenecen a un subgrafo de aristas."
+
+#, fuzzy
+msgid ""
+"Case 3: Source and/or target belong to a vertex that has been contracted."
+msgstr "Caso 3: El origen y/o el destino pertenecen a un vértice."
+
+#, fuzzy
+msgid "``pgr_contractionDeadEnd`` - Proposed"
+msgstr "``pgr_extractVertices``-- Propuesto"
+
+#, fuzzy
+msgid ""
+"``pgr_contractionDeadEnd`` — Performs graph contraction and returns the "
+"contracted vertices and edges."
+msgstr ""
+"``pgr_contraction`` — Realiza la contracción del grafo y devuelve los "
+"vértices y aristas contraídos.."
+
+#, fuzzy
+msgid "A node is considered a dead end node when:"
+msgstr "Un nodo se considera **sin salida** cuando"
+
+msgid "On undirected graphs:"
+msgstr "En grafos no dirigidos:"
+
+msgid "The number of adjacent vertices is 1."
+msgstr "El número de vértices adyacentes es 1."
+
+msgid "On directed graphs:"
+msgstr "En grafos dirigidos:"
+
+#, fuzzy
+msgid "When there is only one adjacent vertex or"
+msgstr "Cuando no hay ruta:"
+
+msgid ""
+"When all edges are incoming regardless of the number of adjacent vertices."
+msgstr ""
+
+#, fuzzy
+msgid "pgr_contractionDeadEnd(`Edges SQL`_, [**options**])"
+msgstr ""
+"pgr_contraction(`SQL de aristas`_, **orden de contracción**, [**opciones**])"
+
+#, fuzzy
+msgid "**options:** ``[directed, forbidden_vertices]``"
+msgstr "**opcionales:** ``[directed, details]``"
+
+#, fuzzy
+msgid "Dead end contraction on an undirected graph."
+msgstr "Vértice sin salida en un grafo sin dirigir"
+
+#, fuzzy
+msgid "The green nodes are dead end nodes."
+msgstr "Los nodos verdes son nodos `dead end`_"
+
+#, fuzzy
+msgid "Node :math:`3` is a dead end node after node :math:`1` is contracted."
+msgstr ""
+"El nodo :math:`u` tiene la información de los nodos que se contrajeron."
+
+msgid "``forbidden_vertices``"
+msgstr "``forbidden_vertices``"
+
+#, fuzzy
+msgid "``ARRAY[`` |ANY-INTEGER| ``]``"
+msgstr "``ARRAY[`` **ANY-INTEGER** ``]``"
+
+msgid "**Empty**"
+msgstr "**vacío**"
+
+#, fuzzy
+msgid "Value = ``e`` indicating the row is an edge."
+msgstr "``e`` cuando la fila es una arista."
+
+#, fuzzy
+msgid "A pseudo `id` of the edge."
+msgstr "Geometría de la arista."
+
+msgid "Identifier of the source vertex of the current edge."
+msgstr "Identificador del vértice de origen de la arista actual."
+
+msgid "Identifier of the target vertex of the current edge."
+msgstr "Identificador del vértice destino de la arista actual."
+
+#, fuzzy
+msgid "Weight of the current edge."
+msgstr "Identificador del vértice de origen de la arista actual."
+
+msgid "Dead end vertex on undirected graph"
+msgstr "Vértice sin salida en un grafo sin dirigir"
+
+msgid "They have only one adjacent node."
+msgstr ""
+
+msgid "Dead end vertex on directed graph"
+msgstr "Vértice sin salida en un grafo dirigido"
+
+#, fuzzy
+msgid "The green nodes are dead end nodes"
+msgstr "Los nodos verdes son nodos `dead end`_"
+
+msgid ""
+"The blue nodes have an unlimited number of incoming and/or outgoing edges."
+msgstr ""
+"Los nodos azules tienen un número ilimitado de aristas entrantes y/o "
+"salientes."
+
+msgid "Node"
+msgstr "Nodo"
+
+msgid "Adjacent nodes"
+msgstr "Nodos adyacentes"
+
+msgid "Dead end"
+msgstr "Sin salida"
+
+msgid "Reason"
+msgstr ""
+
+#, fuzzy
+msgid ":math:`6`"
+msgstr ":math:`a`"
+
+#, fuzzy
+msgid ":math:`\\{1\\}`"
+msgstr ":math:`\\{u\\}`"
+
+#, fuzzy
+msgid "Yes"
+msgstr "sí"
+
+#, fuzzy
+msgid "Has only one adjacent node."
+msgstr "Número de vértices adyacentes"
+
+#, fuzzy
+msgid ":math:`7`"
+msgstr ":math:`a`"
+
+#, fuzzy
+msgid ":math:`\\{2\\}`"
+msgstr ":math:`\\{u\\}`"
+
+#, fuzzy
+msgid ":math:`8`"
+msgstr ":math:`a`"
+
+#, fuzzy
+msgid ":math:`\\{2, 3\\}`"
+msgstr ":math:`\\{v, w\\}`"
+
+msgid "Has more than one adjacent node and all edges are incoming."
+msgstr ""
+
+#, fuzzy
+msgid ":math:`\\{4\\}`"
+msgstr ":math:`\\{u\\}`"
+
+#, fuzzy
+msgid ":math:`10`"
+msgstr ":math:`1`"
+
+#, fuzzy
+msgid ":math:`\\{4, 5\\}`"
+msgstr ":math:`\\{v, w\\}`"
+
+#, fuzzy
+msgid "No"
+msgstr "Nodo"
+
+msgid "Has more than one adjacent node and all edges are outgoing."
+msgstr ""
+
+#, fuzzy
+msgid ":math:`1,2,3,4,5`"
+msgstr ":math:`1`"
+
+#, fuzzy
+msgid "Many adjacent nodes."
+msgstr "Nodos adyacentes"
+
+msgid ""
+"Has more than one adjacent node and some edges are incoming and some are "
+"outgoing."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"From above, nodes :math:`\\{6, 7, 9\\}` are dead ends because the total "
+"number of adjacent vertices is one."
+msgstr ""
+"De arriba, nodes :math:`\\{a, b, d\\}` son callejones sin salida por que el "
+"número de vértices adyacentes es 1. No son necesarios los checks para esos "
+"nodos."
+
+msgid ""
+"When there are more than one adjacent vertex, all edges need to be all "
+"incoming edges otherwise it is not a dead end."
+msgstr ""
+
+#, fuzzy
+msgid "Step by step dead end contraction"
+msgstr "Sólo contracción sin salida"
+
+#, fuzzy
+msgid ""
+"The dead end contraction will stop until there are no more dead end nodes. "
+"For example, from the following graph where :math:`3` is the dead end node:"
+msgstr ""
+"La contracción sin salida se detendrá hasta que no haya más nodos sin "
+"salida. Por ejemplo, del siguiente grafo donde :math:`w` es el nodo `dead "
+"end`_:"
+
+#, fuzzy
+msgid ""
+"After contracting :math:`3`, node :math:`2` is now a dead end node and is "
+"contracted:"
+msgstr ""
+"Después de contraer :math:`w`, el nodo ` :math:`v` es ahora un nodo `dead "
+"end`_ y es contraído:"
+
+#, fuzzy
+msgid ""
+"After contracting :math:`2`, stop. Node :math:`1` has the information of "
+"nodes that were contracted."
+msgstr ""
+"Después de contraer math:`v`, detenerse El nodo math:`u` tiene la "
+"información de los nodos que se contraen."
+
+#, fuzzy
+msgid "Creating the contracted graph"
+msgstr "Usando el grafo contraído"
+
+#, fuzzy
+msgid "Steps for the creation of the contracted graph"
+msgstr "Aristas que pertenecen al grafo contraído."
+
+#, fuzzy
+msgid "Add additional columns."
+msgstr "Añadir columnas adicionales"
+
+#, fuzzy
+msgid "Save results into a table."
+msgstr "Almacenar los `resultados de la contracción`_ en una tabla"
+
+#, fuzzy
+msgid "The contracted vertices are not part of the contracted graph."
+msgstr ""
+"En caso de ''true'' se contrae el vértice, no forma parte del grafo "
+"contraído."
+
+#, fuzzy
+msgid "Using when departure and destination are in the contracted graph"
+msgstr "Caso 1: Tanto el origen como el destino pertenecen al grafo contraído."
+
+#, fuzzy
+msgid "Using when departure/destination is not in the contracted graph"
+msgstr ""
+"En caso de ''true'' se contrae el vértice, no forma parte del grafo "
+"contraído."
+
+#, fuzzy
+msgid "Using when departure and destination are not in the contracted graph"
+msgstr "Caso 1: Tanto el origen como el destino pertenecen al grafo contraído."
+
+#, fuzzy
+msgid "``pgr_contractionLinear`` - Proposed"
+msgstr "``pgr_dijkstraNear`` - Propuesto"
+
+#, fuzzy
+msgid ""
+"``pgr_contractionLinear`` — Performs graph contraction and returns the "
+"contracted vertices and edges."
+msgstr ""
+"``pgr_contraction`` — Realiza la contracción del grafo y devuelve los "
+"vértices y aristas contraídos.."
+
+#, fuzzy
+msgid "pgr_contractionLinear(`Edges SQL`_, [**options**])"
+msgstr ""
+"pgr_contraction(`SQL de aristas`_, **orden de contracción**, [**opciones**])"
+
+#, fuzzy
+msgid "**options:** ``[directed, max_cycles, forbidden_vertices]``"
+msgstr "**opcionales:** ``[ max_cycles, forbidden_vertices, directed]``"
+
+#, fuzzy
+msgid "Linear contraction on an undirected graph."
+msgstr "Usando una tabla de combinaciones en un grafo no dirigido."
+
+#, fuzzy
+msgid ""
+"The green nodes are linear nodes and will not be part of the contracted "
+"graph."
+msgstr ""
+"En caso de ''true'' se contrae el vértice, no forma parte del grafo "
+"contraído."
+
+#, fuzzy
+msgid "All edges adjacent will not be part of the contracted graph."
+msgstr "Aristas que pertenecen al grafo contraído."
+
+#, fuzzy
+msgid "The red lines will be new edges of the contracted graph."
+msgstr "Vértices que pertenecen al grafo contraído."
+
+msgid "**contraction Order**"
+msgstr "**Orden de contracciones**"
+
+msgid ""
+"Number of times the contraction operations on ``contraction_order`` will be "
+"performed."
+msgstr ""
+"Número de veces que se realizarán las operaciones de contracción en el orden "
+"``contraction_order``."
+
+msgid "A node connects two (or more) `linear` edges when"
+msgstr ""
+
+msgid "The number of adjacent vertices is 2."
+msgstr "El número de vértices adyacentes es 2."
+
+msgid "In case of a directed graph, a node is considered a `linear` node when"
+msgstr "En el caso de un grafo dirigido, un nodo se considera `lineal` cuando"
+
+#, fuzzy
+msgid "Linearity is symmetrical."
+msgstr "La linealidad es simétrica"
+
+#, fuzzy
+msgid "Linearity is not symmetrical"
+msgstr "La linealidad es simétrica"
+
+#, fuzzy
+msgid "Graph where linearity is not symmetrical."
+msgstr "La linealidad es simétrica"
+
+msgid ""
+"When the graph is processed as a directed graph, linearity is not "
+"symmetrical, therefore the graph can not be contracted."
+msgstr ""
+
+msgid ""
+"When the same graph is processed as an undirected graph, linearity is "
+"symmetrical, therefore the graph can be contracted."
+msgstr ""
+
+#, fuzzy
+msgid "The three edges can be replaced by one undirected edge"
+msgstr "El gráfico puede dirigido o no."
+
+#, fuzzy
+msgid "Edge :math:`1 - 3`."
+msgstr ":math:`1`"
+
+#, fuzzy
+msgid "With cost: :math:`4`."
+msgstr "Con ``cost``"
+
+#, fuzzy
+msgid "Contracted vertices in the edge: :math:`\\{2\\}`."
+msgstr "Para un grafo dirigido con aristas :math:`\\{1, 2, 3, 4\\}`."
+
+msgid "Linearity is symmetrical"
+msgstr "La linealidad es simétrica"
+
+#, fuzzy
+msgid "Graph where linearity is symmetrical."
+msgstr "La linealidad es simétrica"
+
+#, fuzzy
+msgid "The four edges can be replaced by two directed edges."
+msgstr "El gráfico puede dirigido o no."
+
+#, fuzzy
+msgid "Edge :math:`3 - 1`."
+msgstr ":math:`-1`"
+
+#, fuzzy
+msgid "With cost: :math:`6`."
+msgstr "Con ``cost``"
+
+#, fuzzy
+msgid "The four edges can be replaced by one undirected edge."
+msgstr "El gráfico puede dirigido o no."
+
+#, fuzzy
+msgid "Step by step linear contraction"
+msgstr "Sólo contracción lineal"
+
+#, fuzzy
+msgid ""
+"The linear contraction will stop when there are no more linear edges. For "
+"example from the following graph there are linear edges"
+msgstr ""
+"La contracción lineal se detendrá hasta que no hayan más nodos lineales. Por "
+"ejemplo, en el siguiente grafo donde ` :math:`v` y :math:`w` son nodos "
+"`lineales`_ :"
+
+#, fuzzy
+msgid "Contracting vertex :math:`3`,"
+msgstr "Contrayendo :math:`w`,"
+
+#, fuzzy
+msgid "The vertex :math:`3` is removed from the graph"
+msgstr "El vértice :math:`w` se elimina del grafo"
+
+#, fuzzy
+msgid ""
+"The edges :math:`2 \\rightarrow 3` and :math:`w \\rightarrow z` are removed "
+"from the graph."
+msgstr ""
+"Los aristas :math:`v \\rightarrow w` y :math:`w \\rightarrow z` fueron "
+"eliminados del grafo."
+
+#, fuzzy
+msgid ""
+"A new edge :math:`2 \\rightarrow 4` is inserted represented with red color."
+msgstr ""
+"Se inserta un nuevo arista :math:`v \\rightarrow z` y se representa con "
+"color rojo."
+
+#, fuzzy
+msgid "Contracting vertex :math:`2`:"
+msgstr "Contrayendo :math:`v`:"
+
+#, fuzzy
+msgid "The vertex :math:`2` is removed from the graph"
+msgstr "El vértice :math:`w` se elimina del grafo"
+
+#, fuzzy
+msgid ""
+"The edges :math:`1 \\rightarrow 2` and :math:`2 \\rightarrow 3` are removed "
+"from the graph."
+msgstr ""
+"Los aristas :math:`v \\rightarrow w` y :math:`w \\rightarrow z` fueron "
+"eliminados del grafo."
+
+#, fuzzy
+msgid ""
+"A new edge :math:`1 \\rightarrow 3` is inserted represented with red color."
+msgstr ""
+"Se inserta un nuevo arista :math:`v \\rightarrow z` y se representa con "
+"color rojo."
+
+#, fuzzy
+msgid ""
+"Edge :math:`1 \\rightarrow 3` has the information of cost and the nodes that "
+"were contracted."
+msgstr ""
+"El arista :math:`u \\rightarrow z` tiene la información de los nodos que "
+"fueron contraídos."
+
+#, fuzzy
+msgid "Create the contracted graph."
+msgstr "El grafo contraído"
+
+msgid "``pgr_createTopology``"
+msgstr "``pgr_createTopology``"
 
 msgid ""
 "``pgr_createTopology`` — Builds a network topology based on the geometry "
@@ -11667,11 +11708,8 @@ msgstr ""
 "En este ejemplo se inicia una topología limpia, con 5 aristas y, a "
 "continuación, se incrementa al resto de los bordes."
 
-msgid "The example uses the :doc:`sampledata` network."
-msgstr "En el ejemplo se utiliza la red :doc:`sampledata`."
-
-msgid "pgr_createVerticesTable"
-msgstr "pgr_createVerticesTable"
+msgid "``pgr_createVerticesTable``"
+msgstr "``pgr_createVerticesTable``"
 
 msgid ""
 "``pgr_createVerticesTable`` — Reconstructs the vertices table based on the "
@@ -11936,8 +11974,8 @@ msgstr ""
 "`Wikipedia: Ordenamiento Cuthill-McKee <https://en.wikipedia.org/wiki/"
 "Cuthill%E2%80%93McKee_algorithm>`__"
 
-msgid "pgr_dagShortestPath - Experimental"
-msgstr "pgr_dagShortestPath - Experimental"
+msgid "``pgr_dagShortestPath`` - Experimental"
+msgstr "``pgr_dagShortestPath`` - Experimental"
 
 msgid ""
 "``pgr_dagShortestPath`` — Returns the shortest path for weighted directed "
@@ -12032,11 +12070,19 @@ msgstr "Columnas de Resultados"
 msgid "Making **start_vids** the same as **end_vids**"
 msgstr "Haciendo **vértices de salida** igual que **vértices destino**"
 
+msgid ""
+"`Boost: DAG shortest paths <https://www.boost.org/libs/graph/doc/"
+"dag_shortest_paths.html>`__"
+msgstr ""
+"`Boost: Caminos mas cortos en DAG <https://www.boost.org/libs/graph/doc/"
+"dag_shortest_paths.html>`__"
+
 msgid "https://en.wikipedia.org/wiki/Topological_sorting"
 msgstr "https://en.wikipedia.org/wiki/Topological_sorting"
 
-msgid "``pgr_degree`` -- Proposed"
-msgstr "``pgr_degree`` -- Propuesto"
+#, fuzzy
+msgid "``pgr_degree``"
+msgstr "pgr_degree"
 
 msgid ""
 "``pgr_degree`` — For each vertex in an undirected graph, return the count of "
@@ -12045,8 +12091,59 @@ msgstr ""
 "``pgr_degree`` - Para cada vértice de un grafo no dirigido, devuelve el "
 "número de aristas incidentes en el vértice."
 
-msgid "Calculates the degree of the vertices of an **undirected** graph"
+msgid "Error messages adjustment."
+msgstr ""
+
+msgid "New signature with only Edges SQL."
+msgstr ""
+
+#, fuzzy
+msgid "Calculates the degree of the vertices of an undirected graph"
 msgstr "Calcula el grado de los vértices de un grafo **no dirigido**"
+
+#, fuzzy
+msgid ""
+"The degree (or valency) of a vertex of a graph is the number of edges that "
+"are incident to the vertex."
+msgstr ""
+"``pgr_degree`` - Para cada vértice de un grafo no dirigido, devuelve el "
+"número de aristas incidentes en el vértice."
+
+msgid "A loop contributes 2 to a vertex's degree."
+msgstr ""
+
+msgid "A vertex with degree 0 is called an isolated vertex."
+msgstr ""
+
+#, fuzzy
+msgid "Isolated vertex is not part of the result"
+msgstr ""
+"Corrige la distancia de conducción cuando el vértice no forma parte del grafo"
+
+msgid ""
+"Vertex not participating on the subgraph is considered and isolated vertex."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"There can be a ``dryrun`` execution and the code used to get the answer will "
+"be shown in a PostgreSQL ``NOTICE``."
+msgstr ""
+"Dado que se trata de una ejecución **dry run**, el código de todos los "
+"cálculos se muestra en el ``NOTICE`` de PostgreSQL."
+
+msgid ""
+"The code can be used as base code for the particular application "
+"requirements."
+msgstr ""
+
+#, fuzzy
+msgid "No ordering is performed."
+msgstr "No se realiza ningún pedido"
+
+#, fuzzy
+msgid "pgr_degree(`Edges SQL`_ , [``dryrun``])"
+msgstr "pgr_degree(`SQL de aristas`_ , `SQL de vértices`_, [``dryrun``])"
 
 msgid "pgr_degree(`Edges SQL`_ , `Vertex SQL`_, [``dryrun``])"
 msgstr "pgr_degree(`SQL de aristas`_ , `SQL de vértices`_, [``dryrun``])"
@@ -12054,19 +12151,35 @@ msgstr "pgr_degree(`SQL de aristas`_ , `SQL de vértices`_, [``dryrun``])"
 msgid "RETURNS SETOF |result-degree|"
 msgstr "REGRESA CONJUNTO DE |result-degree|"
 
+msgid "Edges"
+msgstr ""
+
+#, fuzzy
+msgid "example"
+msgstr "Ejemplo"
+
+#, fuzzy
+msgid "Get the degree of the vertices defined on the edges table"
+msgstr ":math:`m` es el grado máximo de los vértices en el grafo."
+
+#, fuzzy
+msgid "Edges and Vertices"
+msgstr "Añadiendo nuevos vértices"
+
 msgid "Extracting the vertex information"
 msgstr "Extraer la información del vértice"
 
-msgid ""
-"pgr_degree can utilize output from `pgr_extractVertices` or can have "
-"`pgr_extractVertices` embedded in the call. For decent size networks, it is "
-"best to prep your vertices table before hand and use that vertices table for "
-"pgr_degree calls."
+msgid "``pgr_degree`` can use :doc:`pgr_extractVertices` embedded in the call."
 msgstr ""
-"pgr_degree puede utilizar la salida de `pgr_extractVertices` o puede tener "
-"`pgr_extractVertices` incrustado en la llamada. Para redes de tamaño "
-"decente, lo mejor es preparar la tabla de vértices de antemano y utilizar "
-"esa tabla de vértices para las llamadas pgr_degree."
+
+msgid ""
+"For decent size networks, it is best to prepare your vertices table before "
+"hand and use it on ``pgr_degree`` calls. (See `Using a vertex table`_)"
+msgstr ""
+
+#, fuzzy
+msgid "Calculate the degree of the nodes:"
+msgstr "Calcula el grado de los vértices de un grafo **no dirigido**"
 
 msgid "`Vertex SQL`_"
 msgstr "`SQL de vértices`_"
@@ -12081,14 +12194,19 @@ msgid "When true do not process and get in a NOTICE the resulting query."
 msgstr ""
 "Cuando verdadero, no procesar y recibir un AVISO de la consulta resultante."
 
+#, fuzzy
+msgid "For the `Edges and Vertices`_ signature:"
+msgstr "Sobre las firmas obsoletas:"
+
+#, fuzzy
+msgid "For the `Edges`_ signature:"
+msgstr "Sobre las firmas obsoletas:"
+
 msgid "Vertex SQL"
 msgstr "SQL de vértices"
 
 msgid "``in_edges``"
 msgstr "``in_edges``"
-
-msgid "``BIGINT[]``"
-msgstr "``BIGINT[]``"
 
 msgid ""
 "Array of identifiers of the edges that have the vertex ``id`` as *first end "
@@ -12122,8 +12240,56 @@ msgstr "``degree``"
 msgid "Number of edges that are incident to the vertex ``id``"
 msgstr "Número de aristas incidentes al vértice ``id``"
 
+#, fuzzy
+msgid "Degree of a loop"
+msgstr "Grado de un subgrafo"
+
+#, fuzzy
+msgid "Using the `Edges`_ signature."
+msgstr "Sobre las firmas obsoletas:"
+
+msgid "Using the `Edges and Vertices`_ signature."
+msgstr ""
+
 msgid "Degree of a sub graph"
 msgstr "Grado de un subgrafo"
+
+#, fuzzy
+msgid "For the following is a subgraph of the :doc:`sampledata`:"
+msgstr "Coloración de grafos de pgRouting :doc:`sampledata`"
+
+msgid ":math:`E = \\{(1, 5 \\leftrightarrow 6), (1, 6 \\leftrightarrow 10)\\}`"
+msgstr ""
+
+msgid ":math:`V = \\{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17\\}`"
+msgstr ""
+
+msgid "The vertices not participating on the edge are considered isolated"
+msgstr ""
+
+msgid "their degree is 0 in the subgraph and"
+msgstr ""
+
+msgid "their degree is not shown in the output."
+msgstr ""
+
+#, fuzzy
+msgid "Using a vertex table"
+msgstr "En la tabla de vértices"
+
+#, fuzzy
+msgid ""
+"For decent size networks, it is best to prepare your vertices table before "
+"hand and use it on ``pgr_degree`` calls."
+msgstr ""
+"pgr_degree puede utilizar la salida de `pgr_extractVertices` o puede tener "
+"`pgr_extractVertices` incrustado en la llamada. Para redes de tamaño "
+"decente, lo mejor es preparar la tabla de vértices de antemano y utilizar "
+"esa tabla de vértices para las llamadas pgr_degree."
+
+#, fuzzy
+msgid "Extract the vertex information and save into a table:"
+msgstr "Extraer la información del vértice"
 
 msgid "Dry run execution"
 msgstr "Ejecución de prueba"
@@ -12142,18 +12308,39 @@ msgstr ""
 "Los resultados se pueden usar como código base para realizar un refinamiento "
 "basado en las necesidades de desarrollo de back-end."
 
-msgid "Degree from an existing table"
-msgstr "Grado a partir de una tabla existente"
+#, fuzzy
+msgid "Finding dead ends"
+msgstr "Callejones sin salida"
 
+#, fuzzy
 msgid ""
-"If you have a vertices table already built using ``pgr_extractVertices`` and "
-"want the degree of the whole graph rather than a subset, you can forgo using "
-"pgr_degree and work with the ``in_edges`` and ``out_edges`` columns directly."
+"If there is a vertices table already built using ``pgr_extractVertices`` and "
+"want the degree of the whole graph rather than a subset, it can be forgo "
+"using ``pgr_degree`` and work with the ``in_edges`` and ``out_edges`` "
+"columns directly."
 msgstr ""
 "Si se tiene una tabla de vértices ya construida usando "
 "``pgr_extractVertices`` y se quiere el grado de todo el grafo en lugar de un "
 "subconjunto, se puede trabajar con las columnas ``in_edges`` y ``out_edges`` "
 "directamente."
+
+#, fuzzy
+msgid "The degree of a dead end is 1."
+msgstr "Los nodos verdes son nodos `dead end`_"
+
+#, fuzzy
+msgid "Finding linear vertices"
+msgstr "Añadiendo nuevos vértices"
+
+#, fuzzy
+msgid "The degree of a linear vertex is 2."
+msgstr "El número de vértices adyacentes es 2."
+
+#, fuzzy
+msgid ""
+"If there is a vertices table already built using the ``pgr_extractVertices``"
+msgstr ""
+"Para obtener la información de los vértices, use :doc:`pgr_extractVertices`"
 
 msgid ":doc:`pgr_extractVertices`"
 msgstr ":doc:`pgr_extractVertices`"
@@ -12170,15 +12357,6 @@ msgstr ""
 
 msgid "Version 3.3.0"
 msgstr "Versión 3.3.0"
-
-msgid "Promoted to **proposed** function"
-msgstr "Promovido a función **propuesta**"
-
-msgid "``pgr_depthFirstSearch`` (`Single Vertex`_)"
-msgstr "``pgr_depthFirstSearch`` (`Vértice único`_)"
-
-msgid "``pgr_depthFirstSearch`` (`Multiple Vertices`_)"
-msgstr "``pgr_depthFirstSearch`` (`Vértices multiples`_)"
 
 msgid ""
 "Depth First Search algorithm is a traversal algorithm which starts from a "
@@ -12249,18 +12427,18 @@ msgstr ""
 "Igual que `Vértice único`_ pero con aristas en orden descendente de ``id``."
 
 msgid ""
-"`Boost: Depth First Search algorithm documentation <https://www.boost.org/"
-"libs/graph/doc/depth_first_search.html>`__"
+"`Boost: Depth First Search <https://www.boost.org/libs/graph/doc/"
+"depth_first_search.html>`__"
 msgstr ""
-"`Boost: Documentación del algoritmo de Primera Búsqueda de Profundidad "
-"<https://www.boost.org/libs/graph/doc/depth_first_search.html>`__"
+"`Boost: Primera Búsqueda de Profundidad <https://www.boost.org/libs/graph/"
+"doc/depth_first_search.html>`__"
 
 msgid ""
-"`Boost: Undirected DFS algorithm documentation <https://www.boost.org/libs/"
-"graph/doc/undirected_dfs.html>`__"
+"`Boost: Undirected DFS <https://www.boost.org/libs/graph/doc/undirected_dfs."
+"html>`__"
 msgstr ""
-"`Boost: Documentación del algoritmo DFS No dirigido <https://www.boost.org/"
-"libs/graph/doc/undirected_dfs.html>`__"
+"`Boost: DFS No dirigido <https://www.boost.org/libs/graph/doc/undirected_dfs."
+"html>`__"
 
 msgid ""
 "`Wikipedia: Depth First Search algorithm <https://en.wikipedia.org/wiki/"
@@ -12279,48 +12457,33 @@ msgstr ""
 msgid "Version 3.5.0"
 msgstr "Versión 3.5.0"
 
-msgid ""
-"``pgr_dijkstra`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
+msgid "pgr_dijkstra(One to One) added ``start_vid`` and ``end_vid`` columns."
 msgstr ""
-"``pgr_dijkstra`` (`Uno a Uno`_) ha añadido las columnas ``start_vid`` y "
-"``end_vid``."
+"pgr_dijkstra(Uno a Uno) ha añadido las columnas ``start_vid`` y ``end_vid``."
 
-msgid "``pgr_dijkstra`` (`One to Many`_) added ``end_vid`` column."
-msgstr "``pgr_dijkstra`` (`Uno a Muchos`_) ha añadido la columna ``end_vid``."
+msgid "pgr_dijkstra(One to Many) added ``end_vid`` column."
+msgstr "pgr_dijkstra(Uno a Muchos) ha añadido la columna ``end_vid``."
 
-msgid "``pgr_dijkstra`` (`Many to One`_) added ``start_vid`` column."
-msgstr ""
-"``pgr_dijkstra`` (`Muchos a Uno`_) ha añadido la columna ``start_vid``."
+msgid "pgr_dijkstra(Many to One) added ``start_vid`` column."
+msgstr "pgr_dijkstra(Muchos a Uno) ha añadido la columna ``start_vid``."
 
 msgid "Version 3.1.0"
 msgstr "Versión 3.1.0"
 
-msgid "``pgr_dijkstra`` (`Combinations`_)"
-msgstr "``pgr_dijkstra`` (`Combinaciones`_)"
-
-msgid "**Official** functions"
-msgstr "Funciones **oficiales**"
-
 msgid "Version 2.2.0"
 msgstr "Version 2.2.0"
 
-msgid "New **proposed** functions:"
-msgstr "Nuevas funciones **propuestas**:"
+msgid "pgr_dijkstra(One to Many)"
+msgstr "pgr_dijkstra(Uno a Muchos)"
 
-msgid "``pgr_dijkstra`` (`One to Many`_)"
-msgstr "``pgr_dijkstra`` (`Uno a Muchos`_)"
+msgid "pgr_dijkstra(Many to One)"
+msgstr "pgr_dijkstra(Muchos a Uno)"
 
-msgid "``pgr_dijkstra`` (`Many to One`_)"
-msgstr "``pgr_dijkstra`` (`Muchos a Uno`_)"
+msgid "pgr_dijkstra(Many to Many)"
+msgstr "pgr_dijkstra(Muchos a Muchos)"
 
-msgid "``pgr_dijkstra`` (`Many to Many`_)"
-msgstr "``pgr_dijkstra`` (`Muchos a Muchos`_)"
-
-msgid "Signature change on ``pgr_dijkstra`` (`One to One`_)"
-msgstr "Cambio de firma en ``pgr_dijkstra`` (`Uno a Uno`_)"
-
-msgid "**Official** ``pgr_dijkstra`` (`One to One`_)"
-msgstr "**Oficial** ``pgr_dijkstra`` (`Uno a Uno`_)"
+msgid "Signature change on pgr_dijkstra(One to One)"
+msgstr "Cambio de firma en pgr_dijkstra(Uno a Uno)"
 
 msgid "pgr_dijkstra(`Edges SQL`_, **start vid**, **end vid**, [``directed``])"
 msgstr ""
@@ -12533,6 +12696,13 @@ msgstr "36) Usando `Muchos a Muchos`_"
 msgid "37) Using `Combinations`_"
 msgstr "37) Usando `Combinaciones`_"
 
+msgid ""
+"`Boost: Dijkstra shortest paths <https://www.boost.org/libs/graph/doc/"
+"dijkstra_shortest_paths.html>`__"
+msgstr ""
+"`Boost: Camino mas corto Dijkstra <https://www.boost.org/libs/graph/doc/"
+"dijkstra_shortest_paths.html>`__"
+
 msgid "https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm"
 msgstr "https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm"
 
@@ -12545,9 +12715,6 @@ msgid ""
 msgstr ""
 "``pgr_dijkstraCost`` - Coste total del camino más corto utilizando el "
 "algoritmo de Dijkstra."
-
-msgid "``pgr_dijkstraCost`` (`Combinations`_)"
-msgstr "``pgr_dijkstraCost`` (`Combinaciones`_)"
 
 msgid ""
 "The ``pgr_dijkstraCost`` function sumarizes of the cost of the shortest path "
@@ -12906,9 +13073,6 @@ msgstr "Cuando ``true``: solo se devolverán los resultados del límite ``cap``"
 msgid "When ``false``: ``cap`` limit per ``Start vid`` will be returned"
 msgstr "Cuando ``false``: ``cap`` límite por ``Start vid`` será devuelto"
 
-msgid "boost: https://www.boost.org/libs/graph/doc/table_of_contents.html"
-msgstr "boost: https://www.boost.org/libs/graph/doc/table_of_contents.html"
-
 msgid "Wikipedia: https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm"
 msgstr "Wikipedia: https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm"
 
@@ -13113,6 +13277,9 @@ msgstr ""
 "``pgr_drivingDistance`` - Devuelve la distancia de manejo desde un nodo de "
 "inicio."
 
+msgid "Standarizing output columns to |result-spantree|"
+msgstr "Estandarización de columnas de resultados a |result-spantree|"
+
 msgid "Added ``depth`` and ``start_vid`` result columns."
 msgstr "Agregado las columnas de resultados``depth`` y ``start_vid``."
 
@@ -13123,14 +13290,17 @@ msgstr ""
 msgid "Added ``depth`` and ``pred`` result columns."
 msgstr "Agregado las columnas de resultados``depth`` y ``pred``."
 
-msgid "Signature change pgr_drivingDistance(single vertex)"
-msgstr "Cambio de firma pgr_drivingDistance(vértice único)"
+msgid "Signature change:"
+msgstr "Cambio de firma:"
 
-msgid "New **Official** pgr_drivingDistance(multiple vertices)"
-msgstr "Nuevo **Oficial** pgr_drivingDistance(multiples vértices)"
+msgid "pgr_drivingDistance(single vertex)"
+msgstr "pgr_drivingDistance(vértice único)"
 
-msgid "Official:: pgr_drivingDistance(single vertex)"
-msgstr "Oficial:: pgr_drivingDistance(vértice único)"
+msgid "New official signature:"
+msgstr "Nueva firma oficial:"
+
+msgid "pgr_drivingDistance(multiple vertices)"
+msgstr "pgr_drivingDistance(múltiples vértices)"
 
 msgid ""
 "Using the Dijkstra algorithm, extracts all the nodes that have costs less "
@@ -13199,8 +13369,8 @@ msgstr ""
 "Desde vértices math:`\\{11, 16\\}` con una distancia de :math:`3.0` en un "
 "grafo no dirigido"
 
-msgid "pgr_edgeColoring - Experimental"
-msgstr "pgr_edgeColoring - Experimental"
+msgid "``pgr_edgeColoring`` - Experimental"
+msgstr "``pgr_edgeColoring`` - Experimental"
 
 msgid ""
 "``pgr_edgeColoring`` — Returns the edge coloring of undirected and loop-free "
@@ -13286,6 +13456,19 @@ msgstr "Regresa el conjunto de |result-edge-color|"
 msgid "Graph coloring of pgRouting :doc:`sampledata`"
 msgstr "Coloración de grafos de pgRouting :doc:`sampledata`"
 
+msgid ""
+"`Boost: Edge Coloring <https://www.boost.org/libs/graph/doc/edge_coloring."
+"html>`__"
+msgstr ""
+"`Boost: Coloración de Segmentos <https://www.boost.org/libs/graph/doc/"
+"edge_coloring.html>`__"
+
+msgid ""
+"`Wikipedia: Graph coloring <https://en.wikipedia.org/wiki/Graph_coloring>`__"
+msgstr ""
+"`Wikipedia: Coloración de grafos <https://en.wikipedia.org/wiki/"
+"Graph_coloring>`__"
+
 msgid "``pgr_edgeDisjointPaths``"
 msgstr "``pgr_edgeDisjointPaths``"
 
@@ -13295,9 +13478,6 @@ msgid ""
 msgstr ""
 "``pgr_edgeDisjointPaths`` — Calcula las rutas de aristas desarticuladas "
 "entre dos grupos de vértices."
-
-msgid "New **proposed** function:"
-msgstr "Nueva función **propuesta**:"
 
 msgid "pgr_edgeDisjointPaths(Combinations)"
 msgstr "pgr_edgeDisjointPaths(Combinaciones)"
@@ -13403,9 +13583,6 @@ msgstr ""
 "maximizan el flujo de las fuentes a los destinos usando el algoritmo de "
 "Edmonds Karp."
 
-msgid "``pgr_edmondsKarp`` (`Combinations`_)"
-msgstr "``pgr_edmondsKarp`` (`Combinaciones`_)"
-
 msgid "Renamed from ``pgr_maxFlowEdmondsKarp``"
 msgstr "Renombrado desde ``pgr_maxFlowEdmondsKarp``"
 
@@ -13427,13 +13604,18 @@ msgstr "pgr_edmondsKarp(`SQL de aristas`_, **salidas**, **destinos**)"
 msgid "pgr_edmondsKarp(`Edges SQL`_, `Combinations SQL`_)"
 msgstr "pgr_edmondsKarp(`SQL de aristas`_, `SQL de combinaciones`_)"
 
-msgid "https://www.boost.org/libs/graph/doc/edmonds_karp_max_flow.html"
-msgstr "https://www.boost.org/libs/graph/doc/edmonds_karp_max_flow.html"
+#, fuzzy
+msgid ""
+"`Boost: Edmonds Karp max flow <https://www.boost.org/libs/graph/doc/"
+"edmonds_karp_max_flow.html>`__"
+msgstr ""
+"`Boost: Flujo máximo Edmonds Karp <https://www.boost.org/libs/graph/doc/"
+"edmonds_karp_max_flow.html>`__"
 
 msgid "https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm"
 msgstr "https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm"
 
-msgid "``pgr_edwardMoore - Experimental``"
+msgid "``pgr_edwardMoore`` - Experimental"
 msgstr "``pgr_edwardMoore`` - Experimental"
 
 msgid ""
@@ -13442,20 +13624,8 @@ msgstr ""
 "``pgr_edwardMoore`` — Devuelve la ruta más cortas usando el algoritmo Edward-"
 "Moore."
 
-msgid "``pgr_edwardMoore`` (`Combinations`_)"
-msgstr "``pgr_edwardMoore`` (`Combinaciones`_)"
-
-msgid "``pgr_edwardMoore`` (`One to One`_)"
-msgstr "``pgr_edwardMoore`` (`Uno a Uno`_)"
-
-msgid "``pgr_edwardMoore`` (`One to Many`_)"
-msgstr "``pgr_edwardMoore`` (`Uno a Muchos`_)"
-
-msgid "``pgr_edwardMoore`` (`Many to One`_)"
-msgstr "``pgr_edwardMoore`` (`Muchos a Uno`_)"
-
-msgid "``pgr_edwardMoore`` (`Many to Many`_)"
-msgstr "``pgr_edwardMoore`` (`Muchos a Muchos`_)"
+msgid "pgr_edwardMoore(Combinations)"
+msgstr "pgr_edwardMoore(Combinaciones)"
 
 msgid ""
 "Edward Moore’s Algorithm is an improvement of the Bellman-Ford Algorithm. It "
@@ -13537,14 +13707,12 @@ msgstr ""
 msgid "https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm"
 msgstr "https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm"
 
-msgid "pgr_extractVertices -- Proposed"
-msgstr "pgr_extractVertices -- Propuesto"
+#, fuzzy
+msgid "``pgr_extractVertices``"
+msgstr "pgr_extractVertices"
 
 msgid "``pgr_extractVertices`` — Extracts the vertices information"
 msgstr "``pgr_extractVertices`` — Extrae la información de los vértices"
-
-msgid "Classified as **proposed** function"
-msgstr "Clasicado como función **propuesta**"
 
 msgid ""
 "This is an auxiliary function for extracting the vertex information of the "
@@ -13662,14 +13830,9 @@ msgstr ""
 "``pgr_findCloseEdges`` - Encuentra las aristas cercanas a una geometría "
 "puntual."
 
-msgid "New **proposed** signatures:"
-msgstr "Nuevas firmas **propuestas**:"
-
-msgid "``pgr_findCloseEdges`` (`One point`_)"
-msgstr "``pgr_findCloseEdges`` (`Un punto`_)"
-
-msgid "``pgr_findCloseEdges`` (`Many points`_)"
-msgstr "``pgr_findCloseEdges`` (`Muchos puntos`_)"
+#, fuzzy
+msgid "``partial`` option is removed."
+msgstr "``n_seq`` se elimina"
 
 msgid ""
 "``pgr_findCloseEdges`` - An utility function that finds the closest edge to "
@@ -13691,7 +13854,8 @@ msgstr ""
 "El código para realizar los cálculos puede obtenerse para realizar los "
 "ajustes específicos que necesite la aplicación."
 
-msgid "``EMTPY SET`` is returned on dryrun executions"
+#, fuzzy
+msgid "``EMPTY SET`` is returned on dryrun executions"
 msgstr "``EMTPY SET`` se devuelve en ejecuciones en seco"
 
 msgid ""
@@ -13704,7 +13868,8 @@ msgid ""
 msgstr ""
 "pgr_findCloseEdges(`Edges SQL`_, **puntos**, **tolerancia**, [**options**])"
 
-msgid "**options:** ``[cap, partial, dryrun]``"
+#, fuzzy
+msgid "**options:** ``[cap, dryrun]``"
 msgstr "**opcionales:** ``[cap, partial, dryrun]``"
 
 msgid "Returns set of |result-find|"
@@ -13713,59 +13878,17 @@ msgstr "Regresa conjunto de |result-find|"
 msgid "One point"
 msgstr "Un punto"
 
-msgid "Default: ``cap => 1``"
-msgstr "Por defecto: ``cap => 1``"
+msgid "Get two close edges to points of interest with :math:`pid = 5`"
+msgstr ""
 
-msgid "Maximum one row answer."
-msgstr "Respuesta de una fila como máximo."
-
-msgid "Default: ``partial => true``"
-msgstr "Por defecto: ``partial => true``"
-
-msgid "With less calculations as possible."
-msgstr "Con menos cálculos posibles."
-
-msgid "Default: ``dryrun => false``"
-msgstr "Por defecto: ``dryrun => false``"
-
-msgid "Process query"
-msgstr "Consulta del proceso"
-
-msgid "Returns"
-msgstr "Devuelve"
-
-msgid "values on ``edge_id``, ``fraction``, ``side`` columns."
-msgstr "valores en las columnas ``edge_id``, ``fraction``, ``side``."
-
-msgid "``NULL`` on ``distance``, ``geom``, ``edge`` columns."
-msgstr "``NULL`` en las columnas ``distance``, ``geom``, ``edge``."
+msgid "``cap => 2``"
+msgstr "``cap => 2``"
 
 msgid "Many points"
 msgstr "Muchos puntos"
 
-msgid ""
-"Find at most :math:`2` edges close to all vertices on the points of interest "
-"table."
+msgid "For each points of interests, find the closest edge."
 msgstr ""
-"Encuentra como máximo :math:`2` aristas cercanas a todos los vértices de la "
-"tabla de puntos de interés."
-
-msgid "One answer per point, as small as possible."
-msgstr "Una respuesta por punto, lo más pequeña posible."
-
-msgid ""
-"Columns ``edge_id``, ``fraction``, ``side`` and ``geom`` are returned with "
-"values."
-msgstr ""
-"Las columnas ``edge_id``, ``fraction``, ``side`` y ``geom`` se devuelven con "
-"valores."
-
-msgid ""
-"``geom`` contains the original point geometry to assist on deterpartialing "
-"to which point geometry the row belongs to."
-msgstr ""
-"``geom`` contiene la geometría de puntos original para ayudar a determinar a "
-"qué geometría de puntos pertenece la fila."
 
 msgid "**point**"
 msgstr "**punto**"
@@ -13791,19 +13914,6 @@ msgstr "Distancia máxima entre geometrías"
 msgid "Limit output rows"
 msgstr "Limitar las filas de salida"
 
-msgid "``partial``"
-msgstr "``parcial``"
-
-msgid ""
-"When ``true`` only columns needed for :doc:`withPoints-category` are "
-"calculated."
-msgstr ""
-"Cuando ``true`` sólo se calculan las columnas necesarias para :doc:"
-"`withPoints-category`."
-
-msgid "When ``false`` all columns are calculated"
-msgstr "Cuando ``false`` se calculan todas las columnas"
-
 msgid "When ``false`` calculations are performed."
 msgstr "Cuando ``false`` se realizan los cálculos."
 
@@ -13820,9 +13930,10 @@ msgstr "La geometría ``LINESTRING`` de la arista."
 msgid "When :math:`cap = 1`, it is the closest edge."
 msgstr "Cuando :math:`cap = 1`, es la arista más cercana."
 
+#, fuzzy
 msgid ""
-"Value in <0,1> that indicates the relative postition from the first end-"
-"point of the edge."
+"Value in <0,1> that indicates the relative position from the first end-point "
+"of the edge."
 msgstr ""
 "El valor entre <0,1> indica la posición relativa desde el primer punto de la "
 "arista."
@@ -13830,64 +13941,90 @@ msgstr ""
 msgid "Value in ``[r, l]`` indicating if the point is:"
 msgstr "Valor en ``[r, l]`` que indica si el punto es:"
 
-msgid "In the right ``r``."
-msgstr "A la derecha ``r``."
-
-msgid "In the left ``l``."
-msgstr "A la izquierda ``l``."
+#, fuzzy
+msgid "At the right ``r`` of the segment."
+msgstr "En cualquier lado del segmento."
 
 msgid "When the point is on the line it is considered to be on the right."
 msgstr "Cuando el punto está en la línea se considera que está a la derecha."
 
+#, fuzzy
+msgid "At the left ``l`` of the segment."
+msgstr "En cualquier lado del segmento."
+
 msgid "``distance``"
 msgstr "``distancia``"
 
-msgid "Distance from point to edge."
+#, fuzzy
+msgid "Distance from the point to the edge."
 msgstr "Distancia del punto a la arista."
 
-msgid "``NULL`` when ``cap = 1`` on the `One point`_ signature"
-msgstr "``NULL`` cuando ``cap = 1`` en la firma de `Un punto`_"
-
-msgid "``POINT`` geometry"
+#, fuzzy
+msgid "Original ``POINT`` geometry."
 msgstr "geometría ``POINT``"
 
+#, fuzzy
 msgid ""
-"`One Point`_: Contains the point on the edge that is ``fraction`` away from "
-"the starting point of the edge."
-msgstr ""
-"`Un Punto`_: Contiene el punto de la arista que está a ``fraction`` del "
-"punto inicial de la arista."
-
-msgid "`Many Points`_: Contains the corresponding **original point**"
-msgstr "`Muchos Puntos`_: Contiene el **punto original** correspondiente"
-
-msgid ""
-"``LINESTRING`` geometry from the **original point** to the closest point of "
-"the edge with identifier ``edge_id``"
+"``LINESTRING`` geometry that connects the original **point** to the closest "
+"point of the edge with identifier ``edge_id``"
 msgstr ""
 "Geometría ``LINESTRING`` desde el **punto original** hasta el punto más "
 "cercano de la arista con identificador ``edge_id``"
 
-msgid "One point results"
-msgstr "Resultados de un punto"
+#, fuzzy
+msgid "One point in an edge"
+msgstr "Ejecución en seco de un punto"
 
-msgid "The green nodes is the **original point**"
+#, fuzzy
+msgid "The green node is the original point."
 msgstr "Los nodos verdes son el **punto original**"
 
+#, fuzzy
+msgid "``geom`` has the value of the original point."
+msgstr "La arista :math:`5` es la más cercana al **punto original**"
+
+#, fuzzy
 msgid ""
-"The geometry ``geom`` is a point on the :math:`sp \\rightarrow ep` edge."
+"The geometry ``edge`` is a line that connects the original point with the "
+"edge :math:`sp \\rightarrow ep` edge."
 msgstr ""
-"La geometría ``geom`` es un punto en la arista :math:`sp \\rightarrow ep`."
+"La geometría ``edge``, marcada como **edge1** y **edge2** es una línea que "
+"conecta el **punto original** con el punto más cercano de la arista :math:"
+"`sp \\rightarrow ep`."
+
+#, fuzzy
+msgid "The point is located at the left of the edge."
+msgstr ""
+"``side``: El **punto original** está situado a la izquierda de la arista :"
+"math:`5`."
+
+msgid "One point dry run execution"
+msgstr "Ejecución en seco de un punto"
+
+#, fuzzy
+msgid "Using the query from the previous example:"
+msgstr "Usando este diseño de tabla para este ejemplo:"
+
+msgid "Returns ``EMPTY SET``."
+msgstr "Devuelve ``CONJUNTO VACÍO``."
+
+msgid "``dryrun => true``"
+msgstr "``dryrun => true``"
+
+#, fuzzy
+msgid "Generates a PostgreSQL ``NOTICE`` with the code used."
+msgstr ""
+"Generar un ``NOTICE`` de PostgreSQL con el código utilizado para calcular "
+"todas las columnas"
 
 msgid ""
-"The geometry ``edge`` is a line that connects the **original point** with "
-"``geom``"
+"The generated code can be used as a starting base code for additional "
+"requirements, like taking into consideration the SRID."
 msgstr ""
-"La geometría ``edge`` es una línea que conecta el **punto original** con "
-"``geom``"
 
-msgid "Many point results"
-msgstr "Resultados de muchos puntos"
+#, fuzzy
+msgid "Many points in an edge"
+msgstr "Ejemplos de muchos puntos"
 
 msgid "The green nodes are the **original points**"
 msgstr "Los nodos verdes son los **puntos originales**"
@@ -13908,158 +14045,8 @@ msgstr ""
 "conecta el **punto original** con el punto más cercano de la arista :math:"
 "`sp \\rightarrow ep`."
 
-msgid "One point examples"
-msgstr "Ejemplos de un punto"
-
-msgid "At most two answers"
-msgstr "Como máximo dos respuestas"
-
-msgid "``cap => 2``"
-msgstr "``cap => 2``"
-
-msgid "Maximum two row answer."
-msgstr "Respuesta de dos filas como máximo."
-
-msgid "Understanding the result"
-msgstr "Comprendiendo el resultado"
-
-msgid "``NULL`` on ``geom``, ``edge``"
-msgstr "``NULL`` en ``geom``, ``edge``"
-
-msgid "``edge_id`` identifier of the edge close to the **original point**"
-msgstr "``edge_id`` identificador de la arista cercana al **punto original**"
-
-msgid ""
-"Two edges are withing :math:`0.5` distance units from the **original "
-"point**: :math:`{5, 8}`"
-msgstr ""
-"Dos aristas están a menos de :math:`0.5` unidades de distancia del **punto "
-"original**: :math:`{5, 8}`"
-
-msgid "For edge :math:`5`:"
-msgstr "Para la arista :math:`5`:"
-
-msgid ""
-"``fraction``: The closest point from the **original point** is at the :math:"
-"`0.8` fraction of the edge :math:`5`."
-msgstr ""
-"``fraction``: El punto más cercano desde el **punto original** está en la "
-"fracción :math:`0.8` del borde :math:`5`."
-
-msgid ""
-"``side``: The **original point** is located to the left side of edge :math:"
-"`5`."
-msgstr ""
-"``side``: El **punto original** está situado a la izquierda de la arista :"
-"math:`5`."
-
-msgid ""
-"``distance``: The **original point** is located :math:`0.1` length units "
-"from edge :math:`5`."
-msgstr ""
-"``distance``: El **punto original** está situado a :math:`0.1` unidades de "
-"longitud de la arista :math:`5`."
-
-msgid "For edge :math:`8`:"
-msgstr "Para la arista :math:`8`:"
-
-msgid ""
-"``fraction``: The closest point from the **original point** is at the :math:"
-"`0.89..` fraction of the edge :math:`8`."
-msgstr ""
-"``fraction``: El punto más cercano desde el **punto original** está en la "
-"fracción :math:`0.89..` del borde :math:`8`."
-
-msgid ""
-"``side``: The **original point** is located to the right side of edge :math:"
-"`8`."
-msgstr ""
-"``side``: El **punto original** está situado a la derecha de la arista :math:"
-"`8`."
-
-msgid ""
-"``distance``: The **original point** is located :math:`0.19..` length units "
-"from edge :math:`8`."
-msgstr ""
-"``distance``: El **punto original** se encuentra a :math:`0.19..` unidades "
-"de longitud de la arista :math:`8`."
-
-msgid "One answer, all columns"
-msgstr "Una respuesta, todas las columnas"
-
-msgid "``partial => false``"
-msgstr "``partial => false``"
-
-msgid "Calculate all columns"
-msgstr "Calcular todas las columnas"
-
-msgid ""
-"``edge_id`` identifier of the edge **closest** to the **original point**"
-msgstr ""
-"``edge_id`` identificador de la arista **más cercana** al **punto original**"
-
-msgid ""
-"From all edges within :math:`0.5` distance units from the **original "
-"point**: :math:`{5}` is the closest one."
-msgstr ""
-"De todos los bordes dentro de :math:`0.5` unidades de distancia desde el "
-"**punto original**: :math:`{5}` es el más cercano."
-
-msgid ""
-"``geom``: Contains the geometry of the closest point on edge :math:`5` from "
-"the **original point**."
-msgstr ""
-"``geom``: Contiene la geometría del punto más cercano de la arista :math:`5` "
-"desde el **punto original**."
-
-msgid ""
-"``edge``: Contains the ``LINESTRING`` geometry of the **original point** to "
-"the closest point on on edge :math:`5` ``geom``"
-msgstr ""
-"``edge``: Contiene la geometría ``LINESTRING`` del **punto original** al "
-"punto más cercano de la arista :math:`5` ``geom``"
-
-msgid "At most two answers with all columns"
-msgstr "Como máximo dos respuestas con todas las columnas"
-
-msgid "Understanding the result:"
-msgstr "Comprender el resultado:"
-
-msgid ""
-"``geom``: Contains the geometry of the closest point on edge :math:`8` from "
-"the **original point**."
-msgstr ""
-"``geom``: Contiene la geometría del punto más cercano de la arista :math:`8` "
-"desde el **punto original**."
-
-msgid ""
-"``edge``: Contains the ``LINESTRING`` geometry of the **original point** to "
-"the closest point on on edge :math:`8` ``geom``"
-msgstr ""
-"``borde``: Contiene la geometría ``LINESTRING`` del **punto original** al "
-"punto más cercano de la arista :math:`8` ``geom``"
-
-msgid "One point dry run execution"
-msgstr "Ejecución en seco de un punto"
-
-msgid "Returns ``EMPTY SET``."
-msgstr "Devuelve ``CONJUNTO VACÍO``."
-
-msgid "``partial => true``"
-msgstr "``partial => true``"
-
-msgid "Is ignored"
-msgstr "Se ignora"
-
-msgid ""
-"Because it is a **dry run** excecution, the code for all calculations are "
-"shown on the PostgreSQL ``NOTICE``."
-msgstr ""
-"Dado que se trata de una ejecución **dry run**, el código de todos los "
-"cálculos se muestra en el ``NOTICE`` de PostgreSQL."
-
-msgid "``dryrun => true``"
-msgstr "``dryrun => true``"
+msgid "Many points dry run execution"
+msgstr "Ejecución en seco de muchos puntos"
 
 msgid "Do not process query"
 msgstr "No procesar la consulta"
@@ -14069,72 +14056,6 @@ msgid ""
 msgstr ""
 "Generar un ``NOTICE`` de PostgreSQL con el código utilizado para calcular "
 "todas las columnas"
-
-msgid "``cap`` and **original point** are used in the code"
-msgstr "``cap`` y **punto original** se utilizan en el código"
-
-msgid "Many points examples"
-msgstr "Ejemplos de muchos puntos"
-
-msgid "At most two answers per point"
-msgstr "Un máximo de dos respuestas por punto"
-
-msgid "``NULL`` on ``edge``"
-msgstr "``NULL`` en ``edge``"
-
-msgid ""
-"``edge_id`` identifier of the edge close to a **original point** (``geom``)"
-msgstr ""
-"``edge_id`` identificador de la arista cercana a un **punto original** "
-"(``geom``)"
-
-msgid ""
-"Two edges at most withing :math:`0.5` distance units from each of the "
-"**original points**:"
-msgstr ""
-"Dos aristas a un máximo de :math:`0.5` unidades de distancia de cada uno de "
-"los **puntos originales**:"
-
-msgid "For ``POINT(1.8 0.4)`` and ``POINT(0.3 1.8)`` only one edge was found."
-msgstr ""
-"Para ``POINT(1.8 0.4)`` y ``POINT(0.3 1.8)`` sólo se encontró una arista."
-
-msgid "For the rest of the points two edges were found."
-msgstr "Para el resto de los puntos se encontraron dos aristas."
-
-msgid "For point ``POINT(2.9 1.8)``"
-msgstr "Para el punto ``POINT(2.9 1.8)``"
-
-msgid ""
-"Edge :math:`5` is before :math:`8` therefore edge :math:`5` has the shortest "
-"distance to ``POINT(2.9 1.8)``."
-msgstr ""
-"La arista :math:`5` está antes que la arista :math:`8` por lo tanto la "
-"arista :math:`5` tiene la distancia más corta a ``POINT(2.9 1.8)``."
-
-msgid "One answer per point, all columns"
-msgstr "Una respuesta por punto, todas las columnas"
-
-msgid "For the **original point** ``POINT(2.9 1.8)``"
-msgstr "Para el **punto original** ``POINT(2.9 1.8)``"
-
-msgid "Edge :math:`5` is the closest edge to the **original point**"
-msgstr "La arista :math:`5` es la más cercana al **punto original**"
-
-msgid ""
-"``geom``: Contains the geometry of the **original point** ``POINT(2.9 1.8)``"
-msgstr ""
-"``geom``: Contiene la geometría del **punto original** ``POINT(2.9 1.8)``"
-
-msgid ""
-"``edge``: Contains the ``LINESTRING`` geometry of the **original point** "
-"(``geom``) to the closest point on on edge."
-msgstr ""
-"``edge``: Contiene la geometría ``LINESTRING`` del **punto original** "
-"(``geom``) al punto más cercano en el borde."
-
-msgid "Many points dry run execution"
-msgstr "Ejecución en seco de muchos puntos"
 
 msgid "Find at most two routes to a given point"
 msgstr "Encontrar como máximo dos rutas a un punto dado"
@@ -14177,12 +14098,12 @@ msgstr ""
 msgid "A unique identifier."
 msgstr "Un identificador único."
 
-msgid ""
-"Identifier of the edge nearest edge that allows an arrival to the point."
-msgstr ""
-"Identificador de la arista más cercana que permite una llegada al punto."
+#, fuzzy
+msgid "Identifier of the nearest segment."
+msgstr "Identificador del vértice."
 
-msgid "Is it on the left, right or both sides of the segment ``edge_id``"
+#, fuzzy
+msgid "Is it on the left, right or both sides of the segment ``edge_id``."
 msgstr ""
 "Está a la izquierda, a la derecha o a ambos lados del segmento ``edge_id``"
 
@@ -14192,14 +14113,44 @@ msgstr "En qué parte del segmento se encuentra el punto."
 msgid "The geometry of the points."
 msgstr "La geometría de los puntos."
 
+#, fuzzy
+msgid "The distance between ``geom`` and the segment ``edge_id``."
+msgstr ""
+"Está a la izquierda, a la derecha o a ambos lados del segmento ``edge_id``"
+
+#, fuzzy
+msgid ""
+"A segment that connects the ``geom`` of the point to the closest point on "
+"the segment ``edge_id``."
+msgstr ""
+"Está a la izquierda, a la derecha o a ambos lados del segmento ``edge_id``"
+
 msgid "``newPoint``"
 msgstr "``newPoint``"
 
-msgid "The geometry of the points moved on top of the segment."
-msgstr "La geometría de los puntos desplazados sobre el segmento."
+msgid "A point on segment ``edge_id`` that is the closest to ``geom``."
+msgstr ""
 
-msgid "Points of interest fillup"
+#, fuzzy
+msgid "Points of interest fill up"
 msgstr "LLenado de puntos de interés"
+
+#, fuzzy
+msgid "Inserting the points of interest."
+msgstr "Puntos de interés"
+
+#, fuzzy
+msgid "Filling the rest of the table."
+msgstr "En la tabla de vértices"
+
+msgid ""
+"Any other additional modification: In this manual, point :math:`6` can be "
+"reached from both sides."
+msgstr ""
+
+#, fuzzy
+msgid "The points of interest:"
+msgstr "Puntos de interés"
 
 msgid "``pgr_floydWarshall``"
 msgstr "``pgr_floydWarshall``"
@@ -14235,9 +14186,6 @@ msgstr ""
 "Boost `Algoritmo floyd-Warshall <https://www.boost.org/libs/graph/doc/"
 "floyd_warshall_shortest.html>`_"
 
-msgid "Queries uses the :doc:`sampledata` network."
-msgstr "Consultas utilizan la red :doc:`sampledata`."
-
 msgid "``pgr_full_version``"
 msgstr "``pgr_full_version``"
 
@@ -14246,9 +14194,6 @@ msgid ""
 msgstr ""
 "``pgr_full_version`` — Obtener los detalles de la información de la versión "
 "de pgRouting."
-
-msgid "New **official** function"
-msgstr "Nueva función **oficial**"
 
 msgid "Get complete details of pgRouting version information"
 msgstr "Obtener los detalles de la información de la versión de pgRouting"
@@ -14316,18 +14261,16 @@ msgstr "``hash``"
 msgid "Git hash of pgRouting build"
 msgstr "Hash de Git de pgRouting"
 
-msgid "``pgr_hawickCircuits - Experimental``"
-msgstr "``pgr_hawickCircuits - Experimental``"
+msgid "``pgr_hawickCircuits`` - Experimental"
+msgstr "``pgr_hawickCircuits`` - Experimental"
 
+#, fuzzy
 msgid ""
-"``pgr_hawickCircuits`` — Returns the list of cirucits using hawick circuits "
+"``pgr_hawickCircuits`` — Returns the list of ciruits using hawick circuits "
 "algorithm."
 msgstr ""
 "``pgr_hawickCircuits`` — Enumeración de los circuitos usando el algoritmo de "
 "circutos de Hawick."
-
-msgid "``pgr_hawickCircuits``"
-msgstr "``pgr_hawickCircuits``"
 
 msgid ""
 "Hawick Circuit algorithm, is published in 2008 by Ken Hawick and Health A. "
@@ -14480,8 +14423,12 @@ msgstr ""
 "El nuevo grafo no es planar porque tiene un subgráfico :math:`K_5`. Las "
 "aristas en azul representan el subgrafo :math:`K_5`."
 
-msgid "https://www.boost.org/libs/graph/doc/boyer_myrvold.html"
-msgstr "https://www.boost.org/libs/graph/doc/boyer_myrvold.html"
+msgid ""
+"`Boost: Boyer Myrvold <https://www.boost.org/libs/graph/doc/boyer_myrvold."
+"html>`__"
+msgstr ""
+"`Boost: Boyer Myrvold <https://www.boost.org/libs/graph/doc/boyer_myrvold."
+"html>`__"
 
 msgid "``pgr_johnson``"
 msgstr "``pgr_johnson``"
@@ -14548,6 +14495,9 @@ msgid ""
 msgstr ""
 "``pgr_kruskalBFS`` — Algoritmo de Kruskal para el Árbol de Expansión Mínimo "
 "con orden de Primera Búsqueda en Anchura."
+
+msgid "Added ``pred`` result columns."
+msgstr "Agregado columna de resultados ``pred``."
 
 msgid ""
 "Visits and extracts the nodes information in Breath First Search ordering of "
@@ -14648,8 +14598,8 @@ msgstr "pgr_kruskalDFS(`SQL de aristas`_, **raíz**, [``max_depth``])"
 msgid "pgr_kruskalDFS(`Edges SQL`_, **root vids**, [``max_depth``])"
 msgstr "pgr_kruskalDFS(`SQL de aristas`_, **raices**, [``max_depth``])"
 
-msgid "pgr_lengauerTarjanDominatorTree -Experimental"
-msgstr "pgr_lengauerTarjanDominatorTree -Experimental"
+msgid "``pgr_lengauerTarjanDominatorTree`` - Experimental"
+msgstr "``pgr_lengauerTarjanDominatorTree`` - Experimental"
 
 msgid ""
 "``pgr_lengauerTarjanDominatorTree`` — Returns the immediate dominator of all "
@@ -14714,11 +14664,11 @@ msgid "Dominator tree of another component."
 msgstr "Árbnol dominante de otro componente."
 
 msgid ""
-"`Boost: Lengauer-Tarjan dominator tree algorithm <https://www.boost.org/libs/"
-"graph/doc/lengauer_tarjan_dominator.htm>`__"
+"`Boost: Lengauer-Tarjan dominator <https://www.boost.org/libs/graph/doc/"
+"lengauer_tarjan_dominator.htm>`__"
 msgstr ""
-"`Boost: Algoritmo Lengauer-Tarjan de árbol dominante <https://www.boost.org/"
-"libs/graph/doc/lengauer_tarjan_dominator.htm>`__"
+"`Boost: Árbol dominante Lengauer-Tarjan <https://www.boost.org/libs/graph/"
+"doc/lengauer_tarjan_dominator.htm>`__"
 
 msgid ""
 "`Wikipedia: dominator tree <https://en.wikipedia.org/wiki/"
@@ -14727,8 +14677,8 @@ msgstr ""
 "'Wikipedia: árbol de dominador' <https://en.wikipedia.org/wiki/"
 "Dominator_(graph_theory)>`__"
 
-msgid "pgr_lineGraph - Proposed"
-msgstr "pgr_lineGraph - Propuesto"
+msgid "``pgr_lineGraph`` - Proposed"
+msgstr "``pgr_lineGraph`` - Propuesto"
 
 msgid ""
 "``pgr_lineGraph`` — Transforms the given graph into its corresponding edge-"
@@ -14736,6 +14686,9 @@ msgid ""
 msgstr ""
 "``pgr_lineGraph`` — Transforma un grafo dado en su grafo correspondiente "
 "basado en aristas."
+
+msgid "Works for directed and undirected graphs."
+msgstr "Funciona para grafos dirigidos y no dirigidos."
 
 msgid ""
 "Given a graph :math:`G`, its line graph :math:`L(G)` is a graph such that:"
@@ -14787,15 +14740,9 @@ msgstr "Para un grafo no dirigido con aristas :math:'{2,4,5,8}'"
 msgid "Gives a local identifier for the edge"
 msgstr "Da un identificador local de la arista"
 
-msgid "Identifier of the source vertex of the current edge."
-msgstr "Identificador del vértice de origen de la arista actual."
-
 msgid "When `negative`: the source is the reverse edge in the original graph."
 msgstr ""
 "Cuando es 'negativo': el origen es la arista inversa en el grafo original."
-
-msgid "Identifier of the target vertex of the current edge."
-msgstr "Identificador del vértice destino de la arista actual."
 
 msgid "When `negative`: the target is the reverse edge in the original graph."
 msgstr ""
@@ -15054,16 +15001,14 @@ msgstr ""
 "Grafo de línea completa del subgrafo de las aristas :math:`\\{4, 7, 8, 10\\}`"
 
 msgid ""
-"The examples of this section are based on the :doc:`sampledata` network. The "
-"examples include the subgraph including edges 4, 7, 8, and 10 with "
+"The examples include the subgraph including edges 4, 7, 8, and 10 with "
 "``reverse_cost``."
 msgstr ""
-"Los ejemplos de esta sección se basan en la red :doc:`sampledata`. Los "
-"ejemplos incluyen el subgrafo que incluye las aristas 4, 7, 8 y 10 con "
+"Los ejemplos incluyen el sub-grafo que incluye las aristas 4, 7, 8 y 10 con "
 "``reverse_cost``."
 
 msgid "The data"
-msgstr ""
+msgstr "Los datos"
 
 msgid ""
 "This example displays how this graph transformation works to create "
@@ -15079,7 +15024,7 @@ msgid "first"
 msgstr "primero"
 
 msgid "The transformation"
-msgstr ""
+msgstr "La transformación"
 
 msgid "|second|"
 msgstr "|second|"
@@ -15122,7 +15067,7 @@ msgid ""
 msgstr ""
 
 msgid "Store edge results"
-msgstr ""
+msgstr "Almacenar resultados de aristas"
 
 msgid ""
 "The first step is to store the results of the ``pgr_lineGraphFull`` call "
@@ -15136,7 +15081,7 @@ msgid "From the original graph's vertex information"
 msgstr ""
 
 msgid "Add the new vertices"
-msgstr ""
+msgstr "Agregar nuevos vértices"
 
 msgid "Filling the mapping table"
 msgstr ""
@@ -15156,7 +15101,7 @@ msgid "Updating values from self loops"
 msgstr ""
 
 msgid "Inspecting the vertices table"
-msgstr ""
+msgstr "Inspeccionando la tabla de vértices"
 
 msgid "Updating from inner self loops"
 msgstr ""
@@ -15298,18 +15243,18 @@ msgstr "pgr_makeConnected(`SQL de aristas`_)"
 msgid "Returns set of |result-component-make|"
 msgstr "Regresa conjunto de |result-component-make|"
 
+msgid "List of edges that are needed to connect the graph."
+msgstr "Lista de aristas que se necesitan para conectar el grafo."
+
 msgid ""
-"Query done on :doc:`sampledata` network gives the list of edges that are "
-"needed to connect the graph."
+"`Boost: make connected <https://www.boost.org/libs/graph/doc/make_connected."
+"html>`__"
 msgstr ""
-"La consulta realizada en la red de :doc:`sampledata` proporciona la lista de "
-"aristas que se necesitan en el grafo para conectarlo."
+"`Boost: conectar <https://www.boost.org/libs/graph/doc/make_connected."
+"html>`__"
 
-msgid "https://www.boost.org/libs/graph/doc/make_connected.html"
-msgstr "https://www.boost.org/libs/graph/doc/make_connected.html"
-
-msgid "pgr_maxCardinalityMatch"
-msgstr "pgr_maxCardinalityMatch"
+msgid "``pgr_maxCardinalityMatch``"
+msgstr "``pgr_maxCardinalityMatch``"
 
 msgid ""
 "``pgr_maxCardinalityMatch`` — Calculates a maximum cardinality matching in a "
@@ -15318,14 +15263,17 @@ msgstr ""
 "``pgr_maxCardinalityMatch`` — Calcula una coincidencia de cardinalidad "
 "máxima en un grafo."
 
+msgid "pgr_maxCardinalityMatch(text) returns only ``edge`` column."
+msgstr "pgr_maxCardinalityMatch(text) regresa solamente la columna ``edge``."
+
 msgid "Deprecated signature"
 msgstr ""
 
-msgid "``pgr_maxCardinalityMatch(text,boolean)``"
-msgstr "``pgr_maxCardinalityMatch(text,boolean)``"
+msgid "pgr_maxCardinalityMatch(text,boolean)"
+msgstr "pgr_maxCardinalityMatch(text,boolean)"
 
-msgid "``directed => false`` when used."
-msgstr ""
+msgid "directed => ``false`` when used."
+msgstr "Con directed => `` false`` cuando se usa."
 
 msgid "Renamed from ``pgr_maximumCardinalityMatching``"
 msgstr "Renombrado de ``pgr_maximumCardinalityMatching``"
@@ -15385,8 +15333,12 @@ msgstr ""
 msgid "Identifier of the edge in the original query."
 msgstr "Identificador de la arista en la consulta original."
 
-msgid "https://www.boost.org/libs/graph/doc/maximum_matching.html"
-msgstr "https://www.boost.org/libs/graph/doc/maximum_matching.html"
+msgid ""
+"`Boost: maximum_matching <https://www.boost.org/libs/graph/doc/"
+"maximum_matching.html>`__"
+msgstr ""
+"`Boost: Coincidencia máxima <https://www.boost.org/libs/graph/doc/"
+"maximum_matching.html>`__"
 
 msgid "https://en.wikipedia.org/wiki/Matching_%28graph_theory%29"
 msgstr "https://en.wikipedia.org/wiki/Matching_%28graph_theory%29"
@@ -15404,12 +15356,6 @@ msgstr ""
 "``pgr_maxFlow`` — Calcula el flujo máximo en un gráfico dirigido desde los "
 "orígene(s) a los destino(s) mediante el algoritmo Push Relabel."
 
-msgid "``pgr_maxFlow`` (`Combinations`_)"
-msgstr "``pgr_maxFlow`` (`Combinaciones`_)"
-
-msgid "New **Proposed** function"
-msgstr "Nueva función **Propuesta**"
-
 msgid "Calculates the maximum flow from the sources to the targets."
 msgstr "Calcula el flujo máximo de las fuentes a los objetivos."
 
@@ -15417,6 +15363,9 @@ msgid ""
 "When the maximum flow is **0** then there is no flow and **0** is returned."
 msgstr ""
 "Cuando el flujo máximo es **0**, entonces no hay flujo y se devuelve **0**."
+
+msgid "There is no flow when source has the same vaule as target."
+msgstr "No hay flujo cuando el origen tiene el mismo valor que el destino."
 
 msgid "Uses the :doc:`pgr_pushRelabel <pgr_pushRelabel>` algorithm."
 msgstr "Use el algoritmo :doc:`pgr_pushRelabel <pgr_pushRelabel>` ."
@@ -15445,8 +15394,12 @@ msgstr ""
 msgid "Maximum flow possible from the source(s) to the target(s)"
 msgstr "Flujo máximo posible desde el/los orígen(es) hacia el/los destino(s)"
 
-msgid "https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html"
-msgstr "https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html"
+msgid ""
+"`Boost: push relabel max flow <https://www.boost.org/libs/graph/doc/"
+"push_relabel_max_flow.html>`__"
+msgstr ""
+"`Boost: Flujo máximo empujar reetiquetar <https://www.boost.org/libs/graph/"
+"doc/push_relabel_max_flow.html>`__"
 
 msgid ""
 "https://en.wikipedia.org/wiki/Push%E2%80%93relabel_maximum_flow_algorithm"
@@ -15463,8 +15416,11 @@ msgstr ""
 "``pgr_maxFlowMinCost`` — Calcula las aristas que minimiza el costo del flujo "
 "maximo en un grafo"
 
-msgid "``pgr_maxFlowMinCost`` (`Combinations`_)"
-msgstr "``pgr_maxFlowMinCost`` (`Combinaciones`_)"
+msgid "pgr_maxFlowMinCost(Combinations)"
+msgstr "pgr_maxFlowMinCost(Combinaciones)"
+
+msgid "|boost| graph inside."
+msgstr "|boost| graph adentro."
 
 msgid "**TODO** check which statement is true:"
 msgstr "**Por hacer** comprobar qué declaración es verdadera:"
@@ -15513,13 +15469,6 @@ msgstr "pgr_maxFlowMinCost(`SQL de aristas`_, `SQL de combinaciones`_)"
 msgid "Returns set of |result-flow-mincost|"
 msgstr "Regresa el conjunto de |result-flow-mincost|"
 
-msgid ""
-"https://www.boost.org/libs/graph/doc/"
-"successive_shortest_path_nonnegative_weights.html"
-msgstr ""
-"https://www.boost.org/libs/graph/doc/"
-"successive_shortest_path_nonnegative_weights.html"
-
 msgid "``pgr_maxFlowMinCost_Cost`` - Experimental"
 msgstr "``pgr_maxFlowMinCost_Cost`` - Experimental"
 
@@ -15530,8 +15479,8 @@ msgstr ""
 "``pgr_maxFlowMinCost_Cost`` — Calcula el costo mínimo para el máximo flujo "
 "en un grafo"
 
-msgid "``pgr_maxFlowMinCost_Cost`` (`Combinations`_)"
-msgstr "``pgr_maxFlowMinCost_Cost`` (`Combinaciones`_)"
+msgid "pgr_maxFlowMinCost_Cost(Combinations)"
+msgstr "pgr_maxFlowMinCost_Cost(Combinaciones)"
 
 msgid "**The cost value of all input edges must be nonnegative.**"
 msgstr ""
@@ -15567,8 +15516,8 @@ msgstr ""
 "Coste Mínimo Flujo Máximo posible desde el/los origen(es) hasta el/los "
 "objetivo(s)"
 
-msgid "pgr_nodeNetwork"
-msgstr "pgr_nodeNetwork"
+msgid "``pgr_nodeNetwork``"
+msgstr "``pgr_nodeNetwork``"
 
 msgid "``pgr_nodeNetwork`` - Nodes an network edge table."
 msgstr ""
@@ -15952,6 +15901,8 @@ msgstr "Firma"
 msgid ""
 "pgr_pickDeliver(`Orders SQL`_, `Vehicles SQL`_, `Matrix SQL`_, [**options**])"
 msgstr ""
+"pgr_pickDeliver(`SQL de ordenes`_, `SQL de vehículos`_, `SQL de matriz`_, "
+"[**opciones**])"
 
 msgid "**options:** ``[factor, max_cycles, initial_sol]``"
 msgstr "**opcionales:** ``[factor, max_cycles, initial_sol]``"
@@ -16060,7 +16011,7 @@ msgid ""
 "projectweb/top/pdptw/li-lim-benchmark/"
 msgstr ""
 
-msgid "There are 25 vehciles in the problem all with the same characteristics."
+msgid "There are 25 vehicles in the problem all with the same characteristics."
 msgstr ""
 
 msgid "The original orders"
@@ -16071,7 +16022,7 @@ msgid ""
 "order."
 msgstr ""
 
-msgid "The original data needs to be converted to an appropiate table:"
+msgid "The original data needs to be converted to an appropriate table:"
 msgstr ""
 
 msgid "The query"
@@ -16191,9 +16142,6 @@ msgstr ""
 "``pgr_pushRelabel`` — Calcula el flujo en los bordes del grafo que maximiza "
 "el flujo de los orígenes a los destinos mediante el Algoritmo Push Relabel."
 
-msgid "``pgr_pushRelabel`` (`Combinations`_)"
-msgstr "``pgr_pushRelabel`` (`Combinaciones`_)"
-
 msgid "Renamed from ``pgr_maxFlowPushRelabel``"
 msgstr "Renombrado de ``pgr_maxFlowPushRelabel``"
 
@@ -16212,8 +16160,8 @@ msgstr "pgr_pushRelabel(`SQL de aristas`_, **salidas**, **destinos**)"
 msgid "pgr_pushRelabel(`Edges SQL`_, `Combinations SQL`_)"
 msgstr "pgr_pushRelabel(`SQL de aristas`_, `SQL de combinaciones`_)"
 
-msgid "pgr_sequentialVertexColoring - Proposed"
-msgstr "pgr_sequentialVertexColoring - Propuesto"
+msgid "``pgr_sequentialVertexColoring`` - Proposed"
+msgstr "``pgr_sequentialVertexColoring`` - Propuesto"
 
 msgid ""
 "``pgr_sequentialVertexColoring`` — Returns the vertex coloring of an "
@@ -16221,9 +16169,6 @@ msgid ""
 msgstr ""
 "``pgr_sequentialVertexColoring`` — Devuelve el color de vértice de un grafo "
 "no dirigido, utilizando un enfoque codicioso."
-
-msgid "Promoted to **proposed** signature"
-msgstr "Promovido a firma **propuesta**"
 
 msgid ""
 "Sequential vertex coloring algorithm is a graph coloring algorithm in which "
@@ -16283,8 +16228,15 @@ msgstr ":math:`k` es el número de colores utilizados."
 msgid "pgr_sequentialVertexColoring(`Edges SQL`_)"
 msgstr "pgr_sequentialVertexColoring(`SQL de aristas`_)"
 
-msgid "pgr_stoerWagner - Experimental"
-msgstr "pgr_stoerWagner - Experimental"
+msgid ""
+"`Boost: Sequential Vertex Coloring <https://www.boost.org/libs/graph/doc/"
+"sequential_vertex_coloring.html>`__"
+msgstr ""
+"`Boost: Coloración Secuencial de Vértices <https://www.boost.org/libs/graph/"
+"doc/sequential_vertex_coloring.html>`__"
+
+msgid "``pgr_stoerWagner`` - Experimental"
+msgstr "``pgr_stoerWagner`` - Experimental"
 
 msgid "``pgr_stoerWagner`` — The min-cut of graph using stoerWagner algorithm."
 msgstr ""
@@ -16390,6 +16342,13 @@ msgstr "corte mínimo de una arista"
 msgid "Using :doc:`pgr_connectedComponents`"
 msgstr "Usando :doc:`pgr_connectedComponents`"
 
+msgid ""
+"`Boost: Stoer Wagner min cut <https://www.boost.org/libs/graph/doc/"
+"stoer_wagner_min_cut.html>`__"
+msgstr ""
+"`Boost: Corte mínimo Stoer Wagner <https://www.boost.org/libs/graph/doc/"
+"stoer_wagner_min_cut.html>`__"
+
 msgid "https://en.wikipedia.org/wiki/Stoer%E2%80%93Wagner_algorithm"
 msgstr "https://en.wikipedia.org/wiki/Stoer%E2%80%93Wagner_algorithm"
 
@@ -16423,10 +16382,10 @@ msgid "The strong components of the graph"
 msgstr "Los componentes fuertes del grafo"
 
 msgid ""
-"Boost: `Strong components <https://www.boost.org/libs/graph/doc/"
+"`Boost: Strong components <https://www.boost.org/libs/graph/doc/"
 "strong_components.html>`__"
 msgstr ""
-"Boost: `Components fuertemente conectados <https://www.boost.org/libs/graph/"
+"`Boost: Componentes fuertemente conectados <https://www.boost.org/libs/graph/"
 "doc/strong_components.html>`__"
 
 msgid ""
@@ -16499,6 +16458,13 @@ msgstr ""
 msgid "Graph is not a DAG"
 msgstr ""
 
+msgid ""
+"`Boost: topological sort <https://www.boost.org/libs/graph/doc/"
+"topological_sort.html>`__"
+msgstr ""
+"`Boost: Ordenamiento topológico <https://www.boost.org/libs/graph/doc/"
+"topological_sort.html>`__"
+
 msgid "``pgr_transitiveClosure`` - Experimental"
 msgstr "``pgr_transitiveClosure`` - Experimental"
 
@@ -16555,57 +16521,54 @@ msgid "Identifiers of the vertices that are reachable from vertex v."
 msgstr ""
 "Identificadores de los vértices que son alcanzables desde el vértice v."
 
+msgid ""
+"`Boost: transitive closure <https://www.boost.org/libs/graph/doc/"
+"transitive_closure.html>`__"
+msgstr ""
+"`Boost: Cierre transitivo <https://www.boost.org/libs/graph/doc/"
+"transitive_closure.html>`__"
+
 msgid "https://en.wikipedia.org/wiki/Transitive_closure"
 msgstr "https://en.wikipedia.org/wiki/Transitive_closure"
 
-msgid "pgr_trsp - Proposed"
-msgstr ""
+msgid "``pgr_trsp``"
+msgstr "``pgr_trsp``"
 
 msgid "``pgr_trsp`` - routing vertices with restrictions."
 msgstr "``pgr_trsp`` - Ruteo con restricciones."
 
-msgid "New proposed signatures"
-msgstr "Nuevas firmas propuestas"
+msgid "pgr_trsp(One to One)"
+msgstr "pgr_trsp(Uno a Uno)"
 
-msgid "``pgr_trsp`` (`One to One`_)"
-msgstr "``pgr_trsp`` (`Uno a Uno`_)"
+msgid "pgr_trsp(One to Many)"
+msgstr "pgr_trsp(Uno a Muchos)"
 
-msgid "``pgr_trsp`` (`One to Many`_)"
-msgstr ""
+msgid "pgr_trsp(Many to One)"
+msgstr "pgr_trsp(Muchos a Uno)"
 
-msgid "``pgr_trsp`` (`Many to One`_)"
-msgstr ""
+msgid "pgr_trsp(Many to Many)"
+msgstr "pgr_trsp(Muchos a Muchos)"
 
-msgid "``pgr_trsp`` (`Many to Many`_)"
-msgstr ""
-
-msgid "``pgr_trsp`` (`Combinations`_)"
-msgstr ""
+msgid "pgr_trsp(Combinations)"
+msgstr "pgr_trsp(Combinaciones)"
 
 msgid "Deprecated signatures"
 msgstr "Firmas obsoletas"
 
-msgid "``pgr_trsp(text,integer,integer,boolean,boolean,text)``"
-msgstr "``pgr_trsp(text,integer,integer,boolean,boolean,text)``"
+msgid "pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)"
+msgstr "pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)"
 
-msgid "``pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)``"
-msgstr ""
-
-msgid "``pgr_trspViaVertices(text,anyarray,boolean,boolean,text)``"
-msgstr ""
-
-msgid ""
-"``pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)``"
-msgstr ""
+msgid "pgr_trspViaVertices(text,anyarray,boolean,boolean,text)"
+msgstr "pgr_trspViaVertices(text,anyarray,boolean,boolean,text)"
 
 msgid "New prototypes"
 msgstr "Nuevos prototipos"
 
-msgid "``pgr_trspViaVertices``"
-msgstr "``pgr_trspViaVertices``"
+msgid "pgr_trspViaVertices"
+msgstr "pgr_trspViaVertices"
 
-msgid "``pgr_trspViaEdges``"
-msgstr "``pgr_trspViaEdges``"
+msgid "pgr_trspViaEdges"
+msgstr "pgr_trspViaEdges"
 
 msgid ""
 "Turn restricted shortest path (TRSP) is an algorithm that receives turn "
@@ -16686,18 +16649,13 @@ msgstr "Usando una tabla de combinaciones en un grafo no dirigido."
 msgid ""
 "`Deprecated documentation <https://docs.pgrouting.org/3.3/en/pgr_trsp.html>`_"
 msgstr ""
+"`Documentación obsoleta <https://docs.pgrouting.org/3.3/en/pgr_trsp.html>`_"
 
-msgid "``pgr_trspVia`` - Proposed"
-msgstr ""
+msgid "``pgr_trspVia``"
+msgstr "``pgr_trspVia``"
 
 msgid ""
 "``pgr_trspVia`` Route that goes through a list of vertices with restrictions."
-msgstr ""
-
-msgid "New proposed function:"
-msgstr ""
-
-msgid "``pgr_trspVia`` (`One Via`_)"
 msgstr ""
 
 msgid ""
@@ -16710,7 +16668,7 @@ msgid "The paths represents the sections of the route."
 msgstr "Las trayectorias representan los tramos de la ruta."
 
 msgid "Execute a :doc:`pgr_dijkstraVia`."
-msgstr ""
+msgstr "Ejecutar un :doc:`pgr_dijkstraVia`."
 
 msgid ""
 "For the set of sub paths of the solution that pass through a restriction then"
@@ -16781,15 +16739,12 @@ msgstr ""
 msgid ":doc:`via-category`"
 msgstr ":doc:`via-category`"
 
-msgid "``pgr_trspVia_withPoints`` - Proposed"
-msgstr ""
+msgid "``pgr_trspVia_withPoints``"
+msgstr "``pgr_trspVia_withPoints``"
 
 msgid ""
 "``pgr_trspVia_withPoints`` - Route that goes through a list of vertices and/"
 "or points with restrictions."
-msgstr ""
-
-msgid "``pgr_trspVia_withPoints`` (`One Via`_)"
 msgstr ""
 
 msgid ""
@@ -16923,7 +16878,7 @@ msgid "Status of \"passes in front\" or \"visits\" of the nodes and points."
 msgstr ""
 
 msgid "The algorithm performs a :doc:`pgr_withPointsVia`"
-msgstr ""
+msgstr "El algoritmo realiza una :doc:`pgr_withPointsVia`"
 
 msgid ""
 "Detects which of the paths pass through a restriction in this case is for "
@@ -16961,28 +16916,10 @@ msgid ""
 "`pgr_trsp` algorithm. In this case a U turn is been done using the same edge."
 msgstr ""
 
-msgid "pgr_trsp_withPoints - Proposed"
-msgstr ""
+msgid "``pgr_trsp_withPoints``"
+msgstr "``pgr_trsp_withPoints``"
 
 msgid "``pgr_trsp_withPoints`` Routing Vertex/Point with restrictions."
-msgstr ""
-
-msgid "New proposed signatures:"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`One to One`_)"
-msgstr "``pgr_trsp_withPoints`` (`Uno a Uno`_)"
-
-msgid "``pgr_trsp_withPoints`` (`One to Many`_)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`Many to One`_)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`Many to Many`_)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`Combinations`_)"
 msgstr ""
 
 msgid ""
@@ -17128,16 +17065,15 @@ msgstr ""
 "Desde el punto :math:`1` y el vértice :math:`6` al punto :math:`3` y el "
 "vértice :math:`1` en un grafo no dirigido, con detalles."
 
-msgid "pgr_turnRestrictedPath - Experimental"
-msgstr "pgr_turnRestrictedPath - Experimental"
+msgid "``pgr_turnRestrictedPath`` - Experimental"
+msgstr "``pgr_turnRestrictedPath`` - Experimental"
 
 msgid ""
-"``pgr_turnRestrictedPath`` Using Yen's algorithm Vertex -Vertex routing with "
-"restrictions"
+"``pgr_turnRestrictedPath`` Using Yen's algorithm Vertex - Vertex routing "
+"with restrictions"
 msgstr ""
-
-msgid "New experimental function"
-msgstr "Nueva función Experimental"
+"``pgr_turnRestrictedPath`` Usando el algoritmo vértice -vértice de Yen para "
+"ruteo con restricciones"
 
 msgid ""
 "Using Yen's algorithm to obtain K shortest paths and analyze the paths to "
@@ -17213,8 +17149,8 @@ msgstr "pgr_version()"
 msgid "pgRouting Version for this documentation"
 msgstr "Versión de pgRouting para esta documentación"
 
-msgid "pgr_vrpOneDepot - Experimental"
-msgstr "pgr_vrpOneDepot - Experimental"
+msgid "``pgr_vrpOneDepot`` - Experimental"
+msgstr "``pgr_vrpOneDepot`` - Experimental"
 
 msgid "**No documentation available**"
 msgstr "**No hay documentación disponible**"
@@ -17222,8 +17158,8 @@ msgstr "**No hay documentación disponible**"
 msgid "**TBD**"
 msgstr "**TBD**"
 
-msgid "``pgr_withPoints`` - Proposed"
-msgstr "``pgr_withPoints`` - Propuesto"
+msgid "``pgr_withPoints``"
+msgstr "``pgr_withPoints``"
 
 msgid ""
 "``pgr_withPoints`` - Returns the shortest path in a graph with additional "
@@ -17398,8 +17334,8 @@ msgstr "Del punto :math:`6` al vértice :math:`11`."
 msgid "Passes in front or visits with left side driving."
 msgstr "Pasa enfrente o visita con lado izquierdo de manejo."
 
-msgid "``pgr_withPointsCost`` - Proposed"
-msgstr "``pgr_withPointsCost`` - Propuesto"
+msgid "``pgr_withPointsCost``"
+msgstr "``pgr_withPointsCost``"
 
 msgid ""
 "``pgr_withPointsCost`` - Calculates the shortest path and returns only the "
@@ -17582,8 +17518,8 @@ msgstr "Topología de manejo del lado izquierdo"
 msgid "Does not matter driving side driving topology"
 msgstr "No importa el lado de manejo"
 
-msgid "``pgr_withPointsCostMatrix`` - proposed"
-msgstr "``pgr_withPointsCostMatrix`` - propuesto"
+msgid "``pgr_withPointsCostMatrix``"
+msgstr "``pgr_withPointsCostMatrix``"
 
 msgid ""
 "``pgr_withPointsCostMatrix`` - Calculates a cost matrix using :doc:"
@@ -17622,8 +17558,8 @@ msgstr ""
 "Encontrar la matriz de costos de las rutas desde el vértice :math:`1` y las "
 "dos ubicaciones más cercanas en el grafo al punto `(2.9, 1.8)`."
 
-msgid "``pgr_withPointsDD`` - Proposed"
-msgstr "``pgr_withPointsDD`` - Propuesto"
+msgid "``pgr_withPointsDD``"
+msgstr "``pgr_withPointsDD``"
 
 msgid ""
 "``pgr_withPointsDD`` - Returns the driving **distance** from a starting "
@@ -17637,8 +17573,11 @@ msgid ""
 "unnamed compulsory **driving side**."
 msgstr ""
 
-msgid "``pgr_withPointsDD`` (`Single vertex`)"
-msgstr "``pgr_withPointsDD`` (`Vértice único`)"
+msgid "pgr_withPointsDD(Single vertex)"
+msgstr "pgr_withPointsDD(Vértice único)"
+
+msgid "pgr_withPointsDD(Multiple vertices)"
+msgstr "pgr_withPointsDD(Múltiples vértices)"
 
 msgid "Added ``depth``, ``pred`` and ``start_vid`` column."
 msgstr "Agregado las columnas ``depth``, ``pred`` y ``start_vid``."
@@ -17655,18 +17594,16 @@ msgid ""
 msgstr ""
 
 msgid ""
-"``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,"
-"boolean)``"
+"pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)"
 msgstr ""
-"``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,"
-"boolean)``"
+"pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)"
 
 msgid ""
-"``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
-"boolean,boolean)``"
+"pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
+"boolean,boolean)"
 msgstr ""
-"``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
-"boolean,boolean)``"
+"pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
+"boolean,boolean)"
 
 msgid ""
 "Modify the graph to include points and using Dijkstra algorithm, extracts "
@@ -17798,8 +17735,8 @@ msgstr ""
 msgid ":doc:`pgr_alphaShape`"
 msgstr ":doc:`pgr_alphaShape`"
 
-msgid "pgr_withPointsKSP - Proposed"
-msgstr "pgr_withPointsKSP - Propuesto"
+msgid "``pgr_withPointsKSP``"
+msgstr "``pgr_withPointsKSP``"
 
 msgid ""
 "``pgr_withPointsKSP`` — Yen's algorithm for K shortest paths using Dijkstra."
@@ -17810,29 +17747,26 @@ msgstr ""
 msgid "Standarizing output columns to |nksp-result|"
 msgstr ""
 
-msgid "``pgr_withPointsKSP`` (One to One)"
-msgstr "``pgr_withPointsKSP`` (Uno a Uno)"
+msgid "pgr_withPointsKSP(One to One)"
+msgstr "pgr_withPointsKSP(Uno a Uno)"
 
-msgid "New overload functions"
-msgstr "Nuevas funciones de sobrecarga"
+msgid "pgr_withPointsKSP(One to Many)"
+msgstr "pgr_withPointsKSP(Uno a Muchos)"
 
-msgid "``pgr_withPointsKSP`` (One to Many)"
-msgstr "``pgr_withPointsKSP`` (Uno a Muchos)"
+msgid "pgr_withPointsKSP(Many to One)"
+msgstr "pgr_withPointsKSP(Muchos a Uno)"
 
-msgid "``pgr_withPointsKSP`` (Many to One)"
-msgstr "``pgr_withPointsKSP`` (Muchos a Uno)"
+msgid "pgr_withPointsKSP(Many to Many)"
+msgstr "pgr_withPointsKSP(Muchos a Muchos)"
 
-msgid "``pgr_withPointsKSP`` (Many to Many)"
-msgstr "``pgr_withPointsKSP`` (Muchos a Muchos)"
-
-msgid "``pgr_withPointsKSP`` (Combinations)"
-msgstr "``pgr_withPointsKSP`` (Combinaciones)"
+msgid "pgr_withPointsKSP(Combinations)"
+msgstr "pgr_withPointsKSP(Combinaciones)"
 
 msgid ""
-"``pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
+"pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
 "boolean)``"
 msgstr ""
-"``pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
+"pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
 "boolean)``"
 
 msgid ""
@@ -17985,16 +17919,14 @@ msgstr ""
 "Obtener :math:`2` rutas, usando topología de manejo por la derecha, desde el "
 "punto :math:`1` al punto :math:`2`, detallado y con rutas procesadas."
 
-msgid "``pgr_withPointsVia`` - Proposed"
-msgstr ""
+msgid "``pgr_withPointsVia``"
+msgstr "``pgr_withPointsVia``"
 
 msgid ""
 "``pgr_withPointsVia`` - Route that goes through a list of vertices and/or "
 "points."
 msgstr ""
-
-msgid "New **proposed** function ``pgr_withPointsVia`` (`One Via`_)"
-msgstr ""
+"``pgr_withPointsVia`` - Ruta que recorre una lista de vértices y/o puntos."
 
 msgid ""
 "Given a graph, a set of points on the graphs edges and a list of vertices, "
@@ -18100,47 +18032,17 @@ msgstr ":doc:`pgr_withPointsDD` - Distancia de conducción."
 msgid ":doc:`pgr_withPointsVia` - Via routing"
 msgstr ":doc:`pgr_withPointsVia` - Ruteo vía ubicaciones"
 
-msgid "These proposed functions do not modify the database."
-msgstr "Estas funciones propuestas no modifican la base de datos."
-
-msgid ""
-":doc:`pgr_degree` - Returns a set of vertices and corresponding count of "
-"incidet edges to the vertex."
-msgstr ""
-
-msgid ""
-":doc:`pgr_extractVertices` - Extracts vertex information based on the edge "
-"table information."
-msgstr ""
-":doc:`pgr_extractVertices` - Extrae información de vértices basada en la "
-"tabla de aristas."
-
 msgid ""
 ":doc:`pgr_lineGraph` - Transformation algorithm for generating a Line Graph."
 msgstr ""
 ":doc:`pgr_lineGraph` - Algoritmo de transformación para generar un grafo de "
 "líneas."
 
-msgid ":doc:`pgr_withPointsVia`"
-msgstr ":doc:`pgr_withPointsVia`"
-
-msgid ":doc:`pgr_trspVia`"
-msgstr ":doc:`pgr_trspVia`"
-
-msgid ":doc:`pgr_trspVia_withPoints`"
-msgstr ":doc:`pgr_trspVia_withPoints`"
-
 msgid ":doc:`withPoints-family` - Functions based on Dijkstra algorithm."
 msgstr ":doc:`withPoints-family` - Funciones basadas en el algoritmo Dijkstra."
 
 msgid "From the :doc:`TRSP-family`:"
 msgstr "Desde :doc:`TRSP-family` :"
-
-msgid "Utilities"
-msgstr "Utilidades"
-
-msgid ":doc:`pgr_findCloseEdges`"
-msgstr ":doc:`pgr_findCloseEdges`"
 
 msgid "Reference"
 msgstr "Referencia"
@@ -18158,14 +18060,254 @@ msgstr ""
 msgid "Mayors"
 msgstr ""
 
+msgid "pgRouting 4"
+msgstr "pgRouting 4"
+
+msgid "Minors 4.x"
+msgstr ""
+
+msgid "pgRouting 4.0"
+msgstr "pgRouting 4.0"
+
 msgid "pgRouting 3"
 msgstr "pgRouting 3"
 
 msgid "Minors 3.x"
 msgstr ""
 
+#, fuzzy
+msgid "pgRouting 3.8"
+msgstr "pgRouting 3.7"
+
+#, fuzzy
+msgid "pgRouting 3.8.0 Release Notes"
+msgstr "Notas de la versión de pgRouting 3.7.0"
+
+#, fuzzy
+msgid "Promotion to official function of pgRouting."
+msgstr "Propuesta cambió a oficial en pgRouting"
+
+msgid "pgr_extractVertices"
+msgstr "pgr_extractVertices"
+
+msgid "pgr_degree"
+msgstr "pgr_degree"
+
+#, fuzzy
+msgid "pgr_findCloseEdges"
+msgstr "``pgr_findCloseEdges``"
+
+msgid "Official functions changes"
+msgstr "Cambios en las funciones oficiales"
+
+#, fuzzy
+msgid ""
+"`#2786 <https://github.com/pgRouting/pgrouting/issues/2786>`__: "
+"pgr_contraction"
+msgstr ""
+"`#1002 <https://github.com/pgRouting/pgrouting/issues/1002>`__: Problemas de "
+"contracción solucionados:"
+
+msgid "New proposed functions"
+msgstr "Nuevas funciones propuestas"
+
+#, fuzzy
+msgid "Contraction"
+msgstr "Contracción:"
+
+#, fuzzy
+msgid ""
+"`#2790 <https://github.com/pgRouting/pgrouting/issues/2790>`__: "
+"pgr_contractionDeadEnd"
+msgstr ""
+"`#2087 <https://github.com/pgRouting/pgrouting/issues/2087>`__: "
+"pgr_extractVertices a propuesto"
+
+#, fuzzy
+msgid ""
+"`#2791 <https://github.com/pgRouting/pgrouting/issues/2791>`__: "
+"pgr_contractionLinear"
+msgstr ""
+"`#1002 <https://github.com/pgRouting/pgrouting/issues/1002>`__: Problemas de "
+"contracción solucionados:"
+
 msgid "pgRouting 3.7"
 msgstr "pgRouting 3.7"
+
+msgid "pgRouting 3.7.3 Release Notes"
+msgstr "Notas de la versión de pgRouting 3.7.3"
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.3 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.3%22>`__"
+msgstr ""
+"Para ver todos los problemas y solicitudes de extracción cerrados para ésta "
+"versión, consulte la `meta cerrada 3.7.3 <https://github.com/pgRouting/"
+"pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.3%22>`__"
+
+msgid ""
+"`#2731 <https://github.com/pgRouting/pgrouting/pull/2731>`__ Build Failure "
+"on Ubuntu 22"
+msgstr ""
+"`#2731 <https://github.com/pgRouting/pgrouting/pull/2731>`__ Construcción "
+"falla en Ubuntu 22"
+
+msgid "pgRouting 3.7.2 Release Notes"
+msgstr "Notas de la versión de pgRouting 3.7.2"
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.2 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.2%22>`__"
+msgstr ""
+"Para ver todos los problemas y solicitudes de extracción cerrados para ésta "
+"versión, consulte la `meta cerrada 3.7.2 <https://github.com/pgRouting/"
+"pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.2%22>`__"
+
+msgid "Build"
+msgstr "Construir"
+
+msgid ""
+"`#2713 <https://github.com/pgRouting/pgrouting/pull/2713>`__ cmake missing "
+"some policies and min version"
+msgstr ""
+"`#2713 <https://github.com/pgRouting/pgrouting/pull/2713>`__ cmake le falta "
+"algunas políticas y versión minima"
+
+msgid "Using OLD policies: CMP0148, CMP0144, CMP0167"
+msgstr ""
+
+msgid "Minimum cmake version 3.12"
+msgstr ""
+
+msgid ""
+"`#2707 <https://github.com/pgRouting/pgrouting/pull/2707>`__ Build failure "
+"in pgRouting 3.7.1 on Alpine"
+msgstr ""
+"`#2707 <https://github.com/pgRouting/pgrouting/pull/2707>`__ Falla de "
+"construcción en Alpine para pgRouting 3.7.1"
+
+msgid ""
+"`#2706 <https://github.com/pgRouting/pgrouting/pull/2706>`__ winnie crashing "
+"on pgr_betweennessCentrality"
+msgstr ""
+"`#2706 <https://github.com/pgRouting/pgrouting/pull/2706>`__ winnie falla en "
+"pgr_betweennessCentrality"
+
+msgid "pgRouting 3.7.1 Release Notes"
+msgstr "Notas de la versión de pgRouting 3.7.1"
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.1 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.1%22>`__"
+msgstr ""
+"Para ver todos los problemas y solicitudes de extracción cerrados para ésta "
+"versión, consulte la `meta cerrada 3.7.1 <https://github.com/pgRouting/"
+"pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.1%22>`__"
+
+msgid ""
+"`#2680 <https://github.com/pgRouting/pgrouting/pull/2680>`__ fails to "
+"compile under mingw64 gcc 13.2"
+msgstr ""
+"`#2680 <https://github.com/pgRouting/pgrouting/pull/2680>`__ Compilación "
+"falla bajo mingw64 gcc 13.2"
+
+msgid ""
+"`#2689 <https://github.com/pgRouting/pgrouting/pull/2689>`__ When point is a "
+"vertex, the withPoints family do not return results."
+msgstr ""
+"`#2689 <https://github.com/pgRouting/pgrouting/pull/2689>`__ Cuando el punto "
+"es un vértice, la familia withPoints no devuelve resultados."
+
+msgid "C/C++ code enhancemet"
+msgstr "Mejora del código C/C++"
+
+msgid "TRSP family"
+msgstr "Familia TRSP"
+
+msgid "pgRouting 3.7.0 Release Notes"
+msgstr "Notas de la versión de pgRouting 3.7.0"
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.0 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.0%22>`__"
+msgstr ""
+"Para ver todos los problemas y solicitudes de extracción cerrados para ésta "
+"versión, consulte la `meta cerrada 3.7.0 <https://github.com/pgRouting/"
+"pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.0%22>`_"
+
+msgid ""
+"`#2656 <https://github.com/pgRouting/pgrouting/pull/2656>`__ Stop support of "
+"PostgreSQL12 on pgrouting v3.7"
+msgstr ""
+"`#2656 <https://github.com/pgRouting/pgrouting/pull/2656>`__ PostgreSQL 12 "
+"no se apya en pgrouting v3.7"
+
+msgid "Stopping support of PostgreSQL 12"
+msgstr "PostgreSQL 12 ya no es soportado"
+
+msgid "CI does not test for PostgreSQL 12"
+msgstr "CI no hace pruebas con PostgreSQL 12"
+
+msgid "New experimental functions"
+msgstr "Nuevas funciones experimentales"
+
+msgid "Metrics"
+msgstr "Métricas"
+
+msgid "pgr_betweennessCentrality"
+msgstr "pgr_betweennessCentrality"
+
+#, fuzzy
+msgid ""
+"`#2605 <https://github.com/pgRouting/pgrouting/pull/2605>`__ Standardize "
+"spanning tree functions output"
+msgstr ""
+"`#2605 <https://github.com/pgRouting/pgrouting/pull/2605>`__ Estandarización "
+"de las salida de las funciones de árbol de expansión"
+
+msgid "Functions:"
+msgstr "Funciones:"
+
+msgid "Experimental promoted to proposed."
+msgstr "Experimental promovido a propuesto."
+
+msgid ""
+"`#2635 <https://github.com/pgRouting/pgrouting/pull/2635>`__ pgr_LineGraph "
+"ignores directed flag and use negative values for identifiers."
+msgstr ""
+"`#2635 <https://github.com/pgRouting/pgrouting/pull/2635>`__ pgr_LineGraph "
+"ignora la bandera directed y usa valores negatives para identificadores."
+
+msgid "``pgr_lineGraph``"
+msgstr "``pgr_lineGraph``"
+
+msgid "Code enhancement"
+msgstr "Mejora del código"
+
+msgid ""
+"`#2599 <https://github.com/pgRouting/pgrouting/pull/2599>`__ Driving "
+"distance cleanup"
+msgstr ""
+"`#2599 <https://github.com/pgRouting/pgrouting/pull/2599>`__ Limpieza de la "
+"distancia de conducción"
+
+msgid ""
+"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ Read postgresql "
+"data on C++"
+msgstr ""
+"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ Leer datos "
+"postgresql en C++"
+
+msgid ""
+"`#2614 <https://github.com/pgRouting/pgrouting/pull/2614>`__ Clang tidy does "
+"not work"
+msgstr ""
+"`#2614 <https://github.com/pgRouting/pgrouting/pull/2614>`__ Clang tidy no "
+"funciona"
 
 msgid "pgRouting 3.6"
 msgstr "pgRouting 3.6"
@@ -18181,9 +18323,6 @@ msgstr ""
 "Para ver todas las incidencias y pull requests cerrados por esta versión, "
 "consulte `Git closed milestone for 3.6.3 <https://github.com/pgRouting/"
 "pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.6.3%22>`__"
-
-msgid "Build"
-msgstr "Construir"
 
 msgid "Explicit minimum requirements:"
 msgstr ""
@@ -18296,70 +18435,56 @@ msgstr ""
 "versión, consulte la `meta cerrada 3.6.0 <https://github.com/pgRouting/"
 "pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.6.0%22>`_"
 
+#, fuzzy
 msgid ""
-"`#2516 <https://github.com/pgRouting/pgrouting/pull/2516>`__ Standarize "
+"`#2516 <https://github.com/pgRouting/pgrouting/pull/2516>`__ Standardize "
 "output pgr_aStar"
 msgstr ""
 "`#2516 <https://github.com/pgRouting/pgrouting/pull/2516>`__ estandarización "
 "de resultados de pgr_aStar"
 
+#, fuzzy
+msgid "Standardize output columns to |short-generic-result|"
+msgstr "Estandarización de las columnas de salida a |short-generic-result|"
+
+#, fuzzy
 msgid ""
-"``pgr_aStar`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
-msgstr ""
-"``pgr_aStar`` (`Uno a Uno`) ha añadido las columnas ``start_vid`` y "
-"``end_vid``."
-
-msgid "``pgr_aStar`` (`One to Many`) added ``end_vid`` column."
-msgstr "``pgr_aStar`` (`Uno a Muchos`) ha añadido la columna ``end_vid``."
-
-msgid "``pgr_aStar`` (`Many to One`) added ``start_vid`` column."
-msgstr "``pgr_aStar`` (`Muchos a Uno`) ha añadido la columna ``start_vid``."
-
-msgid ""
-"`#2523 <https://github.com/pgRouting/pgrouting/pull/2523>`__ Standarize "
+"`#2523 <https://github.com/pgRouting/pgrouting/pull/2523>`__ Standardize "
 "output pgr_bdAstar"
 msgstr ""
 "`#2523 <https://github.com/pgRouting/pgrouting/pull/2523>`__ Estandarización "
 "de resultados de pgr_bdAstar"
 
+#, fuzzy
 msgid ""
-"``pgr_bdAstar`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
-msgstr ""
-"``pgr_bdAstar`` (`Uno a Uno`) ha añadido las columnas ``start_vid`` y "
-"``end_vid``."
-
-msgid "``pgr_bdAstar`` (`One to Many`) added ``end_vid`` column."
-msgstr "``pgr_bdAstar`` (`Uno a Muchos`) ha añadido la columna ``end_vid``."
-
-msgid "``pgr_bdAstar`` (`Many to One`) added ``start_vid`` column."
-msgstr "``pgr_bdAstar`` (`Muchos a Uno`) ha añadido la columna ``start_vid``."
-
-msgid ""
-"`#2547 <https://github.com/pgRouting/pgrouting/pull/2547>`__ Standarize "
+"`#2547 <https://github.com/pgRouting/pgrouting/pull/2547>`__ Standardize "
 "output and modifying signature pgr_KSP"
 msgstr ""
 "`#2547 <https://github.com/pgRouting/pgrouting/pull/2547>`__ Estandarización "
 "de resultados y modificación de firmas de pgr_KSP"
 
+#, fuzzy
 msgid ""
-"`#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ Standarize "
-"output pgr_drivingdistance"
+"`#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ Standardize "
+"output pgr_drivingDistance"
 msgstr ""
 "`#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ Estandarización "
-"de resultados de pgr_drivingdistance"
+"de resultados de pgr_drivingDistance"
 
 msgid "Proposed functions changes"
 msgstr "Cambios en funciones propuestas"
 
+#, fuzzy
 msgid ""
-"`#2544 <https://github.com/pgRouting/pgrouting/pull/2544>`__ Standarize "
+"`#2544 <https://github.com/pgRouting/pgrouting/pull/2544>`__ Standardize "
 "output and modifying signature pgr_withPointsDD"
 msgstr ""
 "`#2544 <https://github.com/pgRouting/pgrouting/pull/2544>`__ Estandarización "
 "de resultados y modificación de firmas de pgr_withPointsDD"
 
+#, fuzzy
 msgid ""
-"`#2546 <https://github.com/pgRouting/pgrouting/pull/2546>`__ Standarize "
+"`#2546 <https://github.com/pgRouting/pgrouting/pull/2546>`__ Standardize "
 "output and modifying signature pgr_withPointsKSP"
 msgstr ""
 "`#2546 <https://github.com/pgRouting/pgrouting/pull/2546>`__ Estandarización "
@@ -18419,11 +18544,12 @@ msgstr ""
 "`#2490 <https://github.com/pgRouting/pgrouting/pull/2490>`__ Lígas "
 "automáticas historiales."
 
-msgid "..rubric:: SQL standarization"
+msgid "..rubric:: Standardize SQL"
 msgstr ""
 
+#, fuzzy
 msgid ""
-"`#2555 <https://github.com/pgRouting/pgrouting/pull/2555>`__ standarize "
+"`#2555 <https://github.com/pgRouting/pgrouting/pull/2555>`__ Standardize "
 "deprecated messages"
 msgstr ""
 "`#2555 <https://github.com/pgRouting/pgrouting/pull/2555>`__ Estandarización "
@@ -18454,9 +18580,6 @@ msgstr "Arreglos a la documentación"
 msgid "Changes on the documentation to the following:"
 msgstr ""
 
-msgid "pgr_degree"
-msgstr "pgr_degree"
-
 msgid "pgr_dijkstra"
 msgstr "pgr_dijkstra"
 
@@ -18474,10 +18597,10 @@ msgstr "Corrección de problema"
 
 msgid ""
 "`#2565 <https://github.com/pgRouting/pgrouting/issues/2565>`__ "
-"pgr_pgr_lengauerTarjanDominatorTree triggers an assertion"
+"pgr_lengauerTarjanDominatorTree triggers an assertion"
 msgstr ""
 "`#2565 <https://github.com/pgRouting/pgrouting/issues/2565>`__ "
-"pgr_pgr_lengauerTarjanDominatorTree genera un error de afirmación"
+"pgr_lengauerTarjanDominatorTree genera un error de afirmación"
 
 msgid "SQL enhancements"
 msgstr "Mejoras SQL"
@@ -18522,18 +18645,6 @@ msgstr ""
 
 msgid "Dijkstra"
 msgstr "Dijkstra"
-
-msgid ""
-"``pgr_dijkstra`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
-msgstr ""
-"``pgr_dijkstra`` (`Uno a Uno`) ha añadido las columnas ``start_vid`` y "
-"``end_vid``."
-
-msgid "``pgr_dijkstra`` (`One to Many`) added ``end_vid`` column."
-msgstr "``pgr_dijkstra`` (`Uno a Muchos`) ha añadido la columna ``end_vid``."
-
-msgid "``pgr_dijkstra`` (`Many to One`) added ``start_vid`` column."
-msgstr "``pgr_dijkstra`` (`Muchos a Uno`) ha añadido la columna ``start_vid``."
 
 msgid "pgRouting 3.4"
 msgstr "pgRouting 3.4"
@@ -18609,14 +18720,14 @@ msgid ""
 "doesn't give all correct shortest path"
 msgstr ""
 
-msgid "New proposed functions"
-msgstr "Nuevas funciones propuestas"
+msgid "New proposed functions."
+msgstr "Nuevas funciones propuestas."
 
 msgid "With points"
 msgstr "Con puntos"
 
-msgid "``pgr_withPointsVia`` (One Via)"
-msgstr "``pgr_withPointsVia`` (Una trayectoria)"
+msgid "pgr_withPointsVia(One Via)"
+msgstr "pgr_withPointsVia(Una Vía)"
 
 msgid "Turn Restrictions"
 msgstr "Restricciones de giro"
@@ -18624,83 +18735,68 @@ msgstr "Restricciones de giro"
 msgid "Via with turn restrictions"
 msgstr "Trayectoria con restricciones de giro"
 
-msgid "``pgr_trspVia`` (One Via)"
-msgstr ""
+msgid "pgr_trspVia(One Via)"
+msgstr "pgr_trspVia(Una Vía)"
 
-msgid "``pgr_trspVia_withPoints`` (One Via)"
-msgstr "``pgr_trspVia_withPoints`` (Muchas trayectorias)"
+msgid "pgr_trspVia_withPoints(One Via)"
+msgstr "pgr_trspVia_withPoints(Una Vía)"
 
-msgid "``pgr_trsp``"
-msgstr "``pgr_trsp``"
+msgid "pgr_trsp_withPoints(One to One)"
+msgstr "pgr_trsp_withPoints(Uno a Uno)"
 
-msgid "``pgr_trsp`` (One to One)"
-msgstr "``pgr_trsp`` (Uno a Uno)"
+msgid "pgr_trsp_withPoints(One to Many)"
+msgstr "pgr_trsp_withPoints(Uno a Muchos)"
 
-msgid "``pgr_trsp`` (One to Many)"
-msgstr "``pgr_trsp`` (Uno a Muchos)"
+msgid "pgr_trsp_withPoints(Many to One)"
+msgstr "pgr_trsp_withPoints(Muchos a Uno)"
 
-msgid "``pgr_trsp`` (Many to One)"
-msgstr "``pgr_trsp`` (Muchos a Uno)"
+msgid "pgr_trsp_withPoints(Many to Many)"
+msgstr "pgr_trsp_withPoints(Muchos a Muchos)"
 
-msgid "``pgr_trsp`` (Many to Many)"
-msgstr "``pgr_trsp`` (Muchos a Muchos)"
-
-msgid "``pgr_trsp`` (Combinations)"
-msgstr "``pgr_trsp`` (Combinaciones)"
-
-msgid "``pgr_trsp_withPoints``"
-msgstr "``pgr_trsp_withPoints``"
-
-msgid "``pgr_trsp_withPoints`` (One to One)"
-msgstr "``pgr_trsp_withPoints`` (Uno a Uno)"
-
-msgid "``pgr_trsp_withPoints`` (One to Many)"
-msgstr "``pgr_trsp_withPoints`` (Uno a Muchos)"
-
-msgid "``pgr_trsp_withPoints`` (Many to One)"
-msgstr "``pgr_trsp_withPoints`` (Muchos a Uno)"
-
-msgid "``pgr_trsp_withPoints`` (Many to Many)"
-msgstr "``pgr_trsp_withPoints`` (Muchos a Muchos)"
-
-msgid "``pgr_trsp_withPoints`` (Combinations)"
-msgstr "``pgr_trsp_withPoints`` (Combinaciones)"
+msgid "pgr_trsp_withPoints(Combinations)"
+msgstr "pgr_trsp_withPoints(Combinaciones)"
 
 msgid "Topology"
 msgstr "Topología"
 
-msgid "``pgr_degree``"
-msgstr ""
+msgid "Utilities"
+msgstr "Utilidades"
 
-msgid "``pgr_findCloseEdges`` (One point)"
-msgstr ""
+msgid "pgr_findCloseEdges(One point)"
+msgstr "pgr_findCloseEdges(Un punto)"
 
-msgid "``pgr_findCloseEdges`` (Many points)"
-msgstr ""
+msgid "pgr_findCloseEdges(Many points)"
+msgstr "pgr_findCloseEdges(Muchos puntos)"
 
 msgid "Ordering"
 msgstr "Ordenamiento"
 
-msgid "``pgr_cuthillMckeeOrdering``"
-msgstr "``pgr_cuthillMckeeOrdering``"
+msgid "pgr_cuthillMckeeOrdering"
+msgstr "pgr_cuthillMckeeOrdering"
+
+msgid "Unclassified"
+msgstr "No clasificado"
+
+msgid "pgr_hawickCircuits"
+msgstr "pgr_hawickCircuits"
 
 msgid "Flow functions"
 msgstr "Funciones de flujo"
 
-msgid "``pgr_maxCardinalityMatch(text)``"
-msgstr "``pgr_maxCardinalityMatch(text)``"
+msgid "pgr_maxCardinalityMatch(text)"
+msgstr "pgr_maxCardinalityMatch(text)"
 
-msgid "Deprecating ``pgr_maxCardinalityMatch(text,boolean)``"
-msgstr ""
+msgid "Deprecating: pgr_maxCardinalityMatch(text,boolean)"
+msgstr "Ossoleto: pgr_maxCardinalityMatch(text,boolean)"
 
 msgid "Deprecated Functions"
 msgstr "Funciones obsoletas"
 
-msgid "``pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)``"
-msgstr "``pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)``"
+msgid "pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)"
+msgstr "pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)"
 
-msgid "``pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)``"
-msgstr ""
+msgid "pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)"
+msgstr "pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)"
 
 msgid "pgRouting 3.3"
 msgstr "pgRouting 3.3"
@@ -18918,9 +19014,6 @@ msgstr "pgr_dijkstraNearCost(Uno a Muchos)"
 msgid "pgr_sequentialVertexColoring"
 msgstr "pgr_sequentialVertexColoring"
 
-msgid "pgr_extractVertices"
-msgstr "pgr_extractVertices"
-
 msgid "Traversal"
 msgstr "Travesía"
 
@@ -19018,12 +19111,6 @@ msgstr ""
 msgid "Removing support for Boost v1.53, v1.54 & v1.55"
 msgstr "Eliminación de soporte para Boost v1.53, v1.54 & v1.55"
 
-msgid "pgr_bellmanFord(Combinations)"
-msgstr "pgr_bellmanFord(Combinaciones)"
-
-msgid "pgr_binaryBreadthFirstSearch(Combinations)"
-msgstr "pgr_binaryBreadthFirstSearch(Combinaciones)"
-
 msgid "pgr_bipartite"
 msgstr "pgr_bipartite"
 
@@ -19032,9 +19119,6 @@ msgstr "pgr_depthFirstSearch"
 
 msgid "Dijkstra Near"
 msgstr "Dijkstra Cercano"
-
-msgid "pgr_edwardMoore(Combinations)"
-msgstr "pgr_edwardMoore(Combinaciones)"
 
 msgid "pgr_isPlanar"
 msgstr "pgr_isPlanar"
@@ -19045,50 +19129,14 @@ msgstr "pgr_lengauerTarjanDominatorTree"
 msgid "pgr_makeConnected"
 msgstr "pgr_makeConnected"
 
-msgid "pgr_maxFlowMinCost(Combinations)"
-msgstr "pgr_maxFlowMinCost(Combinaciones)"
-
-msgid "pgr_maxFlowMinCost_Cost(Combinations)"
-msgstr "pgr_maxFlowMinCost_Cost(Combinaciones)"
-
 msgid "Astar"
 msgstr "Astar"
-
-msgid "pgr_aStar(Combinations)"
-msgstr "pgr_aStar(Combinaciones)"
-
-msgid "pgr_aStarCost(Combinations)"
-msgstr "pgr_aStarCost(Combinaciones)"
 
 msgid "Bidirectional Astar"
 msgstr "Astar Bidireccional"
 
-msgid "pgr_bdAstar(Combinations)"
-msgstr "pgr_bdAstar(Combinaciones)"
-
-msgid "pgr_bdAstarCost(Combinations)"
-msgstr "pgr_bdAstarCost(Combinaciones)"
-
 msgid "Bidirectional Dijkstra"
 msgstr "Dijkstra Bidireccional"
-
-msgid "pgr_bdDijkstra(Combinations)"
-msgstr "pgr_bdDijkstra(Combinaciones)"
-
-msgid "pgr_bdDijkstraCost(Combinations)"
-msgstr "pgr_bdDijkstraCost(Combinaciones)"
-
-msgid "pgr_boykovKolmogorov(Combinations)"
-msgstr "pgr_boykovKolmogorov(Combinaciones)"
-
-msgid "pgr_edmondsKarp(Combinations)"
-msgstr "pgr_edmondsKarp(Combinaciones)"
-
-msgid "pgr_maxFlow(Combinations)"
-msgstr "pgr_maxFlow(Combinaciones)"
-
-msgid "pgr_pushRelabel(Combinations)"
-msgstr "pgr_pushRelabel(Combinaciones)"
 
 msgid "pgRouting 3.1"
 msgstr "pgRouting 3.1"
@@ -19407,8 +19455,8 @@ msgstr ""
 "`#1006 <https://github.com/pgRouting/pgrouting/issues/1006>`__: No hay "
 "pérdida de información2"
 
-msgid "New functions"
-msgstr "Nuevas funciones"
+msgid "New Functions"
+msgstr "Nuevas Funciones"
 
 msgid "Kruskal family"
 msgstr "Familia Kruskal"
@@ -19446,149 +19494,95 @@ msgstr "Propuesta cambió a oficial en pgRouting"
 msgid "aStar Family"
 msgstr "Familia aStar"
 
-msgid "pgr_aStar(one to many)"
-msgstr "pgr_aStar(Uno a Muchos)"
-
-msgid "pgr_aStar(many to one)"
-msgstr "pgr_aStar(muchos a uno)"
-
-msgid "pgr_aStar(many to many)"
-msgstr "pgr_aStar(muchos a muchos)"
-
-msgid "pgr_aStarCost(one to one)"
+msgid "pgr_aStarCost(One to One)"
 msgstr "pgr_aStarCost(Uno a Uno)"
 
-msgid "pgr_aStarCost(one to many)"
+msgid "pgr_aStarCost(One to Many)"
 msgstr "pgr_aStarCost(Uno a Muchos)"
 
-msgid "pgr_aStarCost(many to one)"
-msgstr "pgr_aStarCost(muchos a uno)"
+msgid "pgr_aStarCost(Many to One)"
+msgstr "pgr_aStarCost(Muchos a Uno)"
 
-msgid "pgr_aStarCost(many to many)"
-msgstr "pgr_aStarCost(muchos a muchos)"
+msgid "pgr_aStarCost(Many to Many)"
+msgstr "pgr_aStarCost(Muchos a Muchos)"
 
-msgid "pgr_aStarCostMatrix(one to one)"
-msgstr "pgr_aStarCostMatrix(Uno a Uno)"
-
-msgid "pgr_aStarCostMatrix(one to many)"
-msgstr "pgr_aStarCostMatrix(Uno a Muchos)"
-
-msgid "pgr_aStarCostMatrix(many to one)"
-msgstr "pgr_aStarCostMatrix(muchos a uno)"
-
-msgid "pgr_aStarCostMatrix(many to many)"
-msgstr "pgr_aStarCostMatrix(muchos a muchos)"
+msgid "pgr_aStarCostMatrix"
+msgstr "pgr_aStarCostMatrix"
 
 msgid "bdAstar Family"
 msgstr "Familia bdAstar"
 
-msgid "pgr_bdAstar(one to many)"
-msgstr "pgr_bdAstar(Uno a Muchos)"
-
-msgid "pgr_bdAstar(many to one)"
-msgstr "pgr_bdAstar(muchos a uno)"
-
-msgid "pgr_bdAstar(many to many)"
-msgstr "pgr_bdAstar(muchos a muchos)"
-
-msgid "pgr_bdAstarCost(one to one)"
+msgid "pgr_bdAstarCost(One to One)"
 msgstr "pgr_bdAstarCost(Uno a Uno)"
 
-msgid "pgr_bdAstarCost(one to many)"
+msgid "pgr_bdAstarCost(One to Many)"
 msgstr "pgr_bdAstarCost(Uno a Muchos)"
 
-msgid "pgr_bdAstarCost(many to one)"
-msgstr "pgr_bdAstarCost(muchos a uno)"
+msgid "pgr_bdAstarCost(Many to One)"
+msgstr "pgr_bdAstarCost(Muchos a Uno)"
 
-msgid "pgr_bdAstarCost(many to many)"
-msgstr "pgr_bdAstarCost(muchos a muchos)"
+msgid "pgr_bdAstarCost(Many to Many)"
+msgstr "pgr_bdAstarCost(Muchos a Muchos)"
 
-msgid "pgr_bdAstarCostMatrix(one to one)"
-msgstr "pgr_bdAstarCostMatrix(Uno a Uno)"
-
-msgid "pgr_bdAstarCostMatrix(one to many)"
-msgstr "pgr_bdAstarCostMatrix(Uno a Muchos)"
-
-msgid "pgr_bdAstarCostMatrix(many to one)"
-msgstr "pgr_bdAstarCostMatrix(muchos a uno)"
-
-msgid "pgr_bdAstarCostMatrix(many to many)"
-msgstr "pgr_bdAstarCostMatrix(muchos a muchos)"
+msgid "pgr_bdAstarCostMatrix"
+msgstr "pgr_bdAstarCostMatrix"
 
 msgid "bdDijkstra Family"
 msgstr "bdDijkstra Familia"
 
-msgid "pgr_bdDijkstra(one to many)"
-msgstr "pgr_bdDijkstra(Uno a Muchos)"
+msgid "pgr_bdDijkstraCost(One to One)"
+msgstr "pgr_bdDijkstraCost(Uno a Uno)"
 
-msgid "pgr_bdDijkstra(many to one)"
-msgstr "pgr_bdDijkstra(muchos a uno)"
+msgid "pgr_bdDijkstraCost(One to Many)"
+msgstr "pgr_bdDijkstraCost(Uno a Muchos)"
 
-msgid "pgr_bdDijkstra(many to many)"
-msgstr "pgr_bdDijkstra(muchos a muchos)"
+msgid "pgr_bdDijkstraCost(Many to One)"
+msgstr "pgr_bdDijkstraCost(Muchos a Uno)"
 
-msgid "pgr_bdDijkstraCost(one to one)"
-msgstr "pgr_bdDijkstraCost(uno a uno)"
+msgid "pgr_bdDijkstraCost(Many to Many)"
+msgstr "pgr_bdDijkstraCost(Muchos a Muchos)"
 
-msgid "pgr_bdDijkstraCost(one to many)"
-msgstr "pgr_bdDijkstraCost(uno a muchos)"
-
-msgid "pgr_bdDijkstraCost(many to one)"
-msgstr "pgr_bdDijkstraCost(muchos a uno)"
-
-msgid "pgr_bdDijkstraCost(many to many)"
-msgstr "pgr_bdDijkstraCost(muchos a muchos)"
-
-msgid "pgr_bdDijkstraCostMatrix(one to one)"
-msgstr "pgr_bdDijkstraCostMatrix(uno a uno)"
-
-msgid "pgr_bdDijkstraCostMatrix(one to many)"
-msgstr "pgr_bdDijkstraCostMatrix(uno a muchos)"
-
-msgid "pgr_bdDijkstraCostMatrix(many to one)"
-msgstr "pgr_bdDijkstraCostMatrix(muchos a uno)"
-
-msgid "pgr_bdDijkstraCostMatrix(many to many)"
-msgstr "pgr_bdDijkstraCostMatrix(muchos a muchos)"
+msgid "pgr_bdDijkstraCostMatrix"
+msgstr "pgr_bdDijkstraCostMatrix"
 
 msgid "Flow Family"
 msgstr "Familia Flow"
 
-msgid "pgr_pushRelabel(one to one)"
+msgid "pgr_pushRelabel(One to One)"
 msgstr "pgr_pushRelabel(Uno a Uno)"
 
-msgid "pgr_pushRelabel(one to many)"
+msgid "pgr_pushRelabel(One to Many)"
 msgstr "pgr_pushRelabel(Uno a Muchos)"
 
-msgid "pgr_pushRelabel(many to one)"
-msgstr "pgr_pushRelabel(muchos a uno)"
+msgid "pgr_pushRelabel(Many to One)"
+msgstr "pgr_pushRelabel(Muchos a Uno)"
 
-msgid "pgr_pushRelabel(many to many)"
-msgstr "pgr_pushRelabel(muchos a muchos)"
+msgid "pgr_pushRelabel(Many to Many)"
+msgstr "pgr_pushRelabel(Muchos a Muchos)"
 
-msgid "pgr_edmondsKarp(one to one)"
+msgid "pgr_edmondsKarp(One to One)"
 msgstr "pgr_edmondsKarp(Uno a Uno)"
 
-msgid "pgr_edmondsKarp(one to many)"
+msgid "pgr_edmondsKarp(One to Many)"
 msgstr "pgr_edmondsKarp(Uno a Muchos)"
 
-msgid "pgr_edmondsKarp(many to one)"
-msgstr "pgr_edmondsKarp(muchos a uno)"
+msgid "pgr_edmondsKarp(Many to One)"
+msgstr "pgr_edmondsKarp(Muchos a Uno)"
 
-msgid "pgr_edmondsKarp(many to many)"
-msgstr "pgr_edmondsKarp(muchos a muchos)"
+msgid "pgr_edmondsKarp(Many to Many)"
+msgstr "pgr_edmondsKarp(Muchos a Muchos)"
 
-msgid "pgr_boykovKolmogorov (one to one)"
+msgid "pgr_boykovKolmogorov (One to One)"
 msgstr "pgr_boykovKolmogorov(Uno a Uno)"
 
-msgid "pgr_boykovKolmogorov (one to many)"
+msgid "pgr_boykovKolmogorov (One to Many)"
 msgstr "pgr_boykovKolmogorov(Uno a Muchos)"
 
-msgid "pgr_boykovKolmogorov (many to one)"
-msgstr "pgr_boykovKolmogorov (muchos a uno)"
+msgid "pgr_boykovKolmogorov (Many to One)"
+msgstr "pgr_boykovKolmogorov (Muchos a Uno)"
 
-msgid "pgr_boykovKolmogorov (many to many)"
-msgstr "pgr_boykovKolmogorov (muchos a muchos)"
+msgid "pgr_boykovKolmogorov (Many to Many)"
+msgstr "pgr_boykovKolmogorov (Muchos a Muchos)"
 
 msgid "pgr_maxCardinalityMatching"
 msgstr "pgr_maxCardinalityMatching"
@@ -19596,20 +19590,23 @@ msgstr "pgr_maxCardinalityMatching"
 msgid "pgr_maxFlow"
 msgstr "pgr_maxFlow"
 
-msgid "pgr_edgeDisjointPaths(one to one)"
+msgid "pgr_edgeDisjointPaths(One to One)"
 msgstr "pgr_edgeDisjointPaths(Uno a Uno)"
 
-msgid "pgr_edgeDisjointPaths(one to many)"
+msgid "pgr_edgeDisjointPaths(One to Many)"
 msgstr "pgr_edgeDisjointPaths(Uno a Muchos)"
 
-msgid "pgr_edgeDisjointPaths(many to one)"
-msgstr "pgr_edgeDisjointPaths(muchos a uno)"
+msgid "pgr_edgeDisjointPaths(Many to One)"
+msgstr "pgr_edgeDisjointPaths(Muchos a Uno)"
 
-msgid "pgr_edgeDisjointPaths(many to many)"
-msgstr "pgr_edgeDisjointPaths(muchos a muchos)"
+msgid "pgr_edgeDisjointPaths(Many to Many)"
+msgstr "pgr_edgeDisjointPaths(Muchos a Muchos)"
 
 msgid "Components family"
 msgstr "Familia de Componentes"
+
+msgid "pgr_connectedComponents"
+msgstr "pgr_connectedComponents"
 
 msgid "pgr_strongComponents"
 msgstr "pgr_strongComponents"
@@ -19814,8 +19811,8 @@ msgstr "pgr_floydWarshall"
 msgid "pgr_johnson"
 msgstr "pgr_johnson"
 
-msgid "pgr_astar"
-msgstr "pgr_astar"
+msgid "pgr_aStar"
+msgstr "pgr_aStar"
 
 msgid "pgr_bdAstar"
 msgstr "pgr_bdAstar"
@@ -19834,6 +19831,9 @@ msgstr "pgr_dijkstraCost"
 
 msgid "pgr_drivingDistance"
 msgstr "pgr_drivingDistance"
+
+msgid "pgr_KSP"
+msgstr "pgr_KSP"
 
 msgid "pgr_dijkstraVia (proposed)"
 msgstr "pgr_dijkstraVia (proposed)"
@@ -20065,24 +20065,15 @@ msgstr "Columnas path_id, cost y agg_cost añadidas al resultado"
 msgid "Parameter names changed"
 msgstr "Nombres de parámetros cambiados"
 
-msgid "The many version results are the union of the one to one version"
+msgid "The many version results are the union of the One to One version"
 msgstr ""
-"Los muchos resultados de la versión son la unión de la versión uno a uno"
+"Los muchos resultados de la versión son la unión de la versión Uno a Uno"
 
 msgid "New Signatures"
 msgstr "Nuevas Firmas"
 
-msgid "pgr_bdAstar(one to one)"
+msgid "pgr_bdAstar(One to One)"
 msgstr "pgr_bdAstar(Uno a Uno)"
-
-msgid "New Proposed functions"
-msgstr "Nuevas Funciones Propuestas"
-
-msgid "pgr_bdAstarCostMatrix"
-msgstr "pgr_bdAstarCostMatrix"
-
-msgid "pgr_bdDijkstraCostMatrix"
-msgstr "pgr_bdDijkstraCostMatrix"
 
 msgid "pgr_lineGraph"
 msgstr "pgr_lineGraph"
@@ -20175,32 +20166,8 @@ msgstr ""
 msgid "pgr_bdDijkstra"
 msgstr "pgr_bdDijkstra"
 
-msgid "New Proposed Signatures"
-msgstr "Nuevas Firmas Propuestas"
-
-msgid "pgr_astar(one to many)"
-msgstr "pgr_astar(Uno a Muchos)"
-
-msgid "pgr_astar(many to one)"
-msgstr "pgr_astar(muchos a uno)"
-
-msgid "pgr_astar(many to many)"
-msgstr "pgr_astar(muchos a muchos)"
-
-msgid "pgr_astarCost(one to one)"
-msgstr "pgr_astarCost(Uno a Uno)"
-
-msgid "pgr_astarCost(one to many)"
-msgstr "pgr_astarCost(uno a muchos)"
-
-msgid "pgr_astarCost(many to one)"
-msgstr "pgr_astarCost(muchos a uno)"
-
-msgid "pgr_astarCost(many to many)"
-msgstr "pgr_astarCost(muchos a muchos)"
-
-msgid "pgr_astarCostMatrix"
-msgstr "pgr_astarCostMatrix"
+msgid "Deprecated signatures."
+msgstr "Firmas obsoletas."
 
 msgid "pgr_bddijkstra - use pgr_bdDijkstra instead"
 msgstr "pgr_bddijkstra - utilizar pgr_bdDijkstra en su lugar"
@@ -20285,53 +20252,44 @@ msgstr ""
 msgid "pgr_TSP"
 msgstr "pgr_TSP"
 
-msgid "pgr_aStar"
-msgstr "pgr_aStar"
-
-msgid "New Functions"
-msgstr "Nuevas Funciones"
-
 msgid "pgr_eucledianTSP"
 msgstr "pgr_eucledianTSP"
 
-msgid "pgr_withPointsCostMatrix"
-msgstr "pgr_withPointsCostMatrix"
-
-msgid "pgr_maxFlowPushRelabel(one to one)"
+msgid "pgr_maxFlowPushRelabel(One to One)"
 msgstr "pgr_maxFlowPushRelabel(Uno a Uno)"
 
-msgid "pgr_maxFlowPushRelabel(one to many)"
-msgstr "pgr_maxFlowPushRelabel(uno a muchos)"
+msgid "pgr_maxFlowPushRelabel(One to Many)"
+msgstr "pgr_maxFlowPushRelabel(Uno a Muchos)"
 
-msgid "pgr_maxFlowPushRelabel(many to one)"
-msgstr "pgr_maxFlowPushRelabel(muchos a uno)"
+msgid "pgr_maxFlowPushRelabel(Many to One)"
+msgstr "pgr_maxFlowPushRelabel(Muchos a Uno)"
 
-msgid "pgr_maxFlowPushRelabel(many to many)"
-msgstr "pgr_maxFlowPushRelabel(muchos a muchos)"
+msgid "pgr_maxFlowPushRelabel(Many to Many)"
+msgstr "pgr_maxFlowPushRelabel(Muchos a Muchos)"
 
-msgid "pgr_maxFlowEdmondsKarp(one to one)"
+msgid "pgr_maxFlowEdmondsKarp(One to One)"
 msgstr "pgr_maxFlowEdmondsKarp(Uno a Uno)"
 
-msgid "pgr_maxFlowEdmondsKarp(one to many)"
-msgstr "pgr_maxFlowEdmondsKarp(uno a muchos)"
+msgid "pgr_maxFlowEdmondsKarp(One to Many)"
+msgstr "pgr_maxFlowEdmondsKarp(Uno a Muchos)"
 
-msgid "pgr_maxFlowEdmondsKarp(many to one)"
-msgstr "pgr_maxFlowEdmondsKarp(muchos a uno)"
+msgid "pgr_maxFlowEdmondsKarp(Many to One)"
+msgstr "pgr_maxFlowEdmondsKarp(Muchos a Uno)"
 
-msgid "pgr_maxFlowEdmondsKarp(many to many)"
-msgstr "pgr_maxFlowEdmondsKarp(muchos a muchos)"
+msgid "pgr_maxFlowEdmondsKarp(Many to Many)"
+msgstr "pgr_maxFlowEdmondsKarp(Muchos a Muchos)"
 
-msgid "pgr_maxFlowBoykovKolmogorov (one to one)"
+msgid "pgr_maxFlowBoykovKolmogorov (One to One)"
 msgstr "pgr_maxFlowBoykovKolmogorov(Uno a Uno)"
 
-msgid "pgr_maxFlowBoykovKolmogorov (one to many)"
-msgstr "pgr_maxFlowBoykovKolmogorov (uno a muchos)"
+msgid "pgr_maxFlowBoykovKolmogorov (One to Many)"
+msgstr "pgr_maxFlowBoykovKolmogorov (Uno a Muchos)"
 
-msgid "pgr_maxFlowBoykovKolmogorov (many to one)"
-msgstr "pgr_maxFlowBoykovKolmogorov (muchos a uno)"
+msgid "pgr_maxFlowBoykovKolmogorov (Many to One)"
+msgstr "pgr_maxFlowBoykovKolmogorov (Muchos a Uno)"
 
-msgid "pgr_maxFlowBoykovKolmogorov (many to many)"
-msgstr "pgr_maxFlowBoykovKolmogorov (muchos a muchos)"
+msgid "pgr_maxFlowBoykovKolmogorov (Many to Many)"
+msgstr "pgr_maxFlowBoykovKolmogorov (Muchos a Muchos)"
 
 msgid "pgr_maximumCardinalityMatching"
 msgstr "pgr_maximumCardinalityMatching"
@@ -20342,8 +20300,8 @@ msgstr "pgr_contractGraph"
 msgid "pgr_tsp - use pgr_TSP or pgr_eucledianTSP instead"
 msgstr "pgr_tsp - utilice pgr_TSP o pgr_eucledianTSP en su lugar"
 
-msgid "pgr_astar - use pgr_aStar instead"
-msgstr "pgr_astar - utilice pgr_aStar en su lugar"
+msgid "pgr_aStar - use pgr_aStar instead"
+msgstr "pgr_aStar - utilice pgr_aStar en su lugar"
 
 msgid "pgr_flip_edges"
 msgstr "pgr_flip_edges"
@@ -20444,6 +20402,9 @@ msgstr ""
 msgid "Improvements"
 msgstr "Mejoras"
 
+msgid "pgr_nodeNetwork"
+msgstr "pgr_nodeNetwork"
+
 msgid "Adding a row_where and outall optional parameters"
 msgstr "Adición de un row_where y todos los parámetros opcionales"
 
@@ -20456,53 +20417,50 @@ msgstr "pgr_dijkstra -- para que coincida con lo documentado"
 msgid "pgr_Johnson"
 msgstr "pgr_Johnson"
 
-msgid "pgr_dijkstraCost(one to one)"
+msgid "pgr_dijkstraCost(One to One)"
 msgstr "pgr_dijkstraCost(Uno a Uno)"
 
-msgid "pgr_dijkstraCost(one to many)"
-msgstr "pgr_dijkstraCost(uno a muchos)"
+msgid "pgr_dijkstraCost(One to Many)"
+msgstr "pgr_dijkstraCost(Uno a Muchos)"
 
-msgid "pgr_dijkstraCost(many to one)"
-msgstr "pgr_dijkstraCost(muchos a uno)"
+msgid "pgr_dijkstraCost(Many to One)"
+msgstr "pgr_dijkstraCost(Muchos a Uno)"
 
-msgid "pgr_dijkstraCost(many to many)"
-msgstr "pgr_dijkstraCost(muchos a muchos)"
+msgid "pgr_dijkstraCost(Many to Many)"
+msgstr "pgr_dijkstraCost(Muchos a Muchos)"
 
 msgid "Proposed Functionality"
 msgstr "Funcionalidad Propuesta"
 
-msgid "pgr_withPoints(one to one)"
+msgid "pgr_withPoints(One to One)"
 msgstr "pgr_withPoints(Uno a Uno)"
 
-msgid "pgr_withPoints(one to many)"
-msgstr "pgr_withPoints(uno a muchos)"
+msgid "pgr_withPoints(One to Many)"
+msgstr "pgr_withPoints(Uno a Muchos)"
 
-msgid "pgr_withPoints(many to one)"
-msgstr "pgr_withPoints(muchos a uno)"
+msgid "pgr_withPoints(Many to One)"
+msgstr "pgr_withPoints(Muchos a Uno)"
 
-msgid "pgr_withPoints(many to many)"
-msgstr "pgr_withPoints(muchos a muchos)"
+msgid "pgr_withPoints(Many to Many)"
+msgstr "pgr_withPoints(Muchos a Muchos)"
 
-msgid "pgr_withPointsCost(one to one)"
+msgid "pgr_withPointsCost(One to One)"
 msgstr "pgr_withPointsCost(Uno a Uno)"
 
-msgid "pgr_withPointsCost(one to many)"
-msgstr "pgr_withPointsCost(uno a muchos)"
+msgid "pgr_withPointsCost(One to Many)"
+msgstr "pgr_withPointsCost(Uno a Muchos)"
 
-msgid "pgr_withPointsCost(many to one)"
-msgstr "pgr_withPointsCost(muchos a uno)"
+msgid "pgr_withPointsCost(Many to One)"
+msgstr "pgr_withPointsCost(Muchos a Uno)"
 
-msgid "pgr_withPointsCost(many to many)"
-msgstr "pgr_withPointsCost(muchos a muchos)"
+msgid "pgr_withPointsCost(Many to Many)"
+msgstr "pgr_withPointsCost(Muchos a Muchos)"
 
 msgid "pgr_withPointsDD(single vertex)"
 msgstr "pgr_withPointsDD(vértice único)"
 
 msgid "pgr_withPointsDD(multiple vertices)"
 msgstr "pgr_withPointsDD(múltiples vértices)"
-
-msgid "pgr_withPointsKSP"
-msgstr "pgr_withPointsKSP"
 
 msgid "pgr_dijkstraVia"
 msgstr "pgr_dijkstraVia"
@@ -20540,26 +20498,11 @@ msgstr ""
 "issues for 2.1.0 <https://github.com/pgRouting/pgrouting/issues?"
 "q=is%3Aissue+milestone%3A%22Release+2.1.0%22+is%3Aclosed>`_ en Github."
 
-msgid "pgr_dijkstra(one to many)"
-msgstr "pgr_dijkstra(uno a muchos)"
-
-msgid "pgr_dijkstra(many to one)"
-msgstr "pgr_dijkstra(muchos a uno)"
-
-msgid "pgr_dijkstra(many to many)"
-msgstr "pgr_dijkstra(muchos a muchos)"
-
-msgid "pgr_drivingDistance(multiple vertices)"
-msgstr "pgr_drivingDistance(múltiples vértices)"
-
 msgid "Refactored"
 msgstr "Refactorizado"
 
-msgid "pgr_dijkstra(one to one)"
+msgid "pgr_dijkstra(One to One)"
 msgstr "pgr_dijkstra(Uno a Uno)"
-
-msgid "pgr_drivingDistance(single vertex)"
-msgstr "pgr_drivingDistance(vértice único)"
 
 msgid ""
 "pgr_alphaShape function now can generate better (multi)polygon with holes "
@@ -20947,10 +20890,11 @@ msgstr "Familias de Funciones"
 msgid "Sample Data"
 msgstr "Datos Muestra"
 
+#, fuzzy
 msgid ""
 "The documentation provides very simple example queries based on a small "
-"sample network that resembles a city. To be able to execute the mayority of "
-"the examples queries, follow the instructions bellow."
+"sample network that resembles a city. To be able to execute the majority of "
+"the examples queries, follow the instructions below."
 msgstr ""
 "La documentación proporciona consultas de ejemplo muy simples basadas en una "
 "red muestra pequeña que asemeja una ciudad. Para ser capaz de ejecutar la "
@@ -20967,7 +20911,8 @@ msgstr ""
 
 msgid ""
 "Information known at this point is the geometry of the edges, cost values, "
-"cpacity values, category values and some locations that are not in the graph."
+"capacity values, category values and some locations that are not in the "
+"graph."
 msgstr ""
 
 msgid ""
@@ -20975,14 +20920,11 @@ msgid ""
 "that everything else is calculated."
 msgstr ""
 
-msgid "Edges"
-msgstr ""
-
 msgid ""
 "The database design for the documentation of pgRouting, keeps in the same "
 "row 2 segments, one in the direction of the geometry and the second in the "
-"oposite direction. Therfore some information has the ``reverse_`` prefix "
-"which corresponds to the segment on the oposite direction of the geometry."
+"opposite direction. Therefore some information has the ``reverse_`` prefix "
+"which corresponds to the segment on the opposite direction of the geometry."
 msgstr ""
 
 msgid "Identifier of the starting vertex of the geometry ``geom``."
@@ -21013,7 +20955,7 @@ msgid ":math:`x` coordinate of the starting vertex of the geometry."
 msgstr ""
 
 msgid ""
-"For convinience it is saved on the table but can be calculated as "
+"For convenience it is saved on the table but can be calculated as "
 "``ST_X(ST_StartPoint(geom))``."
 msgstr ""
 
@@ -21021,7 +20963,7 @@ msgid ":math:`y` coordinate of the ending vertex of the geometry."
 msgstr ""
 
 msgid ""
-"For convinience it is saved on the table but can be calculated as "
+"For convenience it is saved on the table but can be calculated as "
 "``ST_Y(ST_EndPoint(geom))``."
 msgstr ""
 
@@ -21032,8 +20974,8 @@ msgid "Starting on PostgreSQL 12::"
 msgstr "A partir de PostgreSQL 12::"
 
 msgid ""
-"Optionally indexes on different columns can be created. The recomendation is "
-"to have"
+"Optionally indexes on different columns can be created. The recommendation "
+"is to have"
 msgstr ""
 
 msgid "``id`` indexed."
@@ -21044,7 +20986,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"``geom`` indexed to speed up gemetry processes that might be needed in the "
+"``geom`` indexed to speed up geometry processes that might be needed in the "
 "front end."
 msgstr ""
 
@@ -21112,10 +21054,13 @@ msgid ""
 "when wanting a route from ``source`` to ``target``."
 msgstr ""
 
+#, fuzzy
 msgid ""
-"For convinence of this documentations, some combinations will be stored on a "
+"For convenience of this documentation, some combinations will be stored on a "
 "table:"
 msgstr ""
+"En esta documentación habrá unos 6 puntos de interés fijos y se almacenarán "
+"en una tabla."
 
 msgid "Inserting the data:"
 msgstr "Insertar los datos:"
@@ -21377,8 +21322,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"pgRouting suplies some functions to create a routing topology and to analyze "
-"the topology."
+"pgRouting supplies some functions to create a routing topology and to "
+"analyze the topology."
 msgstr ""
 
 msgid "Additional functions to create a graph:"
@@ -21400,7 +21345,8 @@ msgstr ""
 msgid "Traversal - Family of functions"
 msgstr "Traversal - Familia de funciones"
 
-msgid "Aditionaly there are 2 categories under this family"
+#, fuzzy
+msgid "Additionally there are 2 categories under this family"
 msgstr "Adicionalmente, hay dos categorías en esta familia"
 
 msgid "Via - Category"
@@ -21416,8 +21362,9 @@ msgstr ""
 "Dado un grafo y una lista de vértices, encuentra el camino mas corto entre :"
 "math:`vertex_i` and :math:`vertex_{i+1}` para todos los vértices"
 
+#, fuzzy
 msgid ""
-"In other words, find a continuos route that visits all the vertices in the "
+"In other words, find a continuous route that visits all the vertices in the "
 "order given."
 msgstr ""
 "En otras palabras, encuentre la ruta continua que visite todos los vértices "
@@ -21829,3 +21776,1928 @@ msgstr "pgr_withPointsDD es pgr_drivingDistance **con puntos**"
 
 msgid "pgr_withPointsvia is pgr_dijkstraVia **with points**"
 msgstr "pgr_withPoints es pgr_dijkstraVia **con puntos**"
+
+#~ msgid "Proposed"
+#~ msgstr "Propuesto"
+
+#~ msgid "Experimental"
+#~ msgstr "Experimental"
+
+#~ msgid "Contraction of the leaf nodes of the graph."
+#~ msgstr "Contracción de los nodos de hoja del grafo."
+
+#~ msgid "There are no outgoing edges and has at least one incoming edge."
+#~ msgstr "No hay aristas salientes y tiene al menos una arista entrante."
+
+#~ msgid "There are no incoming edges and has at least one outgoing edge."
+#~ msgstr "No hay aristas entrantes y tiene al menos una arista saliente."
+
+#~ msgid ""
+#~ "When the conditions are true then the `Operation: Dead End Contraction`_ "
+#~ "can be done."
+#~ msgstr ""
+#~ "Cuando las condiciones son verdaderas, se puede hacer la `Operación: "
+#~ "Contracción de callejón sin salida`_."
+
+#~ msgid "The blue nodes have an unlimited number of edges."
+#~ msgstr "Los nodos azules tienen un número ilimitado de aristas."
+
+#~ msgid ":math:`b`"
+#~ msgstr ":math:`b`"
+
+#~ msgid ":math:`\\{v\\}`"
+#~ msgstr ":math:`\\{v\\}`"
+
+#~ msgid "Number of incoming edges"
+#~ msgstr "Número de aristas entrantes"
+
+#~ msgid "Number of outgoing edges"
+#~ msgstr "Número de aristas salientes"
+
+#~ msgid ":math:`c`"
+#~ msgstr ":math:`c`"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid ":math:`d`"
+#~ msgstr ":math:`d`"
+
+#~ msgid ":math:`\\{x\\}`"
+#~ msgstr ":math:`\\{x\\}`"
+
+#~ msgid ":math:`e`"
+#~ msgstr ":math:`e`"
+
+#~ msgid ":math:`\\{x, y\\}`"
+#~ msgstr ":math:`\\{x, y\\}`"
+
+#~ msgid ""
+#~ "On the following table, nodes :math:`\\{c, e\\}` because the even that "
+#~ "the number of adjacent vertices is not 1 for"
+#~ msgstr ""
+#~ "En al siguiente tabla, nodos :math:`\\{c, e\\}` por que el par del numero "
+#~ "de vértices adyacentes no es 1 para"
+
+#~ msgid "Operation: Dead End Contraction"
+#~ msgstr "Operación: Contracción sin salida"
+
+#~ msgid "In the algorithm, linear contraction is represented by 2."
+#~ msgstr "En el algoritmo, la contracción lineal es representada con un 2."
+
+#~ msgid "Linear"
+#~ msgstr "Lineal"
+
+#~ msgid ""
+#~ "In case of an undirected graph, a node is considered a `linear` node when"
+#~ msgstr ""
+#~ "En el caso de un grafo no dirigido, un nodo se considera un nodo `lineal` "
+#~ "cuando"
+
+#~ msgid "Linear vertex on undirected graph"
+#~ msgstr "Vértice lineal en grafo no dirigido"
+
+#~ msgid "The green nodes are `linear`_ nodes"
+#~ msgstr "Los nodos verdes son `lineales`_"
+
+#~ msgid ""
+#~ "The blue nodes have an unlimited number of incoming and outgoing edges."
+#~ msgstr ""
+#~ "Los nodos azules tienen un número ilimitado de aristas entrantes y "
+#~ "salientes."
+
+#~ msgid "Undirected"
+#~ msgstr "No dirigido"
+
+#~ msgid ":math:`v`"
+#~ msgstr ":math:`v`"
+
+#~ msgid ":math:`\\{u, w\\}`"
+#~ msgstr ":math:`\\{u, w\\}`"
+
+#~ msgid "Linear vertex on directed graph"
+#~ msgstr "Vértice lineal en grafo dirigido"
+
+#~ msgid ""
+#~ "The white node is not linear because the linearity is not symetrical."
+#~ msgstr "El nodo blanco no es linero por que la linealidad no es simétrica."
+
+#~ msgid "It is possible to go :math:`y \\rightarrow c \\rightarrow z`"
+#~ msgstr "Es posible ir a :math:`y \\rightarrow c \\rightarrow z`"
+
+#~ msgid "It's not possible to go :math:`z \\rightarrow c \\rightarrow y`"
+#~ msgstr "No es posible ir a :math:`z \\rightarrow c \\rightarrow y`"
+
+#~ msgid "Is symmetrical?"
+#~ msgstr "Es simétrico?"
+
+#~ msgid ":math:`\\{u, v\\}`"
+#~ msgstr ":math:`\\{u, v\\}`"
+
+#~ msgid ":math:`\\{w, x\\}`"
+#~ msgstr ":math:`\\{w, x\\}`"
+
+#~ msgid ":math:`\\{y, z\\}`"
+#~ msgstr ":math:`\\{y, z\\}`"
+
+#~ msgid "no"
+#~ msgstr "no"
+
+#~ msgid "Operation: Linear Contraction"
+#~ msgstr "Operación: Contracción Lineal"
+
+#~ msgid "The vertex :math:`v` is removed from the graph"
+#~ msgstr "El vértice :math:`v` se elimina del grafo"
+
+#~ msgid ""
+#~ "The edges :math:`u \\rightarrow v` and :math:`v \\rightarrow z` are "
+#~ "removed from the graph."
+#~ msgstr ""
+#~ "Los aristas :math:`u \\rightarrow v` y :math:`v \\rightarrow z` son "
+#~ "removidos del grafo."
+
+#~ msgid ""
+#~ "A new edge :math:`u \\rightarrow z` is inserted represented with red "
+#~ "color."
+#~ msgstr ""
+#~ "Se inserta un nuevo arista :math:`u \\rightarrow z` y se representa con "
+#~ "color rojo."
+
+#~ msgid "Original Data"
+#~ msgstr "Datos Originales"
+
+#~ msgid ""
+#~ "The following query shows the original data involved in the contraction "
+#~ "operation."
+#~ msgstr ""
+#~ "La siguiente consulta muestra los datos originales implicados en la "
+#~ "operación de contracción."
+
+#~ msgid "Contraction results"
+#~ msgstr "Resultados de la Contracción"
+
+#~ msgid ""
+#~ "Adding extra columns to the ``edge_table`` and "
+#~ "``edge_table_vertices_pgr`` tables, where:"
+#~ msgstr ""
+#~ "Agregar de columnas adicionales a las tablas ``edge_table`` y "
+#~ "``edge_table_vertices_pgr`` donde:"
+
+#~ msgid "The vertex table update"
+#~ msgstr "Actualización de la tabla de vértices"
+
+#~ msgid "The modified vertices table:"
+#~ msgstr "La tabla de vértices modificada:"
+
+#~ msgid "The edge table update"
+#~ msgstr "Actialización de la tabla de aristas"
+
+#~ msgid "The modified ``edge_table``."
+#~ msgstr "La modificada ``edge_table``."
+
+#~ msgid "Contracted graph"
+#~ msgstr "Grafo contraído"
+
+#~ msgid "Using the contracted graph with ``pgr_dijkstra``"
+#~ msgstr "Uso del grafo contraído con ``pgr_dijkstra``"
+
+#~ msgid ""
+#~ "Using the `Edges that belong to the contracted graph.`_ on lines 11 to 20."
+#~ msgstr ""
+#~ "Usando las `Aristas que pertenecen al grafo contraído.`_ en las líneas 11 "
+#~ "a 20."
+
+#~ msgid "Case 1"
+#~ msgstr "Caso 1"
+
+#~ msgid ""
+#~ "When both source and target belong to the contracted graph, a path is "
+#~ "found."
+#~ msgstr ""
+#~ "Cuando el origen y el destino pertenecen al grafo contraído, se encuentra "
+#~ "ruta."
+
+#~ msgid "Case 2"
+#~ msgstr "Caso 2"
+
+#~ msgid ""
+#~ "When source and/or target belong to an edge subgraph then a path is not "
+#~ "found."
+#~ msgstr ""
+#~ "Cuando el origen y/o el destino pertenecen a un subgrafo de aristas, no "
+#~ "se encuentra una ruta."
+
+#~ msgid ""
+#~ "In this case, the contracted graph do not have an edge connecting with "
+#~ "node :math:`4`."
+#~ msgstr ""
+#~ "En este caso, el grafo contraído no tiene una arista que se conecte con "
+#~ "el nodo :math:`4`."
+
+#~ msgid "Case 3"
+#~ msgstr "Caso 3"
+
+#~ msgid ""
+#~ "When source and/or target belong to a vertex then a path is not found."
+#~ msgstr ""
+#~ "Cuando el origen y/o el destino pertenecen a un vértice, no se encuentra "
+#~ "ruta."
+
+#~ msgid ""
+#~ "In this case, the contracted graph do not have an edge connecting with "
+#~ "node :math:`7` and of node :math:`4` of the second case."
+#~ msgstr ""
+#~ "En este caso, el grafo contraído no tiene algún arista que conecte con el "
+#~ "nodo :math:`7` ni con el nodo :math:`4` del segundo caso."
+
+#~ msgid "Refining the above function to include nodes that belong to an edge."
+#~ msgstr ""
+#~ "Refinar la función anterior para incluir nodos que pertenezcan a una "
+#~ "arista."
+
+#~ msgid ""
+#~ "The vertices that need to be expanded are calculated on lines 11 to 17."
+#~ msgstr "Los vértices que deben ampliarse se calculan en las líneas 11 a 17."
+
+#~ msgid ""
+#~ "Adding to the contracted graph that additional section on lines 26 to 28."
+#~ msgstr ""
+#~ "Añadiendo al grafo contraído esa sección adicional en las líneas 26 a 28."
+
+#~ msgid ""
+#~ "When source and/or target belong to an edge subgraph, now, a path is "
+#~ "found."
+#~ msgstr ""
+#~ "Cuando el origen y/o el destino pertenecen a un subgrafo de arista, "
+#~ "entonces se encuentra una ruta."
+
+#~ msgid "The routing graph now has an edge connecting with node :math:`4`."
+#~ msgstr ""
+#~ "El grafo de ruteo ahora tiene un arista que se conecta con el nodo :math:"
+#~ "`4`."
+
+#~ msgid ""
+#~ "In this case, the contracted graph do not have an edge connecting with "
+#~ "node :math:`7`."
+#~ msgstr ""
+#~ "En este caso, el grafo contraído no tiene una arista que se conecte con "
+#~ "el nodo :math:`7`."
+
+#~ msgid ""
+#~ "The vertices that need to be expanded are calculated on lines 19 to 24."
+#~ msgstr "Los vértices que deben ampliarse se calculan en las líneas 19 a 24."
+
+#~ msgid ""
+#~ "Adding to the contracted graph that additional section on lines 38 to 40."
+#~ msgstr ""
+#~ "Añadiendo al grafo contraído esa sección adicional en las líneas 38 a 40."
+
+#~ msgid ""
+#~ "The code change do not affect this case so when source and/or target "
+#~ "belong to an edge subgraph, a path is still found."
+#~ msgstr ""
+#~ "El cambio de código no afecta a este caso, por lo que cuando el origen o "
+#~ "el destino pertenecen a un subgrafo de aristas, aún se puede encontrar "
+#~ "ruta."
+
+#~ msgid "When source and/or target belong to a vertex, now, a path is found."
+#~ msgstr ""
+#~ "Cuando el origen y/o el destino pertenecen a un vértice, entonces se "
+#~ "encuentra ruta."
+
+#~ msgid "Now, the routing graph has an edge connecting with node :math:`7`."
+#~ msgstr ""
+#~ "Ahora, el grafo de ruteo tiene un arista que se conecta con el nodo :math:"
+#~ "`7`."
+
+#~ msgid "proposed"
+#~ msgstr "propuesta"
+
+#~ msgid "The weighted directed graph, :math:`G_d(V,E)`, is definied by:"
+#~ msgstr "El gráfico dirigido ponderado, :math:`G_d(V,E)`, se define por:"
+
+#~ msgid ""
+#~ "That information is correct, for example, when the dead end is on the "
+#~ "limit of the imported graph."
+#~ msgstr ""
+#~ "Esa información es correcta, por ejemplo, cuando el punto muerto está en "
+#~ "el límite del gráfico importado."
+
+#~ msgid ""
+#~ "Visually node :math:`4` looks to be as start/ending of 3 edges, but it is "
+#~ "not."
+#~ msgstr ""
+#~ "Visualmente el nodo :math:`4` parece ser el inicio/final de 3 aristas, "
+#~ "pero no lo es."
+
+#~ msgid "Is that correct?"
+#~ msgstr "¿Es correcto?"
+
+#~ msgid ""
+#~ "This information is correct, for example, when the application is taking "
+#~ "into account speed bumps, stop signals."
+#~ msgstr ""
+#~ "Esta información es correcta, por ejemplo, cuando la aplicación tiene en "
+#~ "cuenta los topes o las señales de stop."
+
+#, fuzzy
+#~ msgid ""
+#~ "To upgrade pgRouting in the database to version 3.8.0 use the following "
+#~ "command:"
+#~ msgstr ""
+#~ "Para actualizar pgRouting en la base de datos a la versión 3.7.0 utilice "
+#~ "el siguiente comando:"
+
+#, fuzzy
+#~ msgid "Boost Graph inside"
+#~ msgstr "Adentro: Boost Graph"
+
+#~ msgid "Dead End Contraction"
+#~ msgstr "Contracción Sin Salida"
+
+#~ msgid "Linear Contraction"
+#~ msgstr "Contracción Lineal"
+
+#~ msgid "the added edges by linear contraction."
+#~ msgstr "las aristas añadidas por contracción lineal."
+
+#~ msgid "The pgr_contraction function has the following signature:"
+#~ msgstr "La función pgr_contraction tiene la siguiente firma:"
+
+#~ msgid "``pgr_degree`` -- Proposed"
+#~ msgstr "``pgr_degree`` -- Propuesto"
+
+#~ msgid "Degree from an existing table"
+#~ msgstr "Grado a partir de una tabla existente"
+
+#, fuzzy
+#~ msgid "e Also"
+#~ msgstr "Ver también"
+
+#~ msgid "Classified as **proposed** function"
+#~ msgstr "Clasicado como función **propuesta**"
+
+#~ msgid "``pgr_findCloseEdges`` - Proposed"
+#~ msgstr "``pgr_findCloseEdges`` - Propuesto"
+
+#, fuzzy
+#~ msgid "**options:** [cap, partial, dryrun]``"
+#~ msgstr "**opcionales:** ``[cap, partial, dryrun]``"
+
+#~ msgid "Default: ``cap => 1``"
+#~ msgstr "Por defecto: ``cap => 1``"
+
+#~ msgid "Maximum one row answer."
+#~ msgstr "Respuesta de una fila como máximo."
+
+#~ msgid "Default: ``partial => true``"
+#~ msgstr "Por defecto: ``partial => true``"
+
+#~ msgid "With less calculations as possible."
+#~ msgstr "Con menos cálculos posibles."
+
+#~ msgid "Default: ``dryrun => false``"
+#~ msgstr "Por defecto: ``dryrun => false``"
+
+#~ msgid "Process query"
+#~ msgstr "Consulta del proceso"
+
+#~ msgid "Returns"
+#~ msgstr "Devuelve"
+
+#~ msgid "values on ``edge_id``, ``fraction``, ``side`` columns."
+#~ msgstr "valores en las columnas ``edge_id``, ``fraction``, ``side``."
+
+#~ msgid "``NULL`` on ``distance``, ``geom``, ``edge`` columns."
+#~ msgstr "``NULL`` en las columnas ``distance``, ``geom``, ``edge``."
+
+#~ msgid ""
+#~ "Find at most :math:`2` edges close to all vertices on the points of "
+#~ "interest table."
+#~ msgstr ""
+#~ "Encuentra como máximo :math:`2` aristas cercanas a todos los vértices de "
+#~ "la tabla de puntos de interés."
+
+#~ msgid "One answer per point, as small as possible."
+#~ msgstr "Una respuesta por punto, lo más pequeña posible."
+
+#~ msgid ""
+#~ "Columns ``edge_id``, ``fraction``, ``side`` and ``geom`` are returned "
+#~ "with values."
+#~ msgstr ""
+#~ "Las columnas ``edge_id``, ``fraction``, ``side`` y ``geom`` se devuelven "
+#~ "con valores."
+
+#~ msgid ""
+#~ "``geom`` contains the original point geometry to assist on "
+#~ "deterpartialing to which point geometry the row belongs to."
+#~ msgstr ""
+#~ "``geom`` contiene la geometría de puntos original para ayudar a "
+#~ "determinar a qué geometría de puntos pertenece la fila."
+
+#~ msgid "``partial``"
+#~ msgstr "``parcial``"
+
+#~ msgid ""
+#~ "When ``true`` only columns needed for :doc:`withPoints-category` are "
+#~ "calculated."
+#~ msgstr ""
+#~ "Cuando ``true`` sólo se calculan las columnas necesarias para :doc:"
+#~ "`withPoints-category`."
+
+#~ msgid "When ``false`` all columns are calculated"
+#~ msgstr "Cuando ``false`` se calculan todas las columnas"
+
+#~ msgid "In the right ``r``."
+#~ msgstr "A la derecha ``r``."
+
+#~ msgid "In the left ``l``."
+#~ msgstr "A la izquierda ``l``."
+
+#~ msgid "``NULL`` when ``cap = 1`` on the `One point`_ signature"
+#~ msgstr "``NULL`` cuando ``cap = 1`` en la firma de `Un punto`_"
+
+#~ msgid ""
+#~ "`One Point`_: Contains the point on the edge that is ``fraction`` away "
+#~ "from the starting point of the edge."
+#~ msgstr ""
+#~ "`Un Punto`_: Contiene el punto de la arista que está a ``fraction`` del "
+#~ "punto inicial de la arista."
+
+#~ msgid "`Many Points`_: Contains the corresponding **original point**"
+#~ msgstr "`Muchos Puntos`_: Contiene el **punto original** correspondiente"
+
+#~ msgid "One point results"
+#~ msgstr "Resultados de un punto"
+
+#~ msgid ""
+#~ "The geometry ``geom`` is a point on the :math:`sp \\rightarrow ep` edge."
+#~ msgstr ""
+#~ "La geometría ``geom`` es un punto en la arista :math:`sp \\rightarrow ep`."
+
+#~ msgid ""
+#~ "The geometry ``edge`` is a line that connects the **original point** with "
+#~ "``geom``"
+#~ msgstr ""
+#~ "La geometría ``edge`` es una línea que conecta el **punto original** con "
+#~ "``geom``"
+
+#~ msgid "Many point results"
+#~ msgstr "Resultados de muchos puntos"
+
+#~ msgid "One point examples"
+#~ msgstr "Ejemplos de un punto"
+
+#~ msgid "At most two answers"
+#~ msgstr "Como máximo dos respuestas"
+
+#~ msgid "Maximum two row answer."
+#~ msgstr "Respuesta de dos filas como máximo."
+
+#~ msgid "Understanding the result"
+#~ msgstr "Comprendiendo el resultado"
+
+#~ msgid "``NULL`` on ``geom``, ``edge``"
+#~ msgstr "``NULL`` en ``geom``, ``edge``"
+
+#~ msgid "``edge_id`` identifier of the edge close to the **original point**"
+#~ msgstr ""
+#~ "``edge_id`` identificador de la arista cercana al **punto original**"
+
+#~ msgid ""
+#~ "Two edges are withing :math:`0.5` distance units from the **original "
+#~ "point**: :math:`{5, 8}`"
+#~ msgstr ""
+#~ "Dos aristas están a menos de :math:`0.5` unidades de distancia del "
+#~ "**punto original**: :math:`{5, 8}`"
+
+#~ msgid "For edge :math:`5`:"
+#~ msgstr "Para la arista :math:`5`:"
+
+#~ msgid ""
+#~ "``fraction``: The closest point from the **original point** is at the :"
+#~ "math:`0.8` fraction of the edge :math:`5`."
+#~ msgstr ""
+#~ "``fraction``: El punto más cercano desde el **punto original** está en la "
+#~ "fracción :math:`0.8` del borde :math:`5`."
+
+#~ msgid ""
+#~ "``distance``: The **original point** is located :math:`0.1` length units "
+#~ "from edge :math:`5`."
+#~ msgstr ""
+#~ "``distance``: El **punto original** está situado a :math:`0.1` unidades "
+#~ "de longitud de la arista :math:`5`."
+
+#~ msgid "For edge :math:`8`:"
+#~ msgstr "Para la arista :math:`8`:"
+
+#~ msgid ""
+#~ "``fraction``: The closest point from the **original point** is at the :"
+#~ "math:`0.89..` fraction of the edge :math:`8`."
+#~ msgstr ""
+#~ "``fraction``: El punto más cercano desde el **punto original** está en la "
+#~ "fracción :math:`0.89..` del borde :math:`8`."
+
+#~ msgid ""
+#~ "``side``: The **original point** is located to the right side of edge :"
+#~ "math:`8`."
+#~ msgstr ""
+#~ "``side``: El **punto original** está situado a la derecha de la arista :"
+#~ "math:`8`."
+
+#~ msgid ""
+#~ "``distance``: The **original point** is located :math:`0.19..` length "
+#~ "units from edge :math:`8`."
+#~ msgstr ""
+#~ "``distance``: El **punto original** se encuentra a :math:`0.19..` "
+#~ "unidades de longitud de la arista :math:`8`."
+
+#~ msgid "One answer, all columns"
+#~ msgstr "Una respuesta, todas las columnas"
+
+#~ msgid "``partial => false``"
+#~ msgstr "``partial => false``"
+
+#~ msgid ""
+#~ "``edge_id`` identifier of the edge **closest** to the **original point**"
+#~ msgstr ""
+#~ "``edge_id`` identificador de la arista **más cercana** al **punto "
+#~ "original**"
+
+#~ msgid ""
+#~ "From all edges within :math:`0.5` distance units from the **original "
+#~ "point**: :math:`{5}` is the closest one."
+#~ msgstr ""
+#~ "De todos los bordes dentro de :math:`0.5` unidades de distancia desde el "
+#~ "**punto original**: :math:`{5}` es el más cercano."
+
+#~ msgid ""
+#~ "``geom``: Contains the geometry of the closest point on edge :math:`5` "
+#~ "from the **original point**."
+#~ msgstr ""
+#~ "``geom``: Contiene la geometría del punto más cercano de la arista :math:"
+#~ "`5` desde el **punto original**."
+
+#~ msgid ""
+#~ "``edge``: Contains the ``LINESTRING`` geometry of the **original point** "
+#~ "to the closest point on on edge :math:`5` ``geom``"
+#~ msgstr ""
+#~ "``edge``: Contiene la geometría ``LINESTRING`` del **punto original** al "
+#~ "punto más cercano de la arista :math:`5` ``geom``"
+
+#~ msgid "At most two answers with all columns"
+#~ msgstr "Como máximo dos respuestas con todas las columnas"
+
+#~ msgid "Understanding the result:"
+#~ msgstr "Comprender el resultado:"
+
+#~ msgid ""
+#~ "``geom``: Contains the geometry of the closest point on edge :math:`8` "
+#~ "from the **original point**."
+#~ msgstr ""
+#~ "``geom``: Contiene la geometría del punto más cercano de la arista :math:"
+#~ "`8` desde el **punto original**."
+
+#~ msgid ""
+#~ "``edge``: Contains the ``LINESTRING`` geometry of the **original point** "
+#~ "to the closest point on on edge :math:`8` ``geom``"
+#~ msgstr ""
+#~ "``borde``: Contiene la geometría ``LINESTRING`` del **punto original** al "
+#~ "punto más cercano de la arista :math:`8` ``geom``"
+
+#~ msgid "``partial => true``"
+#~ msgstr "``partial => true``"
+
+#~ msgid "Is ignored"
+#~ msgstr "Se ignora"
+
+#~ msgid "``cap`` and **original point** are used in the code"
+#~ msgstr "``cap`` y **punto original** se utilizan en el código"
+
+#~ msgid "At most two answers per point"
+#~ msgstr "Un máximo de dos respuestas por punto"
+
+#~ msgid "``NULL`` on ``edge``"
+#~ msgstr "``NULL`` en ``edge``"
+
+#~ msgid ""
+#~ "``edge_id`` identifier of the edge close to a **original point** "
+#~ "(``geom``)"
+#~ msgstr ""
+#~ "``edge_id`` identificador de la arista cercana a un **punto original** "
+#~ "(``geom``)"
+
+#~ msgid ""
+#~ "Two edges at most withing :math:`0.5` distance units from each of the "
+#~ "**original points**:"
+#~ msgstr ""
+#~ "Dos aristas a un máximo de :math:`0.5` unidades de distancia de cada uno "
+#~ "de los **puntos originales**:"
+
+#~ msgid ""
+#~ "For ``POINT(1.8 0.4)`` and ``POINT(0.3 1.8)`` only one edge was found."
+#~ msgstr ""
+#~ "Para ``POINT(1.8 0.4)`` y ``POINT(0.3 1.8)`` sólo se encontró una arista."
+
+#~ msgid "For the rest of the points two edges were found."
+#~ msgstr "Para el resto de los puntos se encontraron dos aristas."
+
+#~ msgid "For point ``POINT(2.9 1.8)``"
+#~ msgstr "Para el punto ``POINT(2.9 1.8)``"
+
+#~ msgid ""
+#~ "Edge :math:`5` is before :math:`8` therefore edge :math:`5` has the "
+#~ "shortest distance to ``POINT(2.9 1.8)``."
+#~ msgstr ""
+#~ "La arista :math:`5` está antes que la arista :math:`8` por lo tanto la "
+#~ "arista :math:`5` tiene la distancia más corta a ``POINT(2.9 1.8)``."
+
+#~ msgid "One answer per point, all columns"
+#~ msgstr "Una respuesta por punto, todas las columnas"
+
+#~ msgid "For the **original point** ``POINT(2.9 1.8)``"
+#~ msgstr "Para el **punto original** ``POINT(2.9 1.8)``"
+
+#~ msgid ""
+#~ "``geom``: Contains the geometry of the **original point** ``POINT(2.9 "
+#~ "1.8)``"
+#~ msgstr ""
+#~ "``geom``: Contiene la geometría del **punto original** ``POINT(2.9 1.8)``"
+
+#~ msgid ""
+#~ "``edge``: Contains the ``LINESTRING`` geometry of the **original point** "
+#~ "(``geom``) to the closest point on on edge."
+#~ msgstr ""
+#~ "``edge``: Contiene la geometría ``LINESTRING`` del **punto original** "
+#~ "(``geom``) al punto más cercano en el borde."
+
+#~ msgid ""
+#~ "Identifier of the edge nearest edge that allows an arrival to the point."
+#~ msgstr ""
+#~ "Identificador de la arista más cercana que permite una llegada al punto."
+
+#~ msgid "The geometry of the points moved on top of the segment."
+#~ msgstr "La geometría de los puntos desplazados sobre el segmento."
+
+#, fuzzy
+#~ msgid "``pgr_trsp`` - Proposed"
+#~ msgstr "``pgr_lineGraph`` - Propuesto"
+
+#, fuzzy
+#~ msgid "``pgr_trsp_withPoints`` - Proposed"
+#~ msgstr "``pgr_withPoints`` - Propuesto"
+
+#~ msgid "``pgr_withPoints`` - Proposed"
+#~ msgstr "``pgr_withPoints`` - Propuesto"
+
+#~ msgid "``pgr_withPointsCost`` - Proposed"
+#~ msgstr "``pgr_withPointsCost`` - Propuesto"
+
+#~ msgid "``pgr_withPointsCostMatrix`` - proposed"
+#~ msgstr "``pgr_withPointsCostMatrix`` - propuesto"
+
+#~ msgid "``pgr_withPointsDD`` - Proposed"
+#~ msgstr "``pgr_withPointsDD`` - Propuesto"
+
+#, fuzzy
+#~ msgid ""
+#~ "pgr_withpointsdd(text,text,bigint,double precision,boolean,character,"
+#~ "boolean)``"
+#~ msgstr ""
+#~ "``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,"
+#~ "boolean)``"
+
+#, fuzzy
+#~ msgid ""
+#~ "pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
+#~ "boolean,boolean)``"
+#~ msgstr ""
+#~ "``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
+#~ "boolean,boolean)``"
+
+#, fuzzy
+#~ msgid "``pgr_withPointsKSP`` - Proposed"
+#~ msgstr "``pgr_withPoints`` - Propuesto"
+
+#~ msgid "These proposed functions do not modify the database."
+#~ msgstr "Estas funciones propuestas no modifican la base de datos."
+
+#~ msgid "Utilities Category"
+#~ msgstr "Utilidades - Categoría"
+
+#~ msgid ""
+#~ "`Boost's metric appro's metric approximation <https://www.boost.org/libs/"
+#~ "graph/doc/metric_tsp_approx.html>`__"
+#~ msgstr ""
+#~ "`Algoritmo Métrico de la Librería Boost <https://www.boost.org/libs/graph/"
+#~ "doc/metric_tsp_approx.html>`__"
+
+#~ msgid "Vehicle Routing Functions - Category (Experimental)"
+#~ msgstr "Funciones de Ruteo de Vehículos - Categoría (Experimental)"
+
+#~ msgid "The queries use the :doc:`sampledata` network."
+#~ msgstr "Las consultas utilizan la red :doc:`sampledata` ."
+
+#~ msgid "https://www.boost.org/libs/graph/doc/astar_search.html"
+#~ msgstr "https://www.boost.org/libs/graph/doc/astar_search.html"
+
+#~ msgid "It is expected to terminate faster than pgr_astar"
+#~ msgstr "Se espera que termine más rápido que pgr_astar"
+
+#~ msgid "Previous versions of this page"
+#~ msgstr "Versiones anteriores de esta página"
+
+#~ msgid ""
+#~ "`Boost: Sequential Vertex Coloring algorithm documentation <https://www."
+#~ "boost.org/libs/graph/doc/sequential_vertex_coloring.html>`__"
+#~ msgstr ""
+#~ "`Boost: Documentacion de Algoritmo de Coloración Secuencial de Vertices "
+#~ "<https://www.boost.org/libs/graph/doc/sequential_vertex_coloring.html>`__"
+
+#~ msgid ""
+#~ "`Boost: Edge Coloring Algorithm documentation <https://www.boost.org/libs/"
+#~ "graph/doc/edge_coloring.html>`__"
+#~ msgstr ""
+#~ "`Boost: Algoritmo de Coloración de Segmentos <https://www.boost.org/libs/"
+#~ "graph/doc/edge_coloring.html>`__"
+
+#~ msgid "Adjecent nodes"
+#~ msgstr "Nodos adyacentes"
+
+#~ msgid ":doc:`pgr_topologicalSort`"
+#~ msgstr ":doc:`pgr_topologicalSort`"
+
+#~ msgid "Promoted to **proposed** signature."
+#~ msgstr "Promovido a firma **propuesta**."
+
+#~ msgid "Migration of functions"
+#~ msgstr "Migración de funciones"
+
+#~ msgid "Migrating functions"
+#~ msgstr "Migrando funciones"
+
+#~ msgid "Migration of ``pgr_drivingdistance``"
+#~ msgstr "Migración de ``pgr_drivingDistance``"
+
+#~ msgid "``pgr_drivingdistance`` (Single vertex)"
+#~ msgstr "``pgr_drivingDistance`` (Vértice único)"
+
+#~ msgid "``pgr_drivingdistance`` (Multiple vertices)"
+#~ msgstr "``pgr_drivingDistance`` (Múltiples vértices)"
+
+#~ msgid "Migration of turn restrictions"
+#~ msgstr "Migración de las restricciones de giro"
+
+#~ msgid ""
+#~ ":doc:`pgr_trsp` signatures have changed and many issues have been fixed "
+#~ "in the new signatures. This section will show how to migrate from the old "
+#~ "signatures to the new replacement functions. This also affects the "
+#~ "restrictions."
+#~ msgstr ""
+#~ ":doc:`pgr_trsp` firmas han cambiando y varios problemas han sido "
+#~ "arreglados en las nuevas firmas. Esta sección enseñara como migrar las "
+#~ "viejas firmas a la nueva función de reemplazo. Esto también afecta las "
+#~ "restricciones ."
+
+#~ msgid "The integral type of the ``Edges SQL`` can only be ``INTEGER``."
+#~ msgstr "El tipo integral de ``Edges SQL`` sólo puede ser ``INTEGER``."
+
+#~ msgid "The floating point type of the ``Edges SQL`` can only be ``FLOAT``."
+#~ msgstr ""
+#~ "El tipo de punto flotante del ``Edges SQL`` solo puede ser ``FLOAT``."
+
+#~ msgid "``directed`` flag is compulsory."
+#~ msgstr "La bandera ``directed`` es obligatoria."
+
+#~ msgid "Does not autodetect if ``reverse_cost`` column exist."
+#~ msgstr "No auto-detecta si la columna``reverse_cost`` existe."
+
+#~ msgid ""
+#~ "User must be careful to match the existence of the column with the value "
+#~ "of ``has_rcost`` parameter."
+#~ msgstr ""
+#~ "El usuario debe de tener cuidado al coincidir la existencia de la columna "
+#~ "con el valor del parámetro ``has_rcost``."
+
+#~ msgid "The restrictions inner query is optional."
+#~ msgstr "Las restricciones de consulta interna son opcionales."
+
+#~ msgid "The output column names are meaningless"
+#~ msgstr "Los nombres de la columna de salida no tienen importancia"
+
+#~ msgid "Migrate by using:"
+#~ msgstr "Migra al user:"
+
+#~ msgid ":doc:`pgr_dijkstra` when there are no restrictions,"
+#~ msgstr ":doc:`pgr_dijkstra` cuando no hay restricciones,"
+
+#~ msgid ":doc:`pgr_trsp` (One to One) when there are restrictions."
+#~ msgstr ":doc:`pgr_trsp` (Uno a Uno) cuando hay restricciones."
+
+#~ msgid "Migrating ``pgr_trsp`` (Vertices) using ``pgr_dijkstra``"
+#~ msgstr "Migrar ``pgr_trsp`` (Vértices) usando ``pgr_dijkstra``"
+
+#~ msgid "The following query does not have restrictions."
+#~ msgstr "La siguiente consulta no tiene restricciones."
+
+#~ msgid "A message about deprecation is shown"
+#~ msgstr "Un mensaje sobre lo obsoleto se enseña"
+
+#~ msgid "Deprecated functions will be removed on the next mayor version 4.0.0"
+#~ msgstr ""
+#~ "Funciones obsoletas se eliminaran en la siguiente versión mayor 4.0.0"
+
+#~ msgid "The types casting has been removed."
+#~ msgstr "Se han eliminado la fundición de tipos."
+
+#~ msgid ":doc:`pgr_dijkstra`:"
+#~ msgstr ":doc:`pgr_dijkstra`:"
+
+#~ msgid "Autodetects if ``reverse_cost`` column is in the edges SQL."
+#~ msgstr ""
+#~ "Auto-detecta si la columna``reverse_cost`` está en la SQL de aristas."
+
+#~ msgid "Accepts ``ANY-INTEGER`` on integral types"
+#~ msgstr "Acepta ``ANY-INTEGER`` sobre tipos integrales"
+
+#~ msgid "Accepts ``ANY-NUMERICAL`` on floating point types"
+#~ msgstr "Acepta ``ANY-NUMERICAL`` sobre tipos de puntos flotantes"
+
+#~ msgid "``directed`` flag has a default value of ``true``."
+#~ msgstr "La bandera ``directed`` tiene valor de facto de ``true``."
+
+#~ msgid "Use the same value that on the original query."
+#~ msgstr "Usa el mismo valor de la consulta original."
+
+#~ msgid "In this example it is ``true`` which is the default value."
+#~ msgstr "En este ejemplo ``true`` que es el valor de facto."
+
+#~ msgid "The flag has been omitted and the default is been used."
+#~ msgstr "Se ha omitido la bandera y se ha utilizado el valor por defecto."
+
+#~ msgid ""
+#~ "When the need of using strictly the same (meaningless) names and types of "
+#~ "the function been migrated then:"
+#~ msgstr ""
+#~ "Cuando la necesidad de utilizar estrictamente los mismos nombres (sin "
+#~ "importancia) y los tipos de la función han sido migradas entonces:"
+
+#~ msgid "Migrating ``pgr_trsp`` (Vertices) using ``pgr_trsp``"
+#~ msgstr "Migrando ``pgr_trsp`` (Vértices) usando ``pgr_trsp``"
+
+#~ msgid "The following query has restrictions."
+#~ msgstr "La siguiente consulta tiene restricciones."
+
+#~ msgid "The restrictions are the last parameter of the function"
+#~ msgstr "Las restricciones son el último parámetro de la función"
+
+#~ msgid "Using the old structure of restrictions"
+#~ msgstr "Usando la antigua estructura de restricciones"
+
+#~ msgid "The new structure of restrictions is been used."
+#~ msgstr "La nueva estructura de restricciones han sido utilizados."
+
+#~ msgid "It is the second parameter."
+#~ msgstr "Es el segundo parámetro."
+
+#~ msgid ":doc:`pgr_trsp`:"
+#~ msgstr ":doc:`pgr_trsp`:"
+
+#~ msgid "The integral types of the ``sql`` can only be ``INTEGER``."
+#~ msgstr "Los tipos integrales de ``sql`` solo pueden ser ``INTEGER``."
+
+#~ msgid "The floating point type of the ``sql`` can only be ``FLOAT``."
+#~ msgstr "El tipo de punto flotante del ``sql`` solo pueden ser ``FLOAT``."
+
+#~ msgid "For these migration guide the following points will be used:"
+#~ msgstr "Para los siguientes puntos la guía de migración se utilizara:"
+
+#~ msgid ":doc:`pgr_withPoints` when there are no restrictions,"
+#~ msgstr ":doc:`pgr_withPoints` cuando no hay restricciones,"
+
+#~ msgid ":doc:`pgr_trsp_withPoints` (One to One) when there are restrictions."
+#~ msgstr ":doc:`pgr_trsp_withPoints` (Uno a Uno) cuando hay restricciones."
+
+#~ msgid "Migrating ``pgr_trsp`` (Edges) using ``pgr_withPoints``"
+#~ msgstr "Migrando ``pgr_trsp`` (Aristas) usando ``pgr_withPoints``"
+
+#~ msgid "Use :doc:`pgr_withPoints` instead."
+#~ msgstr "Utilizar en su lugar :doc:`pgr_withPoints`."
+
+#~ msgid ""
+#~ "Do not show details, as the deprecated function does not show details."
+#~ msgstr ""
+#~ "No enseña detalles, pues las funciones obsoletas no enseñan detalles."
+
+#~ msgid ":doc:`pgr_withPoints`:"
+#~ msgstr ":doc:`pgr_withPoints`:"
+
+#~ msgid "On the points query do not include the ``side`` column."
+#~ msgstr "La consulta de puntos con incluye la columna ``side``."
+
+#~ msgid ""
+#~ "When the need of using strictly the same (meaningless) names and types, "
+#~ "and node values of the function been migrated then:"
+#~ msgstr ""
+#~ "Cuando la necesidad de utilizar estrictamente los mismos nombres (sin "
+#~ "importancia) y tipos , y los valores de nodo de la función han sido "
+#~ "migradas entonces:"
+
+#~ msgid "Migrating ``pgr_trsp`` (Edges) using ``pgr_trsp_withPoints``"
+#~ msgstr "Migrando``pgr_trsp`` (Aristas) utilizando ``pgr_trsp_withPoints``"
+
+#~ msgid ":doc:`pgr_trsp_withPoints`:"
+#~ msgstr ":doc:`pgr_trsp_withPoints`:"
+
+#~ msgid "The integral types of the ``Edges SQL`` can only be ``INTEGER``."
+#~ msgstr ""
+#~ "Los tipos enteros de las ``Consultas de Aristas`` solo pueden ser "
+#~ "``ENTEROS``."
+
+#~ msgid ":doc:`pgr_dijkstraVia` when there are no restrictions,"
+#~ msgstr ":doc:`pgr_dijkstraVia` cuando no hay restricciones,"
+
+#~ msgid ":doc:`pgr_trspVia` when there are restrictions."
+#~ msgstr ":doc:`pgr_trspVia` cuando hay restricciones."
+
+#~ msgid "Migrating ``pgr_trspViaVertices`` using ``pgr_dijkstraVia``"
+#~ msgstr "Migrando ``pgr_trspViaVertices`` usando ``pgr_dijkstraVia``"
+
+#~ msgid ":doc:`pgr_dijkstraVia`:"
+#~ msgstr ":doc:`pgr_dijkstraVia`:"
+
+#~ msgid "Migrating ``pgr_trspViaVertices`` using ``pgr_trspVia``"
+#~ msgstr "Migrando ``pgr_trspViaVertices`` usando ``pgr_trspVia``"
+
+#~ msgid ":doc:`pgr_trspVia`:"
+#~ msgstr ":doc:`pgr_trspVia`:"
+
+#~ msgid ""
+#~ "And will travel thru the following Via points :math:"
+#~ "`4\\rightarrow3\\rightarrow6`"
+#~ msgstr ""
+#~ "Viajará a travez de los siguientes puntos de la vía :math:"
+#~ "`4\\rightarrow3\\rightarrow6`"
+
+#~ msgid ":doc:`pgr_withPointsVia` when there are no restrictions,"
+#~ msgstr ":doc:`pgr_withPointsVia` cuando no hay restricciones,"
+
+#~ msgid ":doc:`pgr_trspVia_withPoints` when there are restrictions."
+#~ msgstr ":doc:`pgr_trspVia_withPoints` cuando hay restricciones."
+
+#~ msgid "Migrating ``pgr_trspViaEdges`` using ``pgr_withPointsVia``"
+#~ msgstr "Migrando ``pgr_trspViaEdges`` usando ``pgr_withPointsVia``"
+
+#~ msgid ":doc:`pgr_withPointsVia`:"
+#~ msgstr ":doc:`pgr_withPointsVia`:"
+
+#~ msgid "Migrating ``pgr_trspViaEdges`` using ``pgr_trspVia_withPoints``"
+#~ msgstr "Migrando ``pgr_trspViaEdges`` usando ``pgr_trspVia_withPoints``"
+
+#~ msgid ":doc:`pgr_trspVia_withPoints`:"
+#~ msgstr ":doc:`pgr_trspVia_withPoints`:"
+
+#~ msgid "``pgr_ksp`` (One to One)"
+#~ msgstr "``pgr_ksp`` (Uno a Uno)"
+
+#~ msgid "New overload functions:"
+#~ msgstr "Nuevas funciones de sobrecarga:"
+
+#~ msgid "``pgr_ksp`` (One to Many)"
+#~ msgstr "``pgr_ksp`` (Uno a muchos)"
+
+#~ msgid "``pgr_ksp`` (Many to One)"
+#~ msgstr "``pgr_ksp`` (Muchos a uno)"
+
+#~ msgid "``pgr_ksp`` (Many to Many)"
+#~ msgstr "``pgr_ksp`` (Muchos a muchos)"
+
+#~ msgid "``pgr_ksp`` (Combinations)"
+#~ msgstr "``pgr_ksp`` (Combinaciones)"
+
+#~ msgid "**Official** function"
+#~ msgstr "Función **oficial**"
+
+#~ msgid "New **Official** function"
+#~ msgstr "Nueva función **Oficial**"
+
+#~ msgid ":doc:`sampledata` network."
+#~ msgstr ":doc:`sampledata` ."
+
+#~ msgid ""
+#~ "``pgr_aStar`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
+#~ msgstr ""
+#~ "``pgr_aStar`` (`Uno a Uno`_) ha añadido las columnas ``start_vid`` y "
+#~ "``end_vid``."
+
+#~ msgid "``pgr_aStar`` (`One to Many`_) added ``end_vid`` column."
+#~ msgstr "``pgr_aStar`` (`Uno a Muchos`_) ha añadido la columna ``end_vid``."
+
+#~ msgid "``pgr_aStar`` (`Many to One`_) added ``start_vid`` column."
+#~ msgstr ""
+#~ "``pgr_aStar`` (`Muchos a Uno`_) ha añadido la columna ``start_vid``."
+
+#~ msgid "New **proposed** signature:"
+#~ msgstr "Nueva firma **propuesta**:"
+
+#~ msgid "``pgr_aStar`` (`Combinations`_)"
+#~ msgstr "``pgr_aStar`` (`Combinaciones`_)"
+
+#~ msgid "New **Proposed** signatures:"
+#~ msgstr "Nuevas firmas **propuestas**:"
+
+#~ msgid "``pgr_aStar`` (`One to Many`_)"
+#~ msgstr "``pgr_aStar`` (`Uno a Muchos`_)"
+
+#~ msgid "``pgr_aStar`` (`Many to One`_)"
+#~ msgstr "``pgr_aStar`` (`Muchos a Uno`_)"
+
+#~ msgid "``pgr_aStar`` (`Many to Many`_)"
+#~ msgstr "``pgr_aStar`` (`Muchos a Muchos`_)"
+
+#~ msgid "Signature change on ``pgr_astar`` (`One to One`_)"
+#~ msgstr "Cambio de firma en ``pgr_astar`` (`Uno a Uno`_)"
+
+#~ msgid "**Official** ``pgr_aStar`` (`One to One`_)"
+#~ msgstr "**Oficial** ``pgr_aStar`` (`Uno a Uno`_)"
+
+#~ msgid "pgr_aStarCost"
+#~ msgstr "pgr_aStarCost"
+
+#~ msgid "``pgr_aStarCost`` (`Combinations`_)"
+#~ msgstr "``pgr_aStarCost`` (`Combinaciones`_)"
+
+#~ msgid "New **proposed** function"
+#~ msgstr "Nueva función **propuesta**"
+
+#~ msgid "pgr_analyzeGraph"
+#~ msgstr "pgr_analyzeGraph"
+
+#~ msgid "The examples use the :doc:`sampledata` network."
+#~ msgstr "Los ejemplos usan la red de ejemplo :doc:`sampledata`."
+
+#~ msgid "pgr_analyzeOneWay"
+#~ msgstr "pgr_analyzeOneWay"
+
+#~ msgid "New **experimental** function"
+#~ msgstr "Nueva función **experimental**"
+
+#~ msgid ""
+#~ "Boost: `Biconnected components & articulation points <https://www.boost."
+#~ "org/libs/graph/doc/biconnected_components.html>`__"
+#~ msgstr ""
+#~ "Boost: `Componentes biconectados & y puntos de articulación <https://www."
+#~ "boost.org/libs/graph/doc/biconnected_components.html>`__"
+
+#~ msgid ""
+#~ "``pgr_bdAstar`` (`One to One`_) added ``start_vid`` and ``end_vid`` "
+#~ "columns."
+#~ msgstr ""
+#~ "``pgr_bdAstar`` (`Uno a Uno`_) ha añadido las columnas ``start_vid`` y "
+#~ "``end_vid``."
+
+#~ msgid "``pgr_bdAstar`` (`One to Many`_) added ``end_vid`` column."
+#~ msgstr ""
+#~ "``pgr_bdAstar`` (`Uno a Muchos`_) ha añadido la columna ``end_vid``."
+
+#~ msgid "``pgr_bdAstar`` (`Many to One`_) added ``start_vid`` column."
+#~ msgstr ""
+#~ "``pgr_bdAstar`` (`Muchos a Uno`_) ha añadido la columna ``start_vid``."
+
+#~ msgid "``pgr_bdAstar`` (`Combinations`_)"
+#~ msgstr "``pgr_bdAstar`` (`Combinaciones`_)"
+
+#~ msgid "``pgr_bdAstar`` (`One to Many`_)"
+#~ msgstr "``pgr_bdAstar`` (`Uno a Muchos`_)"
+
+#~ msgid "``pgr_bdAstar`` (`Many to One`_)"
+#~ msgstr "``pgr_bdAstar`` (`Muchos a Uno`_)"
+
+#~ msgid "``pgr_bdAstar`` (`Many to Many`_)"
+#~ msgstr "``pgr_bdAstar`` (`Muchos a Muchos`_)"
+
+#~ msgid "Signature change on ``pgr_bdAstar`` (`One to One`_)"
+#~ msgstr "Cambio de firma en ``pgr_bdAstar`` (`Uno a Uno`_)"
+
+#~ msgid "**Official** ``pgr_bdAstar`` (`One to One`_)"
+#~ msgstr "**Oficial** ``pgr_bdAstar`` (`Uno a Uno`_)"
+
+#~ msgid ""
+#~ "The results are equivalent to the union of the results of the "
+#~ "`pgr_bdAStar(` `One to One`_ `)` on the:"
+#~ msgstr ""
+#~ "Los resultados son equivalentes a la unión de los resultados de "
+#~ "`pgr_bdAStar(` `Uno a Uno`_ `)` en:"
+
+#~ msgid "pgr_bdAstarCost"
+#~ msgstr "pgr_bdAstarCost"
+
+#~ msgid "``pgr_bdAstarCost`` (`Combinations`_)"
+#~ msgstr "``pgr_bdAstarCost`` (`Combinaciones`_)"
+
+#~ msgid "pgr_bdDijkstra(`Combinations`_)"
+#~ msgstr "pgr_bdDijkstra(`Combinaciones`_)"
+
+#~ msgid "New **Proposed** functions:"
+#~ msgstr "Nuevas funciones **Propuestas**:"
+
+#~ msgid "``pgr_bdDijkstra`` (`One to Many`_)"
+#~ msgstr "``pgr_bdDijkstra`` (`Uno a Muchos`_)"
+
+#~ msgid "``pgr_bdDijkstra`` (`Many to One`_)"
+#~ msgstr "``pgr_bdDijkstra`` (`Muchos a Uno`_)"
+
+#~ msgid "``pgr_bdDijkstra`` (`Many to Many`_)"
+#~ msgstr "``pgr_bdDijkstra`` (`Muchos a Muchos`_)"
+
+#~ msgid "Signature change on ``pgr_bdDijsktra`` (`One to One`_)"
+#~ msgstr "La firma cambió en ``pgr_bdDijsktra`` (`Uno a Uno`_)"
+
+#~ msgid "**Official** ``pgr_bdDijkstra`` (`One to One`_)"
+#~ msgstr "**Oficial** ``pgr_bdDijkstra`` (`Uno a Uno`_)"
+
+#~ msgid ""
+#~ "https://www.cs.princeton.edu/courses/archive/spr06/cos423/Handouts/"
+#~ "EPP%20shortest%20path%20algorithms.pdf"
+#~ msgstr ""
+#~ "https://www.cs.princeton.edu/courses/archive/spr06/cos423/Handouts/"
+#~ "EPP%20shortest%20path%20algorithms.pdf"
+
+#~ msgid "``pgr_bdDijkstraCost`` (`Combinations`_)"
+#~ msgstr "``pgr_bdDijkstraCost`` (`Combinaciones`_)"
+
+#~ msgid "New **experimental** signature:"
+#~ msgstr "Nueva firma **experimental**:"
+
+#~ msgid "``pgr_bellmanFord`` (`Combinations`_)"
+#~ msgstr "``pgr_bellmanFord`` (`Combinaciones`_)"
+
+#~ msgid "New **experimental** signatures:"
+#~ msgstr "Nuevas firmas **experimental**:"
+
+#~ msgid "``pgr_bellmanFord`` (`One to One`_)"
+#~ msgstr "``pgr_bellmanFord`` (`Uno a Uno`_)"
+
+#~ msgid "``pgr_bellmanFord`` (`One to Many`_)"
+#~ msgstr "``pgr_bellmanFord`` (`Uno a Muchos`_)"
+
+#~ msgid "``pgr_bellmanFord`` (`Many to One`_)"
+#~ msgstr "``pgr_bellmanFord`` (`Muchos a uno`_)"
+
+#~ msgid "``pgr_bellmanFord`` (`Many to Many`_)"
+#~ msgstr "``pgr_bellmanFord`` (`Muchos a Muchos`_)"
+
+#~ msgid "``pgr_betweennessCentrality``"
+#~ msgstr "``pgr_betweennessCentrality``"
+
+#~ msgid ""
+#~ "``pgr_betweennessCentrality`` - Calculates the relative betweeness "
+#~ "centrality using Brandes Algorithm"
+#~ msgstr ""
+#~ "``pgr_betweennessCentrality`` - Calcula la centralidad intermedia "
+#~ "relativa mediante el algoritmo de Brandes"
+
+#~ msgid "New **experimental** function:"
+#~ msgstr "Nueva función **experimental**:"
+
+#~ msgid ""
+#~ "Boost's `betweenness_centrality <https://www.boost.org/doc/libs/1_84_0/"
+#~ "libs/graph/doc/betweenness_centrality.html>`_"
+#~ msgstr ""
+#~ "`Boost: Centralidad de intermediación <https://www.boost.org/doc/"
+#~ "libs/1_84_0/libs/graph/doc/betweenness_centrality.html>`__"
+
+#~ msgid "Queries use the :doc:`sampledata` network."
+#~ msgstr "Las consultas utilizan la red :doc:`sampledata`."
+
+#~ msgid ""
+#~ "Boost: `Biconnected components <https://www.boost.org/libs/graph/doc/"
+#~ "biconnected_components.html>`__"
+#~ msgstr ""
+#~ "Boost: `Componentes Biconectados <https://www.boost.org/libs/graph/doc/"
+#~ "biconnected_components.html>`__"
+
+#~ msgid "pgr_binaryBreadthFirstSearch(`Combinations`_)"
+#~ msgstr "pgr_binaryBreadthFirstSearch(`Combinaciones`_)"
+
+#~ msgid "pgr_binaryBreadthFirstSearch(`One to One`_)"
+#~ msgstr "pgr_binaryBreadthFirstSearch(`Uno a Uno`_)"
+
+#~ msgid "pgr_binaryBreadthFirstSearch(`One to Many`_)"
+#~ msgstr "pgr_binaryBreadthFirstSearch(`Uno a Muchos`_)"
+
+#~ msgid "pgr_binaryBreadthFirstSearch(`Many to One`_)"
+#~ msgstr "pgr_binaryBreadthFirstSearch(`Muchos a Uno`_)"
+
+#~ msgid "pgr_binaryBreadthFirstSearch(`Many to Many`_)"
+#~ msgstr "pgr_binaryBreadthFirstSearch(`Muchos a Muchos`_)"
+
+#~ msgid "pgr_bipartite -Experimental"
+#~ msgstr "pgr_bipartite - Experimental"
+
+#~ msgid "New **experimental** signature"
+#~ msgstr "Nueva firma **experimental**"
+
+#~ msgid "New **proposed** signature"
+#~ msgstr "Nueva firma **propuesta**"
+
+#~ msgid "``pgr_boykovKolmogorov`` (`Combinations`_)"
+#~ msgstr "``pgr_boykovKolmogorov`` (`Combinaciones`_)"
+
+#~ msgid "**Proposed** function"
+#~ msgstr "Función **propuesta**"
+
+#~ msgid "New **Experimental** function"
+#~ msgstr "Nueva función **Experimental**"
+
+#~ msgid "https://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html"
+#~ msgstr ""
+#~ "https://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html"
+
+#~ msgid "``pgr_breadthFirstSearch`` (`Single Vertex`_)"
+#~ msgstr "``pgr_breadthFirstSearch`` (`Vértice único`_)"
+
+#~ msgid "``pgr_breadthFirstSearch`` (`Multiple Vertices`_)"
+#~ msgstr "``pgr_breadthFirstSearch`` (`Múltiples Vértices`_)"
+
+#~ msgid ""
+#~ "`Boost: Breadth First Search algorithm documentation <https://www.boost."
+#~ "org/libs/graph/doc/breadth_first_search.html>`__"
+#~ msgstr ""
+#~ "`Boost: Breadth First Search <https://www.boost.org/libs/graph/doc/"
+#~ "breadth_first_search.html>`__"
+
+#~ msgid "**Supported versions**"
+#~ msgstr "** Versions soportadas**"
+
+#~ msgid ""
+#~ "Boost: `Connected components <https://www.boost.org/libs/graph/doc/"
+#~ "connected_components.html>`__"
+#~ msgstr ""
+#~ "Boost: `Componente conectado <https://www.boost.org/libs/graph/doc/"
+#~ "connected_components.html>`__"
+
+#~ msgid "pgr_createTopology"
+#~ msgstr "pgr_createTopology"
+
+#~ msgid "The example uses the :doc:`sampledata` network."
+#~ msgstr "En el ejemplo se utiliza la red :doc:`sampledata`."
+
+#~ msgid "pgr_createVerticesTable"
+#~ msgstr "pgr_createVerticesTable"
+
+#~ msgid "pgr_dagShortestPath - Experimental"
+#~ msgstr "pgr_dagShortestPath - Experimental"
+
+#~ msgid "Promoted to **proposed** function"
+#~ msgstr "Promovido a función **propuesta**"
+
+#~ msgid "``pgr_depthFirstSearch`` (`Single Vertex`_)"
+#~ msgstr "``pgr_depthFirstSearch`` (`Vértice único`_)"
+
+#~ msgid "``pgr_depthFirstSearch`` (`Multiple Vertices`_)"
+#~ msgstr "``pgr_depthFirstSearch`` (`Vértices multiples`_)"
+
+#~ msgid ""
+#~ "`Boost: Depth First Search algorithm documentation <https://www.boost.org/"
+#~ "libs/graph/doc/depth_first_search.html>`__"
+#~ msgstr ""
+#~ "`Boost: Documentación del algoritmo de Primera Búsqueda de Profundidad "
+#~ "<https://www.boost.org/libs/graph/doc/depth_first_search.html>`__"
+
+#~ msgid ""
+#~ "`Boost: Undirected DFS algorithm documentation <https://www.boost.org/"
+#~ "libs/graph/doc/undirected_dfs.html>`__"
+#~ msgstr ""
+#~ "`Boost: Documentación del algoritmo DFS No dirigido <https://www.boost."
+#~ "org/libs/graph/doc/undirected_dfs.html>`__"
+
+#~ msgid ""
+#~ "``pgr_dijkstra`` (`One to One`_) added ``start_vid`` and ``end_vid`` "
+#~ "columns."
+#~ msgstr ""
+#~ "``pgr_dijkstra`` (`Uno a Uno`_) ha añadido las columnas ``start_vid`` y "
+#~ "``end_vid``."
+
+#~ msgid "``pgr_dijkstra`` (`One to Many`_) added ``end_vid`` column."
+#~ msgstr ""
+#~ "``pgr_dijkstra`` (`Uno a Muchos`_) ha añadido la columna ``end_vid``."
+
+#~ msgid "``pgr_dijkstra`` (`Many to One`_) added ``start_vid`` column."
+#~ msgstr ""
+#~ "``pgr_dijkstra`` (`Muchos a Uno`_) ha añadido la columna ``start_vid``."
+
+#~ msgid "``pgr_dijkstra`` (`Combinations`_)"
+#~ msgstr "``pgr_dijkstra`` (`Combinaciones`_)"
+
+#~ msgid "**Official** functions"
+#~ msgstr "Funciones **oficiales**"
+
+#~ msgid "New **proposed** functions:"
+#~ msgstr "Nuevas funciones **propuestas**:"
+
+#~ msgid "``pgr_dijkstra`` (`One to Many`_)"
+#~ msgstr "``pgr_dijkstra`` (`Uno a Muchos`_)"
+
+#~ msgid "``pgr_dijkstra`` (`Many to One`_)"
+#~ msgstr "``pgr_dijkstra`` (`Muchos a Uno`_)"
+
+#~ msgid "``pgr_dijkstra`` (`Many to Many`_)"
+#~ msgstr "``pgr_dijkstra`` (`Muchos a Muchos`_)"
+
+#~ msgid "Signature change on ``pgr_dijkstra`` (`One to One`_)"
+#~ msgstr "Cambio de firma en ``pgr_dijkstra`` (`Uno a Uno`_)"
+
+#~ msgid "**Official** ``pgr_dijkstra`` (`One to One`_)"
+#~ msgstr "**Oficial** ``pgr_dijkstra`` (`Uno a Uno`_)"
+
+#~ msgid "``pgr_dijkstraCost`` (`Combinations`_)"
+#~ msgstr "``pgr_dijkstraCost`` (`Combinaciones`_)"
+
+#~ msgid "boost: https://www.boost.org/libs/graph/doc/table_of_contents.html"
+#~ msgstr "boost: https://www.boost.org/libs/graph/doc/table_of_contents.html"
+
+#~ msgid "Signature change pgr_drivingDistance(single vertex)"
+#~ msgstr "Cambio de firma pgr_drivingDistance(vértice único)"
+
+#~ msgid "New **Official** pgr_drivingDistance(multiple vertices)"
+#~ msgstr "Nuevo **Oficial** pgr_drivingDistance(multiples vértices)"
+
+#~ msgid "Official:: pgr_drivingDistance(single vertex)"
+#~ msgstr "Oficial:: pgr_drivingDistance(vértice único)"
+
+#~ msgid "pgr_edgeColoring - Experimental"
+#~ msgstr "pgr_edgeColoring - Experimental"
+
+#~ msgid "New **proposed** function:"
+#~ msgstr "Nueva función **propuesta**:"
+
+#~ msgid "``pgr_edmondsKarp`` (`Combinations`_)"
+#~ msgstr "``pgr_edmondsKarp`` (`Combinaciones`_)"
+
+#~ msgid "https://www.boost.org/libs/graph/doc/edmonds_karp_max_flow.html"
+#~ msgstr "https://www.boost.org/libs/graph/doc/edmonds_karp_max_flow.html"
+
+#~ msgid "``pgr_edwardMoore - Experimental``"
+#~ msgstr "``pgr_edwardMoore`` - Experimental"
+
+#~ msgid "``pgr_edwardMoore`` (`Combinations`_)"
+#~ msgstr "``pgr_edwardMoore`` (`Combinaciones`_)"
+
+#~ msgid "``pgr_edwardMoore`` (`One to One`_)"
+#~ msgstr "``pgr_edwardMoore`` (`Uno a Uno`_)"
+
+#~ msgid "``pgr_edwardMoore`` (`One to Many`_)"
+#~ msgstr "``pgr_edwardMoore`` (`Uno a Muchos`_)"
+
+#~ msgid "``pgr_edwardMoore`` (`Many to One`_)"
+#~ msgstr "``pgr_edwardMoore`` (`Muchos a Uno`_)"
+
+#~ msgid "``pgr_edwardMoore`` (`Many to Many`_)"
+#~ msgstr "``pgr_edwardMoore`` (`Muchos a Muchos`_)"
+
+#~ msgid "pgr_extractVertices -- Proposed"
+#~ msgstr "pgr_extractVertices -- Propuesto"
+
+#~ msgid "New **proposed** signatures:"
+#~ msgstr "Nuevas firmas **propuestas**:"
+
+#~ msgid "``pgr_findCloseEdges`` (`One point`_)"
+#~ msgstr "``pgr_findCloseEdges`` (`Un punto`_)"
+
+#~ msgid "``pgr_findCloseEdges`` (`Many points`_)"
+#~ msgstr "``pgr_findCloseEdges`` (`Muchos puntos`_)"
+
+#~ msgid "Queries uses the :doc:`sampledata` network."
+#~ msgstr "Consultas utilizan la red :doc:`sampledata`."
+
+#~ msgid "New **official** function"
+#~ msgstr "Nueva función **oficial**"
+
+#~ msgid "``pgr_hawickCircuits - Experimental``"
+#~ msgstr "``pgr_hawickCircuits - Experimental``"
+
+#~ msgid "``pgr_hawickCircuits``"
+#~ msgstr "``pgr_hawickCircuits``"
+
+#~ msgid "https://www.boost.org/libs/graph/doc/boyer_myrvold.html"
+#~ msgstr "https://www.boost.org/libs/graph/doc/boyer_myrvold.html"
+
+#~ msgid "pgr_lengauerTarjanDominatorTree -Experimental"
+#~ msgstr "pgr_lengauerTarjanDominatorTree -Experimental"
+
+#~ msgid ""
+#~ "`Boost: Lengauer-Tarjan dominator tree algorithm <https://www.boost.org/"
+#~ "libs/graph/doc/lengauer_tarjan_dominator.htm>`__"
+#~ msgstr ""
+#~ "`Boost: Algoritmo Lengauer-Tarjan de árbol dominante <https://www.boost."
+#~ "org/libs/graph/doc/lengauer_tarjan_dominator.htm>`__"
+
+#~ msgid "pgr_lineGraph - Proposed"
+#~ msgstr "pgr_lineGraph - Propuesto"
+
+#~ msgid ""
+#~ "The examples of this section are based on the :doc:`sampledata` network. "
+#~ "The examples include the subgraph including edges 4, 7, 8, and 10 with "
+#~ "``reverse_cost``."
+#~ msgstr ""
+#~ "Los ejemplos de esta sección se basan en la red :doc:`sampledata`. Los "
+#~ "ejemplos incluyen el subgrafo que incluye las aristas 4, 7, 8 y 10 con "
+#~ "``reverse_cost``."
+
+#~ msgid ""
+#~ "Query done on :doc:`sampledata` network gives the list of edges that are "
+#~ "needed to connect the graph."
+#~ msgstr ""
+#~ "La consulta realizada en la red de :doc:`sampledata` proporciona la lista "
+#~ "de aristas que se necesitan en el grafo para conectarlo."
+
+#~ msgid "https://www.boost.org/libs/graph/doc/make_connected.html"
+#~ msgstr "https://www.boost.org/libs/graph/doc/make_connected.html"
+
+#~ msgid "pgr_maxCardinalityMatch"
+#~ msgstr "pgr_maxCardinalityMatch"
+
+#~ msgid "``pgr_maxCardinalityMatch(text,boolean)``"
+#~ msgstr "``pgr_maxCardinalityMatch(text,boolean)``"
+
+#~ msgid "https://www.boost.org/libs/graph/doc/maximum_matching.html"
+#~ msgstr "https://www.boost.org/libs/graph/doc/maximum_matching.html"
+
+#~ msgid "``pgr_maxFlow`` (`Combinations`_)"
+#~ msgstr "``pgr_maxFlow`` (`Combinaciones`_)"
+
+#~ msgid "New **Proposed** function"
+#~ msgstr "Nueva función **Propuesta**"
+
+#~ msgid "https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html"
+#~ msgstr "https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html"
+
+#~ msgid "``pgr_maxFlowMinCost`` (`Combinations`_)"
+#~ msgstr "``pgr_maxFlowMinCost`` (`Combinaciones`_)"
+
+#~ msgid ""
+#~ "https://www.boost.org/libs/graph/doc/"
+#~ "successive_shortest_path_nonnegative_weights.html"
+#~ msgstr ""
+#~ "https://www.boost.org/libs/graph/doc/"
+#~ "successive_shortest_path_nonnegative_weights.html"
+
+#~ msgid "``pgr_maxFlowMinCost_Cost`` (`Combinations`_)"
+#~ msgstr "``pgr_maxFlowMinCost_Cost`` (`Combinaciones`_)"
+
+#~ msgid "``pgr_pushRelabel`` (`Combinations`_)"
+#~ msgstr "``pgr_pushRelabel`` (`Combinaciones`_)"
+
+#~ msgid "pgr_sequentialVertexColoring - Proposed"
+#~ msgstr "pgr_sequentialVertexColoring - Propuesto"
+
+#~ msgid "Promoted to **proposed** signature"
+#~ msgstr "Promovido a firma **propuesta**"
+
+#~ msgid "pgr_stoerWagner - Experimental"
+#~ msgstr "pgr_stoerWagner - Experimental"
+
+#~ msgid ""
+#~ "Boost: `Strong components <https://www.boost.org/libs/graph/doc/"
+#~ "strong_components.html>`__"
+#~ msgstr ""
+#~ "Boost: `Components fuertemente conectados <https://www.boost.org/libs/"
+#~ "graph/doc/strong_components.html>`__"
+
+#~ msgid "New proposed signatures"
+#~ msgstr "Nuevas firmas propuestas"
+
+#~ msgid "``pgr_trsp`` (`One to One`_)"
+#~ msgstr "``pgr_trsp`` (`Uno a Uno`_)"
+
+#~ msgid "``pgr_trsp(text,integer,integer,boolean,boolean,text)``"
+#~ msgstr "``pgr_trsp(text,integer,integer,boolean,boolean,text)``"
+
+#~ msgid "``pgr_trspViaVertices``"
+#~ msgstr "``pgr_trspViaVertices``"
+
+#~ msgid "``pgr_trspViaEdges``"
+#~ msgstr "``pgr_trspViaEdges``"
+
+#~ msgid "``pgr_trsp_withPoints`` (`One to One`_)"
+#~ msgstr "``pgr_trsp_withPoints`` (`Uno a Uno`_)"
+
+#~ msgid "pgr_turnRestrictedPath - Experimental"
+#~ msgstr "pgr_turnRestrictedPath - Experimental"
+
+#~ msgid "New experimental function"
+#~ msgstr "Nueva función Experimental"
+
+#~ msgid "pgr_vrpOneDepot - Experimental"
+#~ msgstr "pgr_vrpOneDepot - Experimental"
+
+#~ msgid "``pgr_withPointsDD`` (`Single vertex`)"
+#~ msgstr "``pgr_withPointsDD`` (`Vértice único`)"
+
+#~ msgid "pgr_withPointsKSP - Proposed"
+#~ msgstr "pgr_withPointsKSP - Propuesto"
+
+#~ msgid "``pgr_withPointsKSP`` (One to One)"
+#~ msgstr "``pgr_withPointsKSP`` (Uno a Uno)"
+
+#~ msgid "New overload functions"
+#~ msgstr "Nuevas funciones de sobrecarga"
+
+#~ msgid "``pgr_withPointsKSP`` (One to Many)"
+#~ msgstr "``pgr_withPointsKSP`` (Uno a Muchos)"
+
+#~ msgid "``pgr_withPointsKSP`` (Many to One)"
+#~ msgstr "``pgr_withPointsKSP`` (Muchos a Uno)"
+
+#~ msgid "``pgr_withPointsKSP`` (Many to Many)"
+#~ msgstr "``pgr_withPointsKSP`` (Muchos a Muchos)"
+
+#~ msgid "``pgr_withPointsKSP`` (Combinations)"
+#~ msgstr "``pgr_withPointsKSP`` (Combinaciones)"
+
+#~ msgid ""
+#~ "``pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
+#~ "boolean)``"
+#~ msgstr ""
+#~ "``pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
+#~ "boolean)``"
+
+#~ msgid ""
+#~ "``pgr_aStar`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
+#~ msgstr ""
+#~ "``pgr_aStar`` (`Uno a Uno`) ha añadido las columnas ``start_vid`` y "
+#~ "``end_vid``."
+
+#~ msgid "``pgr_aStar`` (`One to Many`) added ``end_vid`` column."
+#~ msgstr "``pgr_aStar`` (`Uno a Muchos`) ha añadido la columna ``end_vid``."
+
+#~ msgid "``pgr_aStar`` (`Many to One`) added ``start_vid`` column."
+#~ msgstr "``pgr_aStar`` (`Muchos a Uno`) ha añadido la columna ``start_vid``."
+
+#~ msgid ""
+#~ "``pgr_bdAstar`` (`One to One`) added ``start_vid`` and ``end_vid`` "
+#~ "columns."
+#~ msgstr ""
+#~ "``pgr_bdAstar`` (`Uno a Uno`) ha añadido las columnas ``start_vid`` y "
+#~ "``end_vid``."
+
+#~ msgid "``pgr_bdAstar`` (`One to Many`) added ``end_vid`` column."
+#~ msgstr "``pgr_bdAstar`` (`Uno a Muchos`) ha añadido la columna ``end_vid``."
+
+#~ msgid "``pgr_bdAstar`` (`Many to One`) added ``start_vid`` column."
+#~ msgstr ""
+#~ "``pgr_bdAstar`` (`Muchos a Uno`) ha añadido la columna ``start_vid``."
+
+#~ msgid ""
+#~ "`#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ Standarize "
+#~ "output pgr_drivingdistance"
+#~ msgstr ""
+#~ "`#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ "
+#~ "Estandarización de resultados de pgr_drivingdistance"
+
+#~ msgid ""
+#~ "`#2565 <https://github.com/pgRouting/pgrouting/issues/2565>`__ "
+#~ "pgr_pgr_lengauerTarjanDominatorTree triggers an assertion"
+#~ msgstr ""
+#~ "`#2565 <https://github.com/pgRouting/pgrouting/issues/2565>`__ "
+#~ "pgr_pgr_lengauerTarjanDominatorTree genera un error de afirmación"
+
+#~ msgid ""
+#~ "``pgr_dijkstra`` (`One to One`) added ``start_vid`` and ``end_vid`` "
+#~ "columns."
+#~ msgstr ""
+#~ "``pgr_dijkstra`` (`Uno a Uno`) ha añadido las columnas ``start_vid`` y "
+#~ "``end_vid``."
+
+#~ msgid "``pgr_dijkstra`` (`One to Many`) added ``end_vid`` column."
+#~ msgstr ""
+#~ "``pgr_dijkstra`` (`Uno a Muchos`) ha añadido la columna ``end_vid``."
+
+#~ msgid "``pgr_dijkstra`` (`Many to One`) added ``start_vid`` column."
+#~ msgstr ""
+#~ "``pgr_dijkstra`` (`Muchos a Uno`) ha añadido la columna ``start_vid``."
+
+#~ msgid "``pgr_withPointsVia`` (One Via)"
+#~ msgstr "``pgr_withPointsVia`` (Una trayectoria)"
+
+#~ msgid "``pgr_trspVia_withPoints`` (One Via)"
+#~ msgstr "``pgr_trspVia_withPoints`` (Muchas trayectorias)"
+
+#~ msgid "``pgr_trsp`` (One to One)"
+#~ msgstr "``pgr_trsp`` (Uno a Uno)"
+
+#~ msgid "``pgr_trsp`` (One to Many)"
+#~ msgstr "``pgr_trsp`` (Uno a Muchos)"
+
+#~ msgid "``pgr_trsp`` (Many to One)"
+#~ msgstr "``pgr_trsp`` (Muchos a Uno)"
+
+#~ msgid "``pgr_trsp`` (Many to Many)"
+#~ msgstr "``pgr_trsp`` (Muchos a Muchos)"
+
+#~ msgid "``pgr_trsp`` (Combinations)"
+#~ msgstr "``pgr_trsp`` (Combinaciones)"
+
+#~ msgid "``pgr_trsp_withPoints`` (One to One)"
+#~ msgstr "``pgr_trsp_withPoints`` (Uno a Uno)"
+
+#~ msgid "``pgr_trsp_withPoints`` (One to Many)"
+#~ msgstr "``pgr_trsp_withPoints`` (Uno a Muchos)"
+
+#~ msgid "``pgr_trsp_withPoints`` (Many to One)"
+#~ msgstr "``pgr_trsp_withPoints`` (Muchos a Uno)"
+
+#~ msgid "``pgr_trsp_withPoints`` (Many to Many)"
+#~ msgstr "``pgr_trsp_withPoints`` (Muchos a Muchos)"
+
+#~ msgid "``pgr_trsp_withPoints`` (Combinations)"
+#~ msgstr "``pgr_trsp_withPoints`` (Combinaciones)"
+
+#~ msgid "``pgr_cuthillMckeeOrdering``"
+#~ msgstr "``pgr_cuthillMckeeOrdering``"
+
+#~ msgid "``pgr_maxCardinalityMatch(text)``"
+#~ msgstr "``pgr_maxCardinalityMatch(text)``"
+
+#~ msgid ""
+#~ "``pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)``"
+#~ msgstr ""
+#~ "``pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)``"
+
+#~ msgid "New functions"
+#~ msgstr "Nuevas funciones"
+
+#~ msgid "pgr_aStar(one to many)"
+#~ msgstr "pgr_aStar(Uno a Muchos)"
+
+#~ msgid "pgr_aStar(many to one)"
+#~ msgstr "pgr_aStar(muchos a uno)"
+
+#~ msgid "pgr_aStar(many to many)"
+#~ msgstr "pgr_aStar(muchos a muchos)"
+
+#~ msgid "pgr_aStarCost(one to one)"
+#~ msgstr "pgr_aStarCost(Uno a Uno)"
+
+#~ msgid "pgr_aStarCost(one to many)"
+#~ msgstr "pgr_aStarCost(Uno a Muchos)"
+
+#~ msgid "pgr_aStarCost(many to one)"
+#~ msgstr "pgr_aStarCost(muchos a uno)"
+
+#~ msgid "pgr_aStarCost(many to many)"
+#~ msgstr "pgr_aStarCost(muchos a muchos)"
+
+#~ msgid "pgr_aStarCostMatrix(one to one)"
+#~ msgstr "pgr_aStarCostMatrix(Uno a Uno)"
+
+#~ msgid "pgr_aStarCostMatrix(one to many)"
+#~ msgstr "pgr_aStarCostMatrix(Uno a Muchos)"
+
+#~ msgid "pgr_aStarCostMatrix(many to one)"
+#~ msgstr "pgr_aStarCostMatrix(muchos a uno)"
+
+#~ msgid "pgr_aStarCostMatrix(many to many)"
+#~ msgstr "pgr_aStarCostMatrix(muchos a muchos)"
+
+#~ msgid "pgr_bdAstar(one to many)"
+#~ msgstr "pgr_bdAstar(Uno a Muchos)"
+
+#~ msgid "pgr_bdAstar(many to one)"
+#~ msgstr "pgr_bdAstar(muchos a uno)"
+
+#~ msgid "pgr_bdAstar(many to many)"
+#~ msgstr "pgr_bdAstar(muchos a muchos)"
+
+#~ msgid "pgr_bdAstarCost(one to one)"
+#~ msgstr "pgr_bdAstarCost(Uno a Uno)"
+
+#~ msgid "pgr_bdAstarCost(one to many)"
+#~ msgstr "pgr_bdAstarCost(Uno a Muchos)"
+
+#~ msgid "pgr_bdAstarCost(many to one)"
+#~ msgstr "pgr_bdAstarCost(muchos a uno)"
+
+#~ msgid "pgr_bdAstarCost(many to many)"
+#~ msgstr "pgr_bdAstarCost(muchos a muchos)"
+
+#~ msgid "pgr_bdAstarCostMatrix(one to one)"
+#~ msgstr "pgr_bdAstarCostMatrix(Uno a Uno)"
+
+#~ msgid "pgr_bdAstarCostMatrix(one to many)"
+#~ msgstr "pgr_bdAstarCostMatrix(Uno a Muchos)"
+
+#~ msgid "pgr_bdAstarCostMatrix(many to one)"
+#~ msgstr "pgr_bdAstarCostMatrix(muchos a uno)"
+
+#~ msgid "pgr_bdAstarCostMatrix(many to many)"
+#~ msgstr "pgr_bdAstarCostMatrix(muchos a muchos)"
+
+#~ msgid "pgr_bdDijkstra(one to many)"
+#~ msgstr "pgr_bdDijkstra(Uno a Muchos)"
+
+#~ msgid "pgr_bdDijkstra(many to one)"
+#~ msgstr "pgr_bdDijkstra(muchos a uno)"
+
+#~ msgid "pgr_bdDijkstra(many to many)"
+#~ msgstr "pgr_bdDijkstra(muchos a muchos)"
+
+#~ msgid "pgr_bdDijkstraCost(one to one)"
+#~ msgstr "pgr_bdDijkstraCost(uno a uno)"
+
+#~ msgid "pgr_bdDijkstraCost(one to many)"
+#~ msgstr "pgr_bdDijkstraCost(uno a muchos)"
+
+#~ msgid "pgr_bdDijkstraCost(many to one)"
+#~ msgstr "pgr_bdDijkstraCost(muchos a uno)"
+
+#~ msgid "pgr_bdDijkstraCost(many to many)"
+#~ msgstr "pgr_bdDijkstraCost(muchos a muchos)"
+
+#~ msgid "pgr_bdDijkstraCostMatrix(one to one)"
+#~ msgstr "pgr_bdDijkstraCostMatrix(uno a uno)"
+
+#~ msgid "pgr_bdDijkstraCostMatrix(one to many)"
+#~ msgstr "pgr_bdDijkstraCostMatrix(uno a muchos)"
+
+#~ msgid "pgr_bdDijkstraCostMatrix(many to one)"
+#~ msgstr "pgr_bdDijkstraCostMatrix(muchos a uno)"
+
+#~ msgid "pgr_bdDijkstraCostMatrix(many to many)"
+#~ msgstr "pgr_bdDijkstraCostMatrix(muchos a muchos)"
+
+#~ msgid "pgr_pushRelabel(one to one)"
+#~ msgstr "pgr_pushRelabel(Uno a Uno)"
+
+#~ msgid "pgr_pushRelabel(one to many)"
+#~ msgstr "pgr_pushRelabel(Uno a Muchos)"
+
+#~ msgid "pgr_pushRelabel(many to one)"
+#~ msgstr "pgr_pushRelabel(muchos a uno)"
+
+#~ msgid "pgr_pushRelabel(many to many)"
+#~ msgstr "pgr_pushRelabel(muchos a muchos)"
+
+#~ msgid "pgr_edmondsKarp(one to one)"
+#~ msgstr "pgr_edmondsKarp(Uno a Uno)"
+
+#~ msgid "pgr_edmondsKarp(one to many)"
+#~ msgstr "pgr_edmondsKarp(Uno a Muchos)"
+
+#~ msgid "pgr_edmondsKarp(many to one)"
+#~ msgstr "pgr_edmondsKarp(muchos a uno)"
+
+#~ msgid "pgr_edmondsKarp(many to many)"
+#~ msgstr "pgr_edmondsKarp(muchos a muchos)"
+
+#~ msgid "pgr_boykovKolmogorov (one to one)"
+#~ msgstr "pgr_boykovKolmogorov(Uno a Uno)"
+
+#~ msgid "pgr_boykovKolmogorov (one to many)"
+#~ msgstr "pgr_boykovKolmogorov(Uno a Muchos)"
+
+#~ msgid "pgr_boykovKolmogorov (many to one)"
+#~ msgstr "pgr_boykovKolmogorov (muchos a uno)"
+
+#~ msgid "pgr_boykovKolmogorov (many to many)"
+#~ msgstr "pgr_boykovKolmogorov (muchos a muchos)"
+
+#~ msgid "pgr_edgeDisjointPaths(one to one)"
+#~ msgstr "pgr_edgeDisjointPaths(Uno a Uno)"
+
+#~ msgid "pgr_edgeDisjointPaths(one to many)"
+#~ msgstr "pgr_edgeDisjointPaths(Uno a Muchos)"
+
+#~ msgid "pgr_edgeDisjointPaths(many to one)"
+#~ msgstr "pgr_edgeDisjointPaths(muchos a uno)"
+
+#~ msgid "pgr_edgeDisjointPaths(many to many)"
+#~ msgstr "pgr_edgeDisjointPaths(muchos a muchos)"
+
+#~ msgid "pgr_astar"
+#~ msgstr "pgr_astar"
+
+#~ msgid "The many version results are the union of the one to one version"
+#~ msgstr ""
+#~ "Los muchos resultados de la versión son la unión de la versión uno a uno"
+
+#~ msgid "pgr_bdAstar(one to one)"
+#~ msgstr "pgr_bdAstar(Uno a Uno)"
+
+#~ msgid "New Proposed functions"
+#~ msgstr "Nuevas Funciones Propuestas"
+
+#~ msgid "New Proposed Signatures"
+#~ msgstr "Nuevas Firmas Propuestas"
+
+#~ msgid "pgr_astar(one to many)"
+#~ msgstr "pgr_astar(Uno a Muchos)"
+
+#~ msgid "pgr_astar(many to one)"
+#~ msgstr "pgr_astar(muchos a uno)"
+
+#~ msgid "pgr_astar(many to many)"
+#~ msgstr "pgr_astar(muchos a muchos)"
+
+#~ msgid "pgr_astarCost(one to one)"
+#~ msgstr "pgr_astarCost(Uno a Uno)"
+
+#~ msgid "pgr_astarCost(one to many)"
+#~ msgstr "pgr_astarCost(uno a muchos)"
+
+#~ msgid "pgr_astarCost(many to one)"
+#~ msgstr "pgr_astarCost(muchos a uno)"
+
+#~ msgid "pgr_astarCost(many to many)"
+#~ msgstr "pgr_astarCost(muchos a muchos)"
+
+#~ msgid "pgr_astarCostMatrix"
+#~ msgstr "pgr_astarCostMatrix"
+
+#~ msgid "pgr_maxFlowPushRelabel(one to one)"
+#~ msgstr "pgr_maxFlowPushRelabel(Uno a Uno)"
+
+#~ msgid "pgr_maxFlowPushRelabel(one to many)"
+#~ msgstr "pgr_maxFlowPushRelabel(uno a muchos)"
+
+#~ msgid "pgr_maxFlowPushRelabel(many to one)"
+#~ msgstr "pgr_maxFlowPushRelabel(muchos a uno)"
+
+#~ msgid "pgr_maxFlowPushRelabel(many to many)"
+#~ msgstr "pgr_maxFlowPushRelabel(muchos a muchos)"
+
+#~ msgid "pgr_maxFlowEdmondsKarp(one to one)"
+#~ msgstr "pgr_maxFlowEdmondsKarp(Uno a Uno)"
+
+#~ msgid "pgr_maxFlowEdmondsKarp(one to many)"
+#~ msgstr "pgr_maxFlowEdmondsKarp(uno a muchos)"
+
+#~ msgid "pgr_maxFlowEdmondsKarp(many to one)"
+#~ msgstr "pgr_maxFlowEdmondsKarp(muchos a uno)"
+
+#~ msgid "pgr_maxFlowEdmondsKarp(many to many)"
+#~ msgstr "pgr_maxFlowEdmondsKarp(muchos a muchos)"
+
+#~ msgid "pgr_maxFlowBoykovKolmogorov (one to one)"
+#~ msgstr "pgr_maxFlowBoykovKolmogorov(Uno a Uno)"
+
+#~ msgid "pgr_maxFlowBoykovKolmogorov (one to many)"
+#~ msgstr "pgr_maxFlowBoykovKolmogorov (uno a muchos)"
+
+#~ msgid "pgr_maxFlowBoykovKolmogorov (many to one)"
+#~ msgstr "pgr_maxFlowBoykovKolmogorov (muchos a uno)"
+
+#~ msgid "pgr_maxFlowBoykovKolmogorov (many to many)"
+#~ msgstr "pgr_maxFlowBoykovKolmogorov (muchos a muchos)"
+
+#~ msgid "pgr_astar - use pgr_aStar instead"
+#~ msgstr "pgr_astar - utilice pgr_aStar en su lugar"
+
+#~ msgid "pgr_dijkstraCost(one to one)"
+#~ msgstr "pgr_dijkstraCost(Uno a Uno)"
+
+#~ msgid "pgr_dijkstraCost(one to many)"
+#~ msgstr "pgr_dijkstraCost(uno a muchos)"
+
+#~ msgid "pgr_dijkstraCost(many to one)"
+#~ msgstr "pgr_dijkstraCost(muchos a uno)"
+
+#~ msgid "pgr_dijkstraCost(many to many)"
+#~ msgstr "pgr_dijkstraCost(muchos a muchos)"
+
+#~ msgid "pgr_withPoints(one to one)"
+#~ msgstr "pgr_withPoints(Uno a Uno)"
+
+#~ msgid "pgr_withPoints(one to many)"
+#~ msgstr "pgr_withPoints(uno a muchos)"
+
+#~ msgid "pgr_withPoints(many to one)"
+#~ msgstr "pgr_withPoints(muchos a uno)"
+
+#~ msgid "pgr_withPoints(many to many)"
+#~ msgstr "pgr_withPoints(muchos a muchos)"
+
+#~ msgid "pgr_withPointsCost(one to one)"
+#~ msgstr "pgr_withPointsCost(Uno a Uno)"
+
+#~ msgid "pgr_withPointsCost(one to many)"
+#~ msgstr "pgr_withPointsCost(uno a muchos)"
+
+#~ msgid "pgr_withPointsCost(many to one)"
+#~ msgstr "pgr_withPointsCost(muchos a uno)"
+
+#~ msgid "pgr_withPointsCost(many to many)"
+#~ msgstr "pgr_withPointsCost(muchos a muchos)"
+
+#~ msgid "pgr_dijkstra(one to many)"
+#~ msgstr "pgr_dijkstra(uno a muchos)"
+
+#~ msgid "pgr_dijkstra(many to one)"
+#~ msgstr "pgr_dijkstra(muchos a uno)"
+
+#~ msgid "pgr_dijkstra(many to many)"
+#~ msgstr "pgr_dijkstra(muchos a muchos)"
+
+#~ msgid "pgr_dijkstra(one to one)"
+#~ msgstr "pgr_dijkstra(Uno a Uno)"

--- a/locale/ja/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/ja/LC_MESSAGES/pgrouting_doc_strings.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-17 00:50+0000\n"
+"POT-Creation-Date: 2025-03-24 14:17+0000\n"
 "PO-Revision-Date: 2024-09-23 01:16+0000\n"
 "Last-Translator: Celia Virginia Vergara Castillo <vicky@erosion.dev>\n"
 "Language-Team: Japanese <https://weblate.osgeo.org/projects/pgrouting/"
@@ -311,9 +311,6 @@ msgstr ""
 msgid ":doc:`pgr_primDFS`"
 msgstr ""
 
-msgid "Proposed"
-msgstr ""
-
 msgid "Proposed functions for next mayor release."
 msgstr "次期リリース予定の機能。"
 
@@ -384,9 +381,6 @@ msgid ""
 "functionality to the new signatures or replacement functions."
 msgstr ""
 
-msgid "Experimental"
-msgstr ""
-
 msgid "Possible server crash"
 msgstr ""
 
@@ -429,7 +423,7 @@ msgstr ""
 msgid "Documentation examples might need to be automatically generated."
 msgstr ""
 
-msgid "Might need a lot of feedback from the comunity."
+msgid "Might need a lot of feedback from the community."
 msgstr ""
 
 msgid "Might depend on a proposed function of pgRouting"
@@ -684,8 +678,8 @@ msgid "References"
 msgstr "参照"
 
 msgid ""
-"`Boost's metric appro's metric approximation <https://www.boost.org/libs/"
-"graph/doc/metric_tsp_approx.html>`__"
+"`Boost: metric TSP approx <https://www.boost.org/libs/graph/doc/"
+"metric_tsp_approx.html>`__"
 msgstr ""
 
 msgid "`University of Waterloo TSP <https://www.math.uwaterloo.ca/tsp/>`__"
@@ -698,7 +692,7 @@ msgstr ""
 "`Wikipedia: 巡回セールスマン問題 <https://en.wikipedia.org/wiki/"
 "Traveling_salesman_problem>`__"
 
-msgid "Vehicle Routing Functions - Category (Experimental)"
+msgid "Vehicle Routing Functions - Category"
 msgstr ""
 
 msgid "Pickup and delivery problem"
@@ -1647,8 +1641,8 @@ msgstr ""
 msgid "https://en.wikipedia.org/wiki/Vehicle_routing_problem"
 msgstr ""
 
-msgid "The queries use the :doc:`sampledata` network."
-msgstr "クエリは :doc:`sampledata` ネットワークを使用します。"
+msgid ":doc:`sampledata`"
+msgstr ""
 
 msgid "A* - Family of functions"
 msgstr ""
@@ -1810,7 +1804,8 @@ msgstr ""
 msgid ":doc:`bdAstar-family`"
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/astar_search.html"
+msgid ""
+"`Boost: A* search <https://www.boost.org/libs/graph/doc/astar_search.html>`__"
 msgstr ""
 
 msgid "https://en.wikipedia.org/wiki/A*_search_algorithm"
@@ -2614,14 +2609,11 @@ msgid ""
 "ending vertex:"
 msgstr ""
 
-msgid "It is expected to terminate faster than pgr_astar"
+msgid "It is expected to terminate faster than pgr_aStar"
 msgstr ""
 
 msgid ":doc:`aStar-family`"
 msgstr ""
-
-msgid "Previous versions of this page"
-msgstr "このページの以前のバージョン"
 
 msgid "Bidirectional Dijkstra - Family of functions"
 msgstr ""
@@ -2765,27 +2757,7 @@ msgid "Identifier of the color of the edge."
 msgstr ""
 
 msgid ""
-"`Boost: Sequential Vertex Coloring algorithm documentation <https://www."
-"boost.org/libs/graph/doc/sequential_vertex_coloring.html>`__"
-msgstr ""
-
-msgid ""
-"`Wikipedia: Graph coloring <https://en.wikipedia.org/wiki/Graph_coloring>`__"
-msgstr ""
-
-msgid ""
-"`Boost: is_bipartite <https://www.boost.org/libs/graph/doc/is_bipartite."
-"html>`__"
-msgstr ""
-
-msgid ""
-"`Wikipedia: bipartite graph <https://en.wikipedia.org/wiki/"
-"Bipartite_graph>`__"
-msgstr ""
-
-msgid ""
-"`Boost: Edge Coloring Algorithm documentation <https://www.boost.org/libs/"
-"graph/doc/edge_coloring.html>`__"
+"`Boost: <https://www.boost.org/libs/graph/doc/table_of_contents.html>`__"
 msgstr ""
 
 msgid "Components - Family of functions"
@@ -2821,6 +2793,9 @@ msgstr ""
 msgid ":doc:`pgr_contraction`"
 msgstr ""
 
+msgid ":doc:`pgr_contractionDeadEnd`"
+msgstr ""
+
 msgid ""
 "In large graphs, like the road graphs, or electric networks, graph "
 "contraction can be used to speed up some graph algorithms. Contraction "
@@ -2849,491 +2824,6 @@ msgstr ""
 msgid ""
 "Decide the order of the contraction algorithms and set the maximum number of "
 "times they are to be executed."
-msgstr ""
-
-msgid "Contraction of the leaf nodes of the graph."
-msgstr ""
-
-msgid "Dead end"
-msgstr ""
-
-msgid "A node is considered a **dead end** node when"
-msgstr ""
-
-msgid "On undirected graphs:"
-msgstr ""
-
-msgid "The number of adjacent vertices is 1."
-msgstr ""
-
-msgid "On directed graphs:"
-msgstr ""
-
-msgid "There are no outgoing edges and has at least one incoming edge."
-msgstr ""
-
-msgid "There are no incoming edges and has at least one outgoing edge."
-msgstr ""
-
-msgid ""
-"When the conditions are true then the `Operation: Dead End Contraction`_ can "
-"be done."
-msgstr ""
-
-msgid "Dead end vertex on undirected graph"
-msgstr ""
-
-msgid "The green nodes are `dead end`_ nodes"
-msgstr ""
-
-msgid "The blue nodes have an unlimited number of edges."
-msgstr ""
-
-msgid "Node"
-msgstr ""
-
-msgid "Adjecent nodes"
-msgstr ""
-
-msgid "Number of adjacent nodes"
-msgstr ""
-
-msgid ":math:`a`"
-msgstr ""
-
-msgid ":math:`\\{u\\}`"
-msgstr ""
-
-msgid ":math:`b`"
-msgstr ""
-
-msgid ":math:`\\{v\\}`"
-msgstr ""
-
-msgid "Dead end vertex on directed graph"
-msgstr ""
-
-msgid ""
-"The blue nodes have an unlimited number of incoming and/or outgoing edges."
-msgstr ""
-
-msgid "Number of incoming edges"
-msgstr ""
-
-msgid "Number of outgoing edges"
-msgstr ""
-
-msgid ":math:`c`"
-msgstr ""
-
-msgid ":math:`\\{v, w\\}`"
-msgstr ""
-
-msgid "2"
-msgstr ""
-
-msgid ":math:`d`"
-msgstr ""
-
-msgid ":math:`\\{x\\}`"
-msgstr ""
-
-msgid ":math:`e`"
-msgstr ""
-
-msgid ":math:`\\{x, y\\}`"
-msgstr ""
-
-msgid ""
-"From above, nodes :math:`\\{a, b, d\\}` are dead ends because the number of "
-"adjacent vertices is 1. No further checks are needed for those nodes."
-msgstr ""
-
-msgid ""
-"On the following table, nodes :math:`\\{c, e\\}` because the even that the "
-"number of adjacent vertices is not 1 for"
-msgstr ""
-
-msgid "Operation: Dead End Contraction"
-msgstr ""
-
-msgid ""
-"The dead end contraction will stop until there are no more dead end nodes. "
-"For example from the following graph where :math:`w` is the `dead end`_ node:"
-msgstr ""
-
-msgid ""
-"After contracting :math:`w`, node :math:`v` is now a `dead end`_ node and is "
-"contracted:"
-msgstr ""
-
-msgid ""
-"After contracting :math:`v`, stop. Node :math:`u` has the information of "
-"nodes that were contrcted."
-msgstr ""
-
-msgid "Node :math:`u` has the information of nodes that were contracted."
-msgstr ""
-
-msgid "In the algorithm, linear contraction is represented by 2."
-msgstr ""
-
-msgid "Linear"
-msgstr ""
-
-msgid ""
-"In case of an undirected graph, a node is considered a `linear` node when"
-msgstr ""
-
-msgid "The number of adjacent vertices is 2."
-msgstr ""
-
-msgid "In case of a directed graph, a node is considered a `linear` node when"
-msgstr ""
-
-msgid "Linearity is symmetrical"
-msgstr ""
-
-msgid "Linear vertex on undirected graph"
-msgstr ""
-
-msgid "The green nodes are `linear`_ nodes"
-msgstr ""
-
-msgid "The blue nodes have an unlimited number of incoming and outgoing edges."
-msgstr ""
-
-msgid "Undirected"
-msgstr ""
-
-msgid ":math:`v`"
-msgstr ""
-
-msgid ":math:`\\{u, w\\}`"
-msgstr ""
-
-msgid "Linear vertex on directed graph"
-msgstr ""
-
-msgid "The white node is not linear because the linearity is not symetrical."
-msgstr ""
-
-msgid "It is possible to go :math:`y \\rightarrow c \\rightarrow z`"
-msgstr ""
-
-msgid "It's not possible to go :math:`z \\rightarrow c \\rightarrow y`"
-msgstr ""
-
-msgid "Is symmetrical?"
-msgstr ""
-
-msgid ":math:`\\{u, v\\}`"
-msgstr ""
-
-msgid "yes"
-msgstr "はい"
-
-msgid ":math:`\\{w, x\\}`"
-msgstr ""
-
-msgid ":math:`\\{y, z\\}`"
-msgstr ""
-
-msgid "no"
-msgstr "いいえ"
-
-msgid "Operation: Linear Contraction"
-msgstr ""
-
-msgid ""
-"The linear contraction will stop when there are no more linear nodes. For "
-"example from the following graph where :math:`v` and :math:`w` are `linear`_ "
-"nodes:"
-msgstr ""
-
-msgid "Contracting :math:`w`,"
-msgstr ""
-
-msgid "The vertex :math:`w` is removed from the graph"
-msgstr ""
-
-msgid ""
-"The edges :math:`v \\rightarrow w` and :math:`w \\rightarrow z` are removed "
-"from the graph."
-msgstr ""
-
-msgid ""
-"A new edge :math:`v \\rightarrow z` is inserted represented with red color."
-msgstr ""
-
-msgid "Contracting :math:`v`:"
-msgstr ""
-
-msgid "The vertex :math:`v` is removed from the graph"
-msgstr ""
-
-msgid ""
-"The edges :math:`u \\rightarrow v` and :math:`v \\rightarrow z` are removed "
-"from the graph."
-msgstr ""
-
-msgid ""
-"A new edge :math:`u \\rightarrow z` is inserted represented with red color."
-msgstr ""
-
-msgid ""
-"Edge :math:`u \\rightarrow z` has the information of nodes that were "
-"contracted."
-msgstr ""
-
-msgid "The cycle"
-msgstr ""
-
-msgid ""
-"Contracting a graph, can be done with more than one operation. The order of "
-"the operations affect the resulting contracted graph, after applying one "
-"operation, the set of vertices that can be contracted by another operation "
-"changes."
-msgstr ""
-
-msgid ""
-"This implementation, cycles ``max_cycles`` times through "
-"``operations_order`` ."
-msgstr ""
-
-msgid "Contracting sample data"
-msgstr ""
-
-msgid ""
-"In this section, building and using a contracted graph will be shown by "
-"example."
-msgstr ""
-
-msgid "The :doc:`sampledata` for an undirected graph is used"
-msgstr ""
-
-msgid "a dead end operation first followed by a linear operation."
-msgstr ""
-
-msgid "Construction of the graph in the database"
-msgstr ""
-
-msgid "Original Data"
-msgstr ""
-
-msgid ""
-"The following query shows the original data involved in the contraction "
-"operation."
-msgstr ""
-
-msgid "The original graph:"
-msgstr ""
-
-msgid "Contraction results"
-msgstr ""
-
-msgid ""
-"The results do not represent the contracted graph. They represent the "
-"changes done to the graph after applying the contraction algorithm."
-msgstr ""
-
-msgid ""
-"Observe that vertices, for example, :math:`6` do not appear in the results "
-"because it was not affected by the contraction algorithm."
-msgstr ""
-
-msgid "After doing the dead end contraction operation:"
-msgstr ""
-
-msgid "After doing the linear contraction operation to the graph above:"
-msgstr ""
-
-msgid "The process to create the contraction graph on the database:"
-msgstr ""
-
-msgid "Add additional columns"
-msgstr ""
-
-msgid ""
-"Adding extra columns to the ``edge_table`` and ``edge_table_vertices_pgr`` "
-"tables, where:"
-msgstr ""
-
-msgid "``contracted_vertices``"
-msgstr ""
-
-msgid "The vertices set belonging to the vertex/edge"
-msgstr ""
-
-msgid "``is_contracted``"
-msgstr ""
-
-msgid "On the vertex table"
-msgstr ""
-
-msgid ""
-"when ``true`` the vertex is contracted, its not part of the contracted graph."
-msgstr ""
-
-msgid ""
-"when ``false`` the vertex is not contracted, its part of the contracted "
-"graph."
-msgstr ""
-
-msgid "``is_new``"
-msgstr ""
-
-msgid "On the edge table"
-msgstr ""
-
-msgid ""
-"when ``true`` the edge was generated by the contraction algorithm. its part "
-"of the contracted graph."
-msgstr ""
-
-msgid ""
-"when ``false`` the edge is an original edge, might be or not part of the "
-"contracted graph."
-msgstr ""
-
-msgid "Store contraction information"
-msgstr ""
-
-msgid "Store the `contraction results`_ in a table"
-msgstr ""
-
-msgid "The vertex table update"
-msgstr ""
-
-msgid ""
-"Use ``is_contracted`` column to indicate the vertices that are contracted."
-msgstr ""
-
-msgid ""
-"Fill ``contracted_vertices`` with the information from the results tha "
-"belong to the vertices."
-msgstr ""
-
-msgid "The modified vertices table:"
-msgstr ""
-
-msgid "The edge table update"
-msgstr ""
-
-msgid "Insert the new edges generated by pgr_contraction."
-msgstr ""
-
-msgid "The modified ``edge_table``."
-msgstr ""
-
-msgid "The contracted graph"
-msgstr ""
-
-msgid "Vertices that belong to the contracted graph."
-msgstr ""
-
-msgid "Edges that belong to the contracted graph."
-msgstr ""
-
-msgid "Contracted graph"
-msgstr ""
-
-msgid "Using the contracted graph"
-msgstr ""
-
-msgid "Using the contracted graph with ``pgr_dijkstra``"
-msgstr ""
-
-msgid ""
-"There are three cases when calculating the shortest path between a given "
-"source and target in a contracted graph:"
-msgstr ""
-
-msgid "Case 1: Both source and target belong to the contracted graph."
-msgstr ""
-
-msgid "Case 2: Source and/or target belong to an edge subgraph."
-msgstr ""
-
-msgid "Case 3: Source and/or target belong to a vertex."
-msgstr ""
-
-msgid ""
-"Using the `Edges that belong to the contracted graph.`_ on lines 11 to 20."
-msgstr ""
-
-msgid "Case 1"
-msgstr ""
-
-msgid ""
-"When both source and target belong to the contracted graph, a path is found."
-msgstr ""
-
-msgid "Case 2"
-msgstr ""
-
-msgid ""
-"When source and/or target belong to an edge subgraph then a path is not "
-"found."
-msgstr ""
-
-msgid ""
-"In this case, the contracted graph do not have an edge connecting with node :"
-"math:`4`."
-msgstr ""
-
-msgid "Case 3"
-msgstr ""
-
-msgid "When source and/or target belong to a vertex then a path is not found."
-msgstr ""
-
-msgid ""
-"In this case, the contracted graph do not have an edge connecting with node :"
-"math:`7` and of node :math:`4` of the second case."
-msgstr ""
-
-msgid "Refining the above function to include nodes that belong to an edge."
-msgstr ""
-
-msgid "The vertices that need to be expanded are calculated on lines 11 to 17."
-msgstr ""
-
-msgid ""
-"Adding to the contracted graph that additional section on lines 26 to 28."
-msgstr ""
-
-msgid ""
-"When source and/or target belong to an edge subgraph, now, a path is found."
-msgstr ""
-
-msgid "The routing graph now has an edge connecting with node :math:`4`."
-msgstr ""
-
-msgid ""
-"In this case, the contracted graph do not have an edge connecting with node :"
-"math:`7`."
-msgstr ""
-
-msgid "The vertices that need to be expanded are calculated on lines 19 to 24."
-msgstr ""
-
-msgid ""
-"Adding to the contracted graph that additional section on lines 38 to 40."
-msgstr ""
-
-msgid ""
-"The code change do not affect this case so when source and/or target belong "
-"to an edge subgraph, a path is still found."
-msgstr ""
-
-msgid "When source and/or target belong to a vertex, now, a path is found."
-msgstr ""
-
-msgid "Now, the routing graph has an edge connecting with node :math:`7`."
-msgstr ""
-
-msgid ":doc:`sampledata`"
 msgstr ""
 
 msgid ""
@@ -3413,9 +2903,6 @@ msgstr ""
 
 msgid ":doc:`pgr_bdDijkstraCostMatrix`"
 msgstr ""
-
-msgid "proposed"
-msgstr "リリース予定"
 
 msgid ":doc:`pgr_withPointsCostMatrix`"
 msgstr ""
@@ -3600,7 +3087,8 @@ msgstr ""
 ":doc:`pgr_KSP` - pgr_dijkstraでYenアルゴリズムを使用してK最短経路を取得しま"
 "す。"
 
-msgid ":doc:`pgr_dijkstraVia` - Get a route of a seuence of vertices."
+#, fuzzy
+msgid ":doc:`pgr_dijkstraVia` - Get a route of a sequence of vertices."
 msgstr ":doc:`pgr_dijkstraVia` - 連続したノードの経路を取得します。"
 
 msgid ":doc:`pgr_dijkstraNear` - Get the route to the nearest vertex."
@@ -3688,8 +3176,8 @@ msgstr "グラフは次のように定義されます:"
 msgid "Directed graph"
 msgstr "導かれたグラフ"
 
-msgid "The weighted directed graph, :math:`G_d(V,E)`, is definied by:"
-msgstr "重みづけされた有向グラフ :math:'G_d(V,E)''は、次のように定義されます:"
+msgid "The weighted directed graph, :math:`G_d(V,E)`, is defined by:"
+msgstr ""
 
 #, fuzzy
 msgid "the set of vertices :math:`V`"
@@ -3722,7 +3210,8 @@ msgstr ""
 msgid "Undirected graph"
 msgstr "導かれないグラフ"
 
-msgid "The weighted undirected graph, :math:`G_u(V,E)`, is definied by:"
+#, fuzzy
+msgid "The weighted undirected graph, :math:`G_u(V,E)`, is defined by:"
 msgstr "重みづけされた無向グラフ :math:'G_u(V,E)''は、次のように定義されます。"
 
 msgid ":math:`V = source \\cup target \\cup {start_v{vid}} \\cup  {end_{vid}}`"
@@ -3863,7 +3352,7 @@ msgstr ""
 msgid ":doc:`pgr_kruskalDD` - Driving Distance based on Kruskal's algorithm"
 msgstr ""
 
-msgid "Post pocessing"
+msgid "Post processing"
 msgstr ""
 
 msgid ":doc:`pgr_alphaShape` - Alpha shape computation"
@@ -3986,6 +3475,11 @@ msgid ""
 "an undirected graph."
 msgstr ""
 
+msgid ""
+":doc:`pgr_topologicalSort` - Linear ordering of the vertices for directed "
+"acyclic graph."
+msgstr ""
+
 #, fuzzy
 msgid ":doc:`metrics-family`"
 msgstr ":doc:`ordering-family`"
@@ -4004,8 +3498,9 @@ msgstr ""
 msgid ":doc:`VRP-category`"
 msgstr ""
 
-msgid "Unclassified"
-msgstr ""
+#, fuzzy
+msgid "Shortest Path Category"
+msgstr "BFS - カテゴリ"
 
 msgid ":doc:`pgr_bellmanFord`"
 msgstr ""
@@ -4016,19 +3511,22 @@ msgstr ""
 msgid ":doc:`pgr_edwardMoore`"
 msgstr ""
 
+msgid "Planar Family"
+msgstr ""
+
 msgid ":doc:`pgr_isPlanar`"
+msgstr ""
+
+msgid "Miscellaneous Algorithms"
+msgstr ""
+
+msgid ":doc:`pgr_lengauerTarjanDominatorTree`"
 msgstr ""
 
 msgid ":doc:`pgr_stoerWagner`"
 msgstr ""
 
-msgid ":doc:`pgr_topologicalSort`"
-msgstr ""
-
 msgid ":doc:`pgr_transitiveClosure`"
-msgstr ""
-
-msgid ":doc:`pgr_lengauerTarjanDominatorTree`"
 msgstr ""
 
 msgid ":doc:`pgr_hawickCircuits`"
@@ -4084,7 +3582,7 @@ msgid ""
 "returned."
 msgstr ""
 
-msgid "There is no flow when source has the same vaule as target."
+msgid "There is no flow when source has the same value as target."
 msgstr ""
 
 msgid "Any duplicated values in source or target are ignored."
@@ -4374,6 +3872,11 @@ msgstr ""
 msgid ":doc:`pgr_kruskalDD`"
 msgstr ""
 
+msgid ""
+":doc:`pgr_degree` - Returns a set of vertices and corresponding count of "
+"incident edges to the vertex."
+msgstr ""
+
 msgid ":doc:`prim-family`"
 msgstr ""
 
@@ -4419,7 +3922,18 @@ msgstr ""
 msgid ":doc:`pgr_nodeNetwork` - to create nodes to a not noded edge table."
 msgstr ""
 
+msgid ""
+":doc:`pgr_extractVertices` - Extracts vertex information based on the edge "
+"table information."
+msgstr ""
+
 msgid ":doc:`pgr_trsp` - Turn Restriction Shortest Path (TRSP)"
+msgstr ""
+
+msgid "Utilities family"
+msgstr ""
+
+msgid ":doc:`pgr_findCloseEdges`"
 msgstr ""
 
 msgid "Functions by categories"
@@ -4437,8 +3951,9 @@ msgstr ""
 msgid ":doc:`KSP-category`"
 msgstr ""
 
-msgid ":doc:`spanningTree-family`"
-msgstr ""
+#, fuzzy
+msgid ":doc:`spanningTree-category`"
+msgstr ":doc:`DFS-category`"
 
 msgid ":doc:`BFS-category`"
 msgstr ""
@@ -4458,116 +3973,184 @@ msgstr ""
 msgid ":doc:`release_notes`"
 msgstr ""
 
-msgid "pgRouting 3.7.0 Release Notes"
+msgid "pgRouting 4.0.0 Release Notes"
 msgstr ""
 
 msgid ""
 "To see all issues & pull requests closed by this release see the `Git closed "
-"milestone for 3.7.0 <https://github.com/pgRouting/pgrouting/issues?"
-"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.0%22>`__"
+"milestone for 4.0.0 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%204.0.0%22>`__"
 msgstr ""
 
-msgid "Support"
-msgstr "サポート"
-
-msgid ""
-"`#2656 <https://github.com/pgRouting/pgrouting/pull/2656>`__ Stop support of "
-"PostgreSQL12 on pgrouting v3.7"
+msgid "Functions promoted to official"
 msgstr ""
 
-msgid "Stopping support of PostgreSQL 12"
+msgid "pgr_trsp"
 msgstr ""
 
-msgid "CI does not test for PostgreSQL 12"
+msgid "pgr_trspVia"
 msgstr ""
 
-msgid "New experimental functions"
+msgid "pgr_trspVia_withPoints"
 msgstr ""
 
-msgid "Metrics"
+msgid "pgr_trsp_withPoints"
 msgstr ""
 
-msgid "pgr_betweennessCentrality"
+msgid "pgr_withPoints"
 msgstr ""
 
-msgid "Official functions changes"
+msgid "pgr_withPointsCost"
 msgstr ""
 
-msgid ""
-"`#2605 <https://github.com/pgRouting/pgrouting/pull/2605>`__ Standarize "
-"spanning tree functions output"
+msgid "pgr_withPointsCostMatrix"
 msgstr ""
 
-msgid "Functions:"
+msgid "pgr_withPointsDD"
 msgstr ""
 
-msgid "``pgr_kruskalDD``"
+msgid "pgr_withPointsKSP"
 msgstr ""
 
-msgid "``pgr_kruskalDFS``"
+msgid "pgr_withPointsVia"
 msgstr ""
 
-msgid "``pgr_kruskalBFS``"
+msgid "Signatures promoted to official"
 msgstr ""
 
-msgid "``pgr_primDD``"
+msgid "pgr_aStar(Combinations)"
 msgstr ""
 
-msgid "``pgr_primDFS``"
+msgid "pgr_aStarCost(Combinations)"
 msgstr ""
 
-msgid "``pgr_primBFS``"
+msgid "pgr_bdAstar(Combinations)"
 msgstr ""
 
-msgid "Standarizing output columns to |result-spantree|"
+msgid "pgr_bdAstarCost(Combinations)"
 msgstr ""
 
-msgid "Added ``pred`` result columns."
+msgid "pgr_bdDijkstra(Combinations)"
 msgstr ""
 
-msgid "Experimental promoted to proposed."
+msgid "pgr_bdDijkstraCost(Combinations)"
 msgstr ""
 
-msgid ""
-"`#2635 <https://github.com/pgRouting/pgrouting/pull/2635>`__ pgr_LineGraph "
-"ignores directed flag and use negative values for identifiers."
+msgid "pgr_dijkstra(Combinations)"
 msgstr ""
 
-msgid "``pgr_lineGraph``"
-msgstr ""
-
-msgid "Promoted to **proposed** signature."
+msgid "pgr_dijkstraCost(Combinations)"
 msgstr ""
 
 #, fuzzy
-msgid "Works for directed and undirected graphs."
-msgstr "導かれないグラフ。"
+msgid "pgr_KSP(All signatures)"
+msgstr "機能"
 
-msgid "Code enhancement"
+msgid "pgr_boykovKolmogorov(Combinations)"
+msgstr ""
+
+msgid "pgr_edmondsKarp(Combinations)"
+msgstr ""
+
+msgid "pgr_maxFlow(Combinations)"
+msgstr ""
+
+msgid "pgr_pushRelabel(Combinations)"
+msgstr ""
+
+msgid "code enhancements:"
+msgstr ""
+
+msgid "Removal of unused C/C++ code"
+msgstr ""
+
+msgid "Removal of SQL deprecated functions"
 msgstr ""
 
 msgid ""
-"`#2599 <https://github.com/pgRouting/pgrouting/pull/2599>`__ Driving "
-"distance cleanup"
+"pgr_trsp(text,integer,double precision,integer,double precision,boolean,"
+"boolean,text)"
+msgstr ""
+
+msgid "pgr_trsp(text,integer,integer,boolean,boolean,text)"
 msgstr ""
 
 msgid ""
-"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ Read postgresql "
-"data on C++"
+"pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)"
+msgstr ""
+
+msgid "pgr_trspviavertices(text,anyarray,boolean,boolean,text)"
+msgstr ""
+
+msgid "Removal of SQL deprecated internal functions"
+msgstr ""
+
+msgid "_pgr_dijkstranear(text,anyarray,anyarray,bigint,boolean)"
+msgstr ""
+
+msgid "_pgr_dijkstranear(text,anyarray,bigint,bigint,boolean)"
+msgstr ""
+
+msgid "_pgr_dijkstranear(text,bigint,anyarray,bigint,boolean)"
+msgstr ""
+
+msgid "_pgr_dijkstra(text,anyarray,anyarray,boolean,boolean,boolean,bigint)"
+msgstr ""
+
+msgid "_pgr_dijkstra(text,text,boolean,boolean,boolean)"
+msgstr ""
+
+msgid "_pgr_drivingdistance(text,anyarray,double precision,boolean,boolean)"
+msgstr ""
+
+msgid "_pgr_kruskal(text,anyarray,text,bigint,double precision)"
+msgstr ""
+
+msgid "_pgr_prim(text,anyarray,text,bigint,double precision)"
 msgstr ""
 
 msgid ""
-"`#2614 <https://github.com/pgRouting/pgrouting/pull/2614>`__ Clang tidy does "
-"not work"
+"_pgr_trsp(text,integer,double precision,integer,double precision,boolean,"
+"boolean,text)"
+msgstr ""
+
+msgid "_pgr_trsp(text,text,anyarray,anyarray,boolean)"
+msgstr ""
+
+msgid "_pgr_trsp(text,text,anyarray,bigint,boolean)"
+msgstr ""
+
+msgid "_pgr_trsp(text,text,bigint,anyarray,boolean)"
+msgstr ""
+
+msgid "_pgr_trsp(text,text,bigint,bigint,boolean)"
+msgstr ""
+
+msgid "_pgr_trspviavertices(text,integer[],boolean,boolean,text)"
+msgstr ""
+
+msgid "_pgr_withpointsvia(text,bigint[],double precision[],boolean)"
+msgstr ""
+
+msgid "_trsp(text,text,anyarray,anyarray,boolean)"
+msgstr ""
+
+msgid "_v4trsp(text,text,anyarray,anyarray,boolean)"
+msgstr ""
+
+msgid "_v4trsp(text,text,text,boolean)"
+msgstr ""
+
+msgid "Deprecation of internal C/C++ functions"
+msgstr ""
+
+msgid "Internal C/C++ functions in legacy"
 msgstr ""
 
 msgid "All releases"
 msgstr ""
 
 msgid "Kruskal - Family of functions"
-msgstr ""
-
-msgid "Boost Graph Inside"
 msgstr ""
 
 msgid ""
@@ -4601,13 +4184,6 @@ msgid "Results can be different because of the changes."
 msgstr ""
 
 msgid "All deprecated functions will be removed on next mayor version 4.0.0"
-msgstr ""
-
-#, fuzzy
-msgid "Migration of functions"
-msgstr "ダイクストラ関連機能"
-
-msgid "Migrating functions"
 msgstr ""
 
 msgid "Migration of ``pgr_aStar``"
@@ -4763,7 +4339,7 @@ msgstr ""
 msgid "If needed add the new columns, for example:"
 msgstr ""
 
-msgid "Migration of ``pgr_drivingdistance``"
+msgid "Migration of ``pgr_drivingDistance``"
 msgstr ""
 
 msgid ""
@@ -4783,10 +4359,10 @@ msgstr ""
 msgid "|result-spantree|"
 msgstr ""
 
-msgid "``pgr_drivingdistance`` (Single vertex)"
+msgid "pgr_drivingDistance(Single vertex)"
 msgstr ""
 
-msgid "``pgr_drivingdistance`` (Multiple vertices)"
+msgid "pgr_drivingDistance(Multiple vertices)"
 msgstr ""
 
 msgid "Output columns were |result-dij-dd|"
@@ -4848,10 +4424,19 @@ msgstr ""
 msgid "|result-bfs|"
 msgstr ""
 
+msgid "``pgr_kruskalDD``"
+msgstr ""
+
 msgid "Single vertex"
 msgstr ""
 
 msgid "Multiple vertices"
+msgstr ""
+
+msgid "``pgr_kruskalDFS``"
+msgstr ""
+
+msgid "``pgr_kruskalBFS``"
 msgstr ""
 
 msgid "Output columns were |result-bfs|"
@@ -5008,6 +4593,15 @@ msgid ""
 "Starting from `v3.7.0 <https://docs.pgrouting.org/3.7/en/migration.html>`__ :"
 "doc:`pgr_primDD`, :doc:`pgr_primBFS` and :doc:`pgr_primDFS` result columns "
 "are being standardized."
+msgstr ""
+
+msgid "``pgr_primDD``"
+msgstr ""
+
+msgid "``pgr_primDFS``"
+msgstr ""
+
+msgid "``pgr_primBFS``"
 msgstr ""
 
 msgid "Prim single vertex"
@@ -5206,7 +4800,127 @@ msgid ""
 "original columns:"
 msgstr ""
 
-msgid "Migration of turn restrictions"
+msgid "Migration of ``pgr_trsp`` (Vertices)"
+msgstr ""
+
+#, fuzzy
+msgid "Signature:"
+msgstr "機能"
+
+msgid "Deprecated"
+msgstr ""
+
+msgid "`v3.4.0 <https://docs.pgrouting.org/3.4>`__"
+msgstr ""
+
+msgid "Removed"
+msgstr ""
+
+msgid "`v4.0.0 <https://docs.pgrouting.org/4.0>`__"
+msgstr ""
+
+#, fuzzy
+msgid ":doc:`pgr_dijkstra`"
+msgstr ":doc:`pgr_kruskalBFS`"
+
+msgid ":doc:`pgr_trsp`"
+msgstr ""
+
+#, fuzzy
+msgid "`Migration of restrictions`_"
+msgstr "ダイクストラ関連機能"
+
+msgid "Use ``pgr_dijkstra`` when there are no restrictions."
+msgstr ""
+
+msgid "Use :doc:`pgr_dijkstra` instead."
+msgstr ""
+
+msgid "To get the original column names:"
+msgstr ""
+
+msgid "``id1`` is the node"
+msgstr ""
+
+msgid "``id2`` is the edge"
+msgstr ""
+
+msgid "Use ``pgr_trsp`` when there are restrictions."
+msgstr ""
+
+msgid "Use :doc:`pgr_trsp` (One to One) instead."
+msgstr ""
+
+msgid "Migration of ``pgr_trsp`` (Edges)"
+msgstr ""
+
+msgid ":doc:`pgr_withPoints`"
+msgstr ""
+
+msgid ":doc:`pgr_trsp_withPoints`"
+msgstr ""
+
+msgid "Use ``pgr_withPoints`` when there are no restrictions."
+msgstr ""
+
+msgid "Use :doc:`pgr_withPoints` (One to One) instead."
+msgstr ""
+
+msgid "Use ``pgr_trsp_withPoints`` when there are restrictions."
+msgstr ""
+
+msgid "Use :doc:`pgr_trsp_withPoints` instead."
+msgstr ""
+
+msgid "Migration of ``pgr_trspViaVertices``"
+msgstr ""
+
+msgid ":doc:`pgr_dijkstraVia`"
+msgstr ""
+
+msgid ":doc:`pgr_trspVia`"
+msgstr ""
+
+msgid "Use ``pgr_dijkstraVia`` when there are no restrictions"
+msgstr ""
+
+msgid "Use :doc:`pgr_dijkstraVia` instead."
+msgstr ""
+
+msgid "``id1`` is the path identifier"
+msgstr ""
+
+msgid "``id2`` is the node"
+msgstr ""
+
+msgid "``id3`` is the edge"
+msgstr ""
+
+msgid "Use ``pgr_trspVia`` when there are restrictions"
+msgstr ""
+
+msgid "Use :doc:`pgr_trspVia` instead."
+msgstr ""
+
+msgid "Migration of ``pgr_trspViaEdges``"
+msgstr ""
+
+msgid ":doc:`pgr_withPointsVia`"
+msgstr ""
+
+msgid ":doc:`pgr_trspVia_withPoints`"
+msgstr ""
+
+msgid "Use ``pgr_withPointsVia`` when there are no restrictions"
+msgstr ""
+
+msgid "Use :doc:`pgr_withPointsVia` instead."
+msgstr ""
+
+msgid "Use ``pgr_trspVia_withPoints`` when there are restrictions"
+msgstr ""
+
+msgid "Use :doc:`pgr_trspVia_withPoints` instead."
 msgstr ""
 
 msgid "Migration of restrictions"
@@ -5352,244 +5066,6 @@ msgid "Will be removed on the next mayor version 4.0.0"
 msgstr ""
 
 msgid "The migrated table contents:"
-msgstr ""
-
-msgid "Migration of ``pgr_trsp`` (Vertices)"
-msgstr ""
-
-msgid ""
-":doc:`pgr_trsp` signatures have changed and many issues have been fixed in "
-"the new signatures. This section will show how to migrate from the old "
-"signatures to the new replacement functions. This also affects the "
-"restrictions."
-msgstr ""
-
-msgid "The integral type of the ``Edges SQL`` can only be ``INTEGER``."
-msgstr ""
-
-msgid "The floating point type of the ``Edges SQL`` can only be ``FLOAT``."
-msgstr ""
-
-msgid "``directed`` flag is compulsory."
-msgstr ""
-
-msgid "Does not autodetect if ``reverse_cost`` column exist."
-msgstr ""
-
-msgid ""
-"User must be careful to match the existence of the column with the value of "
-"``has_rcost`` parameter."
-msgstr ""
-
-msgid "The restrictions inner query is optional."
-msgstr ""
-
-msgid "The output column names are meaningless"
-msgstr ""
-
-msgid "Migrate by using:"
-msgstr ""
-
-msgid ":doc:`pgr_dijkstra` when there are no restrictions,"
-msgstr ""
-
-msgid ":doc:`pgr_trsp` (One to One) when there are restrictions."
-msgstr ""
-
-msgid "Migrating ``pgr_trsp`` (Vertices) using ``pgr_dijkstra``"
-msgstr ""
-
-msgid "The following query does not have restrictions."
-msgstr ""
-
-msgid "A message about deprecation is shown"
-msgstr ""
-
-msgid "Deprecated functions will be removed on the next mayor version 4.0.0"
-msgstr ""
-
-msgid "Use :doc:`pgr_dijkstra` instead."
-msgstr ""
-
-msgid "The types casting has been removed."
-msgstr ""
-
-msgid ":doc:`pgr_dijkstra`:"
-msgstr ""
-
-msgid "Autodetects if ``reverse_cost`` column is in the edges SQL."
-msgstr ""
-
-msgid "Accepts ``ANY-INTEGER`` on integral types"
-msgstr ""
-
-msgid "Accepts ``ANY-NUMERICAL`` on floating point types"
-msgstr ""
-
-msgid "``directed`` flag has a default value of ``true``."
-msgstr ""
-
-msgid "Use the same value that on the original query."
-msgstr ""
-
-msgid "In this example it is ``true`` which is the default value."
-msgstr ""
-
-msgid "The flag has been omitted and the default is been used."
-msgstr ""
-
-msgid ""
-"When the need of using strictly the same (meaningless) names and types of "
-"the function been migrated then:"
-msgstr ""
-
-msgid "``id1`` is the node"
-msgstr ""
-
-msgid "``id2`` is the edge"
-msgstr ""
-
-msgid "Migrating ``pgr_trsp`` (Vertices) using ``pgr_trsp``"
-msgstr ""
-
-#, fuzzy
-msgid "The following query has restrictions."
-msgstr "次のクエリを実行します。"
-
-msgid "The restrictions are the last parameter of the function"
-msgstr ""
-
-msgid "Using the old structure of restrictions"
-msgstr ""
-
-msgid "Use :doc:`pgr_trsp` (One to One) instead."
-msgstr ""
-
-msgid "The new structure of restrictions is been used."
-msgstr ""
-
-msgid "It is the second parameter."
-msgstr ""
-
-msgid ":doc:`pgr_trsp`:"
-msgstr ""
-
-msgid "Migration of ``pgr_trsp`` (Edges)"
-msgstr ""
-
-msgid "The integral types of the ``sql`` can only be ``INTEGER``."
-msgstr ""
-
-msgid "The floating point type of the ``sql`` can only be ``FLOAT``."
-msgstr ""
-
-msgid "For these migration guide the following points will be used:"
-msgstr ""
-
-msgid ":doc:`pgr_withPoints` when there are no restrictions,"
-msgstr ""
-
-msgid ":doc:`pgr_trsp_withPoints` (One to One) when there are restrictions."
-msgstr ""
-
-msgid "Migrating ``pgr_trsp`` (Edges) using ``pgr_withPoints``"
-msgstr ""
-
-msgid "Use :doc:`pgr_withPoints` instead."
-msgstr ""
-
-msgid "Do not show details, as the deprecated function does not show details."
-msgstr ""
-
-msgid ":doc:`pgr_withPoints`:"
-msgstr ""
-
-msgid "On the points query do not include the ``side`` column."
-msgstr ""
-
-msgid ""
-"When the need of using strictly the same (meaningless) names and types, and "
-"node values of the function been migrated then:"
-msgstr ""
-
-msgid "Migrating ``pgr_trsp`` (Edges) using ``pgr_trsp_withPoints``"
-msgstr ""
-
-msgid "Use :doc:`pgr_trsp_withPoints` instead."
-msgstr ""
-
-msgid ":doc:`pgr_trsp_withPoints`:"
-msgstr ""
-
-msgid "Migration of ``pgr_trspViaVertices``"
-msgstr ""
-
-msgid "The integral types of the ``Edges SQL`` can only be ``INTEGER``."
-msgstr ""
-
-msgid ":doc:`pgr_dijkstraVia` when there are no restrictions,"
-msgstr ""
-
-msgid ":doc:`pgr_trspVia` when there are restrictions."
-msgstr ""
-
-msgid "Migrating ``pgr_trspViaVertices`` using ``pgr_dijkstraVia``"
-msgstr ""
-
-msgid "Use :doc:`pgr_dijkstraVia` instead."
-msgstr ""
-
-msgid ":doc:`pgr_dijkstraVia`:"
-msgstr ""
-
-msgid "``id1`` is the path identifier"
-msgstr ""
-
-msgid "``id2`` is the node"
-msgstr ""
-
-msgid "``id3`` is the edge"
-msgstr ""
-
-msgid "Migrating ``pgr_trspViaVertices`` using ``pgr_trspVia``"
-msgstr ""
-
-msgid "Use :doc:`pgr_trspVia` instead."
-msgstr ""
-
-msgid ":doc:`pgr_trspVia`:"
-msgstr ""
-
-msgid "Migration of ``pgr_trspViaEdges``"
-msgstr ""
-
-msgid ""
-"And will travel thru the following Via points :math:"
-"`4\\rightarrow3\\rightarrow6`"
-msgstr ""
-
-msgid ":doc:`pgr_withPointsVia` when there are no restrictions,"
-msgstr ""
-
-msgid ":doc:`pgr_trspVia_withPoints` when there are restrictions."
-msgstr ""
-
-msgid "Migrating ``pgr_trspViaEdges`` using ``pgr_withPointsVia``"
-msgstr ""
-
-msgid "Use :doc:`pgr_withPointsVia` instead."
-msgstr ""
-
-msgid ":doc:`pgr_withPointsVia`:"
-msgstr ""
-
-msgid "Migrating ``pgr_trspViaEdges`` using ``pgr_trspVia_withPoints``"
-msgstr ""
-
-msgid "Use :doc:`pgr_trspVia_withPoints` instead."
-msgstr ""
-
-msgid ":doc:`pgr_trspVia_withPoints`:"
 msgstr ""
 
 msgid ":doc:`withPoints-category`"
@@ -5752,9 +5228,6 @@ msgid ""
 msgstr ""
 
 msgid "Graph with ``cost`` and ``reverse_cost``"
-msgstr ""
-
-msgid "The weighted directed graph, :math:`G_d(V,E)`, is defined by:"
 msgstr ""
 
 msgid "``SELECT id, source, target, cost, reverse_cost FROM edges``"
@@ -6411,17 +5884,29 @@ msgstr ""
 msgid "To get the dead ends:"
 msgstr ""
 
-msgid ""
-"That information is correct, for example, when the dead end is on the limit "
-"of the imported graph."
+msgid "A dead end happens when"
 msgstr ""
 
 msgid ""
-"Visually node :math:`4` looks to be as start/ending of 3 edges, but it is "
-"not."
+"The vertex is the limit of a cul-de-sac, a no-through road or a no-exit road."
 msgstr ""
 
-msgid "Is that correct?"
+#, fuzzy
+msgid "The vertex is on the limit of the imported graph."
+msgstr "導かれないグラフ。"
+
+msgid "If a larger graph is imported then the vertex might not be a dead end"
+msgstr ""
+
+msgid ""
+"Node :math:`4`, is a dead end on the query, even that it visually looks like "
+"an end point of 3 edges."
+msgstr ""
+
+msgid "Is node :math:`4` a dead end or not?"
+msgstr ""
+
+msgid "The answer to that question will depend on the application."
 msgstr ""
 
 msgid "Is there such a small curb:"
@@ -6445,9 +5930,12 @@ msgid ""
 "the segment?"
 msgstr ""
 
+msgid "Depending on the answer, modification of the data might be needed."
+msgstr ""
+
 msgid ""
-"When there are many dead ends, to speed up, the :doc:`contraction-family` "
-"functions can be used to divide the problem."
+"When there are many dead ends, to speed up processing, the :doc:`contraction-"
+"family` functions can be used to contract the graph."
 msgstr ""
 
 msgid "Linear edges"
@@ -6457,13 +5945,14 @@ msgid "To get the linear edges:"
 msgstr ""
 
 msgid ""
-"This information is correct, for example, when the application is taking "
-"into account speed bumps, stop signals."
+"These linear vertices are correct, for example, when those the vertices are "
+"speed bumps, stop signals and the application is taking them into account."
 msgstr ""
 
 msgid ""
-"When there are many linear edges, to speed up, the :doc:`contraction-family` "
-"functions can be used to divide the problem."
+"When there are many linear vertices, that need not to be taken into account, "
+"to speed up the processing, the :doc:`contraction-family` functions can be "
+"used to contract the problem."
 msgstr ""
 
 msgid "Function's structure"
@@ -6727,9 +6216,6 @@ msgstr ""
 msgid "Parameters for the Via functions"
 msgstr ""
 
-msgid ":doc:`pgr_dijkstraVia`"
-msgstr ""
-
 msgid "SQL query as described."
 msgstr ""
 
@@ -6767,9 +6253,6 @@ msgid ""
 msgstr ""
 
 msgid "For the TRSP functions"
-msgstr ""
-
-msgid ":doc:`pgr_trsp`"
 msgstr ""
 
 msgid "Array of identifiers of destination vertices."
@@ -6822,9 +6305,6 @@ msgid ""
 msgstr ""
 
 msgid "Used in functions the following:"
-msgstr ""
-
-msgid ":doc:`pgr_withPoints`"
 msgstr ""
 
 msgid ""
@@ -6978,6 +6458,12 @@ msgid ""
 "the routing function and is within the area of the results."
 msgstr ""
 
+msgid "Given this area:"
+msgstr ""
+
+msgid "Calculate a route:"
+msgstr ""
+
 msgid "How to contribute"
 msgstr ""
 
@@ -7005,7 +6491,7 @@ msgid ""
 "parallel-edges-(KSP)>`__"
 msgstr ""
 
-msgid "Adding Functionaity to pgRouting"
+msgid "Adding Functionality to pgRouting"
 msgstr ""
 
 msgid ""
@@ -7112,7 +6598,7 @@ msgid "Upgrading the database"
 msgstr ""
 
 msgid ""
-"To upgrade pgRouting in the database to version 3.7.0 use the following "
+"To upgrade pgRouting in the database to version 4.0.0 use the following "
 "command:"
 msgstr ""
 
@@ -7567,8 +7053,9 @@ msgstr ""
 msgid ":doc:`migration`"
 msgstr ""
 
-msgid "pgr_KSP"
-msgstr ""
+#, fuzzy
+msgid "``pgr_KSP``"
+msgstr "pgr_TSP"
 
 msgid "``pgr_KSP`` — Yen's algorithm for K shortest paths using Dijkstra."
 msgstr ""
@@ -7577,31 +7064,38 @@ msgid "Availability"
 msgstr "使用可能なバージョン"
 
 #, fuzzy
+msgid "Version 4.0.0"
+msgstr "バージョン 2.0.0"
+
+msgid "All signatures promoted to official."
+msgstr ""
+
+#, fuzzy
 msgid "Version 3.6.0"
 msgstr "バージョン 3.0.0"
 
 msgid "Result columns standarized to: |nksp-result|"
 msgstr ""
 
-msgid "``pgr_ksp`` (One to One)"
+msgid "pgr_ksp(One to One)"
 msgstr ""
 
 msgid "Added ``start_vid`` and ``end_vid`` result columns."
 msgstr ""
 
-msgid "New overload functions:"
-msgstr "新しい **公式** 機能:"
-
-msgid "``pgr_ksp`` (One to Many)"
+msgid "New proposed signatures:"
 msgstr ""
 
-msgid "``pgr_ksp`` (Many to One)"
+msgid "pgr_ksp(One to Many)"
 msgstr ""
 
-msgid "``pgr_ksp`` (Many to Many)"
+msgid "pgr_ksp(Many to One)"
 msgstr ""
 
-msgid "``pgr_ksp`` (Combinations)"
+msgid "pgr_ksp(Many to Many)"
+msgstr ""
+
+msgid "pgr_ksp(Combinations)"
 msgstr ""
 
 msgid "Version 2.1.0"
@@ -7616,12 +7110,19 @@ msgstr ""
 msgid "Version 2.0.0"
 msgstr "バージョン 2.0.0"
 
-msgid "**Official** function"
+#, fuzzy
+msgid "Official function."
 msgstr "**公式** 機能"
 
 msgid ""
 "The K shortest path routing algorithm based on Yen's algorithm. \"K\" is the "
 "number of shortest paths desired."
+msgstr ""
+
+msgid "|Boost| Boost Graph Inside"
+msgstr ""
+
+msgid "Boost Graph Inside"
 msgstr ""
 
 msgid "Signatures"
@@ -7756,7 +7257,7 @@ msgstr ""
 msgid "``pgr_TSP``"
 msgstr ""
 
-msgid "``pgr_TSP`` - Aproximation using *metric* algorithm."
+msgid "``pgr_TSP`` - Approximation using *metric* algorithm."
 msgstr ""
 
 msgid "Availability:"
@@ -7973,7 +7474,12 @@ msgstr ""
 msgid "``pgr_TSPeuclidean``"
 msgstr ""
 
-msgid "``pgr_TSPeuclidean`` - Aproximation using *metric* algorithm."
+msgid "``pgr_TSPeuclidean`` - Approximation using *metric* algorithm."
+msgstr ""
+
+msgid ""
+"Using `Boost: metric TSP approx <https://www.boost.org/libs/graph/doc/"
+"metric_tsp_approx.html>`__"
 msgstr ""
 
 msgid ""
@@ -7989,7 +7495,8 @@ msgstr "バージョン 3.0.0"
 msgid "Name change from pgr_eucledianTSP"
 msgstr "名称が pgr_eucledianTSP から変わりました"
 
-msgid "New **Official** function"
+#, fuzzy
+msgid "New official function."
 msgstr "新しい **公式** 機能"
 
 msgid ""
@@ -8070,56 +7577,49 @@ msgid ""
 "obtained with ``pgr_TSPeuclidean``."
 msgstr ""
 
-msgid ":doc:`sampledata` network."
-msgstr ""
-
 msgid "``pgr_aStar``"
 msgstr ""
 
 msgid "``pgr_aStar`` — Shortest path using the A* algorithm."
 msgstr ""
 
+msgid "Combinations signature promoted to official."
+msgstr ""
+
 msgid "Standarizing output columns to |short-generic-result|"
 msgstr ""
 
-msgid ""
-"``pgr_aStar`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
+msgid "pgr_aStar(One to One) added ``start_vid`` and ``end_vid`` columns."
 msgstr ""
 
-msgid "``pgr_aStar`` (`One to Many`_) added ``end_vid`` column."
+msgid "pgr_aStar(One to Many) added ``end_vid`` column."
 msgstr ""
 
-msgid "``pgr_aStar`` (`Many to One`_) added ``start_vid`` column."
+msgid "pgr_aStar(Many to One) added ``start_vid`` column."
 msgstr ""
 
 msgid "Version 3.2.0"
 msgstr ""
 
-msgid "New **proposed** signature:"
+msgid "New proposed signature:"
 msgstr ""
 
-msgid "``pgr_aStar`` (`Combinations`_)"
+msgid "Function promoted to official."
 msgstr ""
 
 msgid "Version 2.4.0"
 msgstr ""
 
-msgid "New **Proposed** signatures:"
+msgid "pgr_aStar(One to Many)"
 msgstr ""
 
-msgid "``pgr_aStar`` (`One to Many`_)"
+msgid "pgr_aStar(Many to One)"
 msgstr ""
 
-msgid "``pgr_aStar`` (`Many to One`_)"
+msgid "pgr_aStar(Many to Many)"
 msgstr ""
 
-msgid "``pgr_aStar`` (`Many to Many`_)"
-msgstr ""
-
-msgid "Signature change on ``pgr_astar`` (`One to One`_)"
-msgstr ""
-
-msgid "**Official** ``pgr_aStar`` (`One to One`_)"
+msgid "Signature change on pgr_aStar(One to One)"
 msgstr ""
 
 msgid ""
@@ -8193,7 +7693,7 @@ msgstr ""
 msgid "Manually assigned vertex combinations."
 msgstr ""
 
-msgid "pgr_aStarCost"
+msgid "``pgr_aStarCost``"
 msgstr ""
 
 #, fuzzy
@@ -8201,11 +7701,9 @@ msgid ""
 "``pgr_aStarCost`` - Total cost of the shortest path using the A* algorithm."
 msgstr ":doc:`pgr_dijkstraCost` - 最短経路の総コストを集計します。"
 
-msgid "``pgr_aStarCost`` (`Combinations`_)"
-msgstr ""
-
-msgid "New **proposed** function"
-msgstr ""
+#, fuzzy
+msgid "New proposed function."
+msgstr "新しい **公式** 機能"
 
 msgid ""
 "The ``pgr_aStarCost`` function sumarizes of the cost of the shortest path "
@@ -8324,6 +7822,9 @@ msgstr ""
 msgid "Renamed from version 1.x"
 msgstr ""
 
+msgid "Support"
+msgstr "サポート"
+
 msgid "Returns the polygon part of an alpha shape."
 msgstr ""
 
@@ -8396,7 +7897,7 @@ msgstr ""
 msgid "`ST_ConcaveHull <https://postgis.net/docs/ST_ConcaveHull.html>`__"
 msgstr ""
 
-msgid "pgr_analyzeGraph"
+msgid "``pgr_analyzeGraph``"
 msgstr ""
 
 msgid "``pgr_analyzeGraph`` — Analyzes the network topology."
@@ -8658,9 +8159,6 @@ msgid ""
 "table ``othertable``. (note the use of quote_literal)"
 msgstr ""
 
-msgid "The examples use the :doc:`sampledata` network."
-msgstr ""
-
 msgid ":doc:`pgr_analyzeOneWay`"
 msgstr ""
 
@@ -8670,7 +8168,7 @@ msgstr ""
 msgid ":doc:`pgr_nodeNetwork` to create nodes to a not noded edge table."
 msgstr ""
 
-msgid "pgr_analyzeOneWay"
+msgid "``pgr_analyzeOneWay``"
 msgstr ""
 
 msgid ""
@@ -8822,8 +8320,9 @@ msgstr ""
 msgid "Version 2.5.0"
 msgstr ""
 
-msgid "New **experimental** function"
-msgstr ""
+#, fuzzy
+msgid "New experimental function."
+msgstr "新しい **公式** 機能"
 
 msgid ""
 "Those vertices that belong to more than one biconnected component are called "
@@ -8854,7 +8353,7 @@ msgid "Nodes in red are the articulation points."
 msgstr ""
 
 msgid ""
-"Boost: `Biconnected components & articulation points <https://www.boost.org/"
+"`Boost: Biconnected components & articulation points <https://www.boost.org/"
 "libs/graph/doc/biconnected_components.html>`__"
 msgstr ""
 
@@ -8869,37 +8368,30 @@ msgstr ""
 msgid "``pgr_bdAstar`` — Shortest path using the bidirectional A* algorithm."
 msgstr ""
 
-msgid ""
-"``pgr_bdAstar`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
+msgid "pgr_bdAstar(One to One) added ``start_vid`` and ``end_vid`` columns."
 msgstr ""
 
-msgid "``pgr_bdAstar`` (`One to Many`_) added ``end_vid`` column."
+msgid "pgr_bdAstar(One to Many) added ``end_vid`` column."
 msgstr ""
 
-msgid "``pgr_bdAstar`` (`Many to One`_) added ``start_vid`` column."
+msgid "pgr_bdAstar(Many to One) added ``start_vid`` column."
 msgstr ""
 
-msgid "``pgr_bdAstar`` (`Combinations`_)"
+msgid "pgr_bdAstar(One to Many)"
 msgstr ""
 
-msgid "``pgr_bdAstar`` (`One to Many`_)"
+msgid "pgr_bdAstar(Many to One)"
 msgstr ""
 
-msgid "``pgr_bdAstar`` (`Many to One`_)"
+msgid "pgr_bdAstar(Many to Many)"
 msgstr ""
 
-msgid "``pgr_bdAstar`` (`Many to Many`_)"
-msgstr ""
-
-msgid "Signature change on ``pgr_bdAstar`` (`One to One`_)"
-msgstr ""
-
-msgid "**Official** ``pgr_bdAstar`` (`One to One`_)"
+msgid "Signature change on pgr_bdAstar(One to One)"
 msgstr ""
 
 msgid ""
-"The results are equivalent to the union of the results of the `pgr_bdAStar(` "
-"`One to One`_ `)` on the:"
+"The results are equivalent to the union of the results of the "
+"pgr_bdAStar(One to One) on the:"
 msgstr ""
 
 msgid "pgr_bdAstar(`Edges SQL`_, **start vid**, **end vid**, [**options**])"
@@ -8917,15 +8409,12 @@ msgstr ""
 msgid "pgr_bdAstar(`Edges SQL`_, `Combinations SQL`_, [**options**])"
 msgstr ""
 
-msgid "pgr_bdAstarCost"
+msgid "``pgr_bdAstarCost``"
 msgstr ""
 
 msgid ""
 "``pgr_bdAstarCost`` - Total cost of the shortest path using the "
 "bidirectional A* algorithm."
-msgstr ""
-
-msgid "``pgr_bdAstarCost`` (`Combinations`_)"
 msgstr ""
 
 msgid ""
@@ -8974,25 +8463,16 @@ msgid ""
 "algorithm."
 msgstr ""
 
-msgid "pgr_bdDijkstra(`Combinations`_)"
+msgid "pgr_bdDijkstra(One to Many)"
 msgstr ""
 
-msgid "New **Proposed** functions:"
+msgid "pgr_bdDijkstra(Many to One)"
 msgstr ""
 
-msgid "``pgr_bdDijkstra`` (`One to Many`_)"
+msgid "pgr_bdDijkstra(Many to Many)"
 msgstr ""
 
-msgid "``pgr_bdDijkstra`` (`Many to One`_)"
-msgstr ""
-
-msgid "``pgr_bdDijkstra`` (`Many to Many`_)"
-msgstr ""
-
-msgid "Signature change on ``pgr_bdDijsktra`` (`One to One`_)"
-msgstr ""
-
-msgid "**Official** ``pgr_bdDijkstra`` (`One to One`_)"
+msgid "Signature change on pgr_bdDijsktra(One to One)"
 msgstr ""
 
 msgid ""
@@ -9046,11 +8526,6 @@ msgstr ""
 msgid "Using a combinations table on an **undirected** graph"
 msgstr ""
 
-msgid ""
-"https://www.cs.princeton.edu/courses/archive/spr06/cos423/Handouts/"
-"EPP%20shortest%20path%20algorithms.pdf"
-msgstr ""
-
 msgid "https://en.wikipedia.org/wiki/Bidirectional_search"
 msgstr ""
 
@@ -9060,9 +8535,6 @@ msgstr ""
 msgid ""
 "``pgr_bdDijkstraCost`` — Returns the shortest path's cost using "
 "Bidirectional Dijkstra algorithm."
-msgstr ""
-
-msgid "``pgr_bdDijkstraCost`` (`Combinations`_)"
 msgstr ""
 
 msgid ""
@@ -9123,25 +8595,11 @@ msgstr ""
 msgid "``pgr_bellmanFord`` — Shortest path using Bellman-Ford algorithm."
 msgstr ""
 
-msgid "New **experimental** signature:"
-msgstr ""
+#, fuzzy
+msgid "New experimental signature:"
+msgstr "新しい **公式** 機能"
 
-msgid "``pgr_bellmanFord`` (`Combinations`_)"
-msgstr ""
-
-msgid "New **experimental** signatures:"
-msgstr ""
-
-msgid "``pgr_bellmanFord`` (`One to One`_)"
-msgstr ""
-
-msgid "``pgr_bellmanFord`` (`One to Many`_)"
-msgstr ""
-
-msgid "``pgr_bellmanFord`` (`Many to One`_)"
-msgstr ""
-
-msgid "``pgr_bellmanFord`` (`Many to Many`_)"
+msgid "pgr_bellmanFord(Combinations)"
 msgstr ""
 
 msgid ""
@@ -9216,23 +8674,26 @@ msgstr ""
 msgid "Using a combinations table on an **undirected** graph."
 msgstr ""
 
+msgid ""
+"`Boost: Bellman Ford <https://www.boost.org/libs/graph/doc/"
+"bellman_ford_shortest.html>`__"
+msgstr ""
+
 msgid "https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm"
 msgstr ""
 
-msgid "``pgr_betweennessCentrality``"
-msgstr ""
+#, fuzzy
+msgid "``pgr_betweennessCentrality`` - Experimental"
+msgstr "p"
 
 msgid ""
-"``pgr_betweennessCentrality`` - Calculates the relative betweeness "
+"``pgr_betweennessCentrality`` - Calculates the relative betweenness "
 "centrality using Brandes Algorithm"
 msgstr ""
 
 #, fuzzy
 msgid "Version 3.7.0"
 msgstr "バージョン 3.0.0"
-
-msgid "New **experimental** function:"
-msgstr ""
 
 msgid ""
 "The Brandes Algorithm takes advantage of the sparse graphs for evaluating "
@@ -9306,13 +8767,9 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Boost's `betweenness_centrality <https://www.boost.org/doc/libs/1_84_0/libs/"
-"graph/doc/betweenness_centrality.html>`_"
+"`Boost: betweenness centrality <https://www.boost.org/libs/graph/doc/"
+"betweenness_centrality.html>`_"
 msgstr ""
-
-#, fuzzy
-msgid "Queries use the :doc:`sampledata` network."
-msgstr "クエリは :doc:`sampledata` ネットワークを使用します。"
 
 msgid "``pgr_biconnectedComponents``"
 msgstr ""
@@ -9371,11 +8828,6 @@ msgstr ""
 msgid "Identifier of the edge that belongs to the ``component``."
 msgstr ""
 
-msgid ""
-"Boost: `Biconnected components <https://www.boost.org/libs/graph/doc/"
-"biconnected_components.html>`__"
-msgstr ""
-
 msgid "``pgr_binaryBreadthFirstSearch`` - Experimental"
 msgstr ""
 
@@ -9389,19 +8841,7 @@ msgid ""
 "negative integer, is termed as a 'binary graph'."
 msgstr ""
 
-msgid "pgr_binaryBreadthFirstSearch(`Combinations`_)"
-msgstr ""
-
-msgid "pgr_binaryBreadthFirstSearch(`One to One`_)"
-msgstr ""
-
-msgid "pgr_binaryBreadthFirstSearch(`One to Many`_)"
-msgstr ""
-
-msgid "pgr_binaryBreadthFirstSearch(`Many to One`_)"
-msgstr ""
-
-msgid "pgr_binaryBreadthFirstSearch(`Many to Many`_)"
+msgid "pgr_binaryBreadthFirstSearch(Combinations)"
 msgstr ""
 
 msgid ""
@@ -9463,6 +8903,11 @@ msgid ""
 "math:`1``)"
 msgstr ""
 
+msgid ""
+"`Boost: Breadth First Search <https://www.boost.org/libs/graph/doc/"
+"breadth_first_search.html>`__"
+msgstr ""
+
 msgid "https://cp-algorithms.com/graph/01_bfs.html"
 msgstr ""
 
@@ -9470,15 +8915,12 @@ msgid ""
 "https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm#Specialized_variants"
 msgstr ""
 
-msgid "pgr_bipartite -Experimental"
+msgid "``pgr_bipartite`` - Experimental"
 msgstr ""
 
 msgid ""
 "``pgr_bipartite`` — Disjoint sets of vertices such that no two vertices "
 "within the same set are adjacent."
-msgstr ""
-
-msgid "New **experimental** signature"
 msgstr ""
 
 msgid ""
@@ -9527,6 +8969,16 @@ msgstr ""
 msgid "Edges in blue represent odd length cycle subgraph."
 msgstr ""
 
+msgid ""
+"`Boost: is_bipartite <https://www.boost.org/libs/graph/doc/is_bipartite."
+"html>`__"
+msgstr ""
+
+msgid ""
+"`Wikipedia: bipartite graph <https://en.wikipedia.org/wiki/"
+"Bipartite_graph>`__"
+msgstr ""
+
 msgid "``pgr_boykovKolmogorov``"
 msgstr ""
 
@@ -9536,19 +8988,10 @@ msgid ""
 "algorithm."
 msgstr ""
 
-msgid "New **proposed** signature"
-msgstr ""
-
-msgid "``pgr_boykovKolmogorov`` (`Combinations`_)"
-msgstr ""
-
 msgid "Renamed from ``pgr_maxFlowBoykovKolmogorov``"
 msgstr ""
 
-msgid "**Proposed** function"
-msgstr ""
-
-msgid "New **Experimental** function"
+msgid "Function promoted to proposed."
 msgstr ""
 
 msgid "Running time: Polynomial"
@@ -9590,7 +9033,9 @@ msgid ""
 "math:`\\{5, 6\\}` to vertices :math:`\\{10, 15, 14\\}`."
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html"
+msgid ""
+"`Boost: Boykov Kolmogorov max flow <https://www.boost.org/libs/graph/doc/"
+"boykov_kolmogorov_max_flow.html>`__"
 msgstr ""
 
 msgid "``pgr_breadthFirstSearch`` - Experimental"
@@ -9599,12 +9044,6 @@ msgstr ""
 msgid ""
 "``pgr_breadthFirstSearch`` — Returns the traversal order(s) using Breadth "
 "First Search algorithm."
-msgstr ""
-
-msgid "``pgr_breadthFirstSearch`` (`Single Vertex`_)"
-msgstr ""
-
-msgid "``pgr_breadthFirstSearch`` (`Multiple Vertices`_)"
 msgstr ""
 
 msgid ""
@@ -9672,11 +9111,6 @@ msgid "descending"
 msgstr ""
 
 msgid ""
-"`Boost: Breadth First Search algorithm documentation <https://www.boost.org/"
-"libs/graph/doc/breadth_first_search.html>`__"
-msgstr ""
-
-msgid ""
 "`Wikipedia: Breadth First Search algorithm <https://en.wikipedia.org/wiki/"
 "Breadth-first_search>`__"
 msgstr ""
@@ -9714,7 +9148,9 @@ msgstr ""
 msgid "https://en.wikipedia.org/wiki/Bridge_%28graph_theory%29"
 msgstr ""
 
-msgid "**Supported versions**"
+msgid ""
+"`Boost: Connected components <https://www.boost.org/libs/graph/doc/"
+"connected_components.html>`__"
 msgstr ""
 
 msgid "``pgr_chinesePostman`` - Experimental"
@@ -9772,7 +9208,7 @@ msgstr ""
 msgid "Minimum costs of a circuit path."
 msgstr ""
 
-msgid "pgr_connectedComponents"
+msgid "``pgr_connectedComponents``"
 msgstr ""
 
 msgid ""
@@ -9810,11 +9246,6 @@ msgid "Connecting disconnected components"
 msgstr ""
 
 msgid ""
-"Boost: `Connected components <https://www.boost.org/libs/graph/doc/"
-"connected_components.html>`__"
-msgstr ""
-
-msgid ""
 "wikipedia: `Connected component <https://en.wikipedia.org/wiki/"
 "Connected_component_(graph_theory)>`__"
 msgstr ""
@@ -9825,6 +9256,27 @@ msgstr ""
 msgid ""
 "``pgr_contraction`` — Performs graph contraction and returns the contracted "
 "vertices and edges."
+msgstr ""
+
+#, fuzzy
+msgid "Version 3.8.0"
+msgstr "バージョン 3.0.0"
+
+#, fuzzy
+msgid "New signature:"
+msgstr "機能"
+
+msgid ""
+"Previously compulsory parameter **Contraction order** is now optional with "
+"name ``methods``."
+msgstr ""
+
+#, fuzzy
+msgid "New name and order of optional parameters."
+msgstr "オプションとなるパラメータ"
+
+msgid ""
+"Deprecated signature pgr_contraction(text,bigint[],integer,bigint[],boolean)"
 msgstr ""
 
 msgid "Name change from ``pgr_contractGraph``"
@@ -9839,57 +9291,67 @@ msgid ""
 "original edges decreasing the total time and space used in graph algorithms."
 msgstr ""
 
-msgid "Does not return the full contracted graph"
+#, fuzzy
+msgid "Does not return the full contracted graph."
+msgstr "次のクエリを実行します。"
+
+msgid "Only changes on the graph are returned."
 msgstr ""
 
-msgid "Only changes on the graph are returned"
+msgid "The returned values include:"
 msgstr ""
 
-msgid "Currnetly there are two types of contraction methods"
+msgid "The new edges generated by linear contraction."
 msgstr ""
 
-msgid "Dead End Contraction"
-msgstr ""
-
-msgid "Linear Contraction"
-msgstr ""
-
-msgid "The returned values include"
-msgstr ""
-
-msgid "the added edges by linear contraction."
-msgstr ""
-
-msgid "the modified vertices by dead end contraction."
+msgid "The modified vertices generated by dead end contraction."
 msgstr ""
 
 msgid "The returned values are ordered as follows:"
 msgstr ""
 
-msgid "column ``id`` ascending when type is ``v``"
+msgid "column ``id`` ascending when its a modified vertex."
 msgstr ""
 
-msgid "column ``id`` descending when type is ``e``"
+msgid "column ``id`` with negative numbers descending when its a new edge."
 msgstr ""
 
-msgid "The pgr_contraction function has the following signature:"
+msgid ""
+"Currently there are two types of contraction methods included in this "
+"function:"
 msgstr ""
 
-msgid "pgr_contraction(`Edges SQL`_, **contraction order**, [**options**])"
+msgid "Dead End Contraction. See :doc:`pgr_contractionDeadEnd`."
 msgstr ""
 
-msgid "**options:** ``[ max_cycles, forbidden_vertices, directed]``"
+msgid "Linear Contraction. See :doc:`pgr_contractionLinear`."
+msgstr ""
+
+#, fuzzy
+msgid "pgr_contraction(`Edges SQL`_, [**options**])"
+msgstr "pg"
+
+msgid "**options:** ``[directed, methods, cycles, forbidden]``"
 msgstr ""
 
 msgid "Returns set of |result-contract|"
 msgstr ""
 
-msgid ""
-"Making a dead end and linear contraction in that order on an undirected "
-"graph."
+#, fuzzy
+msgid "Dead end and linear contraction in that order on an undirected graph."
+msgstr "導かれないグラフ。"
+
+msgid "Contraction optional parameters"
 msgstr ""
 
-msgid "**contraction Order**"
+msgid "``methods``"
+msgstr ""
+
+#, fuzzy
+msgid "``INTEGER[]``"
+msgstr "``INTEGER``"
+
+msgid "``ARRAY[1,2]``"
 msgstr ""
 
 msgid "Ordered contraction operations."
@@ -9901,24 +9363,26 @@ msgstr ""
 msgid "2 = Linear contraction"
 msgstr ""
 
-msgid "Contraction optional parameters"
-msgstr ""
-
-msgid "``forbidden_vertices``"
-msgstr ""
-
-msgid "**Empty**"
-msgstr ""
-
-msgid "Identifiers of vertices forbidden for contraction."
+msgid "``cycles``"
 msgstr ""
 
 msgid ":math:`1`"
 msgstr ""
 
-msgid ""
-"Number of times the contraction operations on ``contraction_order`` will be "
-"performed."
+msgid "Number of times the contraction methods will be performed."
+msgstr ""
+
+msgid "``forbidden``"
+msgstr ""
+
+msgid "``BIGINT[]``"
+msgstr ""
+
+#, fuzzy
+msgid "``ARRAY[]::BIGINT[]``"
+msgstr "``BIGINT``"
+
+msgid "Identifiers of vertices forbidden for contraction."
 msgstr ""
 
 msgid "The function returns a single row. The columns of the row are:"
@@ -9927,19 +9391,19 @@ msgstr ""
 msgid "``type``"
 msgstr ""
 
-msgid "Type of the ``id``."
+msgid "Type of the row."
 msgstr ""
 
 msgid "``v`` when the row is a vertex."
 msgstr ""
 
-msgid "Column ``id`` has a positive value"
+msgid "Column ``id`` has a positive value."
 msgstr ""
 
 msgid "``e`` when the row is an edge."
 msgstr ""
 
-msgid "Column ``id`` has a negative value"
+msgid "Column ``id`` has a negative value."
 msgstr ""
 
 msgid "All numbers on this column are ``DISTINCT``"
@@ -9960,6 +9424,9 @@ msgstr ""
 msgid ""
 "Representing a pseudo `id` as is not incorporated in the set of original "
 "edges."
+msgstr ""
+
+msgid "``contracted_vertices``"
 msgstr ""
 
 msgid "Array of contracted vertex identifiers."
@@ -9988,7 +9455,539 @@ msgstr ""
 msgid "Only linear contraction"
 msgstr ""
 
-msgid "pgr_createTopology"
+msgid "The cycle"
+msgstr ""
+
+msgid ""
+"Contracting a graph can be done with more than one operation. The order of "
+"the operations affect the resulting contracted graph, after applying one "
+"operation, the set of vertices that can be contracted by another operation "
+"changes."
+msgstr ""
+
+msgid "This implementation cycles ``cycles`` times through the ``methods`` ."
+msgstr ""
+
+msgid "Contracting sample data"
+msgstr ""
+
+msgid ""
+"In this section, building and using a contracted graph will be shown by "
+"example."
+msgstr ""
+
+msgid "The :doc:`sampledata` for an undirected graph is used"
+msgstr ""
+
+msgid "a dead end operation first followed by a linear operation."
+msgstr ""
+
+msgid "Construction of the graph in the database"
+msgstr ""
+
+msgid "The original graph:"
+msgstr ""
+
+msgid ""
+"The results do not represent the contracted graph. They represent the "
+"changes that need to be done to the graph after applying the contraction "
+"methods."
+msgstr ""
+
+msgid ""
+"Observe that vertices, for example, :math:`6` do not appear in the results "
+"because it was not affected by the contraction algorithm."
+msgstr ""
+
+msgid "After doing the dead end contraction operation:"
+msgstr ""
+
+msgid "After doing the linear contraction operation to the graph above:"
+msgstr ""
+
+msgid "The process to create the contraction graph on the database:"
+msgstr ""
+
+msgid "Add additional columns"
+msgstr ""
+
+msgid ""
+"Adding extra columns to the edges and vertices tables. In this documentation "
+"the following will be used:"
+msgstr ""
+
+#, fuzzy
+msgid "Column."
+msgstr "カラム"
+
+msgid "The vertices set belonging to the vertex/edge"
+msgstr ""
+
+msgid "``is_contracted``"
+msgstr ""
+
+msgid "On the vertex table"
+msgstr ""
+
+msgid ""
+"when ``true`` the vertex is contracted, its not part of the contracted graph."
+msgstr ""
+
+msgid ""
+"when ``false`` the vertex is not contracted, its part of the contracted "
+"graph."
+msgstr ""
+
+msgid "``is_new``"
+msgstr ""
+
+msgid "On the edge table"
+msgstr ""
+
+msgid ""
+"when ``true`` the edge was generated by the contraction algorithm. its part "
+"of the contracted graph."
+msgstr ""
+
+msgid ""
+"when ``false`` the edge is an original edge, might be or not part of the "
+"contracted graph."
+msgstr ""
+
+msgid "Store contraction information"
+msgstr ""
+
+msgid "Store the contraction results in a table."
+msgstr ""
+
+msgid "Update the edges and vertices tables"
+msgstr ""
+
+msgid ""
+"Use ``is_contracted`` column to indicate the vertices that are contracted."
+msgstr ""
+
+msgid ""
+"Fill ``contracted_vertices`` with the information from the results that "
+"belong to the vertices."
+msgstr ""
+
+msgid "Insert the new edges generated by pgr_contraction."
+msgstr ""
+
+msgid "The contracted graph"
+msgstr ""
+
+msgid "Vertices that belong to the contracted graph."
+msgstr ""
+
+msgid "Edges that belong to the contracted graph."
+msgstr ""
+
+msgid "Visually:"
+msgstr ""
+
+msgid "Using the contracted graph"
+msgstr ""
+
+msgid ""
+"Depending on the final application the graph is to be prepared. In this "
+"example the final application will be to calculate the cost from two "
+"vertices in the original graph by using the contracted graph with "
+"``pgr_dijkstraCost``"
+msgstr ""
+
+msgid ""
+"There are three cases when calculating the shortest path between a given "
+"source and target in a contracted graph:"
+msgstr ""
+
+msgid "Case 1: Both source and target belong to the contracted graph."
+msgstr ""
+
+msgid "Case 2: Source and/or target belong to an edge subgraph."
+msgstr ""
+
+msgid "Case 3: Source and/or target belong to a vertex."
+msgstr ""
+
+msgid "The final application should consider all of those cases."
+msgstr ""
+
+msgid "Create a view (or table) of the contracted graph:"
+msgstr ""
+
+msgid "Create the function that will use the contracted graph."
+msgstr ""
+
+msgid ""
+"Case 2: Source and/or target belong to an edge that has contracted vertices."
+msgstr ""
+
+msgid ""
+"Case 3: Source and/or target belong to a vertex that has been contracted."
+msgstr ""
+
+msgid "``pgr_contractionDeadEnd`` - Proposed"
+msgstr ""
+
+msgid ""
+"``pgr_contractionDeadEnd`` — Performs graph contraction and returns the "
+"contracted vertices and edges."
+msgstr ""
+
+msgid "A node is considered a dead end node when:"
+msgstr ""
+
+msgid "On undirected graphs:"
+msgstr ""
+
+msgid "The number of adjacent vertices is 1."
+msgstr ""
+
+msgid "On directed graphs:"
+msgstr ""
+
+msgid "When there is only one adjacent vertex or"
+msgstr ""
+
+msgid ""
+"When all edges are incoming regardless of the number of adjacent vertices."
+msgstr ""
+
+msgid "pgr_contractionDeadEnd(`Edges SQL`_, [**options**])"
+msgstr ""
+
+msgid "**options:** ``[directed, forbidden_vertices]``"
+msgstr ""
+
+#, fuzzy
+msgid "Dead end contraction on an undirected graph."
+msgstr "導かれないグラフ。"
+
+msgid "The green nodes are dead end nodes."
+msgstr ""
+
+msgid "Node :math:`3` is a dead end node after node :math:`1` is contracted."
+msgstr ""
+
+msgid "``forbidden_vertices``"
+msgstr ""
+
+msgid "``ARRAY[`` |ANY-INTEGER| ``]``"
+msgstr ""
+
+msgid "**Empty**"
+msgstr ""
+
+msgid "Value = ``e`` indicating the row is an edge."
+msgstr ""
+
+msgid "A pseudo `id` of the edge."
+msgstr ""
+
+msgid "Identifier of the source vertex of the current edge."
+msgstr ""
+
+msgid "Identifier of the target vertex of the current edge."
+msgstr ""
+
+msgid "Weight of the current edge."
+msgstr ""
+
+msgid "Dead end vertex on undirected graph"
+msgstr ""
+
+msgid "They have only one adjacent node."
+msgstr ""
+
+msgid "Dead end vertex on directed graph"
+msgstr ""
+
+msgid "The green nodes are dead end nodes"
+msgstr ""
+
+msgid ""
+"The blue nodes have an unlimited number of incoming and/or outgoing edges."
+msgstr ""
+
+msgid "Node"
+msgstr ""
+
+msgid "Adjacent nodes"
+msgstr ""
+
+msgid "Dead end"
+msgstr ""
+
+msgid "Reason"
+msgstr ""
+
+#, fuzzy
+msgid ":math:`6`"
+msgstr ":math:`9`"
+
+#, fuzzy
+msgid ":math:`\\{1\\}`"
+msgstr ":math:`9`"
+
+#, fuzzy
+msgid "Yes"
+msgstr "はい"
+
+msgid "Has only one adjacent node."
+msgstr ""
+
+#, fuzzy
+msgid ":math:`7`"
+msgstr ":math:`9`"
+
+#, fuzzy
+msgid ":math:`\\{2\\}`"
+msgstr ":math:`9`"
+
+#, fuzzy
+msgid ":math:`8`"
+msgstr ":math:`9`"
+
+#, fuzzy
+msgid ":math:`\\{2, 3\\}`"
+msgstr ":math:`9`"
+
+msgid "Has more than one adjacent node and all edges are incoming."
+msgstr ""
+
+#, fuzzy
+msgid ":math:`\\{4\\}`"
+msgstr ":math:`9`"
+
+#, fuzzy
+msgid ":math:`10`"
+msgstr ":math:`9`"
+
+#, fuzzy
+msgid ":math:`\\{4, 5\\}`"
+msgstr ":math:`9`"
+
+msgid "No"
+msgstr ""
+
+msgid "Has more than one adjacent node and all edges are outgoing."
+msgstr ""
+
+#, fuzzy
+msgid ":math:`1,2,3,4,5`"
+msgstr ":math:`9`"
+
+msgid "Many adjacent nodes."
+msgstr ""
+
+msgid ""
+"Has more than one adjacent node and some edges are incoming and some are "
+"outgoing."
+msgstr ""
+
+msgid ""
+"From above, nodes :math:`\\{6, 7, 9\\}` are dead ends because the total "
+"number of adjacent vertices is one."
+msgstr ""
+
+msgid ""
+"When there are more than one adjacent vertex, all edges need to be all "
+"incoming edges otherwise it is not a dead end."
+msgstr ""
+
+msgid "Step by step dead end contraction"
+msgstr ""
+
+msgid ""
+"The dead end contraction will stop until there are no more dead end nodes. "
+"For example, from the following graph where :math:`3` is the dead end node:"
+msgstr ""
+
+msgid ""
+"After contracting :math:`3`, node :math:`2` is now a dead end node and is "
+"contracted:"
+msgstr ""
+
+msgid ""
+"After contracting :math:`2`, stop. Node :math:`1` has the information of "
+"nodes that were contracted."
+msgstr ""
+
+#, fuzzy
+msgid "Creating the contracted graph"
+msgstr "次のクエリを実行します。"
+
+msgid "Steps for the creation of the contracted graph"
+msgstr ""
+
+#, fuzzy
+msgid "Add additional columns."
+msgstr "追加の具体例"
+
+msgid "Save results into a table."
+msgstr ""
+
+msgid "The contracted vertices are not part of the contracted graph."
+msgstr ""
+
+msgid "Using when departure and destination are in the contracted graph"
+msgstr ""
+
+msgid "Using when departure/destination is not in the contracted graph"
+msgstr ""
+
+msgid "Using when departure and destination are not in the contracted graph"
+msgstr ""
+
+msgid "``pgr_contractionLinear`` - Proposed"
+msgstr ""
+
+msgid ""
+"``pgr_contractionLinear`` — Performs graph contraction and returns the "
+"contracted vertices and edges."
+msgstr ""
+
+#, fuzzy
+msgid "pgr_contractionLinear(`Edges SQL`_, [**options**])"
+msgstr "p"
+
+msgid "**options:** ``[directed, max_cycles, forbidden_vertices]``"
+msgstr ""
+
+#, fuzzy
+msgid "Linear contraction on an undirected graph."
+msgstr "導かれないグラフ。"
+
+msgid ""
+"The green nodes are linear nodes and will not be part of the contracted "
+"graph."
+msgstr ""
+
+msgid "All edges adjacent will not be part of the contracted graph."
+msgstr ""
+
+msgid "The red lines will be new edges of the contracted graph."
+msgstr ""
+
+msgid "**contraction Order**"
+msgstr ""
+
+msgid ""
+"Number of times the contraction operations on ``contraction_order`` will be "
+"performed."
+msgstr ""
+
+msgid "A node connects two (or more) `linear` edges when"
+msgstr ""
+
+msgid "The number of adjacent vertices is 2."
+msgstr ""
+
+msgid "In case of a directed graph, a node is considered a `linear` node when"
+msgstr ""
+
+msgid "Linearity is symmetrical."
+msgstr ""
+
+msgid "Linearity is not symmetrical"
+msgstr ""
+
+msgid "Graph where linearity is not symmetrical."
+msgstr ""
+
+msgid ""
+"When the graph is processed as a directed graph, linearity is not "
+"symmetrical, therefore the graph can not be contracted."
+msgstr ""
+
+msgid ""
+"When the same graph is processed as an undirected graph, linearity is "
+"symmetrical, therefore the graph can be contracted."
+msgstr ""
+
+msgid "The three edges can be replaced by one undirected edge"
+msgstr ""
+
+#, fuzzy
+msgid "Edge :math:`1 - 3`."
+msgstr "エッジのセット :math:`5`:"
+
+msgid "With cost: :math:`4`."
+msgstr ""
+
+msgid "Contracted vertices in the edge: :math:`\\{2\\}`."
+msgstr ""
+
+msgid "Linearity is symmetrical"
+msgstr ""
+
+msgid "Graph where linearity is symmetrical."
+msgstr ""
+
+msgid "The four edges can be replaced by two directed edges."
+msgstr ""
+
+#, fuzzy
+msgid "Edge :math:`3 - 1`."
+msgstr "エッジのセット :math:`5`:"
+
+msgid "With cost: :math:`6`."
+msgstr ""
+
+msgid "The four edges can be replaced by one undirected edge."
+msgstr ""
+
+msgid "Step by step linear contraction"
+msgstr ""
+
+msgid ""
+"The linear contraction will stop when there are no more linear edges. For "
+"example from the following graph there are linear edges"
+msgstr ""
+
+msgid "Contracting vertex :math:`3`,"
+msgstr ""
+
+msgid "The vertex :math:`3` is removed from the graph"
+msgstr ""
+
+msgid ""
+"The edges :math:`2 \\rightarrow 3` and :math:`w \\rightarrow z` are removed "
+"from the graph."
+msgstr ""
+
+msgid ""
+"A new edge :math:`2 \\rightarrow 4` is inserted represented with red color."
+msgstr ""
+
+#, fuzzy
+msgid "Contracting vertex :math:`2`:"
+msgstr "エッジのセット :math:`5`:"
+
+msgid "The vertex :math:`2` is removed from the graph"
+msgstr ""
+
+msgid ""
+"The edges :math:`1 \\rightarrow 2` and :math:`2 \\rightarrow 3` are removed "
+"from the graph."
+msgstr ""
+
+msgid ""
+"A new edge :math:`1 \\rightarrow 3` is inserted represented with red color."
+msgstr ""
+
+msgid ""
+"Edge :math:`1 \\rightarrow 3` has the information of cost and the nodes that "
+"were contracted."
+msgstr ""
+
+#, fuzzy
+msgid "Create the contracted graph."
+msgstr "次のクエリを実行します。"
+
+msgid "``pgr_createTopology``"
 msgstr ""
 
 msgid ""
@@ -10191,10 +10190,7 @@ msgid ""
 "to the rest of the edges."
 msgstr ""
 
-msgid "The example uses the :doc:`sampledata` network."
-msgstr ""
-
-msgid "pgr_createVerticesTable"
+msgid "``pgr_createVerticesTable``"
 msgstr ""
 
 msgid ""
@@ -10412,7 +10408,7 @@ msgid ""
 "Cuthill%E2%80%93McKee_algorithm>`__"
 msgstr ""
 
-msgid "pgr_dagShortestPath - Experimental"
+msgid "``pgr_dagShortestPath`` - Experimental"
 msgstr ""
 
 msgid ""
@@ -10494,19 +10490,66 @@ msgstr "結果として返却されるカラム"
 msgid "Making **start_vids** the same as **end_vids**"
 msgstr ""
 
+msgid ""
+"`Boost: DAG shortest paths <https://www.boost.org/libs/graph/doc/"
+"dag_shortest_paths.html>`__"
+msgstr ""
+
 msgid "https://en.wikipedia.org/wiki/Topological_sorting"
 msgstr ""
 
-msgid "``pgr_degree`` -- Proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_degree``"
+msgstr "pgr_TSP"
 
 msgid ""
 "``pgr_degree`` — For each vertex in an undirected graph, return the count of "
 "edges incident to the vertex."
 msgstr ""
 
-msgid "Calculates the degree of the vertices of an **undirected** graph"
+msgid "Error messages adjustment."
 msgstr ""
+
+msgid "New signature with only Edges SQL."
+msgstr ""
+
+msgid "Calculates the degree of the vertices of an undirected graph"
+msgstr ""
+
+msgid ""
+"The degree (or valency) of a vertex of a graph is the number of edges that "
+"are incident to the vertex."
+msgstr ""
+
+msgid "A loop contributes 2 to a vertex's degree."
+msgstr ""
+
+msgid "A vertex with degree 0 is called an isolated vertex."
+msgstr ""
+
+msgid "Isolated vertex is not part of the result"
+msgstr ""
+
+msgid ""
+"Vertex not participating on the subgraph is considered and isolated vertex."
+msgstr ""
+
+msgid ""
+"There can be a ``dryrun`` execution and the code used to get the answer will "
+"be shown in a PostgreSQL ``NOTICE``."
+msgstr ""
+
+msgid ""
+"The code can be used as base code for the particular application "
+"requirements."
+msgstr ""
+
+msgid "No ordering is performed."
+msgstr ""
+
+#, fuzzy
+msgid "pgr_degree(`Edges SQL`_ , [``dryrun``])"
+msgstr "p"
 
 msgid "pgr_degree(`Edges SQL`_ , `Vertex SQL`_, [``dryrun``])"
 msgstr ""
@@ -10514,14 +10557,32 @@ msgstr ""
 msgid "RETURNS SETOF |result-degree|"
 msgstr ""
 
+msgid "Edges"
+msgstr ""
+
+#, fuzzy
+msgid "example"
+msgstr "例"
+
+msgid "Get the degree of the vertices defined on the edges table"
+msgstr ""
+
+#, fuzzy
+msgid "Edges and Vertices"
+msgstr "索引とテーブル"
+
 msgid "Extracting the vertex information"
 msgstr ""
 
+msgid "``pgr_degree`` can use :doc:`pgr_extractVertices` embedded in the call."
+msgstr ""
+
 msgid ""
-"pgr_degree can utilize output from `pgr_extractVertices` or can have "
-"`pgr_extractVertices` embedded in the call. For decent size networks, it is "
-"best to prep your vertices table before hand and use that vertices table for "
-"pgr_degree calls."
+"For decent size networks, it is best to prepare your vertices table before "
+"hand and use it on ``pgr_degree`` calls. (See `Using a vertex table`_)"
+msgstr ""
+
+msgid "Calculate the degree of the nodes:"
 msgstr ""
 
 msgid "`Vertex SQL`_"
@@ -10536,13 +10597,16 @@ msgstr ""
 msgid "When true do not process and get in a NOTICE the resulting query."
 msgstr ""
 
+msgid "For the `Edges and Vertices`_ signature:"
+msgstr ""
+
+msgid "For the `Edges`_ signature:"
+msgstr ""
+
 msgid "Vertex SQL"
 msgstr ""
 
 msgid "``in_edges``"
-msgstr ""
-
-msgid "``BIGINT[]``"
 msgstr ""
 
 msgid ""
@@ -10573,7 +10637,45 @@ msgstr ""
 msgid "Number of edges that are incident to the vertex ``id``"
 msgstr ""
 
+msgid "Degree of a loop"
+msgstr ""
+
+msgid "Using the `Edges`_ signature."
+msgstr ""
+
+msgid "Using the `Edges and Vertices`_ signature."
+msgstr ""
+
 msgid "Degree of a sub graph"
+msgstr ""
+
+msgid "For the following is a subgraph of the :doc:`sampledata`:"
+msgstr ""
+
+msgid ":math:`E = \\{(1, 5 \\leftrightarrow 6), (1, 6 \\leftrightarrow 10)\\}`"
+msgstr ""
+
+msgid ":math:`V = \\{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17\\}`"
+msgstr ""
+
+msgid "The vertices not participating on the edge are considered isolated"
+msgstr ""
+
+msgid "their degree is 0 in the subgraph and"
+msgstr ""
+
+msgid "their degree is not shown in the output."
+msgstr ""
+
+msgid "Using a vertex table"
+msgstr ""
+
+msgid ""
+"For decent size networks, it is best to prepare your vertices table before "
+"hand and use it on ``pgr_degree`` calls."
+msgstr ""
+
+msgid "Extract the vertex information and save into a table:"
 msgstr ""
 
 msgid "Dry run execution"
@@ -10589,13 +10691,27 @@ msgid ""
 "backend development needs."
 msgstr ""
 
-msgid "Degree from an existing table"
+msgid "Finding dead ends"
 msgstr ""
 
 msgid ""
-"If you have a vertices table already built using ``pgr_extractVertices`` and "
-"want the degree of the whole graph rather than a subset, you can forgo using "
-"pgr_degree and work with the ``in_edges`` and ``out_edges`` columns directly."
+"If there is a vertices table already built using ``pgr_extractVertices`` and "
+"want the degree of the whole graph rather than a subset, it can be forgo "
+"using ``pgr_degree`` and work with the ``in_edges`` and ``out_edges`` "
+"columns directly."
+msgstr ""
+
+msgid "The degree of a dead end is 1."
+msgstr ""
+
+msgid "Finding linear vertices"
+msgstr ""
+
+msgid "The degree of a linear vertex is 2."
+msgstr ""
+
+msgid ""
+"If there is a vertices table already built using the ``pgr_extractVertices``"
 msgstr ""
 
 msgid ":doc:`pgr_extractVertices`"
@@ -10610,15 +10726,6 @@ msgid ""
 msgstr ""
 
 msgid "Version 3.3.0"
-msgstr ""
-
-msgid "Promoted to **proposed** function"
-msgstr ""
-
-msgid "``pgr_depthFirstSearch`` (`Single Vertex`_)"
-msgstr ""
-
-msgid "``pgr_depthFirstSearch`` (`Multiple Vertices`_)"
 msgstr ""
 
 msgid ""
@@ -10674,13 +10781,13 @@ msgid "Same as `Single vertex`_ but with edges in descending order of ``id``."
 msgstr ""
 
 msgid ""
-"`Boost: Depth First Search algorithm documentation <https://www.boost.org/"
-"libs/graph/doc/depth_first_search.html>`__"
+"`Boost: Depth First Search <https://www.boost.org/libs/graph/doc/"
+"depth_first_search.html>`__"
 msgstr ""
 
 msgid ""
-"`Boost: Undirected DFS algorithm documentation <https://www.boost.org/libs/"
-"graph/doc/undirected_dfs.html>`__"
+"`Boost: Undirected DFS <https://www.boost.org/libs/graph/doc/undirected_dfs."
+"html>`__"
 msgstr ""
 
 msgid ""
@@ -10698,44 +10805,31 @@ msgstr ""
 msgid "Version 3.5.0"
 msgstr "バージョン 3.0.0"
 
-msgid ""
-"``pgr_dijkstra`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
+msgid "pgr_dijkstra(One to One) added ``start_vid`` and ``end_vid`` columns."
 msgstr ""
 
-msgid "``pgr_dijkstra`` (`One to Many`_) added ``end_vid`` column."
+msgid "pgr_dijkstra(One to Many) added ``end_vid`` column."
 msgstr ""
 
-msgid "``pgr_dijkstra`` (`Many to One`_) added ``start_vid`` column."
+msgid "pgr_dijkstra(Many to One) added ``start_vid`` column."
 msgstr ""
 
 msgid "Version 3.1.0"
 msgstr ""
 
-msgid "``pgr_dijkstra`` (`Combinations`_)"
-msgstr ""
-
-msgid "**Official** functions"
-msgstr ""
-
 msgid "Version 2.2.0"
 msgstr ""
 
-msgid "New **proposed** functions:"
+msgid "pgr_dijkstra(One to Many)"
 msgstr ""
 
-msgid "``pgr_dijkstra`` (`One to Many`_)"
+msgid "pgr_dijkstra(Many to One)"
 msgstr ""
 
-msgid "``pgr_dijkstra`` (`Many to One`_)"
+msgid "pgr_dijkstra(Many to Many)"
 msgstr ""
 
-msgid "``pgr_dijkstra`` (`Many to Many`_)"
-msgstr ""
-
-msgid "Signature change on ``pgr_dijkstra`` (`One to One`_)"
-msgstr ""
-
-msgid "**Official** ``pgr_dijkstra`` (`One to One`_)"
+msgid "Signature change on pgr_dijkstra(One to One)"
 msgstr ""
 
 #, fuzzy
@@ -10924,6 +11018,11 @@ msgstr ""
 msgid "37) Using `Combinations`_"
 msgstr ""
 
+msgid ""
+"`Boost: Dijkstra shortest paths <https://www.boost.org/libs/graph/doc/"
+"dijkstra_shortest_paths.html>`__"
+msgstr ""
+
 msgid "https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm"
 msgstr ""
 
@@ -10935,9 +11034,6 @@ msgid ""
 "``pgr_dijkstraCost`` - Total cost of the shortest path using Dijkstra "
 "algorithm."
 msgstr ":doc:`pgr_dijkstraCost` - 最短経路の総コストを集計します。"
-
-msgid "``pgr_dijkstraCost`` (`Combinations`_)"
-msgstr ""
 
 #, fuzzy
 msgid ""
@@ -11227,9 +11323,6 @@ msgstr ""
 msgid "When ``false``: ``cap`` limit per ``Start vid`` will be returned"
 msgstr ""
 
-msgid "boost: https://www.boost.org/libs/graph/doc/table_of_contents.html"
-msgstr ""
-
 msgid "Wikipedia: https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm"
 msgstr ""
 
@@ -11396,6 +11489,9 @@ msgid ""
 "``pgr_drivingDistance`` - Returns the driving distance from a start node."
 msgstr ""
 
+msgid "Standarizing output columns to |result-spantree|"
+msgstr ""
+
 msgid "Added ``depth`` and ``start_vid`` result columns."
 msgstr ""
 
@@ -11405,13 +11501,17 @@ msgstr ""
 msgid "Added ``depth`` and ``pred`` result columns."
 msgstr ""
 
-msgid "Signature change pgr_drivingDistance(single vertex)"
+#, fuzzy
+msgid "Signature change:"
+msgstr "変更機能"
+
+msgid "pgr_drivingDistance(single vertex)"
 msgstr ""
 
-msgid "New **Official** pgr_drivingDistance(multiple vertices)"
+msgid "New official signature:"
 msgstr ""
 
-msgid "Official:: pgr_drivingDistance(single vertex)"
+msgid "pgr_drivingDistance(multiple vertices)"
 msgstr ""
 
 msgid ""
@@ -11467,7 +11567,7 @@ msgid ""
 "undirected graph"
 msgstr ""
 
-msgid "pgr_edgeColoring - Experimental"
+msgid "``pgr_edgeColoring`` - Experimental"
 msgstr ""
 
 msgid ""
@@ -11541,15 +11641,21 @@ msgstr ""
 msgid "Graph coloring of pgRouting :doc:`sampledata`"
 msgstr ""
 
+msgid ""
+"`Boost: Edge Coloring <https://www.boost.org/libs/graph/doc/edge_coloring."
+"html>`__"
+msgstr ""
+
+msgid ""
+"`Wikipedia: Graph coloring <https://en.wikipedia.org/wiki/Graph_coloring>`__"
+msgstr ""
+
 msgid "``pgr_edgeDisjointPaths``"
 msgstr ""
 
 msgid ""
 "``pgr_edgeDisjointPaths`` — Calculates edge disjoint paths between two "
 "groups of vertices."
-msgstr ""
-
-msgid "New **proposed** function:"
 msgstr ""
 
 msgid "pgr_edgeDisjointPaths(Combinations)"
@@ -11633,9 +11739,6 @@ msgid ""
 "the flow from the sources to the targets using Edmonds Karp Algorithm."
 msgstr ""
 
-msgid "``pgr_edmondsKarp`` (`Combinations`_)"
-msgstr ""
-
 msgid "Renamed from ``pgr_maxFlowEdmondsKarp``"
 msgstr ""
 
@@ -11657,32 +11760,22 @@ msgstr ""
 msgid "pgr_edmondsKarp(`Edges SQL`_, `Combinations SQL`_)"
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/edmonds_karp_max_flow.html"
+msgid ""
+"`Boost: Edmonds Karp max flow <https://www.boost.org/libs/graph/doc/"
+"edmonds_karp_max_flow.html>`__"
 msgstr ""
 
 msgid "https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm"
 msgstr ""
 
-msgid "``pgr_edwardMoore - Experimental``"
+msgid "``pgr_edwardMoore`` - Experimental"
 msgstr ""
 
 msgid ""
 "``pgr_edwardMoore`` — Returns the shortest path using Edward-Moore algorithm."
 msgstr ""
 
-msgid "``pgr_edwardMoore`` (`Combinations`_)"
-msgstr ""
-
-msgid "``pgr_edwardMoore`` (`One to One`_)"
-msgstr ""
-
-msgid "``pgr_edwardMoore`` (`One to Many`_)"
-msgstr ""
-
-msgid "``pgr_edwardMoore`` (`Many to One`_)"
-msgstr ""
-
-msgid "``pgr_edwardMoore`` (`Many to Many`_)"
+msgid "pgr_edwardMoore(Combinations)"
 msgstr ""
 
 msgid ""
@@ -11744,13 +11837,10 @@ msgstr ""
 msgid "https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm"
 msgstr ""
 
-msgid "pgr_extractVertices -- Proposed"
+msgid "``pgr_extractVertices``"
 msgstr ""
 
 msgid "``pgr_extractVertices`` — Extracts the vertices information"
-msgstr ""
-
-msgid "Classified as **proposed** function"
 msgstr ""
 
 msgid ""
@@ -11851,13 +11941,7 @@ msgstr ""
 msgid "``pgr_findCloseEdges`` - Finds the close edges to a point geometry."
 msgstr ""
 
-msgid "New **proposed** signatures:"
-msgstr ""
-
-msgid "``pgr_findCloseEdges`` (`One point`_)"
-msgstr ""
-
-msgid "``pgr_findCloseEdges`` (`Many points`_)"
+msgid "``partial`` option is removed."
 msgstr ""
 
 msgid ""
@@ -11874,7 +11958,7 @@ msgid ""
 "adjustments needed by the application."
 msgstr ""
 
-msgid "``EMTPY SET`` is returned on dryrun executions"
+msgid "``EMPTY SET`` is returned on dryrun executions"
 msgstr ""
 
 msgid ""
@@ -11885,7 +11969,7 @@ msgid ""
 "pgr_findCloseEdges(`Edges SQL`_, **points**, **tolerance**, [**options**])"
 msgstr ""
 
-msgid "**options:** ``[cap, partial, dryrun]``"
+msgid "**options:** ``[cap, dryrun]``"
 msgstr ""
 
 msgid "Returns set of |result-find|"
@@ -11894,52 +11978,16 @@ msgstr ""
 msgid "One point"
 msgstr ""
 
-msgid "Default: ``cap => 1``"
+msgid "Get two close edges to points of interest with :math:`pid = 5`"
 msgstr ""
 
-msgid "Maximum one row answer."
-msgstr ""
-
-msgid "Default: ``partial => true``"
-msgstr ""
-
-msgid "With less calculations as possible."
-msgstr ""
-
-msgid "Default: ``dryrun => false``"
-msgstr ""
-
-msgid "Process query"
-msgstr ""
-
-msgid "Returns"
-msgstr ""
-
-msgid "values on ``edge_id``, ``fraction``, ``side`` columns."
-msgstr ""
-
-msgid "``NULL`` on ``distance``, ``geom``, ``edge`` columns."
+msgid "``cap => 2``"
 msgstr ""
 
 msgid "Many points"
 msgstr ""
 
-msgid ""
-"Find at most :math:`2` edges close to all vertices on the points of interest "
-"table."
-msgstr ""
-
-msgid "One answer per point, as small as possible."
-msgstr ""
-
-msgid ""
-"Columns ``edge_id``, ``fraction``, ``side`` and ``geom`` are returned with "
-"values."
-msgstr ""
-
-msgid ""
-"``geom`` contains the original point geometry to assist on deterpartialing "
-"to which point geometry the row belongs to."
+msgid "For each points of interests, find the closest edge."
 msgstr ""
 
 msgid "**point**"
@@ -11966,17 +12014,6 @@ msgstr ""
 msgid "Limit output rows"
 msgstr ""
 
-msgid "``partial``"
-msgstr ""
-
-msgid ""
-"When ``true`` only columns needed for :doc:`withPoints-category` are "
-"calculated."
-msgstr ""
-
-msgid "When ``false`` all columns are calculated"
-msgstr ""
-
 msgid "When ``false`` calculations are performed."
 msgstr ""
 
@@ -11991,64 +12028,78 @@ msgstr ""
 msgid "When :math:`cap = 1`, it is the closest edge."
 msgstr ""
 
+#, fuzzy
 msgid ""
-"Value in <0,1> that indicates the relative postition from the first end-"
-"point of the edge."
+"Value in <0,1> that indicates the relative position from the first end-point "
+"of the edge."
 msgstr ""
+":math:`path\\_seq' は、:math:'node' または :math:'edge' の経路内の相対位置を"
+"示しています。"
 
 msgid "Value in ``[r, l]`` indicating if the point is:"
 msgstr ""
 
-msgid "In the right ``r``."
-msgstr ""
-
-msgid "In the left ``l``."
+msgid "At the right ``r`` of the segment."
 msgstr ""
 
 msgid "When the point is on the line it is considered to be on the right."
 msgstr ""
 
+msgid "At the left ``l`` of the segment."
+msgstr ""
+
 msgid "``distance``"
 msgstr ""
 
-msgid "Distance from point to edge."
+msgid "Distance from the point to the edge."
 msgstr ""
 
-msgid "``NULL`` when ``cap = 1`` on the `One point`_ signature"
-msgstr ""
-
-msgid "``POINT`` geometry"
+msgid "Original ``POINT`` geometry."
 msgstr ""
 
 msgid ""
-"`One Point`_: Contains the point on the edge that is ``fraction`` away from "
-"the starting point of the edge."
+"``LINESTRING`` geometry that connects the original **point** to the closest "
+"point of the edge with identifier ``edge_id``"
 msgstr ""
 
-msgid "`Many Points`_: Contains the corresponding **original point**"
+msgid "One point in an edge"
 msgstr ""
 
-msgid ""
-"``LINESTRING`` geometry from the **original point** to the closest point of "
-"the edge with identifier ``edge_id``"
+msgid "The green node is the original point."
 msgstr ""
 
-msgid "One point results"
-msgstr ""
-
-msgid "The green nodes is the **original point**"
+msgid "``geom`` has the value of the original point."
 msgstr ""
 
 msgid ""
-"The geometry ``geom`` is a point on the :math:`sp \\rightarrow ep` edge."
+"The geometry ``edge`` is a line that connects the original point with the "
+"edge :math:`sp \\rightarrow ep` edge."
+msgstr ""
+
+msgid "The point is located at the left of the edge."
+msgstr ""
+
+msgid "One point dry run execution"
+msgstr ""
+
+msgid "Using the query from the previous example:"
+msgstr ""
+
+msgid "Returns ``EMPTY SET``."
+msgstr ""
+
+msgid "``dryrun => true``"
+msgstr ""
+
+msgid "Generates a PostgreSQL ``NOTICE`` with the code used."
 msgstr ""
 
 msgid ""
-"The geometry ``edge`` is a line that connects the **original point** with "
-"``geom``"
+"The generated code can be used as a starting base code for additional "
+"requirements, like taking into consideration the SRID."
 msgstr ""
 
-msgid "Many point results"
+msgid "Many points in an edge"
 msgstr ""
 
 msgid "The green nodes are the **original points**"
@@ -12065,131 +12116,7 @@ msgid ""
 "\\rightarrow ep` edge."
 msgstr ""
 
-msgid "One point examples"
-msgstr ""
-
-msgid "At most two answers"
-msgstr ""
-
-msgid "``cap => 2``"
-msgstr ""
-
-msgid "Maximum two row answer."
-msgstr ""
-
-msgid "Understanding the result"
-msgstr ""
-
-msgid "``NULL`` on ``geom``, ``edge``"
-msgstr ""
-
-msgid "``edge_id`` identifier of the edge close to the **original point**"
-msgstr ""
-
-msgid ""
-"Two edges are withing :math:`0.5` distance units from the **original "
-"point**: :math:`{5, 8}`"
-msgstr ""
-
-#, fuzzy
-msgid "For edge :math:`5`:"
-msgstr "エッジのセット :math:`5`:"
-
-msgid ""
-"``fraction``: The closest point from the **original point** is at the :math:"
-"`0.8` fraction of the edge :math:`5`."
-msgstr ""
-
-msgid ""
-"``side``: The **original point** is located to the left side of edge :math:"
-"`5`."
-msgstr ""
-
-msgid ""
-"``distance``: The **original point** is located :math:`0.1` length units "
-"from edge :math:`5`."
-msgstr ""
-
-msgid "For edge :math:`8`:"
-msgstr "エッジのセット :math:`8`:"
-
-msgid ""
-"``fraction``: The closest point from the **original point** is at the :math:"
-"`0.89..` fraction of the edge :math:`8`."
-msgstr ""
-
-msgid ""
-"``side``: The **original point** is located to the right side of edge :math:"
-"`8`."
-msgstr ""
-
-msgid ""
-"``distance``: The **original point** is located :math:`0.19..` length units "
-"from edge :math:`8`."
-msgstr ""
-
-msgid "One answer, all columns"
-msgstr ""
-
-msgid "``partial => false``"
-msgstr ""
-
-msgid "Calculate all columns"
-msgstr ""
-
-msgid ""
-"``edge_id`` identifier of the edge **closest** to the **original point**"
-msgstr ""
-
-msgid ""
-"From all edges within :math:`0.5` distance units from the **original "
-"point**: :math:`{5}` is the closest one."
-msgstr ""
-
-msgid ""
-"``geom``: Contains the geometry of the closest point on edge :math:`5` from "
-"the **original point**."
-msgstr ""
-
-msgid ""
-"``edge``: Contains the ``LINESTRING`` geometry of the **original point** to "
-"the closest point on on edge :math:`5` ``geom``"
-msgstr ""
-
-msgid "At most two answers with all columns"
-msgstr ""
-
-msgid "Understanding the result:"
-msgstr ""
-
-msgid ""
-"``geom``: Contains the geometry of the closest point on edge :math:`8` from "
-"the **original point**."
-msgstr ""
-
-msgid ""
-"``edge``: Contains the ``LINESTRING`` geometry of the **original point** to "
-"the closest point on on edge :math:`8` ``geom``"
-msgstr ""
-
-msgid "One point dry run execution"
-msgstr ""
-
-msgid "Returns ``EMPTY SET``."
-msgstr ""
-
-msgid "``partial => true``"
-msgstr ""
-
-msgid "Is ignored"
-msgstr ""
-
-msgid ""
-"Because it is a **dry run** excecution, the code for all calculations are "
-"shown on the PostgreSQL ``NOTICE``."
-msgstr ""
-
-msgid "``dryrun => true``"
+msgid "Many points dry run execution"
 msgstr ""
 
 msgid "Do not process query"
@@ -12197,62 +12124,6 @@ msgstr ""
 
 msgid ""
 "Generate a PostgreSQL ``NOTICE`` with the code used to calculate all columns"
-msgstr ""
-
-msgid "``cap`` and **original point** are used in the code"
-msgstr ""
-
-msgid "Many points examples"
-msgstr ""
-
-msgid "At most two answers per point"
-msgstr ""
-
-msgid "``NULL`` on ``edge``"
-msgstr ""
-
-msgid ""
-"``edge_id`` identifier of the edge close to a **original point** (``geom``)"
-msgstr ""
-
-msgid ""
-"Two edges at most withing :math:`0.5` distance units from each of the "
-"**original points**:"
-msgstr ""
-
-msgid "For ``POINT(1.8 0.4)`` and ``POINT(0.3 1.8)`` only one edge was found."
-msgstr ""
-
-msgid "For the rest of the points two edges were found."
-msgstr ""
-
-msgid "For point ``POINT(2.9 1.8)``"
-msgstr ""
-
-msgid ""
-"Edge :math:`5` is before :math:`8` therefore edge :math:`5` has the shortest "
-"distance to ``POINT(2.9 1.8)``."
-msgstr ""
-
-msgid "One answer per point, all columns"
-msgstr ""
-
-msgid "For the **original point** ``POINT(2.9 1.8)``"
-msgstr ""
-
-msgid "Edge :math:`5` is the closest edge to the **original point**"
-msgstr ""
-
-msgid ""
-"``geom``: Contains the geometry of the **original point** ``POINT(2.9 1.8)``"
-msgstr ""
-
-msgid ""
-"``edge``: Contains the ``LINESTRING`` geometry of the **original point** "
-"(``geom``) to the closest point on on edge."
-msgstr ""
-
-msgid "Many points dry run execution"
 msgstr ""
 
 msgid "Find at most two routes to a given point"
@@ -12289,11 +12160,11 @@ msgstr ""
 msgid "A unique identifier."
 msgstr ""
 
-msgid ""
-"Identifier of the edge nearest edge that allows an arrival to the point."
-msgstr ""
+#, fuzzy
+msgid "Identifier of the nearest segment."
+msgstr "開始ノードの識別子。"
 
-msgid "Is it on the left, right or both sides of the segment ``edge_id``"
+msgid "Is it on the left, right or both sides of the segment ``edge_id``."
 msgstr ""
 
 msgid "Where in the segment is the point located."
@@ -12302,13 +12173,35 @@ msgstr ""
 msgid "The geometry of the points."
 msgstr ""
 
+msgid "The distance between ``geom`` and the segment ``edge_id``."
+msgstr ""
+
+msgid ""
+"A segment that connects the ``geom`` of the point to the closest point on "
+"the segment ``edge_id``."
+msgstr ""
+
 msgid "``newPoint``"
 msgstr ""
 
-msgid "The geometry of the points moved on top of the segment."
+msgid "A point on segment ``edge_id`` that is the closest to ``geom``."
 msgstr ""
 
-msgid "Points of interest fillup"
+msgid "Points of interest fill up"
+msgstr ""
+
+msgid "Inserting the points of interest."
+msgstr ""
+
+msgid "Filling the rest of the table."
+msgstr ""
+
+msgid ""
+"Any other additional modification: In this manual, point :math:`6` can be "
+"reached from both sides."
+msgstr ""
+
+msgid "The points of interest:"
 msgstr ""
 
 msgid "``pgr_floydWarshall``"
@@ -12337,17 +12230,11 @@ msgid ""
 "floyd_warshall_shortest.html>`_"
 msgstr ""
 
-msgid "Queries uses the :doc:`sampledata` network."
-msgstr ""
-
 msgid "``pgr_full_version``"
 msgstr ""
 
 msgid ""
 "``pgr_full_version`` — Get the details of pgRouting version information."
-msgstr ""
-
-msgid "New **official** function"
 msgstr ""
 
 msgid "Get complete details of pgRouting version information"
@@ -12416,15 +12303,12 @@ msgstr ""
 msgid "Git hash of pgRouting build"
 msgstr ""
 
-msgid "``pgr_hawickCircuits - Experimental``"
+msgid "``pgr_hawickCircuits`` - Experimental"
 msgstr ""
 
 msgid ""
-"``pgr_hawickCircuits`` — Returns the list of cirucits using hawick circuits "
+"``pgr_hawickCircuits`` — Returns the list of ciruits using hawick circuits "
 "algorithm."
-msgstr ""
-
-msgid "``pgr_hawickCircuits``"
 msgstr ""
 
 msgid ""
@@ -12551,7 +12435,9 @@ msgid ""
 "blue represent :math:`K_5` subgraph."
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/boyer_myrvold.html"
+msgid ""
+"`Boost: Boyer Myrvold <https://www.boost.org/libs/graph/doc/boyer_myrvold."
+"html>`__"
 msgstr ""
 
 msgid "``pgr_johnson``"
@@ -12604,6 +12490,9 @@ msgstr ""
 msgid ""
 "``pgr_kruskalBFS`` — Kruskal's algorithm for Minimum Spanning Tree with "
 "breadth First Search ordering."
+msgstr ""
+
+msgid "Added ``pred`` result columns."
 msgstr ""
 
 msgid ""
@@ -12681,7 +12570,7 @@ msgstr ""
 msgid "pgr_kruskalDFS(`Edges SQL`_, **root vids**, [``max_depth``])"
 msgstr ""
 
-msgid "pgr_lengauerTarjanDominatorTree -Experimental"
+msgid "``pgr_lengauerTarjanDominatorTree`` - Experimental"
 msgstr ""
 
 msgid ""
@@ -12739,8 +12628,8 @@ msgid "Dominator tree of another component."
 msgstr ""
 
 msgid ""
-"`Boost: Lengauer-Tarjan dominator tree algorithm <https://www.boost.org/libs/"
-"graph/doc/lengauer_tarjan_dominator.htm>`__"
+"`Boost: Lengauer-Tarjan dominator <https://www.boost.org/libs/graph/doc/"
+"lengauer_tarjan_dominator.htm>`__"
 msgstr ""
 
 msgid ""
@@ -12748,13 +12637,17 @@ msgid ""
 "Dominator_(graph_theory)>`__"
 msgstr ""
 
-msgid "pgr_lineGraph - Proposed"
+msgid "``pgr_lineGraph`` - Proposed"
 msgstr ""
 
 msgid ""
 "``pgr_lineGraph`` — Transforms the given graph into its corresponding edge-"
 "based graph."
 msgstr ""
+
+#, fuzzy
+msgid "Works for directed and undirected graphs."
+msgstr "導かれないグラフ。"
 
 msgid ""
 "Given a graph :math:`G`, its line graph :math:`L(G)` is a graph such that:"
@@ -12799,13 +12692,7 @@ msgstr ""
 msgid "Gives a local identifier for the edge"
 msgstr ""
 
-msgid "Identifier of the source vertex of the current edge."
-msgstr ""
-
 msgid "When `negative`: the source is the reverse edge in the original graph."
-msgstr ""
-
-msgid "Identifier of the target vertex of the current edge."
 msgstr ""
 
 msgid "When `negative`: the target is the reverse edge in the original graph."
@@ -13022,8 +12909,7 @@ msgid "Full line graph of subgraph of edges :math:`\\{4, 7, 8, 10\\}`"
 msgstr ""
 
 msgid ""
-"The examples of this section are based on the :doc:`sampledata` network. The "
-"examples include the subgraph including edges 4, 7, 8, and 10 with "
+"The examples include the subgraph including edges 4, 7, 8, and 10 with "
 "``reverse_cost``."
 msgstr ""
 
@@ -13242,15 +13128,15 @@ msgstr ""
 msgid "Returns set of |result-component-make|"
 msgstr ""
 
+msgid "List of edges that are needed to connect the graph."
+msgstr ""
+
 msgid ""
-"Query done on :doc:`sampledata` network gives the list of edges that are "
-"needed to connect the graph."
+"`Boost: make connected <https://www.boost.org/libs/graph/doc/make_connected."
+"html>`__"
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/make_connected.html"
-msgstr ""
-
-msgid "pgr_maxCardinalityMatch"
+msgid "``pgr_maxCardinalityMatch``"
 msgstr ""
 
 msgid ""
@@ -13258,13 +13144,16 @@ msgid ""
 "graph."
 msgstr ""
 
+msgid "pgr_maxCardinalityMatch(text) returns only ``edge`` column."
+msgstr ""
+
 msgid "Deprecated signature"
 msgstr ""
 
-msgid "``pgr_maxCardinalityMatch(text,boolean)``"
+msgid "pgr_maxCardinalityMatch(text,boolean)"
 msgstr ""
 
-msgid "``directed => false`` when used."
+msgid "directed => ``false`` when used."
 msgstr ""
 
 msgid "Renamed from ``pgr_maximumCardinalityMatching``"
@@ -13315,7 +13204,9 @@ msgstr ""
 msgid "Identifier of the edge in the original query."
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/maximum_matching.html"
+msgid ""
+"`Boost: maximum_matching <https://www.boost.org/libs/graph/doc/"
+"maximum_matching.html>`__"
 msgstr ""
 
 msgid "https://en.wikipedia.org/wiki/Matching_%28graph_theory%29"
@@ -13332,17 +13223,14 @@ msgid ""
 "source(s) to the targets(s) using the Push Relabel algorithm."
 msgstr ""
 
-msgid "``pgr_maxFlow`` (`Combinations`_)"
-msgstr ""
-
-msgid "New **Proposed** function"
-msgstr ""
-
 msgid "Calculates the maximum flow from the sources to the targets."
 msgstr ""
 
 msgid ""
 "When the maximum flow is **0** then there is no flow and **0** is returned."
+msgstr ""
+
+msgid "There is no flow when source has the same vaule as target."
 msgstr ""
 
 msgid "Uses the :doc:`pgr_pushRelabel <pgr_pushRelabel>` algorithm."
@@ -13372,7 +13260,9 @@ msgstr ""
 msgid "Maximum flow possible from the source(s) to the target(s)"
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html"
+msgid ""
+"`Boost: push relabel max flow <https://www.boost.org/libs/graph/doc/"
+"push_relabel_max_flow.html>`__"
 msgstr ""
 
 msgid ""
@@ -13387,7 +13277,10 @@ msgid ""
 "of the maximum flow on a graph"
 msgstr ""
 
-msgid "``pgr_maxFlowMinCost`` (`Combinations`_)"
+msgid "pgr_maxFlowMinCost(Combinations)"
+msgstr ""
+
+msgid "|boost| graph inside."
 msgstr ""
 
 msgid "**TODO** check which statement is true:"
@@ -13431,11 +13324,6 @@ msgstr ""
 msgid "Returns set of |result-flow-mincost|"
 msgstr ""
 
-msgid ""
-"https://www.boost.org/libs/graph/doc/"
-"successive_shortest_path_nonnegative_weights.html"
-msgstr ""
-
 msgid "``pgr_maxFlowMinCost_Cost`` - Experimental"
 msgstr ""
 
@@ -13444,7 +13332,7 @@ msgid ""
 "maximum flow on a graph"
 msgstr ""
 
-msgid "``pgr_maxFlowMinCost_Cost`` (`Combinations`_)"
+msgid "pgr_maxFlowMinCost_Cost(Combinations)"
 msgstr ""
 
 msgid "**The cost value of all input edges must be nonnegative.**"
@@ -13477,7 +13365,7 @@ msgstr ""
 msgid "Minimum Cost Maximum Flow possible from the source(s) to the target(s)"
 msgstr ""
 
-msgid "pgr_nodeNetwork"
+msgid "``pgr_nodeNetwork``"
 msgstr ""
 
 msgid "``pgr_nodeNetwork`` - Nodes an network edge table."
@@ -13908,7 +13796,7 @@ msgid ""
 "projectweb/top/pdptw/li-lim-benchmark/"
 msgstr ""
 
-msgid "There are 25 vehciles in the problem all with the same characteristics."
+msgid "There are 25 vehicles in the problem all with the same characteristics."
 msgstr ""
 
 msgid "The original orders"
@@ -13919,7 +13807,7 @@ msgid ""
 "order."
 msgstr ""
 
-msgid "The original data needs to be converted to an appropiate table:"
+msgid "The original data needs to be converted to an appropriate table:"
 msgstr ""
 
 msgid "The query"
@@ -14018,9 +13906,6 @@ msgid ""
 "the flow from the sources to the targets using Push Relabel Algorithm."
 msgstr ""
 
-msgid "``pgr_pushRelabel`` (`Combinations`_)"
-msgstr ""
-
 msgid "Renamed from ``pgr_maxFlowPushRelabel``"
 msgstr ""
 
@@ -14039,15 +13924,12 @@ msgstr ""
 msgid "pgr_pushRelabel(`Edges SQL`_, `Combinations SQL`_)"
 msgstr ""
 
-msgid "pgr_sequentialVertexColoring - Proposed"
+msgid "``pgr_sequentialVertexColoring`` - Proposed"
 msgstr ""
 
 msgid ""
 "``pgr_sequentialVertexColoring`` — Returns the vertex coloring of an "
 "undirected graph, using greedy approach."
-msgstr ""
-
-msgid "Promoted to **proposed** signature"
 msgstr ""
 
 msgid ""
@@ -14092,7 +13974,12 @@ msgstr ""
 msgid "pgr_sequentialVertexColoring(`Edges SQL`_)"
 msgstr ""
 
-msgid "pgr_stoerWagner - Experimental"
+msgid ""
+"`Boost: Sequential Vertex Coloring <https://www.boost.org/libs/graph/doc/"
+"sequential_vertex_coloring.html>`__"
+msgstr ""
+
+msgid "``pgr_stoerWagner`` - Experimental"
 msgstr ""
 
 msgid "``pgr_stoerWagner`` — The min-cut of graph using stoerWagner algorithm."
@@ -14177,6 +14064,11 @@ msgstr ""
 msgid "Using :doc:`pgr_connectedComponents`"
 msgstr ""
 
+msgid ""
+"`Boost: Stoer Wagner min cut <https://www.boost.org/libs/graph/doc/"
+"stoer_wagner_min_cut.html>`__"
+msgstr ""
+
 msgid "https://en.wikipedia.org/wiki/Stoer%E2%80%93Wagner_algorithm"
 msgstr ""
 
@@ -14206,7 +14098,7 @@ msgid "The strong components of the graph"
 msgstr ""
 
 msgid ""
-"Boost: `Strong components <https://www.boost.org/libs/graph/doc/"
+"`Boost: Strong components <https://www.boost.org/libs/graph/doc/"
 "strong_components.html>`__"
 msgstr ""
 
@@ -14271,6 +14163,11 @@ msgstr ""
 msgid "Graph is not a DAG"
 msgstr ""
 
+msgid ""
+"`Boost: topological sort <https://www.boost.org/libs/graph/doc/"
+"topological_sort.html>`__"
+msgstr ""
+
 msgid "``pgr_transitiveClosure`` - Experimental"
 msgstr ""
 
@@ -14326,56 +14223,52 @@ msgstr ""
 msgid "Identifiers of the vertices that are reachable from vertex v."
 msgstr ""
 
+msgid ""
+"`Boost: transitive closure <https://www.boost.org/libs/graph/doc/"
+"transitive_closure.html>`__"
+msgstr ""
+
 msgid "https://en.wikipedia.org/wiki/Transitive_closure"
 msgstr ""
 
-msgid "pgr_trsp - Proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_trsp``"
+msgstr "pgr_TSP"
 
 msgid "``pgr_trsp`` - routing vertices with restrictions."
 msgstr ""
 
-msgid "New proposed signatures"
+msgid "pgr_trsp(One to One)"
 msgstr ""
 
-msgid "``pgr_trsp`` (`One to One`_)"
+msgid "pgr_trsp(One to Many)"
 msgstr ""
 
-msgid "``pgr_trsp`` (`One to Many`_)"
+msgid "pgr_trsp(Many to One)"
 msgstr ""
 
-msgid "``pgr_trsp`` (`Many to One`_)"
+msgid "pgr_trsp(Many to Many)"
 msgstr ""
 
-msgid "``pgr_trsp`` (`Many to Many`_)"
-msgstr ""
-
-msgid "``pgr_trsp`` (`Combinations`_)"
+msgid "pgr_trsp(Combinations)"
 msgstr ""
 
 msgid "Deprecated signatures"
 msgstr ""
 
-msgid "``pgr_trsp(text,integer,integer,boolean,boolean,text)``"
+msgid "pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)"
 msgstr ""
 
-msgid "``pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)``"
-msgstr ""
-
-msgid "``pgr_trspViaVertices(text,anyarray,boolean,boolean,text)``"
-msgstr ""
-
-msgid ""
-"``pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)``"
+msgid "pgr_trspViaVertices(text,anyarray,boolean,boolean,text)"
 msgstr ""
 
 msgid "New prototypes"
 msgstr ""
 
-msgid "``pgr_trspViaVertices``"
+msgid "pgr_trspViaVertices"
 msgstr ""
 
-msgid "``pgr_trspViaEdges``"
+msgid "pgr_trspViaEdges"
 msgstr ""
 
 msgid ""
@@ -14448,17 +14341,12 @@ msgid ""
 "`Deprecated documentation <https://docs.pgrouting.org/3.3/en/pgr_trsp.html>`_"
 msgstr ""
 
-msgid "``pgr_trspVia`` - Proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_trspVia``"
+msgstr "pgr_TSP"
 
 msgid ""
 "``pgr_trspVia`` Route that goes through a list of vertices with restrictions."
-msgstr ""
-
-msgid "New proposed function:"
-msgstr ""
-
-msgid "``pgr_trspVia`` (`One Via`_)"
 msgstr ""
 
 msgid ""
@@ -14538,15 +14426,12 @@ msgstr ""
 msgid ":doc:`via-category`"
 msgstr ""
 
-msgid "``pgr_trspVia_withPoints`` - Proposed"
+msgid "``pgr_trspVia_withPoints``"
 msgstr ""
 
 msgid ""
 "``pgr_trspVia_withPoints`` - Route that goes through a list of vertices and/"
 "or points with restrictions."
-msgstr ""
-
-msgid "``pgr_trspVia_withPoints`` (`One Via`_)"
 msgstr ""
 
 msgid ""
@@ -14708,28 +14593,10 @@ msgid ""
 "`pgr_trsp` algorithm. In this case a U turn is been done using the same edge."
 msgstr ""
 
-msgid "pgr_trsp_withPoints - Proposed"
+msgid "``pgr_trsp_withPoints``"
 msgstr ""
 
 msgid "``pgr_trsp_withPoints`` Routing Vertex/Point with restrictions."
-msgstr ""
-
-msgid "New proposed signatures:"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`One to One`_)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`One to Many`_)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`Many to One`_)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`Many to Many`_)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`Combinations`_)"
 msgstr ""
 
 msgid ""
@@ -14841,17 +14708,13 @@ msgid ""
 "`1` on an undirected graph, with details."
 msgstr ""
 
-msgid "pgr_turnRestrictedPath - Experimental"
+msgid "``pgr_turnRestrictedPath`` - Experimental"
 msgstr ""
 
 msgid ""
-"``pgr_turnRestrictedPath`` Using Yen's algorithm Vertex -Vertex routing with "
-"restrictions"
+"``pgr_turnRestrictedPath`` Using Yen's algorithm Vertex - Vertex routing "
+"with restrictions"
 msgstr ""
-
-#, fuzzy
-msgid "New experimental function"
-msgstr "新しい **公式** 機能"
 
 msgid ""
 "Using Yen's algorithm to obtain K shortest paths and analyze the paths to "
@@ -14924,7 +14787,7 @@ msgstr ""
 msgid "pgRouting Version for this documentation"
 msgstr ""
 
-msgid "pgr_vrpOneDepot - Experimental"
+msgid "``pgr_vrpOneDepot`` - Experimental"
 msgstr ""
 
 msgid "**No documentation available**"
@@ -14933,8 +14796,9 @@ msgstr ""
 msgid "**TBD**"
 msgstr ""
 
-msgid "``pgr_withPoints`` - Proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_withPoints``"
+msgstr "pgr_TSP"
 
 msgid ""
 "``pgr_withPoints`` - Returns the shortest path in a graph with additional "
@@ -15076,7 +14940,7 @@ msgstr ""
 msgid "Passes in front or visits with left side driving."
 msgstr ""
 
-msgid "``pgr_withPointsCost`` - Proposed"
+msgid "``pgr_withPointsCost``"
 msgstr ""
 
 msgid ""
@@ -15220,7 +15084,7 @@ msgstr ""
 msgid "Does not matter driving side driving topology"
 msgstr ""
 
-msgid "``pgr_withPointsCostMatrix`` - proposed"
+msgid "``pgr_withPointsCostMatrix``"
 msgstr ""
 
 msgid ""
@@ -15252,7 +15116,7 @@ msgid ""
 "locations on the graph of point `(2.9, 1.8)`."
 msgstr ""
 
-msgid "``pgr_withPointsDD`` - Proposed"
+msgid "``pgr_withPointsDD``"
 msgstr ""
 
 msgid ""
@@ -15265,7 +15129,10 @@ msgid ""
 "unnamed compulsory **driving side**."
 msgstr ""
 
-msgid "``pgr_withPointsDD`` (`Single vertex`)"
+msgid "pgr_withPointsDD(Single vertex)"
+msgstr ""
+
+msgid "pgr_withPointsDD(Multiple vertices)"
 msgstr ""
 
 msgid "Added ``depth``, ``pred`` and ``start_vid`` column."
@@ -15283,13 +15150,12 @@ msgid ""
 msgstr ""
 
 msgid ""
-"``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,"
-"boolean)``"
+"pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)"
 msgstr ""
 
 msgid ""
-"``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
-"boolean,boolean)``"
+"pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
+"boolean,boolean)"
 msgstr ""
 
 msgid ""
@@ -15400,8 +15266,9 @@ msgstr ""
 msgid ":doc:`pgr_alphaShape`"
 msgstr ""
 
-msgid "pgr_withPointsKSP - Proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_withPointsKSP``"
+msgstr "pgr_TSP"
 
 msgid ""
 "``pgr_withPointsKSP`` — Yen's algorithm for K shortest paths using Dijkstra."
@@ -15410,27 +15277,23 @@ msgstr ""
 msgid "Standarizing output columns to |nksp-result|"
 msgstr ""
 
-msgid "``pgr_withPointsKSP`` (One to One)"
+msgid "pgr_withPointsKSP(One to One)"
 msgstr ""
 
-#, fuzzy
-msgid "New overload functions"
-msgstr "新しい **公式** 機能"
-
-msgid "``pgr_withPointsKSP`` (One to Many)"
+msgid "pgr_withPointsKSP(One to Many)"
 msgstr ""
 
-msgid "``pgr_withPointsKSP`` (Many to One)"
+msgid "pgr_withPointsKSP(Many to One)"
 msgstr ""
 
-msgid "``pgr_withPointsKSP`` (Many to Many)"
+msgid "pgr_withPointsKSP(Many to Many)"
 msgstr ""
 
-msgid "``pgr_withPointsKSP`` (Combinations)"
+msgid "pgr_withPointsKSP(Combinations)"
 msgstr ""
 
 msgid ""
-"``pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
+"pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
 "boolean)``"
 msgstr ""
 
@@ -15552,15 +15415,12 @@ msgid ""
 "to point :math:`2` with heap paths and details."
 msgstr ""
 
-msgid "``pgr_withPointsVia`` - Proposed"
+msgid "``pgr_withPointsVia``"
 msgstr ""
 
 msgid ""
 "``pgr_withPointsVia`` - Route that goes through a list of vertices and/or "
 "points."
-msgstr ""
-
-msgid "New **proposed** function ``pgr_withPointsVia`` (`One Via`_)"
 msgstr ""
 
 msgid ""
@@ -15645,42 +15505,14 @@ msgstr ""
 msgid ":doc:`pgr_withPointsVia` - Via routing"
 msgstr ""
 
-msgid "These proposed functions do not modify the database."
-msgstr ""
-
-msgid ""
-":doc:`pgr_degree` - Returns a set of vertices and corresponding count of "
-"incidet edges to the vertex."
-msgstr ""
-
-msgid ""
-":doc:`pgr_extractVertices` - Extracts vertex information based on the edge "
-"table information."
-msgstr ""
-
 msgid ""
 ":doc:`pgr_lineGraph` - Transformation algorithm for generating a Line Graph."
-msgstr ""
-
-msgid ":doc:`pgr_withPointsVia`"
-msgstr ""
-
-msgid ":doc:`pgr_trspVia`"
-msgstr ""
-
-msgid ":doc:`pgr_trspVia_withPoints`"
 msgstr ""
 
 msgid ":doc:`withPoints-family` - Functions based on Dijkstra algorithm."
 msgstr ""
 
 msgid "From the :doc:`TRSP-family`:"
-msgstr ""
-
-msgid "Utilities"
-msgstr ""
-
-msgid ":doc:`pgr_findCloseEdges`"
 msgstr ""
 
 #, fuzzy
@@ -15698,13 +15530,205 @@ msgstr ""
 msgid "Mayors"
 msgstr ""
 
+msgid "pgRouting 4"
+msgstr ""
+
+msgid "Minors 4.x"
+msgstr ""
+
+msgid "pgRouting 4.0"
+msgstr ""
+
 msgid "pgRouting 3"
 msgstr ""
 
 msgid "Minors 3.x"
 msgstr ""
 
+msgid "pgRouting 3.8"
+msgstr ""
+
+msgid "pgRouting 3.8.0 Release Notes"
+msgstr ""
+
+msgid "Promotion to official function of pgRouting."
+msgstr ""
+
+msgid "pgr_extractVertices"
+msgstr ""
+
+msgid "pgr_degree"
+msgstr ""
+
+msgid "pgr_findCloseEdges"
+msgstr ""
+
+msgid "Official functions changes"
+msgstr ""
+
+msgid ""
+"`#2786 <https://github.com/pgRouting/pgrouting/issues/2786>`__: "
+"pgr_contraction"
+msgstr ""
+
+#, fuzzy
+msgid "New proposed functions"
+msgstr "新しい **公式** 機能"
+
+#, fuzzy
+msgid "Contraction"
+msgstr "序章"
+
+msgid ""
+"`#2790 <https://github.com/pgRouting/pgrouting/issues/2790>`__: "
+"pgr_contractionDeadEnd"
+msgstr ""
+
+msgid ""
+"`#2791 <https://github.com/pgRouting/pgrouting/issues/2791>`__: "
+"pgr_contractionLinear"
+msgstr ""
+
 msgid "pgRouting 3.7"
+msgstr ""
+
+msgid "pgRouting 3.7.3 Release Notes"
+msgstr ""
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.3 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.3%22>`__"
+msgstr ""
+
+msgid ""
+"`#2731 <https://github.com/pgRouting/pgrouting/pull/2731>`__ Build Failure "
+"on Ubuntu 22"
+msgstr ""
+
+msgid "pgRouting 3.7.2 Release Notes"
+msgstr ""
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.2 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.2%22>`__"
+msgstr ""
+
+msgid "Build"
+msgstr ""
+
+msgid ""
+"`#2713 <https://github.com/pgRouting/pgrouting/pull/2713>`__ cmake missing "
+"some policies and min version"
+msgstr ""
+
+msgid "Using OLD policies: CMP0148, CMP0144, CMP0167"
+msgstr ""
+
+msgid "Minimum cmake version 3.12"
+msgstr ""
+
+msgid ""
+"`#2707 <https://github.com/pgRouting/pgrouting/pull/2707>`__ Build failure "
+"in pgRouting 3.7.1 on Alpine"
+msgstr ""
+
+msgid ""
+"`#2706 <https://github.com/pgRouting/pgrouting/pull/2706>`__ winnie crashing "
+"on pgr_betweennessCentrality"
+msgstr ""
+
+msgid "pgRouting 3.7.1 Release Notes"
+msgstr ""
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.1 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.1%22>`__"
+msgstr ""
+
+msgid ""
+"`#2680 <https://github.com/pgRouting/pgrouting/pull/2680>`__ fails to "
+"compile under mingw64 gcc 13.2"
+msgstr ""
+
+msgid ""
+"`#2689 <https://github.com/pgRouting/pgrouting/pull/2689>`__ When point is a "
+"vertex, the withPoints family do not return results."
+msgstr ""
+
+msgid "C/C++ code enhancemet"
+msgstr ""
+
+#, fuzzy
+msgid "TRSP family"
+msgstr ":doc:`TSP-family`"
+
+msgid "pgRouting 3.7.0 Release Notes"
+msgstr ""
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.0 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.0%22>`__"
+msgstr ""
+
+msgid ""
+"`#2656 <https://github.com/pgRouting/pgrouting/pull/2656>`__ Stop support of "
+"PostgreSQL12 on pgrouting v3.7"
+msgstr ""
+
+msgid "Stopping support of PostgreSQL 12"
+msgstr ""
+
+msgid "CI does not test for PostgreSQL 12"
+msgstr ""
+
+msgid "New experimental functions"
+msgstr ""
+
+msgid "Metrics"
+msgstr ""
+
+msgid "pgr_betweennessCentrality"
+msgstr ""
+
+msgid ""
+"`#2605 <https://github.com/pgRouting/pgrouting/pull/2605>`__ Standardize "
+"spanning tree functions output"
+msgstr ""
+
+msgid "Functions:"
+msgstr ""
+
+msgid "Experimental promoted to proposed."
+msgstr ""
+
+msgid ""
+"`#2635 <https://github.com/pgRouting/pgrouting/pull/2635>`__ pgr_LineGraph "
+"ignores directed flag and use negative values for identifiers."
+msgstr ""
+
+msgid "``pgr_lineGraph``"
+msgstr ""
+
+msgid "Code enhancement"
+msgstr ""
+
+msgid ""
+"`#2599 <https://github.com/pgRouting/pgrouting/pull/2599>`__ Driving "
+"distance cleanup"
+msgstr ""
+
+msgid ""
+"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ Read postgresql "
+"data on C++"
+msgstr ""
+
+msgid ""
+"`#2614 <https://github.com/pgRouting/pgrouting/pull/2614>`__ Clang tidy does "
+"not work"
 msgstr ""
 
 msgid "pgRouting 3.6"
@@ -15717,9 +15741,6 @@ msgid ""
 "To see all issues & pull requests closed by this release see the `Git closed "
 "milestone for 3.6.3 <https://github.com/pgRouting/pgrouting/issues?"
 "utf8=%E2%9C%93&q=milestone%3A%22Release%203.6.3%22>`__"
-msgstr ""
-
-msgid "Build"
 msgstr ""
 
 msgid "Explicit minimum requirements:"
@@ -15824,43 +15845,26 @@ msgid ""
 msgstr ""
 
 msgid ""
-"`#2516 <https://github.com/pgRouting/pgrouting/pull/2516>`__ Standarize "
+"`#2516 <https://github.com/pgRouting/pgrouting/pull/2516>`__ Standardize "
 "output pgr_aStar"
 msgstr ""
 
-msgid ""
-"``pgr_aStar`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
-msgstr ""
-
-msgid "``pgr_aStar`` (`One to Many`) added ``end_vid`` column."
-msgstr ""
-
-msgid "``pgr_aStar`` (`Many to One`) added ``start_vid`` column."
+msgid "Standardize output columns to |short-generic-result|"
 msgstr ""
 
 msgid ""
-"`#2523 <https://github.com/pgRouting/pgrouting/pull/2523>`__ Standarize "
+"`#2523 <https://github.com/pgRouting/pgrouting/pull/2523>`__ Standardize "
 "output pgr_bdAstar"
 msgstr ""
 
 msgid ""
-"``pgr_bdAstar`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
-msgstr ""
-
-msgid "``pgr_bdAstar`` (`One to Many`) added ``end_vid`` column."
-msgstr ""
-
-msgid "``pgr_bdAstar`` (`Many to One`) added ``start_vid`` column."
-msgstr ""
-
-msgid ""
-"`#2547 <https://github.com/pgRouting/pgrouting/pull/2547>`__ Standarize "
+"`#2547 <https://github.com/pgRouting/pgrouting/pull/2547>`__ Standardize "
 "output and modifying signature pgr_KSP"
 msgstr ""
 
 msgid ""
-"`#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ Standarize "
-"output pgr_drivingdistance"
+"`#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ Standardize "
+"output pgr_drivingDistance"
 msgstr ""
 
 #, fuzzy
@@ -15868,12 +15872,12 @@ msgid "Proposed functions changes"
 msgstr "次期リリース予定の機能。"
 
 msgid ""
-"`#2544 <https://github.com/pgRouting/pgrouting/pull/2544>`__ Standarize "
+"`#2544 <https://github.com/pgRouting/pgrouting/pull/2544>`__ Standardize "
 "output and modifying signature pgr_withPointsDD"
 msgstr ""
 
 msgid ""
-"`#2546 <https://github.com/pgRouting/pgrouting/pull/2546>`__ Standarize "
+"`#2546 <https://github.com/pgRouting/pgrouting/pull/2546>`__ Standardize "
 "output and modifying signature pgr_withPointsKSP"
 msgstr ""
 
@@ -15917,11 +15921,11 @@ msgid ""
 "history links."
 msgstr ""
 
-msgid "..rubric:: SQL standarization"
+msgid "..rubric:: Standardize SQL"
 msgstr ""
 
 msgid ""
-"`#2555 <https://github.com/pgRouting/pgrouting/pull/2555>`__ standarize "
+"`#2555 <https://github.com/pgRouting/pgrouting/pull/2555>`__ Standardize "
 "deprecated messages"
 msgstr ""
 
@@ -15948,9 +15952,6 @@ msgstr "ドキュメントには改良が必要な場合があります。"
 msgid "Changes on the documentation to the following:"
 msgstr ""
 
-msgid "pgr_degree"
-msgstr ""
-
 msgid "pgr_dijkstra"
 msgstr ""
 
@@ -15968,7 +15969,7 @@ msgstr ""
 
 msgid ""
 "`#2565 <https://github.com/pgRouting/pgrouting/issues/2565>`__ "
-"pgr_pgr_lengauerTarjanDominatorTree triggers an assertion"
+"pgr_lengauerTarjanDominatorTree triggers an assertion"
 msgstr ""
 
 msgid "SQL enhancements"
@@ -16006,16 +16007,6 @@ msgid ""
 msgstr ""
 
 msgid "Dijkstra"
-msgstr ""
-
-msgid ""
-"``pgr_dijkstra`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
-msgstr ""
-
-msgid "``pgr_dijkstra`` (`One to Many`) added ``end_vid`` column."
-msgstr ""
-
-msgid "``pgr_dijkstra`` (`Many to One`) added ``start_vid`` column."
 msgstr ""
 
 msgid "pgRouting 3.4"
@@ -16074,13 +16065,14 @@ msgid ""
 "doesn't give all correct shortest path"
 msgstr ""
 
-msgid "New proposed functions"
-msgstr ""
+#, fuzzy
+msgid "New proposed functions."
+msgstr "新しい **公式** 機能"
 
 msgid "With points"
 msgstr ""
 
-msgid "``pgr_withPointsVia`` (One Via)"
+msgid "pgr_withPointsVia(One Via)"
 msgstr ""
 
 msgid "Turn Restrictions"
@@ -16089,82 +16081,67 @@ msgstr ""
 msgid "Via with turn restrictions"
 msgstr ""
 
-msgid "``pgr_trspVia`` (One Via)"
+msgid "pgr_trspVia(One Via)"
 msgstr ""
 
-msgid "``pgr_trspVia_withPoints`` (One Via)"
+msgid "pgr_trspVia_withPoints(One Via)"
 msgstr ""
 
-msgid "``pgr_trsp``"
+msgid "pgr_trsp_withPoints(One to One)"
 msgstr ""
 
-msgid "``pgr_trsp`` (One to One)"
+msgid "pgr_trsp_withPoints(One to Many)"
 msgstr ""
 
-msgid "``pgr_trsp`` (One to Many)"
+msgid "pgr_trsp_withPoints(Many to One)"
 msgstr ""
 
-msgid "``pgr_trsp`` (Many to One)"
+msgid "pgr_trsp_withPoints(Many to Many)"
 msgstr ""
 
-msgid "``pgr_trsp`` (Many to Many)"
-msgstr ""
-
-msgid "``pgr_trsp`` (Combinations)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints``"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (One to One)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (One to Many)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (Many to One)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (Many to Many)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (Combinations)"
+msgid "pgr_trsp_withPoints(Combinations)"
 msgstr ""
 
 msgid "Topology"
 msgstr ""
 
-msgid "``pgr_degree``"
+msgid "Utilities"
 msgstr ""
 
-msgid "``pgr_findCloseEdges`` (One point)"
+msgid "pgr_findCloseEdges(One point)"
 msgstr ""
 
-msgid "``pgr_findCloseEdges`` (Many points)"
+msgid "pgr_findCloseEdges(Many points)"
 msgstr ""
 
 msgid "Ordering"
 msgstr ""
 
-msgid "``pgr_cuthillMckeeOrdering``"
+msgid "pgr_cuthillMckeeOrdering"
+msgstr ""
+
+msgid "Unclassified"
+msgstr ""
+
+msgid "pgr_hawickCircuits"
 msgstr ""
 
 msgid "Flow functions"
 msgstr ""
 
-msgid "``pgr_maxCardinalityMatch(text)``"
+msgid "pgr_maxCardinalityMatch(text)"
 msgstr ""
 
-msgid "Deprecating ``pgr_maxCardinalityMatch(text,boolean)``"
+msgid "Deprecating: pgr_maxCardinalityMatch(text,boolean)"
 msgstr ""
 
 msgid "Deprecated Functions"
 msgstr ""
 
-msgid "``pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)``"
+msgid "pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)"
 msgstr ""
 
-msgid "``pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)``"
+msgid "pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)"
 msgstr ""
 
 msgid "pgRouting 3.3"
@@ -16350,9 +16327,6 @@ msgstr ""
 msgid "pgr_sequentialVertexColoring"
 msgstr ""
 
-msgid "pgr_extractVertices"
-msgstr ""
-
 msgid "Traversal"
 msgstr ""
 
@@ -16426,12 +16400,6 @@ msgstr ""
 msgid "Removing support for Boost v1.53, v1.54 & v1.55"
 msgstr ""
 
-msgid "pgr_bellmanFord(Combinations)"
-msgstr ""
-
-msgid "pgr_binaryBreadthFirstSearch(Combinations)"
-msgstr ""
-
 msgid "pgr_bipartite"
 msgstr ""
 
@@ -16439,9 +16407,6 @@ msgid "pgr_depthFirstSearch"
 msgstr ""
 
 msgid "Dijkstra Near"
-msgstr ""
-
-msgid "pgr_edwardMoore(Combinations)"
 msgstr ""
 
 msgid "pgr_isPlanar"
@@ -16453,49 +16418,13 @@ msgstr ""
 msgid "pgr_makeConnected"
 msgstr ""
 
-msgid "pgr_maxFlowMinCost(Combinations)"
-msgstr ""
-
-msgid "pgr_maxFlowMinCost_Cost(Combinations)"
-msgstr ""
-
 msgid "Astar"
-msgstr ""
-
-msgid "pgr_aStar(Combinations)"
-msgstr ""
-
-msgid "pgr_aStarCost(Combinations)"
 msgstr ""
 
 msgid "Bidirectional Astar"
 msgstr ""
 
-msgid "pgr_bdAstar(Combinations)"
-msgstr ""
-
-msgid "pgr_bdAstarCost(Combinations)"
-msgstr ""
-
 msgid "Bidirectional Dijkstra"
-msgstr ""
-
-msgid "pgr_bdDijkstra(Combinations)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCost(Combinations)"
-msgstr ""
-
-msgid "pgr_boykovKolmogorov(Combinations)"
-msgstr ""
-
-msgid "pgr_edmondsKarp(Combinations)"
-msgstr ""
-
-msgid "pgr_maxFlow(Combinations)"
-msgstr ""
-
-msgid "pgr_pushRelabel(Combinations)"
 msgstr ""
 
 msgid "pgRouting 3.1"
@@ -16732,7 +16661,7 @@ msgid ""
 "information"
 msgstr ""
 
-msgid "New functions"
+msgid "New Functions"
 msgstr ""
 
 msgid "Kruskal family"
@@ -16771,148 +16700,94 @@ msgstr ""
 msgid "aStar Family"
 msgstr ""
 
-msgid "pgr_aStar(one to many)"
+msgid "pgr_aStarCost(One to One)"
 msgstr ""
 
-msgid "pgr_aStar(many to one)"
+msgid "pgr_aStarCost(One to Many)"
 msgstr ""
 
-msgid "pgr_aStar(many to many)"
+msgid "pgr_aStarCost(Many to One)"
 msgstr ""
 
-msgid "pgr_aStarCost(one to one)"
+msgid "pgr_aStarCost(Many to Many)"
 msgstr ""
 
-msgid "pgr_aStarCost(one to many)"
-msgstr ""
-
-msgid "pgr_aStarCost(many to one)"
-msgstr ""
-
-msgid "pgr_aStarCost(many to many)"
-msgstr ""
-
-msgid "pgr_aStarCostMatrix(one to one)"
-msgstr ""
-
-msgid "pgr_aStarCostMatrix(one to many)"
-msgstr ""
-
-msgid "pgr_aStarCostMatrix(many to one)"
-msgstr ""
-
-msgid "pgr_aStarCostMatrix(many to many)"
+msgid "pgr_aStarCostMatrix"
 msgstr ""
 
 msgid "bdAstar Family"
 msgstr ""
 
-msgid "pgr_bdAstar(one to many)"
+msgid "pgr_bdAstarCost(One to One)"
 msgstr ""
 
-msgid "pgr_bdAstar(many to one)"
+msgid "pgr_bdAstarCost(One to Many)"
 msgstr ""
 
-msgid "pgr_bdAstar(many to many)"
+msgid "pgr_bdAstarCost(Many to One)"
 msgstr ""
 
-msgid "pgr_bdAstarCost(one to one)"
+msgid "pgr_bdAstarCost(Many to Many)"
 msgstr ""
 
-msgid "pgr_bdAstarCost(one to many)"
-msgstr ""
-
-msgid "pgr_bdAstarCost(many to one)"
-msgstr ""
-
-msgid "pgr_bdAstarCost(many to many)"
-msgstr ""
-
-msgid "pgr_bdAstarCostMatrix(one to one)"
-msgstr ""
-
-msgid "pgr_bdAstarCostMatrix(one to many)"
-msgstr ""
-
-msgid "pgr_bdAstarCostMatrix(many to one)"
-msgstr ""
-
-msgid "pgr_bdAstarCostMatrix(many to many)"
+msgid "pgr_bdAstarCostMatrix"
 msgstr ""
 
 msgid "bdDijkstra Family"
 msgstr ""
 
-msgid "pgr_bdDijkstra(one to many)"
+msgid "pgr_bdDijkstraCost(One to One)"
 msgstr ""
 
-msgid "pgr_bdDijkstra(many to one)"
+msgid "pgr_bdDijkstraCost(One to Many)"
 msgstr ""
 
-msgid "pgr_bdDijkstra(many to many)"
+msgid "pgr_bdDijkstraCost(Many to One)"
 msgstr ""
 
-msgid "pgr_bdDijkstraCost(one to one)"
+msgid "pgr_bdDijkstraCost(Many to Many)"
 msgstr ""
 
-msgid "pgr_bdDijkstraCost(one to many)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCost(many to one)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCost(many to many)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCostMatrix(one to one)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCostMatrix(one to many)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCostMatrix(many to one)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCostMatrix(many to many)"
+msgid "pgr_bdDijkstraCostMatrix"
 msgstr ""
 
 msgid "Flow Family"
 msgstr ""
 
-msgid "pgr_pushRelabel(one to one)"
+msgid "pgr_pushRelabel(One to One)"
 msgstr ""
 
-msgid "pgr_pushRelabel(one to many)"
+msgid "pgr_pushRelabel(One to Many)"
 msgstr ""
 
-msgid "pgr_pushRelabel(many to one)"
+msgid "pgr_pushRelabel(Many to One)"
 msgstr ""
 
-msgid "pgr_pushRelabel(many to many)"
+msgid "pgr_pushRelabel(Many to Many)"
 msgstr ""
 
-msgid "pgr_edmondsKarp(one to one)"
+msgid "pgr_edmondsKarp(One to One)"
 msgstr ""
 
-msgid "pgr_edmondsKarp(one to many)"
+msgid "pgr_edmondsKarp(One to Many)"
 msgstr ""
 
-msgid "pgr_edmondsKarp(many to one)"
+msgid "pgr_edmondsKarp(Many to One)"
 msgstr ""
 
-msgid "pgr_edmondsKarp(many to many)"
+msgid "pgr_edmondsKarp(Many to Many)"
 msgstr ""
 
-msgid "pgr_boykovKolmogorov (one to one)"
+msgid "pgr_boykovKolmogorov (One to One)"
 msgstr ""
 
-msgid "pgr_boykovKolmogorov (one to many)"
+msgid "pgr_boykovKolmogorov (One to Many)"
 msgstr ""
 
-msgid "pgr_boykovKolmogorov (many to one)"
+msgid "pgr_boykovKolmogorov (Many to One)"
 msgstr ""
 
-msgid "pgr_boykovKolmogorov (many to many)"
+msgid "pgr_boykovKolmogorov (Many to Many)"
 msgstr ""
 
 msgid "pgr_maxCardinalityMatching"
@@ -16921,19 +16796,22 @@ msgstr ""
 msgid "pgr_maxFlow"
 msgstr ""
 
-msgid "pgr_edgeDisjointPaths(one to one)"
+msgid "pgr_edgeDisjointPaths(One to One)"
 msgstr ""
 
-msgid "pgr_edgeDisjointPaths(one to many)"
+msgid "pgr_edgeDisjointPaths(One to Many)"
 msgstr ""
 
-msgid "pgr_edgeDisjointPaths(many to one)"
+msgid "pgr_edgeDisjointPaths(Many to One)"
 msgstr ""
 
-msgid "pgr_edgeDisjointPaths(many to many)"
+msgid "pgr_edgeDisjointPaths(Many to Many)"
 msgstr ""
 
 msgid "Components family"
+msgstr ""
+
+msgid "pgr_connectedComponents"
 msgstr ""
 
 msgid "pgr_strongComponents"
@@ -17122,7 +17000,7 @@ msgstr ""
 msgid "pgr_johnson"
 msgstr ""
 
-msgid "pgr_astar"
+msgid "pgr_aStar"
 msgstr ""
 
 msgid "pgr_bdAstar"
@@ -17141,6 +17019,9 @@ msgid "pgr_dijkstraCost"
 msgstr ""
 
 msgid "pgr_drivingDistance"
+msgstr ""
+
+msgid "pgr_KSP"
 msgstr ""
 
 msgid "pgr_dijkstraVia (proposed)"
@@ -17341,22 +17222,13 @@ msgstr ""
 msgid "Parameter names changed"
 msgstr ""
 
-msgid "The many version results are the union of the one to one version"
+msgid "The many version results are the union of the One to One version"
 msgstr ""
 
 msgid "New Signatures"
 msgstr ""
 
-msgid "pgr_bdAstar(one to one)"
-msgstr ""
-
-msgid "New Proposed functions"
-msgstr ""
-
-msgid "pgr_bdAstarCostMatrix"
-msgstr ""
-
-msgid "pgr_bdDijkstraCostMatrix"
+msgid "pgr_bdAstar(One to One)"
 msgstr ""
 
 msgid "pgr_lineGraph"
@@ -17439,31 +17311,7 @@ msgstr ""
 msgid "pgr_bdDijkstra"
 msgstr ""
 
-msgid "New Proposed Signatures"
-msgstr ""
-
-msgid "pgr_astar(one to many)"
-msgstr ""
-
-msgid "pgr_astar(many to one)"
-msgstr ""
-
-msgid "pgr_astar(many to many)"
-msgstr ""
-
-msgid "pgr_astarCost(one to one)"
-msgstr ""
-
-msgid "pgr_astarCost(one to many)"
-msgstr ""
-
-msgid "pgr_astarCost(many to one)"
-msgstr ""
-
-msgid "pgr_astarCost(many to many)"
-msgstr ""
-
-msgid "pgr_astarCostMatrix"
+msgid "Deprecated signatures."
 msgstr ""
 
 msgid "pgr_bddijkstra - use pgr_bdDijkstra instead"
@@ -17535,52 +17383,43 @@ msgstr ""
 msgid "pgr_TSP"
 msgstr "pgr_TSP"
 
-msgid "pgr_aStar"
-msgstr ""
-
-msgid "New Functions"
-msgstr ""
-
 msgid "pgr_eucledianTSP"
 msgstr ""
 
-msgid "pgr_withPointsCostMatrix"
+msgid "pgr_maxFlowPushRelabel(One to One)"
 msgstr ""
 
-msgid "pgr_maxFlowPushRelabel(one to one)"
+msgid "pgr_maxFlowPushRelabel(One to Many)"
 msgstr ""
 
-msgid "pgr_maxFlowPushRelabel(one to many)"
+msgid "pgr_maxFlowPushRelabel(Many to One)"
 msgstr ""
 
-msgid "pgr_maxFlowPushRelabel(many to one)"
+msgid "pgr_maxFlowPushRelabel(Many to Many)"
 msgstr ""
 
-msgid "pgr_maxFlowPushRelabel(many to many)"
+msgid "pgr_maxFlowEdmondsKarp(One to One)"
 msgstr ""
 
-msgid "pgr_maxFlowEdmondsKarp(one to one)"
+msgid "pgr_maxFlowEdmondsKarp(One to Many)"
 msgstr ""
 
-msgid "pgr_maxFlowEdmondsKarp(one to many)"
+msgid "pgr_maxFlowEdmondsKarp(Many to One)"
 msgstr ""
 
-msgid "pgr_maxFlowEdmondsKarp(many to one)"
+msgid "pgr_maxFlowEdmondsKarp(Many to Many)"
 msgstr ""
 
-msgid "pgr_maxFlowEdmondsKarp(many to many)"
+msgid "pgr_maxFlowBoykovKolmogorov (One to One)"
 msgstr ""
 
-msgid "pgr_maxFlowBoykovKolmogorov (one to one)"
+msgid "pgr_maxFlowBoykovKolmogorov (One to Many)"
 msgstr ""
 
-msgid "pgr_maxFlowBoykovKolmogorov (one to many)"
+msgid "pgr_maxFlowBoykovKolmogorov (Many to One)"
 msgstr ""
 
-msgid "pgr_maxFlowBoykovKolmogorov (many to one)"
-msgstr ""
-
-msgid "pgr_maxFlowBoykovKolmogorov (many to many)"
+msgid "pgr_maxFlowBoykovKolmogorov (Many to Many)"
 msgstr ""
 
 msgid "pgr_maximumCardinalityMatching"
@@ -17592,7 +17431,7 @@ msgstr ""
 msgid "pgr_tsp - use pgr_TSP or pgr_eucledianTSP instead"
 msgstr ""
 
-msgid "pgr_astar - use pgr_aStar instead"
+msgid "pgr_aStar - use pgr_aStar instead"
 msgstr ""
 
 msgid "pgr_flip_edges"
@@ -17679,6 +17518,9 @@ msgstr ""
 msgid "Improvements"
 msgstr ""
 
+msgid "pgr_nodeNetwork"
+msgstr ""
+
 msgid "Adding a row_where and outall optional parameters"
 msgstr ""
 
@@ -17691,53 +17533,50 @@ msgstr ""
 msgid "pgr_Johnson"
 msgstr ""
 
-msgid "pgr_dijkstraCost(one to one)"
+msgid "pgr_dijkstraCost(One to One)"
 msgstr ""
 
-msgid "pgr_dijkstraCost(one to many)"
+msgid "pgr_dijkstraCost(One to Many)"
 msgstr ""
 
-msgid "pgr_dijkstraCost(many to one)"
+msgid "pgr_dijkstraCost(Many to One)"
 msgstr ""
 
-msgid "pgr_dijkstraCost(many to many)"
+msgid "pgr_dijkstraCost(Many to Many)"
 msgstr ""
 
 #, fuzzy
 msgid "Proposed Functionality"
 msgstr "次期リリース予定の機能。"
 
-msgid "pgr_withPoints(one to one)"
+msgid "pgr_withPoints(One to One)"
 msgstr ""
 
-msgid "pgr_withPoints(one to many)"
+msgid "pgr_withPoints(One to Many)"
 msgstr ""
 
-msgid "pgr_withPoints(many to one)"
+msgid "pgr_withPoints(Many to One)"
 msgstr ""
 
-msgid "pgr_withPoints(many to many)"
+msgid "pgr_withPoints(Many to Many)"
 msgstr ""
 
-msgid "pgr_withPointsCost(one to one)"
+msgid "pgr_withPointsCost(One to One)"
 msgstr ""
 
-msgid "pgr_withPointsCost(one to many)"
+msgid "pgr_withPointsCost(One to Many)"
 msgstr ""
 
-msgid "pgr_withPointsCost(many to one)"
+msgid "pgr_withPointsCost(Many to One)"
 msgstr ""
 
-msgid "pgr_withPointsCost(many to many)"
+msgid "pgr_withPointsCost(Many to Many)"
 msgstr ""
 
 msgid "pgr_withPointsDD(single vertex)"
 msgstr ""
 
 msgid "pgr_withPointsDD(multiple vertices)"
-msgstr ""
-
-msgid "pgr_withPointsKSP"
 msgstr ""
 
 msgid "pgr_dijkstraVia"
@@ -17773,25 +17612,10 @@ msgid ""
 "q=is%3Aissue+milestone%3A%22Release+2.1.0%22+is%3Aclosed>`_ on Github."
 msgstr ""
 
-msgid "pgr_dijkstra(one to many)"
-msgstr ""
-
-msgid "pgr_dijkstra(many to one)"
-msgstr ""
-
-msgid "pgr_dijkstra(many to many)"
-msgstr ""
-
-msgid "pgr_drivingDistance(multiple vertices)"
-msgstr ""
-
 msgid "Refactored"
 msgstr ""
 
-msgid "pgr_dijkstra(one to one)"
-msgstr ""
-
-msgid "pgr_drivingDistance(single vertex)"
+msgid "pgr_dijkstra(One to One)"
 msgstr ""
 
 msgid ""
@@ -18130,8 +17954,8 @@ msgstr "サンプルデータ"
 
 msgid ""
 "The documentation provides very simple example queries based on a small "
-"sample network that resembles a city. To be able to execute the mayority of "
-"the examples queries, follow the instructions bellow."
+"sample network that resembles a city. To be able to execute the majority of "
+"the examples queries, follow the instructions below."
 msgstr ""
 
 msgid "Main graph"
@@ -18145,7 +17969,8 @@ msgstr ""
 
 msgid ""
 "Information known at this point is the geometry of the edges, cost values, "
-"cpacity values, category values and some locations that are not in the graph."
+"capacity values, category values and some locations that are not in the "
+"graph."
 msgstr ""
 
 msgid ""
@@ -18153,14 +17978,11 @@ msgid ""
 "that everything else is calculated."
 msgstr ""
 
-msgid "Edges"
-msgstr ""
-
 msgid ""
 "The database design for the documentation of pgRouting, keeps in the same "
 "row 2 segments, one in the direction of the geometry and the second in the "
-"oposite direction. Therfore some information has the ``reverse_`` prefix "
-"which corresponds to the segment on the oposite direction of the geometry."
+"opposite direction. Therefore some information has the ``reverse_`` prefix "
+"which corresponds to the segment on the opposite direction of the geometry."
 msgstr ""
 
 msgid "Identifier of the starting vertex of the geometry ``geom``."
@@ -18191,7 +18013,7 @@ msgid ":math:`x` coordinate of the starting vertex of the geometry."
 msgstr ""
 
 msgid ""
-"For convinience it is saved on the table but can be calculated as "
+"For convenience it is saved on the table but can be calculated as "
 "``ST_X(ST_StartPoint(geom))``."
 msgstr ""
 
@@ -18199,7 +18021,7 @@ msgid ":math:`y` coordinate of the ending vertex of the geometry."
 msgstr ""
 
 msgid ""
-"For convinience it is saved on the table but can be calculated as "
+"For convenience it is saved on the table but can be calculated as "
 "``ST_Y(ST_EndPoint(geom))``."
 msgstr ""
 
@@ -18210,8 +18032,8 @@ msgid "Starting on PostgreSQL 12::"
 msgstr ""
 
 msgid ""
-"Optionally indexes on different columns can be created. The recomendation is "
-"to have"
+"Optionally indexes on different columns can be created. The recommendation "
+"is to have"
 msgstr ""
 
 msgid "``id`` indexed."
@@ -18222,7 +18044,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"``geom`` indexed to speed up gemetry processes that might be needed in the "
+"``geom`` indexed to speed up geometry processes that might be needed in the "
 "front end."
 msgstr ""
 
@@ -18291,7 +18113,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"For convinence of this documentations, some combinations will be stored on a "
+"For convenience of this documentation, some combinations will be stored on a "
 "table:"
 msgstr ""
 
@@ -18501,8 +18323,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"pgRouting suplies some functions to create a routing topology and to analyze "
-"the topology."
+"pgRouting supplies some functions to create a routing topology and to "
+"analyze the topology."
 msgstr ""
 
 msgid "Additional functions to create a graph:"
@@ -18523,7 +18345,7 @@ msgstr ""
 msgid "Traversal - Family of functions"
 msgstr ""
 
-msgid "Aditionaly there are 2 categories under this family"
+msgid "Additionally there are 2 categories under this family"
 msgstr ""
 
 msgid "Via - Category"
@@ -18538,7 +18360,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"In other words, find a continuos route that visits all the vertices in the "
+"In other words, find a continuous route that visits all the vertices in the "
 "order given."
 msgstr ""
 
@@ -18912,3 +18734,37 @@ msgstr ""
 
 msgid "pgr_withPointsvia is pgr_dijkstraVia **with points**"
 msgstr ""
+
+#~ msgid "no"
+#~ msgstr "いいえ"
+
+#~ msgid "proposed"
+#~ msgstr "リリース予定"
+
+#~ msgid "The weighted directed graph, :math:`G_d(V,E)`, is definied by:"
+#~ msgstr ""
+#~ "重みづけされた有向グラフ :math:'G_d(V,E)''は、次のように定義されます:"
+
+#, fuzzy
+#~ msgid "e Also"
+#~ msgstr "参照"
+
+#~ msgid "For edge :math:`8`:"
+#~ msgstr "エッジのセット :math:`8`:"
+
+#~ msgid "The queries use the :doc:`sampledata` network."
+#~ msgstr "クエリは :doc:`sampledata` ネットワークを使用します。"
+
+#~ msgid "Previous versions of this page"
+#~ msgstr "このページの以前のバージョン"
+
+#, fuzzy
+#~ msgid "The following query has restrictions."
+#~ msgstr "次のクエリを実行します。"
+
+#~ msgid "New overload functions:"
+#~ msgstr "新しい **公式** 機能:"
+
+#, fuzzy
+#~ msgid "Queries use the :doc:`sampledata` network."
+#~ msgstr "クエリは :doc:`sampledata` ネットワークを使用します。"

--- a/locale/ko/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/ko/LC_MESSAGES/pgrouting_doc_strings.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-17 00:50+0000\n"
+"POT-Creation-Date: 2025-03-24 14:17+0000\n"
 "PO-Revision-Date: 2022-12-13 12:30+0000\n"
 "Last-Translator: Hyung-Gyu Ryoo <hyunggyu.ryoo@gmail.com>\n"
 "Language-Team: Korean <https://weblate.osgeo.org/projects/pgrouting/"
@@ -296,9 +296,6 @@ msgstr ":doc:`pgr_kruskalDFS`"
 msgid ":doc:`pgr_primDFS`"
 msgstr ":doc:`pgr_primDFS`"
 
-msgid "Proposed"
-msgstr ""
-
 msgid "Proposed functions for next mayor release."
 msgstr ""
 
@@ -366,9 +363,6 @@ msgid ""
 "functionality to the new signatures or replacement functions."
 msgstr ""
 
-msgid "Experimental"
-msgstr ""
-
 msgid "Possible server crash"
 msgstr ""
 
@@ -411,7 +405,7 @@ msgstr ""
 msgid "Documentation examples might need to be automatically generated."
 msgstr ""
 
-msgid "Might need a lot of feedback from the comunity."
+msgid "Might need a lot of feedback from the community."
 msgstr ""
 
 msgid "Might depend on a proposed function of pgRouting"
@@ -657,8 +651,8 @@ msgid "References"
 msgstr ""
 
 msgid ""
-"`Boost's metric appro's metric approximation <https://www.boost.org/libs/"
-"graph/doc/metric_tsp_approx.html>`__"
+"`Boost: metric TSP approx <https://www.boost.org/libs/graph/doc/"
+"metric_tsp_approx.html>`__"
 msgstr ""
 
 msgid "`University of Waterloo TSP <https://www.math.uwaterloo.ca/tsp/>`__"
@@ -669,7 +663,7 @@ msgid ""
 "Traveling_salesman_problem>`__"
 msgstr ""
 
-msgid "Vehicle Routing Functions - Category (Experimental)"
+msgid "Vehicle Routing Functions - Category"
 msgstr ""
 
 msgid "Pickup and delivery problem"
@@ -1618,8 +1612,8 @@ msgstr ""
 msgid "https://en.wikipedia.org/wiki/Vehicle_routing_problem"
 msgstr ""
 
-msgid "The queries use the :doc:`sampledata` network."
-msgstr ""
+msgid ":doc:`sampledata`"
+msgstr ":doc:`sampledata`"
 
 msgid "A* - Family of functions"
 msgstr ""
@@ -1780,7 +1774,8 @@ msgstr ""
 msgid ":doc:`bdAstar-family`"
 msgstr ":doc:`bdAstar-family`"
 
-msgid "https://www.boost.org/libs/graph/doc/astar_search.html"
+msgid ""
+"`Boost: A* search <https://www.boost.org/libs/graph/doc/astar_search.html>`__"
 msgstr ""
 
 msgid "https://en.wikipedia.org/wiki/A*_search_algorithm"
@@ -2587,14 +2582,11 @@ msgid ""
 "ending vertex:"
 msgstr ""
 
-msgid "It is expected to terminate faster than pgr_astar"
+msgid "It is expected to terminate faster than pgr_aStar"
 msgstr ""
 
 msgid ":doc:`aStar-family`"
 msgstr ":doc:`aStar-family`"
-
-msgid "Previous versions of this page"
-msgstr ""
 
 msgid "Bidirectional Dijkstra - Family of functions"
 msgstr ""
@@ -2742,27 +2734,7 @@ msgid "Identifier of the color of the edge."
 msgstr ""
 
 msgid ""
-"`Boost: Sequential Vertex Coloring algorithm documentation <https://www."
-"boost.org/libs/graph/doc/sequential_vertex_coloring.html>`__"
-msgstr ""
-
-msgid ""
-"`Wikipedia: Graph coloring <https://en.wikipedia.org/wiki/Graph_coloring>`__"
-msgstr ""
-
-msgid ""
-"`Boost: is_bipartite <https://www.boost.org/libs/graph/doc/is_bipartite."
-"html>`__"
-msgstr ""
-
-msgid ""
-"`Wikipedia: bipartite graph <https://en.wikipedia.org/wiki/"
-"Bipartite_graph>`__"
-msgstr ""
-
-msgid ""
-"`Boost: Edge Coloring Algorithm documentation <https://www.boost.org/libs/"
-"graph/doc/edge_coloring.html>`__"
+"`Boost: <https://www.boost.org/libs/graph/doc/table_of_contents.html>`__"
 msgstr ""
 
 msgid "Components - Family of functions"
@@ -2798,6 +2770,10 @@ msgstr ""
 msgid ":doc:`pgr_contraction`"
 msgstr ":doc:`pgr_contraction`"
 
+#, fuzzy
+msgid ":doc:`pgr_contractionDeadEnd`"
+msgstr ":doc:`pgr_contraction`"
+
 msgid ""
 "In large graphs, like the road graphs, or electric networks, graph "
 "contraction can be used to speed up some graph algorithms. Contraction "
@@ -2827,491 +2803,6 @@ msgid ""
 "Decide the order of the contraction algorithms and set the maximum number of "
 "times they are to be executed."
 msgstr ""
-
-msgid "Contraction of the leaf nodes of the graph."
-msgstr ""
-
-msgid "Dead end"
-msgstr ""
-
-msgid "A node is considered a **dead end** node when"
-msgstr ""
-
-msgid "On undirected graphs:"
-msgstr ""
-
-msgid "The number of adjacent vertices is 1."
-msgstr ""
-
-msgid "On directed graphs:"
-msgstr ""
-
-msgid "There are no outgoing edges and has at least one incoming edge."
-msgstr ""
-
-msgid "There are no incoming edges and has at least one outgoing edge."
-msgstr ""
-
-msgid ""
-"When the conditions are true then the `Operation: Dead End Contraction`_ can "
-"be done."
-msgstr ""
-
-msgid "Dead end vertex on undirected graph"
-msgstr ""
-
-msgid "The green nodes are `dead end`_ nodes"
-msgstr ""
-
-msgid "The blue nodes have an unlimited number of edges."
-msgstr ""
-
-msgid "Node"
-msgstr ""
-
-msgid "Adjecent nodes"
-msgstr ""
-
-msgid "Number of adjacent nodes"
-msgstr ""
-
-msgid ":math:`a`"
-msgstr ""
-
-msgid ":math:`\\{u\\}`"
-msgstr ""
-
-msgid ":math:`b`"
-msgstr ""
-
-msgid ":math:`\\{v\\}`"
-msgstr ""
-
-msgid "Dead end vertex on directed graph"
-msgstr ""
-
-msgid ""
-"The blue nodes have an unlimited number of incoming and/or outgoing edges."
-msgstr ""
-
-msgid "Number of incoming edges"
-msgstr ""
-
-msgid "Number of outgoing edges"
-msgstr ""
-
-msgid ":math:`c`"
-msgstr ""
-
-msgid ":math:`\\{v, w\\}`"
-msgstr ""
-
-msgid "2"
-msgstr ""
-
-msgid ":math:`d`"
-msgstr ""
-
-msgid ":math:`\\{x\\}`"
-msgstr ""
-
-msgid ":math:`e`"
-msgstr ""
-
-msgid ":math:`\\{x, y\\}`"
-msgstr ""
-
-msgid ""
-"From above, nodes :math:`\\{a, b, d\\}` are dead ends because the number of "
-"adjacent vertices is 1. No further checks are needed for those nodes."
-msgstr ""
-
-msgid ""
-"On the following table, nodes :math:`\\{c, e\\}` because the even that the "
-"number of adjacent vertices is not 1 for"
-msgstr ""
-
-msgid "Operation: Dead End Contraction"
-msgstr ""
-
-msgid ""
-"The dead end contraction will stop until there are no more dead end nodes. "
-"For example from the following graph where :math:`w` is the `dead end`_ node:"
-msgstr ""
-
-msgid ""
-"After contracting :math:`w`, node :math:`v` is now a `dead end`_ node and is "
-"contracted:"
-msgstr ""
-
-msgid ""
-"After contracting :math:`v`, stop. Node :math:`u` has the information of "
-"nodes that were contrcted."
-msgstr ""
-
-msgid "Node :math:`u` has the information of nodes that were contracted."
-msgstr ""
-
-msgid "In the algorithm, linear contraction is represented by 2."
-msgstr ""
-
-msgid "Linear"
-msgstr ""
-
-msgid ""
-"In case of an undirected graph, a node is considered a `linear` node when"
-msgstr ""
-
-msgid "The number of adjacent vertices is 2."
-msgstr ""
-
-msgid "In case of a directed graph, a node is considered a `linear` node when"
-msgstr ""
-
-msgid "Linearity is symmetrical"
-msgstr ""
-
-msgid "Linear vertex on undirected graph"
-msgstr ""
-
-msgid "The green nodes are `linear`_ nodes"
-msgstr ""
-
-msgid "The blue nodes have an unlimited number of incoming and outgoing edges."
-msgstr ""
-
-msgid "Undirected"
-msgstr ""
-
-msgid ":math:`v`"
-msgstr ""
-
-msgid ":math:`\\{u, w\\}`"
-msgstr ""
-
-msgid "Linear vertex on directed graph"
-msgstr ""
-
-msgid "The white node is not linear because the linearity is not symetrical."
-msgstr ""
-
-msgid "It is possible to go :math:`y \\rightarrow c \\rightarrow z`"
-msgstr ""
-
-msgid "It's not possible to go :math:`z \\rightarrow c \\rightarrow y`"
-msgstr ""
-
-msgid "Is symmetrical?"
-msgstr ""
-
-msgid ":math:`\\{u, v\\}`"
-msgstr ""
-
-msgid "yes"
-msgstr ""
-
-msgid ":math:`\\{w, x\\}`"
-msgstr ""
-
-msgid ":math:`\\{y, z\\}`"
-msgstr ""
-
-msgid "no"
-msgstr ""
-
-msgid "Operation: Linear Contraction"
-msgstr ""
-
-msgid ""
-"The linear contraction will stop when there are no more linear nodes. For "
-"example from the following graph where :math:`v` and :math:`w` are `linear`_ "
-"nodes:"
-msgstr ""
-
-msgid "Contracting :math:`w`,"
-msgstr ""
-
-msgid "The vertex :math:`w` is removed from the graph"
-msgstr ""
-
-msgid ""
-"The edges :math:`v \\rightarrow w` and :math:`w \\rightarrow z` are removed "
-"from the graph."
-msgstr ""
-
-msgid ""
-"A new edge :math:`v \\rightarrow z` is inserted represented with red color."
-msgstr ""
-
-msgid "Contracting :math:`v`:"
-msgstr ""
-
-msgid "The vertex :math:`v` is removed from the graph"
-msgstr ""
-
-msgid ""
-"The edges :math:`u \\rightarrow v` and :math:`v \\rightarrow z` are removed "
-"from the graph."
-msgstr ""
-
-msgid ""
-"A new edge :math:`u \\rightarrow z` is inserted represented with red color."
-msgstr ""
-
-msgid ""
-"Edge :math:`u \\rightarrow z` has the information of nodes that were "
-"contracted."
-msgstr ""
-
-msgid "The cycle"
-msgstr ""
-
-msgid ""
-"Contracting a graph, can be done with more than one operation. The order of "
-"the operations affect the resulting contracted graph, after applying one "
-"operation, the set of vertices that can be contracted by another operation "
-"changes."
-msgstr ""
-
-msgid ""
-"This implementation, cycles ``max_cycles`` times through "
-"``operations_order`` ."
-msgstr ""
-
-msgid "Contracting sample data"
-msgstr ""
-
-msgid ""
-"In this section, building and using a contracted graph will be shown by "
-"example."
-msgstr ""
-
-msgid "The :doc:`sampledata` for an undirected graph is used"
-msgstr ""
-
-msgid "a dead end operation first followed by a linear operation."
-msgstr ""
-
-msgid "Construction of the graph in the database"
-msgstr ""
-
-msgid "Original Data"
-msgstr ""
-
-msgid ""
-"The following query shows the original data involved in the contraction "
-"operation."
-msgstr ""
-
-msgid "The original graph:"
-msgstr ""
-
-msgid "Contraction results"
-msgstr ""
-
-msgid ""
-"The results do not represent the contracted graph. They represent the "
-"changes done to the graph after applying the contraction algorithm."
-msgstr ""
-
-msgid ""
-"Observe that vertices, for example, :math:`6` do not appear in the results "
-"because it was not affected by the contraction algorithm."
-msgstr ""
-
-msgid "After doing the dead end contraction operation:"
-msgstr ""
-
-msgid "After doing the linear contraction operation to the graph above:"
-msgstr ""
-
-msgid "The process to create the contraction graph on the database:"
-msgstr ""
-
-msgid "Add additional columns"
-msgstr ""
-
-msgid ""
-"Adding extra columns to the ``edge_table`` and ``edge_table_vertices_pgr`` "
-"tables, where:"
-msgstr ""
-
-msgid "``contracted_vertices``"
-msgstr ""
-
-msgid "The vertices set belonging to the vertex/edge"
-msgstr ""
-
-msgid "``is_contracted``"
-msgstr ""
-
-msgid "On the vertex table"
-msgstr ""
-
-msgid ""
-"when ``true`` the vertex is contracted, its not part of the contracted graph."
-msgstr ""
-
-msgid ""
-"when ``false`` the vertex is not contracted, its part of the contracted "
-"graph."
-msgstr ""
-
-msgid "``is_new``"
-msgstr ""
-
-msgid "On the edge table"
-msgstr ""
-
-msgid ""
-"when ``true`` the edge was generated by the contraction algorithm. its part "
-"of the contracted graph."
-msgstr ""
-
-msgid ""
-"when ``false`` the edge is an original edge, might be or not part of the "
-"contracted graph."
-msgstr ""
-
-msgid "Store contraction information"
-msgstr ""
-
-msgid "Store the `contraction results`_ in a table"
-msgstr ""
-
-msgid "The vertex table update"
-msgstr ""
-
-msgid ""
-"Use ``is_contracted`` column to indicate the vertices that are contracted."
-msgstr ""
-
-msgid ""
-"Fill ``contracted_vertices`` with the information from the results tha "
-"belong to the vertices."
-msgstr ""
-
-msgid "The modified vertices table:"
-msgstr ""
-
-msgid "The edge table update"
-msgstr ""
-
-msgid "Insert the new edges generated by pgr_contraction."
-msgstr ""
-
-msgid "The modified ``edge_table``."
-msgstr ""
-
-msgid "The contracted graph"
-msgstr ""
-
-msgid "Vertices that belong to the contracted graph."
-msgstr ""
-
-msgid "Edges that belong to the contracted graph."
-msgstr ""
-
-msgid "Contracted graph"
-msgstr ""
-
-msgid "Using the contracted graph"
-msgstr ""
-
-msgid "Using the contracted graph with ``pgr_dijkstra``"
-msgstr ""
-
-msgid ""
-"There are three cases when calculating the shortest path between a given "
-"source and target in a contracted graph:"
-msgstr ""
-
-msgid "Case 1: Both source and target belong to the contracted graph."
-msgstr ""
-
-msgid "Case 2: Source and/or target belong to an edge subgraph."
-msgstr ""
-
-msgid "Case 3: Source and/or target belong to a vertex."
-msgstr ""
-
-msgid ""
-"Using the `Edges that belong to the contracted graph.`_ on lines 11 to 20."
-msgstr ""
-
-msgid "Case 1"
-msgstr ""
-
-msgid ""
-"When both source and target belong to the contracted graph, a path is found."
-msgstr ""
-
-msgid "Case 2"
-msgstr ""
-
-msgid ""
-"When source and/or target belong to an edge subgraph then a path is not "
-"found."
-msgstr ""
-
-msgid ""
-"In this case, the contracted graph do not have an edge connecting with node :"
-"math:`4`."
-msgstr ""
-
-msgid "Case 3"
-msgstr ""
-
-msgid "When source and/or target belong to a vertex then a path is not found."
-msgstr ""
-
-msgid ""
-"In this case, the contracted graph do not have an edge connecting with node :"
-"math:`7` and of node :math:`4` of the second case."
-msgstr ""
-
-msgid "Refining the above function to include nodes that belong to an edge."
-msgstr ""
-
-msgid "The vertices that need to be expanded are calculated on lines 11 to 17."
-msgstr ""
-
-msgid ""
-"Adding to the contracted graph that additional section on lines 26 to 28."
-msgstr ""
-
-msgid ""
-"When source and/or target belong to an edge subgraph, now, a path is found."
-msgstr ""
-
-msgid "The routing graph now has an edge connecting with node :math:`4`."
-msgstr ""
-
-msgid ""
-"In this case, the contracted graph do not have an edge connecting with node :"
-"math:`7`."
-msgstr ""
-
-msgid "The vertices that need to be expanded are calculated on lines 19 to 24."
-msgstr ""
-
-msgid ""
-"Adding to the contracted graph that additional section on lines 38 to 40."
-msgstr ""
-
-msgid ""
-"The code change do not affect this case so when source and/or target belong "
-"to an edge subgraph, a path is still found."
-msgstr ""
-
-msgid "When source and/or target belong to a vertex, now, a path is found."
-msgstr ""
-
-msgid "Now, the routing graph has an edge connecting with node :math:`7`."
-msgstr ""
-
-msgid ":doc:`sampledata`"
-msgstr ":doc:`sampledata`"
 
 msgid ""
 "https://www.cs.cmu.edu/afs/cs/academic/class/15210-f12/www/lectures/"
@@ -3390,9 +2881,6 @@ msgstr ":doc:`pgr_bdAstarCostMatrix`"
 
 msgid ":doc:`pgr_bdDijkstraCostMatrix`"
 msgstr ":doc:`pgr_bdDijkstraCostMatrix`"
-
-msgid "proposed"
-msgstr ""
 
 msgid ":doc:`pgr_withPointsCostMatrix`"
 msgstr ":doc:`pgr_withPointsCostMatrix`"
@@ -3571,7 +3059,7 @@ msgid ""
 msgstr ""
 ":doc:`pgr_KSP` - K 최단 경로를 얻기 위해 pgr_dijkstra로 Yen 알고리즘을 사용."
 
-msgid ":doc:`pgr_dijkstraVia` - Get a route of a seuence of vertices."
+msgid ":doc:`pgr_dijkstraVia` - Get a route of a sequence of vertices."
 msgstr ""
 
 msgid ":doc:`pgr_dijkstraNear` - Get the route to the nearest vertex."
@@ -3656,7 +3144,7 @@ msgstr ""
 msgid "Directed graph"
 msgstr ""
 
-msgid "The weighted directed graph, :math:`G_d(V,E)`, is definied by:"
+msgid "The weighted directed graph, :math:`G_d(V,E)`, is defined by:"
 msgstr ""
 
 msgid "the set of vertices :math:`V`"
@@ -3681,7 +3169,7 @@ msgstr ""
 msgid "Undirected graph"
 msgstr ""
 
-msgid "The weighted undirected graph, :math:`G_u(V,E)`, is definied by:"
+msgid "The weighted undirected graph, :math:`G_u(V,E)`, is defined by:"
 msgstr ""
 
 msgid ":math:`V = source \\cup target \\cup {start_v{vid}} \\cup  {end_{vid}}`"
@@ -3796,7 +3284,8 @@ msgstr ""
 msgid ":doc:`pgr_kruskalDD` - Driving Distance based on Kruskal's algorithm"
 msgstr ""
 
-msgid "Post pocessing"
+#, fuzzy
+msgid "Post processing"
 msgstr "포스트 프로세싱"
 
 msgid ":doc:`pgr_alphaShape` - Alpha shape computation"
@@ -3918,6 +3407,11 @@ msgid ""
 "an undirected graph."
 msgstr ""
 
+msgid ""
+":doc:`pgr_topologicalSort` - Linear ordering of the vertices for directed "
+"acyclic graph."
+msgstr ""
+
 #, fuzzy
 msgid ":doc:`metrics-family`"
 msgstr ":doc:`prim-family`"
@@ -3936,8 +3430,9 @@ msgstr ""
 msgid ":doc:`VRP-category`"
 msgstr ":doc:`VRP-category`"
 
-msgid "Unclassified"
-msgstr ""
+#, fuzzy
+msgid "Shortest Path Category"
+msgstr "BFS - 카테고리"
 
 msgid ":doc:`pgr_bellmanFord`"
 msgstr ":doc:`pgr_bellmanFord`"
@@ -3948,20 +3443,23 @@ msgstr ":doc:`pgr_dagShortestPath`"
 msgid ":doc:`pgr_edwardMoore`"
 msgstr ":doc:`pgr_edwardMoore`"
 
+msgid "Planar Family"
+msgstr ""
+
 msgid ":doc:`pgr_isPlanar`"
 msgstr ":doc:`pgr_isPlanar`"
+
+msgid "Miscellaneous Algorithms"
+msgstr ""
+
+msgid ":doc:`pgr_lengauerTarjanDominatorTree`"
+msgstr ":doc:`pgr_lengauerTarjanDominatorTree`"
 
 msgid ":doc:`pgr_stoerWagner`"
 msgstr ":doc:`pgr_stoerWagner`"
 
-msgid ":doc:`pgr_topologicalSort`"
-msgstr ":doc:`pgr_topologicalSort`"
-
 msgid ":doc:`pgr_transitiveClosure`"
 msgstr ":doc:`pgr_transitiveClosure`"
-
-msgid ":doc:`pgr_lengauerTarjanDominatorTree`"
-msgstr ":doc:`pgr_lengauerTarjanDominatorTree`"
 
 msgid ":doc:`pgr_hawickCircuits`"
 msgstr ":doc:`pgr_hawickCircuits`"
@@ -4016,7 +3514,7 @@ msgid ""
 "returned."
 msgstr ""
 
-msgid "There is no flow when source has the same vaule as target."
+msgid "There is no flow when source has the same value as target."
 msgstr ""
 
 msgid "Any duplicated values in source or target are ignored."
@@ -4309,6 +3807,11 @@ msgstr ":doc:`pgr_kruskal`"
 msgid ":doc:`pgr_kruskalDD`"
 msgstr ":doc:`pgr_kruskalDD`"
 
+msgid ""
+":doc:`pgr_degree` - Returns a set of vertices and corresponding count of "
+"incident edges to the vertex."
+msgstr ""
+
 msgid ":doc:`prim-family`"
 msgstr ":doc:`prim-family`"
 
@@ -4356,8 +3859,19 @@ msgstr ""
 msgid ":doc:`pgr_nodeNetwork` - to create nodes to a not noded edge table."
 msgstr ""
 
+msgid ""
+":doc:`pgr_extractVertices` - Extracts vertex information based on the edge "
+"table information."
+msgstr ""
+
 msgid ":doc:`pgr_trsp` - Turn Restriction Shortest Path (TRSP)"
 msgstr ""
+
+msgid "Utilities family"
+msgstr ""
+
+msgid ":doc:`pgr_findCloseEdges`"
+msgstr ":doc:`pgr_findCloseEdges`"
 
 msgid "Functions by categories"
 msgstr "카테고리별 함수"
@@ -4374,7 +3888,8 @@ msgstr ":doc:`drivingDistance-category`"
 msgid ":doc:`KSP-category`"
 msgstr ":doc:`KSP-category`"
 
-msgid ":doc:`spanningTree-family`"
+#, fuzzy
+msgid ":doc:`spanningTree-category`"
 msgstr ":doc:`spanningTree-family`"
 
 msgid ":doc:`BFS-category`"
@@ -4395,118 +3910,193 @@ msgstr ":doc:`experimental`"
 msgid ":doc:`release_notes`"
 msgstr ":doc:`release_notes`"
 
-msgid "pgRouting 3.7.0 Release Notes"
+msgid "pgRouting 4.0.0 Release Notes"
 msgstr ""
 
 msgid ""
 "To see all issues & pull requests closed by this release see the `Git closed "
-"milestone for 3.7.0 <https://github.com/pgRouting/pgrouting/issues?"
-"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.0%22>`__"
+"milestone for 4.0.0 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%204.0.0%22>`__"
 msgstr ""
 
-msgid "Support"
-msgstr ""
-
-msgid ""
-"`#2656 <https://github.com/pgRouting/pgrouting/pull/2656>`__ Stop support of "
-"PostgreSQL12 on pgrouting v3.7"
+msgid "Functions promoted to official"
 msgstr ""
 
 #, fuzzy
-msgid "Stopping support of PostgreSQL 12"
-msgstr "PostgreSQL 설정"
+msgid "pgr_trsp"
+msgstr ":doc:`pgr_trsp`"
 
-msgid "CI does not test for PostgreSQL 12"
-msgstr ""
+#, fuzzy
+msgid "pgr_trspVia"
+msgstr ":doc:`pgr_trsp`"
 
-msgid "New experimental functions"
-msgstr ""
+#, fuzzy
+msgid "pgr_trspVia_withPoints"
+msgstr ":doc:`pgr_trspVia_withPoints`"
 
-msgid "Metrics"
-msgstr ""
+#, fuzzy
+msgid "pgr_trsp_withPoints"
+msgstr ":doc:`pgr_trspVia_withPoints`"
 
-msgid "pgr_betweennessCentrality"
-msgstr ""
+#, fuzzy
+msgid "pgr_withPoints"
+msgstr ":doc:`pgr_withPoints`"
 
-msgid "Official functions changes"
-msgstr ""
+#, fuzzy
+msgid "pgr_withPointsCost"
+msgstr ":doc:`pgr_withPointsCost`"
 
-msgid ""
-"`#2605 <https://github.com/pgRouting/pgrouting/pull/2605>`__ Standarize "
-"spanning tree functions output"
-msgstr ""
-
-msgid "Functions:"
-msgstr ""
-
-msgid "``pgr_kruskalDD``"
-msgstr ""
-
-msgid "``pgr_kruskalDFS``"
-msgstr ""
-
-msgid "``pgr_kruskalBFS``"
-msgstr ""
-
-msgid "``pgr_primDD``"
-msgstr ""
-
-msgid "``pgr_primDFS``"
-msgstr ""
-
-msgid "``pgr_primBFS``"
-msgstr ""
-
-msgid "Standarizing output columns to |result-spantree|"
-msgstr ""
-
-msgid "Added ``pred`` result columns."
-msgstr ""
-
-msgid "Experimental promoted to proposed."
-msgstr ""
-
-msgid ""
-"`#2635 <https://github.com/pgRouting/pgrouting/pull/2635>`__ pgr_LineGraph "
-"ignores directed flag and use negative values for identifiers."
+msgid "pgr_withPointsCostMatrix"
 msgstr ""
 
 #, fuzzy
-msgid "``pgr_lineGraph``"
-msgstr ":doc:`pgr_analyzeGraph`"
+msgid "pgr_withPointsDD"
+msgstr ":doc:`pgr_withPoints`"
 
-msgid "Promoted to **proposed** signature."
+msgid "pgr_withPointsKSP"
 msgstr ""
 
 #, fuzzy
-msgid "Works for directed and undirected graphs."
-msgstr ":doc:`pgr_bridges` - 무방향 그래프의 브릿지."
+msgid "pgr_withPointsVia"
+msgstr ":doc:`pgr_withPointsVia`"
 
-msgid "Code enhancement"
+msgid "Signatures promoted to official"
+msgstr ""
+
+msgid "pgr_aStar(Combinations)"
+msgstr ""
+
+msgid "pgr_aStarCost(Combinations)"
+msgstr ""
+
+msgid "pgr_bdAstar(Combinations)"
+msgstr ""
+
+msgid "pgr_bdAstarCost(Combinations)"
+msgstr ""
+
+msgid "pgr_bdDijkstra(Combinations)"
+msgstr ""
+
+msgid "pgr_bdDijkstraCost(Combinations)"
+msgstr ""
+
+#, fuzzy
+msgid "pgr_dijkstra(Combinations)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
+
+#, fuzzy
+msgid "pgr_dijkstraCost(Combinations)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
+
+msgid "pgr_KSP(All signatures)"
+msgstr ""
+
+msgid "pgr_boykovKolmogorov(Combinations)"
+msgstr ""
+
+msgid "pgr_edmondsKarp(Combinations)"
+msgstr ""
+
+msgid "pgr_maxFlow(Combinations)"
+msgstr ""
+
+msgid "pgr_pushRelabel(Combinations)"
+msgstr ""
+
+msgid "code enhancements:"
+msgstr ""
+
+msgid "Removal of unused C/C++ code"
+msgstr ""
+
+msgid "Removal of SQL deprecated functions"
 msgstr ""
 
 msgid ""
-"`#2599 <https://github.com/pgRouting/pgrouting/pull/2599>`__ Driving "
-"distance cleanup"
+"pgr_trsp(text,integer,double precision,integer,double precision,boolean,"
+"boolean,text)"
+msgstr ""
+
+msgid "pgr_trsp(text,integer,integer,boolean,boolean,text)"
 msgstr ""
 
 msgid ""
-"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ Read postgresql "
-"data on C++"
+"pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)"
+msgstr ""
+
+msgid "pgr_trspviavertices(text,anyarray,boolean,boolean,text)"
+msgstr ""
+
+msgid "Removal of SQL deprecated internal functions"
+msgstr ""
+
+msgid "_pgr_dijkstranear(text,anyarray,anyarray,bigint,boolean)"
+msgstr ""
+
+msgid "_pgr_dijkstranear(text,anyarray,bigint,bigint,boolean)"
+msgstr ""
+
+msgid "_pgr_dijkstranear(text,bigint,anyarray,bigint,boolean)"
+msgstr ""
+
+msgid "_pgr_dijkstra(text,anyarray,anyarray,boolean,boolean,boolean,bigint)"
+msgstr ""
+
+msgid "_pgr_dijkstra(text,text,boolean,boolean,boolean)"
+msgstr ""
+
+msgid "_pgr_drivingdistance(text,anyarray,double precision,boolean,boolean)"
+msgstr ""
+
+msgid "_pgr_kruskal(text,anyarray,text,bigint,double precision)"
+msgstr ""
+
+msgid "_pgr_prim(text,anyarray,text,bigint,double precision)"
 msgstr ""
 
 msgid ""
-"`#2614 <https://github.com/pgRouting/pgrouting/pull/2614>`__ Clang tidy does "
-"not work"
+"_pgr_trsp(text,integer,double precision,integer,double precision,boolean,"
+"boolean,text)"
+msgstr ""
+
+msgid "_pgr_trsp(text,text,anyarray,anyarray,boolean)"
+msgstr ""
+
+msgid "_pgr_trsp(text,text,anyarray,bigint,boolean)"
+msgstr ""
+
+msgid "_pgr_trsp(text,text,bigint,anyarray,boolean)"
+msgstr ""
+
+msgid "_pgr_trsp(text,text,bigint,bigint,boolean)"
+msgstr ""
+
+msgid "_pgr_trspviavertices(text,integer[],boolean,boolean,text)"
+msgstr ""
+
+msgid "_pgr_withpointsvia(text,bigint[],double precision[],boolean)"
+msgstr ""
+
+msgid "_trsp(text,text,anyarray,anyarray,boolean)"
+msgstr ""
+
+msgid "_v4trsp(text,text,anyarray,anyarray,boolean)"
+msgstr ""
+
+msgid "_v4trsp(text,text,text,boolean)"
+msgstr ""
+
+msgid "Deprecation of internal C/C++ functions"
+msgstr ""
+
+msgid "Internal C/C++ functions in legacy"
 msgstr ""
 
 msgid "All releases"
 msgstr ""
 
 msgid "Kruskal - Family of functions"
-msgstr ""
-
-msgid "Boost Graph Inside"
 msgstr ""
 
 msgid ""
@@ -4541,14 +4131,6 @@ msgstr ""
 
 msgid "All deprecated functions will be removed on next mayor version 4.0.0"
 msgstr ""
-
-#, fuzzy
-msgid "Migration of functions"
-msgstr ":doc:`pgr_withPoints`"
-
-#, fuzzy
-msgid "Migrating functions"
-msgstr ":doc:`routingFunctions`"
 
 msgid "Migration of ``pgr_aStar``"
 msgstr ""
@@ -4703,7 +4285,7 @@ msgid "If needed add the new columns, for example:"
 msgstr ""
 
 #, fuzzy
-msgid "Migration of ``pgr_drivingdistance``"
+msgid "Migration of ``pgr_drivingDistance``"
 msgstr ":doc:`pgr_withPoints`"
 
 msgid ""
@@ -4724,11 +4306,12 @@ msgid "|result-spantree|"
 msgstr ""
 
 #, fuzzy
-msgid "``pgr_drivingdistance`` (Single vertex)"
+msgid "pgr_drivingDistance(Single vertex)"
 msgstr ":doc:`pgr_drivingDistance`"
 
-msgid "``pgr_drivingdistance`` (Multiple vertices)"
-msgstr ""
+#, fuzzy
+msgid "pgr_drivingDistance(Multiple vertices)"
+msgstr ":doc:`pgr_drivingDistance`"
 
 msgid "Output columns were |result-dij-dd|"
 msgstr ""
@@ -4787,10 +4370,19 @@ msgstr ""
 msgid "|result-bfs|"
 msgstr ""
 
+msgid "``pgr_kruskalDD``"
+msgstr ""
+
 msgid "Single vertex"
 msgstr ""
 
 msgid "Multiple vertices"
+msgstr ""
+
+msgid "``pgr_kruskalDFS``"
+msgstr ""
+
+msgid "``pgr_kruskalBFS``"
 msgstr ""
 
 msgid "Output columns were |result-bfs|"
@@ -4946,6 +4538,15 @@ msgid ""
 "Starting from `v3.7.0 <https://docs.pgrouting.org/3.7/en/migration.html>`__ :"
 "doc:`pgr_primDD`, :doc:`pgr_primBFS` and :doc:`pgr_primDFS` result columns "
 "are being standardized."
+msgstr ""
+
+msgid "``pgr_primDD``"
+msgstr ""
+
+msgid "``pgr_primDFS``"
+msgstr ""
+
+msgid "``pgr_primBFS``"
 msgstr ""
 
 msgid "Prim single vertex"
@@ -5145,7 +4746,128 @@ msgid ""
 "original columns:"
 msgstr ""
 
-msgid "Migration of turn restrictions"
+msgid "Migration of ``pgr_trsp`` (Vertices)"
+msgstr ""
+
+msgid "Signature:"
+msgstr ""
+
+msgid "Deprecated"
+msgstr ""
+
+msgid "`v3.4.0 <https://docs.pgrouting.org/3.4>`__"
+msgstr ""
+
+msgid "Removed"
+msgstr ""
+
+msgid "`v4.0.0 <https://docs.pgrouting.org/4.0>`__"
+msgstr ""
+
+#, fuzzy
+msgid ":doc:`pgr_dijkstra`"
+msgstr ":doc:`pgr_dijkstraVia`"
+
+msgid ":doc:`pgr_trsp`"
+msgstr ":doc:`pgr_trsp`"
+
+#, fuzzy
+msgid "`Migration of restrictions`_"
+msgstr ":doc:`pgr_withPoints`"
+
+msgid "Use ``pgr_dijkstra`` when there are no restrictions."
+msgstr ""
+
+msgid "Use :doc:`pgr_dijkstra` instead."
+msgstr ""
+
+msgid "To get the original column names:"
+msgstr ""
+
+msgid "``id1`` is the node"
+msgstr ""
+
+msgid "``id2`` is the edge"
+msgstr ""
+
+msgid "Use ``pgr_trsp`` when there are restrictions."
+msgstr ""
+
+msgid "Use :doc:`pgr_trsp` (One to One) instead."
+msgstr ""
+
+msgid "Migration of ``pgr_trsp`` (Edges)"
+msgstr ""
+
+msgid ":doc:`pgr_withPoints`"
+msgstr ":doc:`pgr_withPoints`"
+
+#, fuzzy
+msgid ":doc:`pgr_trsp_withPoints`"
+msgstr ":doc:`pgr_trspVia_withPoints`"
+
+msgid "Use ``pgr_withPoints`` when there are no restrictions."
+msgstr ""
+
+#, fuzzy
+msgid "Use :doc:`pgr_withPoints` (One to One) instead."
+msgstr ":doc:`pgr_withPointsCostMatrix`"
+
+msgid "Use ``pgr_trsp_withPoints`` when there are restrictions."
+msgstr ""
+
+msgid "Use :doc:`pgr_trsp_withPoints` instead."
+msgstr ""
+
+msgid "Migration of ``pgr_trspViaVertices``"
+msgstr ""
+
+msgid ":doc:`pgr_dijkstraVia`"
+msgstr ":doc:`pgr_dijkstraVia`"
+
+msgid ":doc:`pgr_trspVia`"
+msgstr ":doc:`pgr_trspVia`"
+
+msgid "Use ``pgr_dijkstraVia`` when there are no restrictions"
+msgstr ""
+
+msgid "Use :doc:`pgr_dijkstraVia` instead."
+msgstr ""
+
+msgid "``id1`` is the path identifier"
+msgstr ""
+
+msgid "``id2`` is the node"
+msgstr ""
+
+msgid "``id3`` is the edge"
+msgstr ""
+
+msgid "Use ``pgr_trspVia`` when there are restrictions"
+msgstr ""
+
+msgid "Use :doc:`pgr_trspVia` instead."
+msgstr ""
+
+msgid "Migration of ``pgr_trspViaEdges``"
+msgstr ""
+
+msgid ":doc:`pgr_withPointsVia`"
+msgstr ":doc:`pgr_withPointsVia`"
+
+msgid ":doc:`pgr_trspVia_withPoints`"
+msgstr ":doc:`pgr_trspVia_withPoints`"
+
+msgid "Use ``pgr_withPointsVia`` when there are no restrictions"
+msgstr ""
+
+msgid "Use :doc:`pgr_withPointsVia` instead."
+msgstr ""
+
+msgid "Use ``pgr_trspVia_withPoints`` when there are restrictions"
+msgstr ""
+
+msgid "Use :doc:`pgr_trspVia_withPoints` instead."
 msgstr ""
 
 msgid "Migration of restrictions"
@@ -5291,243 +5013,6 @@ msgid "Will be removed on the next mayor version 4.0.0"
 msgstr ""
 
 msgid "The migrated table contents:"
-msgstr ""
-
-msgid "Migration of ``pgr_trsp`` (Vertices)"
-msgstr ""
-
-msgid ""
-":doc:`pgr_trsp` signatures have changed and many issues have been fixed in "
-"the new signatures. This section will show how to migrate from the old "
-"signatures to the new replacement functions. This also affects the "
-"restrictions."
-msgstr ""
-
-msgid "The integral type of the ``Edges SQL`` can only be ``INTEGER``."
-msgstr ""
-
-msgid "The floating point type of the ``Edges SQL`` can only be ``FLOAT``."
-msgstr ""
-
-msgid "``directed`` flag is compulsory."
-msgstr ""
-
-msgid "Does not autodetect if ``reverse_cost`` column exist."
-msgstr ""
-
-msgid ""
-"User must be careful to match the existence of the column with the value of "
-"``has_rcost`` parameter."
-msgstr ""
-
-msgid "The restrictions inner query is optional."
-msgstr ""
-
-msgid "The output column names are meaningless"
-msgstr ""
-
-msgid "Migrate by using:"
-msgstr ""
-
-msgid ":doc:`pgr_dijkstra` when there are no restrictions,"
-msgstr ""
-
-msgid ":doc:`pgr_trsp` (One to One) when there are restrictions."
-msgstr ""
-
-msgid "Migrating ``pgr_trsp`` (Vertices) using ``pgr_dijkstra``"
-msgstr ""
-
-msgid "The following query does not have restrictions."
-msgstr ""
-
-msgid "A message about deprecation is shown"
-msgstr ""
-
-msgid "Deprecated functions will be removed on the next mayor version 4.0.0"
-msgstr ""
-
-msgid "Use :doc:`pgr_dijkstra` instead."
-msgstr ""
-
-msgid "The types casting has been removed."
-msgstr ""
-
-msgid ":doc:`pgr_dijkstra`:"
-msgstr ""
-
-msgid "Autodetects if ``reverse_cost`` column is in the edges SQL."
-msgstr ""
-
-msgid "Accepts ``ANY-INTEGER`` on integral types"
-msgstr ""
-
-msgid "Accepts ``ANY-NUMERICAL`` on floating point types"
-msgstr ""
-
-msgid "``directed`` flag has a default value of ``true``."
-msgstr ""
-
-msgid "Use the same value that on the original query."
-msgstr ""
-
-msgid "In this example it is ``true`` which is the default value."
-msgstr ""
-
-msgid "The flag has been omitted and the default is been used."
-msgstr ""
-
-msgid ""
-"When the need of using strictly the same (meaningless) names and types of "
-"the function been migrated then:"
-msgstr ""
-
-msgid "``id1`` is the node"
-msgstr ""
-
-msgid "``id2`` is the edge"
-msgstr ""
-
-msgid "Migrating ``pgr_trsp`` (Vertices) using ``pgr_trsp``"
-msgstr ""
-
-msgid "The following query has restrictions."
-msgstr ""
-
-msgid "The restrictions are the last parameter of the function"
-msgstr ""
-
-msgid "Using the old structure of restrictions"
-msgstr ""
-
-msgid "Use :doc:`pgr_trsp` (One to One) instead."
-msgstr ""
-
-msgid "The new structure of restrictions is been used."
-msgstr ""
-
-msgid "It is the second parameter."
-msgstr ""
-
-msgid ":doc:`pgr_trsp`:"
-msgstr ""
-
-msgid "Migration of ``pgr_trsp`` (Edges)"
-msgstr ""
-
-msgid "The integral types of the ``sql`` can only be ``INTEGER``."
-msgstr ""
-
-msgid "The floating point type of the ``sql`` can only be ``FLOAT``."
-msgstr ""
-
-msgid "For these migration guide the following points will be used:"
-msgstr ""
-
-msgid ":doc:`pgr_withPoints` when there are no restrictions,"
-msgstr ""
-
-msgid ":doc:`pgr_trsp_withPoints` (One to One) when there are restrictions."
-msgstr ""
-
-msgid "Migrating ``pgr_trsp`` (Edges) using ``pgr_withPoints``"
-msgstr ""
-
-msgid "Use :doc:`pgr_withPoints` instead."
-msgstr ""
-
-msgid "Do not show details, as the deprecated function does not show details."
-msgstr ""
-
-msgid ":doc:`pgr_withPoints`:"
-msgstr ""
-
-msgid "On the points query do not include the ``side`` column."
-msgstr ""
-
-msgid ""
-"When the need of using strictly the same (meaningless) names and types, and "
-"node values of the function been migrated then:"
-msgstr ""
-
-msgid "Migrating ``pgr_trsp`` (Edges) using ``pgr_trsp_withPoints``"
-msgstr ""
-
-msgid "Use :doc:`pgr_trsp_withPoints` instead."
-msgstr ""
-
-msgid ":doc:`pgr_trsp_withPoints`:"
-msgstr ""
-
-msgid "Migration of ``pgr_trspViaVertices``"
-msgstr ""
-
-msgid "The integral types of the ``Edges SQL`` can only be ``INTEGER``."
-msgstr ""
-
-msgid ":doc:`pgr_dijkstraVia` when there are no restrictions,"
-msgstr ""
-
-msgid ":doc:`pgr_trspVia` when there are restrictions."
-msgstr ""
-
-msgid "Migrating ``pgr_trspViaVertices`` using ``pgr_dijkstraVia``"
-msgstr ""
-
-msgid "Use :doc:`pgr_dijkstraVia` instead."
-msgstr ""
-
-msgid ":doc:`pgr_dijkstraVia`:"
-msgstr ""
-
-msgid "``id1`` is the path identifier"
-msgstr ""
-
-msgid "``id2`` is the node"
-msgstr ""
-
-msgid "``id3`` is the edge"
-msgstr ""
-
-msgid "Migrating ``pgr_trspViaVertices`` using ``pgr_trspVia``"
-msgstr ""
-
-msgid "Use :doc:`pgr_trspVia` instead."
-msgstr ""
-
-msgid ":doc:`pgr_trspVia`:"
-msgstr ""
-
-msgid "Migration of ``pgr_trspViaEdges``"
-msgstr ""
-
-msgid ""
-"And will travel thru the following Via points :math:"
-"`4\\rightarrow3\\rightarrow6`"
-msgstr ""
-
-msgid ":doc:`pgr_withPointsVia` when there are no restrictions,"
-msgstr ""
-
-msgid ":doc:`pgr_trspVia_withPoints` when there are restrictions."
-msgstr ""
-
-msgid "Migrating ``pgr_trspViaEdges`` using ``pgr_withPointsVia``"
-msgstr ""
-
-msgid "Use :doc:`pgr_withPointsVia` instead."
-msgstr ""
-
-msgid ":doc:`pgr_withPointsVia`:"
-msgstr ""
-
-msgid "Migrating ``pgr_trspViaEdges`` using ``pgr_trspVia_withPoints``"
-msgstr ""
-
-msgid "Use :doc:`pgr_trspVia_withPoints` instead."
-msgstr ""
-
-msgid ":doc:`pgr_trspVia_withPoints`:"
 msgstr ""
 
 msgid ":doc:`withPoints-category`"
@@ -5689,9 +5174,6 @@ msgid ""
 msgstr ""
 
 msgid "Graph with ``cost`` and ``reverse_cost``"
-msgstr ""
-
-msgid "The weighted directed graph, :math:`G_d(V,E)`, is defined by:"
 msgstr ""
 
 msgid "``SELECT id, source, target, cost, reverse_cost FROM edges``"
@@ -6349,17 +5831,28 @@ msgstr ""
 msgid "To get the dead ends:"
 msgstr ""
 
-msgid ""
-"That information is correct, for example, when the dead end is on the limit "
-"of the imported graph."
+msgid "A dead end happens when"
 msgstr ""
 
 msgid ""
-"Visually node :math:`4` looks to be as start/ending of 3 edges, but it is "
-"not."
+"The vertex is the limit of a cul-de-sac, a no-through road or a no-exit road."
 msgstr ""
 
-msgid "Is that correct?"
+msgid "The vertex is on the limit of the imported graph."
+msgstr ""
+
+msgid "If a larger graph is imported then the vertex might not be a dead end"
+msgstr ""
+
+msgid ""
+"Node :math:`4`, is a dead end on the query, even that it visually looks like "
+"an end point of 3 edges."
+msgstr ""
+
+msgid "Is node :math:`4` a dead end or not?"
+msgstr ""
+
+msgid "The answer to that question will depend on the application."
 msgstr ""
 
 msgid "Is there such a small curb:"
@@ -6383,9 +5876,12 @@ msgid ""
 "the segment?"
 msgstr ""
 
+msgid "Depending on the answer, modification of the data might be needed."
+msgstr ""
+
 msgid ""
-"When there are many dead ends, to speed up, the :doc:`contraction-family` "
-"functions can be used to divide the problem."
+"When there are many dead ends, to speed up processing, the :doc:`contraction-"
+"family` functions can be used to contract the graph."
 msgstr ""
 
 msgid "Linear edges"
@@ -6395,13 +5891,14 @@ msgid "To get the linear edges:"
 msgstr ""
 
 msgid ""
-"This information is correct, for example, when the application is taking "
-"into account speed bumps, stop signals."
+"These linear vertices are correct, for example, when those the vertices are "
+"speed bumps, stop signals and the application is taking them into account."
 msgstr ""
 
 msgid ""
-"When there are many linear edges, to speed up, the :doc:`contraction-family` "
-"functions can be used to divide the problem."
+"When there are many linear vertices, that need not to be taken into account, "
+"to speed up the processing, the :doc:`contraction-family` functions can be "
+"used to contract the problem."
 msgstr ""
 
 msgid "Function's structure"
@@ -6664,9 +6161,6 @@ msgstr ""
 msgid "Parameters for the Via functions"
 msgstr ""
 
-msgid ":doc:`pgr_dijkstraVia`"
-msgstr ":doc:`pgr_dijkstraVia`"
-
 msgid "SQL query as described."
 msgstr ""
 
@@ -6705,9 +6199,6 @@ msgstr ""
 
 msgid "For the TRSP functions"
 msgstr ""
-
-msgid ":doc:`pgr_trsp`"
-msgstr ":doc:`pgr_trsp`"
 
 msgid "Array of identifiers of destination vertices."
 msgstr ""
@@ -6760,9 +6251,6 @@ msgstr ""
 
 msgid "Used in functions the following:"
 msgstr ""
-
-msgid ":doc:`pgr_withPoints`"
-msgstr ":doc:`pgr_withPoints`"
 
 msgid ""
 "Returns set of ``(seq, path_seq [, start_pid] [, end_pid], node, edge, cost, "
@@ -6914,6 +6402,12 @@ msgid ""
 "the routing function and is within the area of the results."
 msgstr ""
 
+msgid "Given this area:"
+msgstr ""
+
+msgid "Calculate a route:"
+msgstr ""
+
 msgid "How to contribute"
 msgstr ""
 
@@ -6941,7 +6435,7 @@ msgid ""
 "parallel-edges-(KSP)>`__"
 msgstr ""
 
-msgid "Adding Functionaity to pgRouting"
+msgid "Adding Functionality to pgRouting"
 msgstr ""
 
 msgid ""
@@ -7048,7 +6542,7 @@ msgid "Upgrading the database"
 msgstr "데이터베이스 업그레이드"
 
 msgid ""
-"To upgrade pgRouting in the database to version 3.7.0 use the following "
+"To upgrade pgRouting in the database to version 4.0.0 use the following "
 "command:"
 msgstr ""
 
@@ -7496,13 +6990,20 @@ msgstr ""
 msgid ":doc:`migration`"
 msgstr ":doc:`migration`"
 
-msgid "pgr_KSP"
-msgstr ""
+#, fuzzy
+msgid "``pgr_KSP``"
+msgstr ":doc:`pgr_withPoints`"
 
 msgid "``pgr_KSP`` — Yen's algorithm for K shortest paths using Dijkstra."
 msgstr ""
 
 msgid "Availability"
+msgstr ""
+
+msgid "Version 4.0.0"
+msgstr ""
+
+msgid "All signatures promoted to official."
 msgstr ""
 
 msgid "Version 3.6.0"
@@ -7512,29 +7013,29 @@ msgid "Result columns standarized to: |nksp-result|"
 msgstr ""
 
 #, fuzzy
-msgid "``pgr_ksp`` (One to One)"
+msgid "pgr_ksp(One to One)"
 msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 msgid "Added ``start_vid`` and ``end_vid`` result columns."
 msgstr ""
 
-msgid "New overload functions:"
+msgid "New proposed signatures:"
 msgstr ""
 
 #, fuzzy
-msgid "``pgr_ksp`` (One to Many)"
+msgid "pgr_ksp(One to Many)"
 msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 #, fuzzy
-msgid "``pgr_ksp`` (Many to One)"
+msgid "pgr_ksp(Many to One)"
 msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 #, fuzzy
-msgid "``pgr_ksp`` (Many to Many)"
+msgid "pgr_ksp(Many to Many)"
 msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 #, fuzzy
-msgid "``pgr_ksp`` (Combinations)"
+msgid "pgr_ksp(Combinations)"
 msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 msgid "Version 2.1.0"
@@ -7549,12 +7050,18 @@ msgstr ""
 msgid "Version 2.0.0"
 msgstr ""
 
-msgid "**Official** function"
+msgid "Official function."
 msgstr ""
 
 msgid ""
 "The K shortest path routing algorithm based on Yen's algorithm. \"K\" is the "
 "number of shortest paths desired."
+msgstr ""
+
+msgid "|Boost| Boost Graph Inside"
+msgstr ""
+
+msgid "Boost Graph Inside"
 msgstr ""
 
 msgid "Signatures"
@@ -7682,7 +7189,7 @@ msgstr ""
 msgid "``pgr_TSP``"
 msgstr ""
 
-msgid "``pgr_TSP`` - Aproximation using *metric* algorithm."
+msgid "``pgr_TSP`` - Approximation using *metric* algorithm."
 msgstr ""
 
 msgid "Availability:"
@@ -7898,7 +7405,12 @@ msgstr ""
 msgid "``pgr_TSPeuclidean``"
 msgstr ""
 
-msgid "``pgr_TSPeuclidean`` - Aproximation using *metric* algorithm."
+msgid "``pgr_TSPeuclidean`` - Approximation using *metric* algorithm."
+msgstr ""
+
+msgid ""
+"Using `Boost: metric TSP approx <https://www.boost.org/libs/graph/doc/"
+"metric_tsp_approx.html>`__"
 msgstr ""
 
 msgid ""
@@ -7914,7 +7426,7 @@ msgstr ""
 msgid "Name change from pgr_eucledianTSP"
 msgstr ""
 
-msgid "New **Official** function"
+msgid "New official function."
 msgstr ""
 
 msgid ""
@@ -7995,56 +7507,52 @@ msgid ""
 "obtained with ``pgr_TSPeuclidean``."
 msgstr ""
 
-msgid ":doc:`sampledata` network."
-msgstr ""
-
 msgid "``pgr_aStar``"
 msgstr ""
 
 msgid "``pgr_aStar`` — Shortest path using the A* algorithm."
 msgstr ""
 
+msgid "Combinations signature promoted to official."
+msgstr ""
+
 msgid "Standarizing output columns to |short-generic-result|"
 msgstr ""
 
-msgid ""
-"``pgr_aStar`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
+msgid "pgr_aStar(One to One) added ``start_vid`` and ``end_vid`` columns."
 msgstr ""
 
-msgid "``pgr_aStar`` (`One to Many`_) added ``end_vid`` column."
+msgid "pgr_aStar(One to Many) added ``end_vid`` column."
 msgstr ""
 
-msgid "``pgr_aStar`` (`Many to One`_) added ``start_vid`` column."
+msgid "pgr_aStar(Many to One) added ``start_vid`` column."
 msgstr ""
 
 msgid "Version 3.2.0"
 msgstr ""
 
-msgid "New **proposed** signature:"
+msgid "New proposed signature:"
 msgstr ""
 
-msgid "``pgr_aStar`` (`Combinations`_)"
+msgid "Function promoted to official."
 msgstr ""
 
 msgid "Version 2.4.0"
 msgstr ""
 
-msgid "New **Proposed** signatures:"
-msgstr ""
+#, fuzzy
+msgid "pgr_aStar(One to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_aStar`` (`One to Many`_)"
-msgstr ""
+#, fuzzy
+msgid "pgr_aStar(Many to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_aStar`` (`Many to One`_)"
-msgstr ""
+#, fuzzy
+msgid "pgr_aStar(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_aStar`` (`Many to Many`_)"
-msgstr ""
-
-msgid "Signature change on ``pgr_astar`` (`One to One`_)"
-msgstr ""
-
-msgid "**Official** ``pgr_aStar`` (`One to One`_)"
+msgid "Signature change on pgr_aStar(One to One)"
 msgstr ""
 
 msgid ""
@@ -8118,19 +7626,18 @@ msgstr ""
 msgid "Manually assigned vertex combinations."
 msgstr ""
 
-msgid "pgr_aStarCost"
-msgstr ""
+#, fuzzy
+msgid "``pgr_aStarCost``"
+msgstr ":doc:`pgr_aStarCost`"
 
 #, fuzzy
 msgid ""
 "``pgr_aStarCost`` - Total cost of the shortest path using the A* algorithm."
 msgstr ":doc:`pgr_aStarCost` - 최단 경로의 집계 비용 반환."
 
-msgid "``pgr_aStarCost`` (`Combinations`_)"
-msgstr ""
-
-msgid "New **proposed** function"
-msgstr ""
+#, fuzzy
+msgid "New proposed function."
+msgstr ":doc:`routingFunctions`"
 
 #, fuzzy
 msgid ""
@@ -8250,6 +7757,9 @@ msgstr ""
 msgid "Renamed from version 1.x"
 msgstr ""
 
+msgid "Support"
+msgstr ""
+
 msgid "Returns the polygon part of an alpha shape."
 msgstr ""
 
@@ -8322,8 +7832,9 @@ msgstr ":doc:`pgr_drivingDistance`"
 msgid "`ST_ConcaveHull <https://postgis.net/docs/ST_ConcaveHull.html>`__"
 msgstr ""
 
-msgid "pgr_analyzeGraph"
-msgstr ""
+#, fuzzy
+msgid "``pgr_analyzeGraph``"
+msgstr ":doc:`pgr_analyzeGraph`"
 
 msgid "``pgr_analyzeGraph`` — Analyzes the network topology."
 msgstr ""
@@ -8584,9 +8095,6 @@ msgid ""
 "table ``othertable``. (note the use of quote_literal)"
 msgstr ""
 
-msgid "The examples use the :doc:`sampledata` network."
-msgstr ""
-
 msgid ":doc:`pgr_analyzeOneWay`"
 msgstr ":doc:`pgr_analyzeOneWay`"
 
@@ -8596,8 +8104,9 @@ msgstr ":doc:`pgr_createVerticesTable`"
 msgid ":doc:`pgr_nodeNetwork` to create nodes to a not noded edge table."
 msgstr ""
 
-msgid "pgr_analyzeOneWay"
-msgstr ""
+#, fuzzy
+msgid "``pgr_analyzeOneWay``"
+msgstr ":doc:`pgr_analyzeOneWay`"
 
 msgid ""
 "``pgr_analyzeOneWay`` — Analyzes oneway Sstreets and identifies flipped "
@@ -8748,7 +8257,7 @@ msgstr ""
 msgid "Version 2.5.0"
 msgstr ""
 
-msgid "New **experimental** function"
+msgid "New experimental function."
 msgstr ""
 
 msgid ""
@@ -8780,7 +8289,7 @@ msgid "Nodes in red are the articulation points."
 msgstr ""
 
 msgid ""
-"Boost: `Biconnected components & articulation points <https://www.boost.org/"
+"`Boost: Biconnected components & articulation points <https://www.boost.org/"
 "libs/graph/doc/biconnected_components.html>`__"
 msgstr ""
 
@@ -8795,37 +8304,33 @@ msgstr ""
 msgid "``pgr_bdAstar`` — Shortest path using the bidirectional A* algorithm."
 msgstr ""
 
-msgid ""
-"``pgr_bdAstar`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
+msgid "pgr_bdAstar(One to One) added ``start_vid`` and ``end_vid`` columns."
 msgstr ""
 
-msgid "``pgr_bdAstar`` (`One to Many`_) added ``end_vid`` column."
+msgid "pgr_bdAstar(One to Many) added ``end_vid`` column."
 msgstr ""
 
-msgid "``pgr_bdAstar`` (`Many to One`_) added ``start_vid`` column."
+msgid "pgr_bdAstar(Many to One) added ``start_vid`` column."
 msgstr ""
 
-msgid "``pgr_bdAstar`` (`Combinations`_)"
-msgstr ""
+#, fuzzy
+msgid "pgr_bdAstar(One to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_bdAstar`` (`One to Many`_)"
-msgstr ""
+#, fuzzy
+msgid "pgr_bdAstar(Many to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_bdAstar`` (`Many to One`_)"
-msgstr ""
+#, fuzzy
+msgid "pgr_bdAstar(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_bdAstar`` (`Many to Many`_)"
-msgstr ""
-
-msgid "Signature change on ``pgr_bdAstar`` (`One to One`_)"
-msgstr ""
-
-msgid "**Official** ``pgr_bdAstar`` (`One to One`_)"
+msgid "Signature change on pgr_bdAstar(One to One)"
 msgstr ""
 
 msgid ""
-"The results are equivalent to the union of the results of the `pgr_bdAStar(` "
-"`One to One`_ `)` on the:"
+"The results are equivalent to the union of the results of the "
+"pgr_bdAStar(One to One) on the:"
 msgstr ""
 
 msgid "pgr_bdAstar(`Edges SQL`_, **start vid**, **end vid**, [**options**])"
@@ -8843,15 +8348,13 @@ msgstr ""
 msgid "pgr_bdAstar(`Edges SQL`_, `Combinations SQL`_, [**options**])"
 msgstr ""
 
-msgid "pgr_bdAstarCost"
-msgstr ""
+#, fuzzy
+msgid "``pgr_bdAstarCost``"
+msgstr ":doc:`pgr_bdAstarCost`"
 
 msgid ""
 "``pgr_bdAstarCost`` - Total cost of the shortest path using the "
 "bidirectional A* algorithm."
-msgstr ""
-
-msgid "``pgr_bdAstarCost`` (`Combinations`_)"
 msgstr ""
 
 msgid ""
@@ -8901,25 +8404,19 @@ msgid ""
 "algorithm."
 msgstr ":doc:`pgr_bdDijkstra` - 최단 경로를 위한 양방향 다익스트라 알고리즘."
 
-msgid "pgr_bdDijkstra(`Combinations`_)"
-msgstr ""
+#, fuzzy
+msgid "pgr_bdDijkstra(One to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "New **Proposed** functions:"
-msgstr ""
+#, fuzzy
+msgid "pgr_bdDijkstra(Many to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_bdDijkstra`` (`One to Many`_)"
-msgstr ""
+#, fuzzy
+msgid "pgr_bdDijkstra(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_bdDijkstra`` (`Many to One`_)"
-msgstr ""
-
-msgid "``pgr_bdDijkstra`` (`Many to Many`_)"
-msgstr ""
-
-msgid "Signature change on ``pgr_bdDijsktra`` (`One to One`_)"
-msgstr ""
-
-msgid "**Official** ``pgr_bdDijkstra`` (`One to One`_)"
+msgid "Signature change on pgr_bdDijsktra(One to One)"
 msgstr ""
 
 msgid ""
@@ -8973,11 +8470,6 @@ msgstr ""
 msgid "Using a combinations table on an **undirected** graph"
 msgstr ""
 
-msgid ""
-"https://www.cs.princeton.edu/courses/archive/spr06/cos423/Handouts/"
-"EPP%20shortest%20path%20algorithms.pdf"
-msgstr ""
-
 msgid "https://en.wikipedia.org/wiki/Bidirectional_search"
 msgstr ""
 
@@ -8987,9 +8479,6 @@ msgstr ""
 msgid ""
 "``pgr_bdDijkstraCost`` — Returns the shortest path's cost using "
 "Bidirectional Dijkstra algorithm."
-msgstr ""
-
-msgid "``pgr_bdDijkstraCost`` (`Combinations`_)"
 msgstr ""
 
 msgid ""
@@ -9050,25 +8539,10 @@ msgstr ""
 msgid "``pgr_bellmanFord`` — Shortest path using Bellman-Ford algorithm."
 msgstr ""
 
-msgid "New **experimental** signature:"
+msgid "New experimental signature:"
 msgstr ""
 
-msgid "``pgr_bellmanFord`` (`Combinations`_)"
-msgstr ""
-
-msgid "New **experimental** signatures:"
-msgstr ""
-
-msgid "``pgr_bellmanFord`` (`One to One`_)"
-msgstr ""
-
-msgid "``pgr_bellmanFord`` (`One to Many`_)"
-msgstr ""
-
-msgid "``pgr_bellmanFord`` (`Many to One`_)"
-msgstr ""
-
-msgid "``pgr_bellmanFord`` (`Many to Many`_)"
+msgid "pgr_bellmanFord(Combinations)"
 msgstr ""
 
 msgid ""
@@ -9143,21 +8617,23 @@ msgstr ""
 msgid "Using a combinations table on an **undirected** graph."
 msgstr ""
 
+msgid ""
+"`Boost: Bellman Ford <https://www.boost.org/libs/graph/doc/"
+"bellman_ford_shortest.html>`__"
+msgstr ""
+
 msgid "https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm"
 msgstr ""
 
-msgid "``pgr_betweennessCentrality``"
+msgid "``pgr_betweennessCentrality`` - Experimental"
 msgstr ""
 
 msgid ""
-"``pgr_betweennessCentrality`` - Calculates the relative betweeness "
+"``pgr_betweennessCentrality`` - Calculates the relative betweenness "
 "centrality using Brandes Algorithm"
 msgstr ""
 
 msgid "Version 3.7.0"
-msgstr ""
-
-msgid "New **experimental** function:"
 msgstr ""
 
 msgid ""
@@ -9230,11 +8706,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Boost's `betweenness_centrality <https://www.boost.org/doc/libs/1_84_0/libs/"
-"graph/doc/betweenness_centrality.html>`_"
-msgstr ""
-
-msgid "Queries use the :doc:`sampledata` network."
+"`Boost: betweenness centrality <https://www.boost.org/libs/graph/doc/"
+"betweenness_centrality.html>`_"
 msgstr ""
 
 msgid "``pgr_biconnectedComponents``"
@@ -9294,11 +8767,6 @@ msgstr ""
 msgid "Identifier of the edge that belongs to the ``component``."
 msgstr ""
 
-msgid ""
-"Boost: `Biconnected components <https://www.boost.org/libs/graph/doc/"
-"biconnected_components.html>`__"
-msgstr ""
-
 msgid "``pgr_binaryBreadthFirstSearch`` - Experimental"
 msgstr ""
 
@@ -9312,19 +8780,7 @@ msgid ""
 "negative integer, is termed as a 'binary graph'."
 msgstr ""
 
-msgid "pgr_binaryBreadthFirstSearch(`Combinations`_)"
-msgstr ""
-
-msgid "pgr_binaryBreadthFirstSearch(`One to One`_)"
-msgstr ""
-
-msgid "pgr_binaryBreadthFirstSearch(`One to Many`_)"
-msgstr ""
-
-msgid "pgr_binaryBreadthFirstSearch(`Many to One`_)"
-msgstr ""
-
-msgid "pgr_binaryBreadthFirstSearch(`Many to Many`_)"
+msgid "pgr_binaryBreadthFirstSearch(Combinations)"
 msgstr ""
 
 msgid ""
@@ -9386,6 +8842,11 @@ msgid ""
 "math:`1``)"
 msgstr ""
 
+msgid ""
+"`Boost: Breadth First Search <https://www.boost.org/libs/graph/doc/"
+"breadth_first_search.html>`__"
+msgstr ""
+
 msgid "https://cp-algorithms.com/graph/01_bfs.html"
 msgstr ""
 
@@ -9393,15 +8854,12 @@ msgid ""
 "https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm#Specialized_variants"
 msgstr ""
 
-msgid "pgr_bipartite -Experimental"
+msgid "``pgr_bipartite`` - Experimental"
 msgstr ""
 
 msgid ""
 "``pgr_bipartite`` — Disjoint sets of vertices such that no two vertices "
 "within the same set are adjacent."
-msgstr ""
-
-msgid "New **experimental** signature"
 msgstr ""
 
 msgid ""
@@ -9450,6 +8908,16 @@ msgstr ""
 msgid "Edges in blue represent odd length cycle subgraph."
 msgstr ""
 
+msgid ""
+"`Boost: is_bipartite <https://www.boost.org/libs/graph/doc/is_bipartite."
+"html>`__"
+msgstr ""
+
+msgid ""
+"`Wikipedia: bipartite graph <https://en.wikipedia.org/wiki/"
+"Bipartite_graph>`__"
+msgstr ""
+
 msgid "``pgr_boykovKolmogorov``"
 msgstr ""
 
@@ -9459,19 +8927,10 @@ msgid ""
 "algorithm."
 msgstr ""
 
-msgid "New **proposed** signature"
-msgstr ""
-
-msgid "``pgr_boykovKolmogorov`` (`Combinations`_)"
-msgstr ""
-
 msgid "Renamed from ``pgr_maxFlowBoykovKolmogorov``"
 msgstr ""
 
-msgid "**Proposed** function"
-msgstr ""
-
-msgid "New **Experimental** function"
+msgid "Function promoted to proposed."
 msgstr ""
 
 msgid "Running time: Polynomial"
@@ -9513,7 +8972,9 @@ msgid ""
 "math:`\\{5, 6\\}` to vertices :math:`\\{10, 15, 14\\}`."
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html"
+msgid ""
+"`Boost: Boykov Kolmogorov max flow <https://www.boost.org/libs/graph/doc/"
+"boykov_kolmogorov_max_flow.html>`__"
 msgstr ""
 
 msgid "``pgr_breadthFirstSearch`` - Experimental"
@@ -9522,12 +8983,6 @@ msgstr ""
 msgid ""
 "``pgr_breadthFirstSearch`` — Returns the traversal order(s) using Breadth "
 "First Search algorithm."
-msgstr ""
-
-msgid "``pgr_breadthFirstSearch`` (`Single Vertex`_)"
-msgstr ""
-
-msgid "``pgr_breadthFirstSearch`` (`Multiple Vertices`_)"
 msgstr ""
 
 msgid ""
@@ -9595,11 +9050,6 @@ msgid "descending"
 msgstr ""
 
 msgid ""
-"`Boost: Breadth First Search algorithm documentation <https://www.boost.org/"
-"libs/graph/doc/breadth_first_search.html>`__"
-msgstr ""
-
-msgid ""
 "`Wikipedia: Breadth First Search algorithm <https://en.wikipedia.org/wiki/"
 "Breadth-first_search>`__"
 msgstr ""
@@ -9637,9 +9087,10 @@ msgstr ""
 msgid "https://en.wikipedia.org/wiki/Bridge_%28graph_theory%29"
 msgstr ""
 
-#, fuzzy
-msgid "**Supported versions**"
-msgstr "짧은 버전"
+msgid ""
+"`Boost: Connected components <https://www.boost.org/libs/graph/doc/"
+"connected_components.html>`__"
+msgstr ""
 
 msgid "``pgr_chinesePostman`` - Experimental"
 msgstr ""
@@ -9696,7 +9147,7 @@ msgstr ""
 msgid "Minimum costs of a circuit path."
 msgstr ""
 
-msgid "pgr_connectedComponents"
+msgid "``pgr_connectedComponents``"
 msgstr ""
 
 msgid ""
@@ -9734,11 +9185,6 @@ msgid "Connecting disconnected components"
 msgstr ""
 
 msgid ""
-"Boost: `Connected components <https://www.boost.org/libs/graph/doc/"
-"connected_components.html>`__"
-msgstr ""
-
-msgid ""
 "wikipedia: `Connected component <https://en.wikipedia.org/wiki/"
 "Connected_component_(graph_theory)>`__"
 msgstr ""
@@ -9749,6 +9195,24 @@ msgstr ""
 msgid ""
 "``pgr_contraction`` — Performs graph contraction and returns the contracted "
 "vertices and edges."
+msgstr ""
+
+msgid "Version 3.8.0"
+msgstr ""
+
+msgid "New signature:"
+msgstr ""
+
+msgid ""
+"Previously compulsory parameter **Contraction order** is now optional with "
+"name ``methods``."
+msgstr ""
+
+msgid "New name and order of optional parameters."
+msgstr ""
+
+msgid ""
+"Deprecated signature pgr_contraction(text,bigint[],integer,bigint[],boolean)"
 msgstr ""
 
 msgid "Name change from ``pgr_contractGraph``"
@@ -9763,57 +9227,63 @@ msgid ""
 "original edges decreasing the total time and space used in graph algorithms."
 msgstr ""
 
-msgid "Does not return the full contracted graph"
+msgid "Does not return the full contracted graph."
 msgstr ""
 
-msgid "Only changes on the graph are returned"
+msgid "Only changes on the graph are returned."
 msgstr ""
 
-msgid "Currnetly there are two types of contraction methods"
+msgid "The returned values include:"
 msgstr ""
 
-msgid "Dead End Contraction"
+msgid "The new edges generated by linear contraction."
 msgstr ""
 
-msgid "Linear Contraction"
-msgstr ""
-
-msgid "The returned values include"
-msgstr ""
-
-msgid "the added edges by linear contraction."
-msgstr ""
-
-msgid "the modified vertices by dead end contraction."
+msgid "The modified vertices generated by dead end contraction."
 msgstr ""
 
 msgid "The returned values are ordered as follows:"
 msgstr ""
 
-msgid "column ``id`` ascending when type is ``v``"
+msgid "column ``id`` ascending when its a modified vertex."
 msgstr ""
 
-msgid "column ``id`` descending when type is ``e``"
+msgid "column ``id`` with negative numbers descending when its a new edge."
 msgstr ""
 
-msgid "The pgr_contraction function has the following signature:"
+msgid ""
+"Currently there are two types of contraction methods included in this "
+"function:"
 msgstr ""
 
-msgid "pgr_contraction(`Edges SQL`_, **contraction order**, [**options**])"
+msgid "Dead End Contraction. See :doc:`pgr_contractionDeadEnd`."
 msgstr ""
 
-msgid "**options:** ``[ max_cycles, forbidden_vertices, directed]``"
+msgid "Linear Contraction. See :doc:`pgr_contractionLinear`."
+msgstr ""
+
+msgid "pgr_contraction(`Edges SQL`_, [**options**])"
+msgstr ""
+
+msgid "**options:** ``[directed, methods, cycles, forbidden]``"
 msgstr ""
 
 msgid "Returns set of |result-contract|"
 msgstr ""
 
-msgid ""
-"Making a dead end and linear contraction in that order on an undirected "
-"graph."
+msgid "Dead end and linear contraction in that order on an undirected graph."
 msgstr ""
 
-msgid "**contraction Order**"
+msgid "Contraction optional parameters"
+msgstr ""
+
+msgid "``methods``"
+msgstr ""
+
+msgid "``INTEGER[]``"
+msgstr ""
+
+msgid "``ARRAY[1,2]``"
 msgstr ""
 
 msgid "Ordered contraction operations."
@@ -9825,24 +9295,25 @@ msgstr ""
 msgid "2 = Linear contraction"
 msgstr ""
 
-msgid "Contraction optional parameters"
-msgstr ""
-
-msgid "``forbidden_vertices``"
-msgstr ""
-
-msgid "**Empty**"
-msgstr ""
-
-msgid "Identifiers of vertices forbidden for contraction."
+msgid "``cycles``"
 msgstr ""
 
 msgid ":math:`1`"
 msgstr ""
 
-msgid ""
-"Number of times the contraction operations on ``contraction_order`` will be "
-"performed."
+msgid "Number of times the contraction methods will be performed."
+msgstr ""
+
+msgid "``forbidden``"
+msgstr ""
+
+msgid "``BIGINT[]``"
+msgstr ""
+
+msgid "``ARRAY[]::BIGINT[]``"
+msgstr ""
+
+msgid "Identifiers of vertices forbidden for contraction."
 msgstr ""
 
 msgid "The function returns a single row. The columns of the row are:"
@@ -9851,19 +9322,19 @@ msgstr ""
 msgid "``type``"
 msgstr ""
 
-msgid "Type of the ``id``."
+msgid "Type of the row."
 msgstr ""
 
 msgid "``v`` when the row is a vertex."
 msgstr ""
 
-msgid "Column ``id`` has a positive value"
+msgid "Column ``id`` has a positive value."
 msgstr ""
 
 msgid "``e`` when the row is an edge."
 msgstr ""
 
-msgid "Column ``id`` has a negative value"
+msgid "Column ``id`` has a negative value."
 msgstr ""
 
 msgid "All numbers on this column are ``DISTINCT``"
@@ -9884,6 +9355,9 @@ msgstr ""
 msgid ""
 "Representing a pseudo `id` as is not incorporated in the set of original "
 "edges."
+msgstr ""
+
+msgid "``contracted_vertices``"
 msgstr ""
 
 msgid "Array of contracted vertex identifiers."
@@ -9912,7 +9386,528 @@ msgstr ""
 msgid "Only linear contraction"
 msgstr ""
 
-msgid "pgr_createTopology"
+msgid "The cycle"
+msgstr ""
+
+msgid ""
+"Contracting a graph can be done with more than one operation. The order of "
+"the operations affect the resulting contracted graph, after applying one "
+"operation, the set of vertices that can be contracted by another operation "
+"changes."
+msgstr ""
+
+msgid "This implementation cycles ``cycles`` times through the ``methods`` ."
+msgstr ""
+
+msgid "Contracting sample data"
+msgstr ""
+
+msgid ""
+"In this section, building and using a contracted graph will be shown by "
+"example."
+msgstr ""
+
+msgid "The :doc:`sampledata` for an undirected graph is used"
+msgstr ""
+
+msgid "a dead end operation first followed by a linear operation."
+msgstr ""
+
+msgid "Construction of the graph in the database"
+msgstr ""
+
+msgid "The original graph:"
+msgstr ""
+
+msgid ""
+"The results do not represent the contracted graph. They represent the "
+"changes that need to be done to the graph after applying the contraction "
+"methods."
+msgstr ""
+
+msgid ""
+"Observe that vertices, for example, :math:`6` do not appear in the results "
+"because it was not affected by the contraction algorithm."
+msgstr ""
+
+msgid "After doing the dead end contraction operation:"
+msgstr ""
+
+msgid "After doing the linear contraction operation to the graph above:"
+msgstr ""
+
+msgid "The process to create the contraction graph on the database:"
+msgstr ""
+
+msgid "Add additional columns"
+msgstr ""
+
+msgid ""
+"Adding extra columns to the edges and vertices tables. In this documentation "
+"the following will be used:"
+msgstr ""
+
+msgid "Column."
+msgstr ""
+
+msgid "The vertices set belonging to the vertex/edge"
+msgstr ""
+
+msgid "``is_contracted``"
+msgstr ""
+
+msgid "On the vertex table"
+msgstr ""
+
+msgid ""
+"when ``true`` the vertex is contracted, its not part of the contracted graph."
+msgstr ""
+
+msgid ""
+"when ``false`` the vertex is not contracted, its part of the contracted "
+"graph."
+msgstr ""
+
+msgid "``is_new``"
+msgstr ""
+
+msgid "On the edge table"
+msgstr ""
+
+msgid ""
+"when ``true`` the edge was generated by the contraction algorithm. its part "
+"of the contracted graph."
+msgstr ""
+
+msgid ""
+"when ``false`` the edge is an original edge, might be or not part of the "
+"contracted graph."
+msgstr ""
+
+msgid "Store contraction information"
+msgstr ""
+
+msgid "Store the contraction results in a table."
+msgstr ""
+
+msgid "Update the edges and vertices tables"
+msgstr ""
+
+msgid ""
+"Use ``is_contracted`` column to indicate the vertices that are contracted."
+msgstr ""
+
+msgid ""
+"Fill ``contracted_vertices`` with the information from the results that "
+"belong to the vertices."
+msgstr ""
+
+msgid "Insert the new edges generated by pgr_contraction."
+msgstr ""
+
+msgid "The contracted graph"
+msgstr ""
+
+msgid "Vertices that belong to the contracted graph."
+msgstr ""
+
+msgid "Edges that belong to the contracted graph."
+msgstr ""
+
+msgid "Visually:"
+msgstr ""
+
+msgid "Using the contracted graph"
+msgstr ""
+
+msgid ""
+"Depending on the final application the graph is to be prepared. In this "
+"example the final application will be to calculate the cost from two "
+"vertices in the original graph by using the contracted graph with "
+"``pgr_dijkstraCost``"
+msgstr ""
+
+msgid ""
+"There are three cases when calculating the shortest path between a given "
+"source and target in a contracted graph:"
+msgstr ""
+
+msgid "Case 1: Both source and target belong to the contracted graph."
+msgstr ""
+
+msgid "Case 2: Source and/or target belong to an edge subgraph."
+msgstr ""
+
+msgid "Case 3: Source and/or target belong to a vertex."
+msgstr ""
+
+msgid "The final application should consider all of those cases."
+msgstr ""
+
+msgid "Create a view (or table) of the contracted graph:"
+msgstr ""
+
+msgid "Create the function that will use the contracted graph."
+msgstr ""
+
+msgid ""
+"Case 2: Source and/or target belong to an edge that has contracted vertices."
+msgstr ""
+
+msgid ""
+"Case 3: Source and/or target belong to a vertex that has been contracted."
+msgstr ""
+
+#, fuzzy
+msgid "``pgr_contractionDeadEnd`` - Proposed"
+msgstr ":doc:`pgr_extractVertices`"
+
+msgid ""
+"``pgr_contractionDeadEnd`` — Performs graph contraction and returns the "
+"contracted vertices and edges."
+msgstr ""
+
+msgid "A node is considered a dead end node when:"
+msgstr ""
+
+msgid "On undirected graphs:"
+msgstr ""
+
+msgid "The number of adjacent vertices is 1."
+msgstr ""
+
+msgid "On directed graphs:"
+msgstr ""
+
+msgid "When there is only one adjacent vertex or"
+msgstr ""
+
+msgid ""
+"When all edges are incoming regardless of the number of adjacent vertices."
+msgstr ""
+
+msgid "pgr_contractionDeadEnd(`Edges SQL`_, [**options**])"
+msgstr ""
+
+msgid "**options:** ``[directed, forbidden_vertices]``"
+msgstr ""
+
+#, fuzzy
+msgid "Dead end contraction on an undirected graph."
+msgstr ":doc:`pgr_bridges` - 무방향 그래프의 브릿지."
+
+msgid "The green nodes are dead end nodes."
+msgstr ""
+
+msgid "Node :math:`3` is a dead end node after node :math:`1` is contracted."
+msgstr ""
+
+msgid "``forbidden_vertices``"
+msgstr ""
+
+msgid "``ARRAY[`` |ANY-INTEGER| ``]``"
+msgstr ""
+
+msgid "**Empty**"
+msgstr ""
+
+msgid "Value = ``e`` indicating the row is an edge."
+msgstr ""
+
+msgid "A pseudo `id` of the edge."
+msgstr ""
+
+msgid "Identifier of the source vertex of the current edge."
+msgstr ""
+
+msgid "Identifier of the target vertex of the current edge."
+msgstr ""
+
+msgid "Weight of the current edge."
+msgstr ""
+
+msgid "Dead end vertex on undirected graph"
+msgstr ""
+
+msgid "They have only one adjacent node."
+msgstr ""
+
+msgid "Dead end vertex on directed graph"
+msgstr ""
+
+msgid "The green nodes are dead end nodes"
+msgstr ""
+
+msgid ""
+"The blue nodes have an unlimited number of incoming and/or outgoing edges."
+msgstr ""
+
+msgid "Node"
+msgstr ""
+
+msgid "Adjacent nodes"
+msgstr ""
+
+msgid "Dead end"
+msgstr ""
+
+msgid "Reason"
+msgstr ""
+
+#, fuzzy
+msgid ":math:`6`"
+msgstr ":math:`G(V,E)`"
+
+msgid ":math:`\\{1\\}`"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
+
+msgid "Has only one adjacent node."
+msgstr ""
+
+#, fuzzy
+msgid ":math:`7`"
+msgstr ":math:`G(V,E)`"
+
+msgid ":math:`\\{2\\}`"
+msgstr ""
+
+#, fuzzy
+msgid ":math:`8`"
+msgstr ":math:`G(V,E)`"
+
+#, fuzzy
+msgid ":math:`\\{2, 3\\}`"
+msgstr ":math:`G(V,E)`"
+
+msgid "Has more than one adjacent node and all edges are incoming."
+msgstr ""
+
+msgid ":math:`\\{4\\}`"
+msgstr ""
+
+#, fuzzy
+msgid ":math:`10`"
+msgstr ":math:`G(V,E)`"
+
+#, fuzzy
+msgid ":math:`\\{4, 5\\}`"
+msgstr ":math:`G(V,E)`"
+
+msgid "No"
+msgstr ""
+
+msgid "Has more than one adjacent node and all edges are outgoing."
+msgstr ""
+
+msgid ":math:`1,2,3,4,5`"
+msgstr ""
+
+msgid "Many adjacent nodes."
+msgstr ""
+
+msgid ""
+"Has more than one adjacent node and some edges are incoming and some are "
+"outgoing."
+msgstr ""
+
+msgid ""
+"From above, nodes :math:`\\{6, 7, 9\\}` are dead ends because the total "
+"number of adjacent vertices is one."
+msgstr ""
+
+msgid ""
+"When there are more than one adjacent vertex, all edges need to be all "
+"incoming edges otherwise it is not a dead end."
+msgstr ""
+
+msgid "Step by step dead end contraction"
+msgstr ""
+
+msgid ""
+"The dead end contraction will stop until there are no more dead end nodes. "
+"For example, from the following graph where :math:`3` is the dead end node:"
+msgstr ""
+
+msgid ""
+"After contracting :math:`3`, node :math:`2` is now a dead end node and is "
+"contracted:"
+msgstr ""
+
+msgid ""
+"After contracting :math:`2`, stop. Node :math:`1` has the information of "
+"nodes that were contracted."
+msgstr ""
+
+msgid "Creating the contracted graph"
+msgstr ""
+
+msgid "Steps for the creation of the contracted graph"
+msgstr ""
+
+msgid "Add additional columns."
+msgstr ""
+
+msgid "Save results into a table."
+msgstr ""
+
+msgid "The contracted vertices are not part of the contracted graph."
+msgstr ""
+
+msgid "Using when departure and destination are in the contracted graph"
+msgstr ""
+
+msgid "Using when departure/destination is not in the contracted graph"
+msgstr ""
+
+msgid "Using when departure and destination are not in the contracted graph"
+msgstr ""
+
+#, fuzzy
+msgid "``pgr_contractionLinear`` - Proposed"
+msgstr ":doc:`pgr_extractVertices`"
+
+msgid ""
+"``pgr_contractionLinear`` — Performs graph contraction and returns the "
+"contracted vertices and edges."
+msgstr ""
+
+msgid "pgr_contractionLinear(`Edges SQL`_, [**options**])"
+msgstr ""
+
+msgid "**options:** ``[directed, max_cycles, forbidden_vertices]``"
+msgstr ""
+
+#, fuzzy
+msgid "Linear contraction on an undirected graph."
+msgstr ":doc:`pgr_bridges` - 무방향 그래프의 브릿지."
+
+msgid ""
+"The green nodes are linear nodes and will not be part of the contracted "
+"graph."
+msgstr ""
+
+msgid "All edges adjacent will not be part of the contracted graph."
+msgstr ""
+
+msgid "The red lines will be new edges of the contracted graph."
+msgstr ""
+
+msgid "**contraction Order**"
+msgstr ""
+
+msgid ""
+"Number of times the contraction operations on ``contraction_order`` will be "
+"performed."
+msgstr ""
+
+msgid "A node connects two (or more) `linear` edges when"
+msgstr ""
+
+msgid "The number of adjacent vertices is 2."
+msgstr ""
+
+msgid "In case of a directed graph, a node is considered a `linear` node when"
+msgstr ""
+
+msgid "Linearity is symmetrical."
+msgstr ""
+
+msgid "Linearity is not symmetrical"
+msgstr ""
+
+msgid "Graph where linearity is not symmetrical."
+msgstr ""
+
+msgid ""
+"When the graph is processed as a directed graph, linearity is not "
+"symmetrical, therefore the graph can not be contracted."
+msgstr ""
+
+msgid ""
+"When the same graph is processed as an undirected graph, linearity is "
+"symmetrical, therefore the graph can be contracted."
+msgstr ""
+
+msgid "The three edges can be replaced by one undirected edge"
+msgstr ""
+
+msgid "Edge :math:`1 - 3`."
+msgstr ""
+
+msgid "With cost: :math:`4`."
+msgstr ""
+
+msgid "Contracted vertices in the edge: :math:`\\{2\\}`."
+msgstr ""
+
+msgid "Linearity is symmetrical"
+msgstr ""
+
+msgid "Graph where linearity is symmetrical."
+msgstr ""
+
+msgid "The four edges can be replaced by two directed edges."
+msgstr ""
+
+msgid "Edge :math:`3 - 1`."
+msgstr ""
+
+msgid "With cost: :math:`6`."
+msgstr ""
+
+msgid "The four edges can be replaced by one undirected edge."
+msgstr ""
+
+msgid "Step by step linear contraction"
+msgstr ""
+
+msgid ""
+"The linear contraction will stop when there are no more linear edges. For "
+"example from the following graph there are linear edges"
+msgstr ""
+
+msgid "Contracting vertex :math:`3`,"
+msgstr ""
+
+msgid "The vertex :math:`3` is removed from the graph"
+msgstr ""
+
+msgid ""
+"The edges :math:`2 \\rightarrow 3` and :math:`w \\rightarrow z` are removed "
+"from the graph."
+msgstr ""
+
+msgid ""
+"A new edge :math:`2 \\rightarrow 4` is inserted represented with red color."
+msgstr ""
+
+msgid "Contracting vertex :math:`2`:"
+msgstr ""
+
+msgid "The vertex :math:`2` is removed from the graph"
+msgstr ""
+
+msgid ""
+"The edges :math:`1 \\rightarrow 2` and :math:`2 \\rightarrow 3` are removed "
+"from the graph."
+msgstr ""
+
+msgid ""
+"A new edge :math:`1 \\rightarrow 3` is inserted represented with red color."
+msgstr ""
+
+msgid ""
+"Edge :math:`1 \\rightarrow 3` has the information of cost and the nodes that "
+"were contracted."
+msgstr ""
+
+msgid "Create the contracted graph."
+msgstr ""
+
+msgid "``pgr_createTopology``"
 msgstr ""
 
 msgid ""
@@ -10115,11 +10110,9 @@ msgid ""
 "to the rest of the edges."
 msgstr ""
 
-msgid "The example uses the :doc:`sampledata` network."
-msgstr ""
-
-msgid "pgr_createVerticesTable"
-msgstr ""
+#, fuzzy
+msgid "``pgr_createVerticesTable``"
+msgstr ":doc:`pgr_createVerticesTable`"
 
 msgid ""
 "``pgr_createVerticesTable`` — Reconstructs the vertices table based on the "
@@ -10334,8 +10327,9 @@ msgid ""
 "Cuthill%E2%80%93McKee_algorithm>`__"
 msgstr ""
 
-msgid "pgr_dagShortestPath - Experimental"
-msgstr ""
+#, fuzzy
+msgid "``pgr_dagShortestPath`` - Experimental"
+msgstr ":doc:`pgr_dagShortestPath`"
 
 msgid ""
 "``pgr_dagShortestPath`` — Returns the shortest path for weighted directed "
@@ -10414,18 +10408,64 @@ msgstr "결과 컬럼"
 msgid "Making **start_vids** the same as **end_vids**"
 msgstr ""
 
+msgid ""
+"`Boost: DAG shortest paths <https://www.boost.org/libs/graph/doc/"
+"dag_shortest_paths.html>`__"
+msgstr ""
+
 msgid "https://en.wikipedia.org/wiki/Topological_sorting"
 msgstr ""
 
-msgid "``pgr_degree`` -- Proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_degree``"
+msgstr ":doc:`pgr_analyzeGraph`"
 
 msgid ""
 "``pgr_degree`` — For each vertex in an undirected graph, return the count of "
 "edges incident to the vertex."
 msgstr ""
 
-msgid "Calculates the degree of the vertices of an **undirected** graph"
+msgid "Error messages adjustment."
+msgstr ""
+
+msgid "New signature with only Edges SQL."
+msgstr ""
+
+msgid "Calculates the degree of the vertices of an undirected graph"
+msgstr ""
+
+msgid ""
+"The degree (or valency) of a vertex of a graph is the number of edges that "
+"are incident to the vertex."
+msgstr ""
+
+msgid "A loop contributes 2 to a vertex's degree."
+msgstr ""
+
+msgid "A vertex with degree 0 is called an isolated vertex."
+msgstr ""
+
+msgid "Isolated vertex is not part of the result"
+msgstr ""
+
+msgid ""
+"Vertex not participating on the subgraph is considered and isolated vertex."
+msgstr ""
+
+msgid ""
+"There can be a ``dryrun`` execution and the code used to get the answer will "
+"be shown in a PostgreSQL ``NOTICE``."
+msgstr ""
+
+msgid ""
+"The code can be used as base code for the particular application "
+"requirements."
+msgstr ""
+
+msgid "No ordering is performed."
+msgstr ""
+
+msgid "pgr_degree(`Edges SQL`_ , [``dryrun``])"
 msgstr ""
 
 msgid "pgr_degree(`Edges SQL`_ , `Vertex SQL`_, [``dryrun``])"
@@ -10434,14 +10474,31 @@ msgstr ""
 msgid "RETURNS SETOF |result-degree|"
 msgstr ""
 
+msgid "Edges"
+msgstr ""
+
+msgid "example"
+msgstr ""
+
+msgid "Get the degree of the vertices defined on the edges table"
+msgstr ""
+
+#, fuzzy
+msgid "Edges and Vertices"
+msgstr "색인과 표"
+
 msgid "Extracting the vertex information"
 msgstr ""
 
+msgid "``pgr_degree`` can use :doc:`pgr_extractVertices` embedded in the call."
+msgstr ""
+
 msgid ""
-"pgr_degree can utilize output from `pgr_extractVertices` or can have "
-"`pgr_extractVertices` embedded in the call. For decent size networks, it is "
-"best to prep your vertices table before hand and use that vertices table for "
-"pgr_degree calls."
+"For decent size networks, it is best to prepare your vertices table before "
+"hand and use it on ``pgr_degree`` calls. (See `Using a vertex table`_)"
+msgstr ""
+
+msgid "Calculate the degree of the nodes:"
 msgstr ""
 
 msgid "`Vertex SQL`_"
@@ -10456,13 +10513,16 @@ msgstr ""
 msgid "When true do not process and get in a NOTICE the resulting query."
 msgstr ""
 
+msgid "For the `Edges and Vertices`_ signature:"
+msgstr ""
+
+msgid "For the `Edges`_ signature:"
+msgstr ""
+
 msgid "Vertex SQL"
 msgstr ""
 
 msgid "``in_edges``"
-msgstr ""
-
-msgid "``BIGINT[]``"
 msgstr ""
 
 msgid ""
@@ -10493,7 +10553,45 @@ msgstr ""
 msgid "Number of edges that are incident to the vertex ``id``"
 msgstr ""
 
+msgid "Degree of a loop"
+msgstr ""
+
+msgid "Using the `Edges`_ signature."
+msgstr ""
+
+msgid "Using the `Edges and Vertices`_ signature."
+msgstr ""
+
 msgid "Degree of a sub graph"
+msgstr ""
+
+msgid "For the following is a subgraph of the :doc:`sampledata`:"
+msgstr ""
+
+msgid ":math:`E = \\{(1, 5 \\leftrightarrow 6), (1, 6 \\leftrightarrow 10)\\}`"
+msgstr ""
+
+msgid ":math:`V = \\{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17\\}`"
+msgstr ""
+
+msgid "The vertices not participating on the edge are considered isolated"
+msgstr ""
+
+msgid "their degree is 0 in the subgraph and"
+msgstr ""
+
+msgid "their degree is not shown in the output."
+msgstr ""
+
+msgid "Using a vertex table"
+msgstr ""
+
+msgid ""
+"For decent size networks, it is best to prepare your vertices table before "
+"hand and use it on ``pgr_degree`` calls."
+msgstr ""
+
+msgid "Extract the vertex information and save into a table:"
 msgstr ""
 
 msgid "Dry run execution"
@@ -10509,13 +10607,28 @@ msgid ""
 "backend development needs."
 msgstr ""
 
-msgid "Degree from an existing table"
+msgid "Finding dead ends"
 msgstr ""
 
 msgid ""
-"If you have a vertices table already built using ``pgr_extractVertices`` and "
-"want the degree of the whole graph rather than a subset, you can forgo using "
-"pgr_degree and work with the ``in_edges`` and ``out_edges`` columns directly."
+"If there is a vertices table already built using ``pgr_extractVertices`` and "
+"want the degree of the whole graph rather than a subset, it can be forgo "
+"using ``pgr_degree`` and work with the ``in_edges`` and ``out_edges`` "
+"columns directly."
+msgstr ""
+
+msgid "The degree of a dead end is 1."
+msgstr ""
+
+#, fuzzy
+msgid "Finding linear vertices"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
+
+msgid "The degree of a linear vertex is 2."
+msgstr ""
+
+msgid ""
+"If there is a vertices table already built using the ``pgr_extractVertices``"
 msgstr ""
 
 msgid ":doc:`pgr_extractVertices`"
@@ -10530,15 +10643,6 @@ msgid ""
 msgstr ""
 
 msgid "Version 3.3.0"
-msgstr ""
-
-msgid "Promoted to **proposed** function"
-msgstr ""
-
-msgid "``pgr_depthFirstSearch`` (`Single Vertex`_)"
-msgstr ""
-
-msgid "``pgr_depthFirstSearch`` (`Multiple Vertices`_)"
 msgstr ""
 
 msgid ""
@@ -10594,13 +10698,13 @@ msgid "Same as `Single vertex`_ but with edges in descending order of ``id``."
 msgstr ""
 
 msgid ""
-"`Boost: Depth First Search algorithm documentation <https://www.boost.org/"
-"libs/graph/doc/depth_first_search.html>`__"
+"`Boost: Depth First Search <https://www.boost.org/libs/graph/doc/"
+"depth_first_search.html>`__"
 msgstr ""
 
 msgid ""
-"`Boost: Undirected DFS algorithm documentation <https://www.boost.org/libs/"
-"graph/doc/undirected_dfs.html>`__"
+"`Boost: Undirected DFS <https://www.boost.org/libs/graph/doc/undirected_dfs."
+"html>`__"
 msgstr ""
 
 msgid ""
@@ -10617,44 +10721,34 @@ msgstr ""
 msgid "Version 3.5.0"
 msgstr ""
 
-msgid ""
-"``pgr_dijkstra`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
+msgid "pgr_dijkstra(One to One) added ``start_vid`` and ``end_vid`` columns."
 msgstr ""
 
-msgid "``pgr_dijkstra`` (`One to Many`_) added ``end_vid`` column."
+msgid "pgr_dijkstra(One to Many) added ``end_vid`` column."
 msgstr ""
 
-msgid "``pgr_dijkstra`` (`Many to One`_) added ``start_vid`` column."
+msgid "pgr_dijkstra(Many to One) added ``start_vid`` column."
 msgstr ""
 
 msgid "Version 3.1.0"
 msgstr ""
 
-msgid "``pgr_dijkstra`` (`Combinations`_)"
-msgstr ""
-
-msgid "**Official** functions"
-msgstr ""
-
 msgid "Version 2.2.0"
 msgstr ""
 
-msgid "New **proposed** functions:"
-msgstr ""
+#, fuzzy
+msgid "pgr_dijkstra(One to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_dijkstra`` (`One to Many`_)"
-msgstr ""
+#, fuzzy
+msgid "pgr_dijkstra(Many to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_dijkstra`` (`Many to One`_)"
-msgstr ""
+#, fuzzy
+msgid "pgr_dijkstra(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_dijkstra`` (`Many to Many`_)"
-msgstr ""
-
-msgid "Signature change on ``pgr_dijkstra`` (`One to One`_)"
-msgstr ""
-
-msgid "**Official** ``pgr_dijkstra`` (`One to One`_)"
+msgid "Signature change on pgr_dijkstra(One to One)"
 msgstr ""
 
 msgid "pgr_dijkstra(`Edges SQL`_, **start vid**, **end vid**, [``directed``])"
@@ -10840,6 +10934,11 @@ msgstr ""
 msgid "37) Using `Combinations`_"
 msgstr ""
 
+msgid ""
+"`Boost: Dijkstra shortest paths <https://www.boost.org/libs/graph/doc/"
+"dijkstra_shortest_paths.html>`__"
+msgstr ""
+
 msgid "https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm"
 msgstr ""
 
@@ -10851,9 +10950,6 @@ msgid ""
 "``pgr_dijkstraCost`` - Total cost of the shortest path using Dijkstra "
 "algorithm."
 msgstr ":doc:`pgr_aStarCost` - 최단 경로의 집계 비용 반환."
-
-msgid "``pgr_dijkstraCost`` (`Combinations`_)"
-msgstr ""
 
 #, fuzzy
 msgid ""
@@ -11143,9 +11239,6 @@ msgstr ""
 msgid "When ``false``: ``cap`` limit per ``Start vid`` will be returned"
 msgstr ""
 
-msgid "boost: https://www.boost.org/libs/graph/doc/table_of_contents.html"
-msgstr ""
-
 msgid "Wikipedia: https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm"
 msgstr ""
 
@@ -11312,6 +11405,9 @@ msgid ""
 "``pgr_drivingDistance`` - Returns the driving distance from a start node."
 msgstr ""
 
+msgid "Standarizing output columns to |result-spantree|"
+msgstr ""
+
 msgid "Added ``depth`` and ``start_vid`` result columns."
 msgstr ""
 
@@ -11321,13 +11417,16 @@ msgstr ""
 msgid "Added ``depth`` and ``pred`` result columns."
 msgstr ""
 
-msgid "Signature change pgr_drivingDistance(single vertex)"
+msgid "Signature change:"
 msgstr ""
 
-msgid "New **Official** pgr_drivingDistance(multiple vertices)"
+msgid "pgr_drivingDistance(single vertex)"
 msgstr ""
 
-msgid "Official:: pgr_drivingDistance(single vertex)"
+msgid "New official signature:"
+msgstr ""
+
+msgid "pgr_drivingDistance(multiple vertices)"
 msgstr ""
 
 msgid ""
@@ -11382,7 +11481,7 @@ msgid ""
 "undirected graph"
 msgstr ""
 
-msgid "pgr_edgeColoring - Experimental"
+msgid "``pgr_edgeColoring`` - Experimental"
 msgstr ""
 
 msgid ""
@@ -11456,15 +11555,21 @@ msgstr ""
 msgid "Graph coloring of pgRouting :doc:`sampledata`"
 msgstr ""
 
+msgid ""
+"`Boost: Edge Coloring <https://www.boost.org/libs/graph/doc/edge_coloring."
+"html>`__"
+msgstr ""
+
+msgid ""
+"`Wikipedia: Graph coloring <https://en.wikipedia.org/wiki/Graph_coloring>`__"
+msgstr ""
+
 msgid "``pgr_edgeDisjointPaths``"
 msgstr ""
 
 msgid ""
 "``pgr_edgeDisjointPaths`` — Calculates edge disjoint paths between two "
 "groups of vertices."
-msgstr ""
-
-msgid "New **proposed** function:"
 msgstr ""
 
 msgid "pgr_edgeDisjointPaths(Combinations)"
@@ -11548,9 +11653,6 @@ msgid ""
 "the flow from the sources to the targets using Edmonds Karp Algorithm."
 msgstr ""
 
-msgid "``pgr_edmondsKarp`` (`Combinations`_)"
-msgstr ""
-
 msgid "Renamed from ``pgr_maxFlowEdmondsKarp``"
 msgstr ""
 
@@ -11572,32 +11674,23 @@ msgstr ""
 msgid "pgr_edmondsKarp(`Edges SQL`_, `Combinations SQL`_)"
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/edmonds_karp_max_flow.html"
+msgid ""
+"`Boost: Edmonds Karp max flow <https://www.boost.org/libs/graph/doc/"
+"edmonds_karp_max_flow.html>`__"
 msgstr ""
 
 msgid "https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm"
 msgstr ""
 
-msgid "``pgr_edwardMoore - Experimental``"
-msgstr ""
+#, fuzzy
+msgid "``pgr_edwardMoore`` - Experimental"
+msgstr ":doc:`pgr_edwardMoore`"
 
 msgid ""
 "``pgr_edwardMoore`` — Returns the shortest path using Edward-Moore algorithm."
 msgstr ""
 
-msgid "``pgr_edwardMoore`` (`Combinations`_)"
-msgstr ""
-
-msgid "``pgr_edwardMoore`` (`One to One`_)"
-msgstr ""
-
-msgid "``pgr_edwardMoore`` (`One to Many`_)"
-msgstr ""
-
-msgid "``pgr_edwardMoore`` (`Many to One`_)"
-msgstr ""
-
-msgid "``pgr_edwardMoore`` (`Many to Many`_)"
+msgid "pgr_edwardMoore(Combinations)"
 msgstr ""
 
 msgid ""
@@ -11659,13 +11752,11 @@ msgstr ""
 msgid "https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm"
 msgstr ""
 
-msgid "pgr_extractVertices -- Proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_extractVertices``"
+msgstr ":doc:`pgr_extractVertices`"
 
 msgid "``pgr_extractVertices`` — Extracts the vertices information"
-msgstr ""
-
-msgid "Classified as **proposed** function"
 msgstr ""
 
 msgid ""
@@ -11760,19 +11851,14 @@ msgid ""
 "= true``."
 msgstr ""
 
+#, fuzzy
 msgid "``pgr_findCloseEdges``"
-msgstr ""
+msgstr ":doc:`pgr_findCloseEdges`"
 
 msgid "``pgr_findCloseEdges`` - Finds the close edges to a point geometry."
 msgstr ""
 
-msgid "New **proposed** signatures:"
-msgstr ""
-
-msgid "``pgr_findCloseEdges`` (`One point`_)"
-msgstr ""
-
-msgid "``pgr_findCloseEdges`` (`Many points`_)"
+msgid "``partial`` option is removed."
 msgstr ""
 
 msgid ""
@@ -11789,7 +11875,7 @@ msgid ""
 "adjustments needed by the application."
 msgstr ""
 
-msgid "``EMTPY SET`` is returned on dryrun executions"
+msgid "``EMPTY SET`` is returned on dryrun executions"
 msgstr ""
 
 msgid ""
@@ -11800,7 +11886,7 @@ msgid ""
 "pgr_findCloseEdges(`Edges SQL`_, **points**, **tolerance**, [**options**])"
 msgstr ""
 
-msgid "**options:** ``[cap, partial, dryrun]``"
+msgid "**options:** ``[cap, dryrun]``"
 msgstr ""
 
 msgid "Returns set of |result-find|"
@@ -11809,52 +11895,16 @@ msgstr ""
 msgid "One point"
 msgstr ""
 
-msgid "Default: ``cap => 1``"
+msgid "Get two close edges to points of interest with :math:`pid = 5`"
 msgstr ""
 
-msgid "Maximum one row answer."
-msgstr ""
-
-msgid "Default: ``partial => true``"
-msgstr ""
-
-msgid "With less calculations as possible."
-msgstr ""
-
-msgid "Default: ``dryrun => false``"
-msgstr ""
-
-msgid "Process query"
-msgstr ""
-
-msgid "Returns"
-msgstr ""
-
-msgid "values on ``edge_id``, ``fraction``, ``side`` columns."
-msgstr ""
-
-msgid "``NULL`` on ``distance``, ``geom``, ``edge`` columns."
+msgid "``cap => 2``"
 msgstr ""
 
 msgid "Many points"
 msgstr ""
 
-msgid ""
-"Find at most :math:`2` edges close to all vertices on the points of interest "
-"table."
-msgstr ""
-
-msgid "One answer per point, as small as possible."
-msgstr ""
-
-msgid ""
-"Columns ``edge_id``, ``fraction``, ``side`` and ``geom`` are returned with "
-"values."
-msgstr ""
-
-msgid ""
-"``geom`` contains the original point geometry to assist on deterpartialing "
-"to which point geometry the row belongs to."
+msgid "For each points of interests, find the closest edge."
 msgstr ""
 
 msgid "**point**"
@@ -11881,17 +11931,6 @@ msgstr ""
 msgid "Limit output rows"
 msgstr ""
 
-msgid "``partial``"
-msgstr ""
-
-msgid ""
-"When ``true`` only columns needed for :doc:`withPoints-category` are "
-"calculated."
-msgstr ""
-
-msgid "When ``false`` all columns are calculated"
-msgstr ""
-
 msgid "When ``false`` calculations are performed."
 msgstr ""
 
@@ -11907,63 +11946,74 @@ msgid "When :math:`cap = 1`, it is the closest edge."
 msgstr ""
 
 msgid ""
-"Value in <0,1> that indicates the relative postition from the first end-"
-"point of the edge."
+"Value in <0,1> that indicates the relative position from the first end-point "
+"of the edge."
 msgstr ""
 
 msgid "Value in ``[r, l]`` indicating if the point is:"
 msgstr ""
 
-msgid "In the right ``r``."
-msgstr ""
-
-msgid "In the left ``l``."
+msgid "At the right ``r`` of the segment."
 msgstr ""
 
 msgid "When the point is on the line it is considered to be on the right."
 msgstr ""
 
+msgid "At the left ``l`` of the segment."
+msgstr ""
+
 msgid "``distance``"
 msgstr ""
 
-msgid "Distance from point to edge."
+msgid "Distance from the point to the edge."
 msgstr ""
 
-msgid "``NULL`` when ``cap = 1`` on the `One point`_ signature"
-msgstr ""
-
-msgid "``POINT`` geometry"
+msgid "Original ``POINT`` geometry."
 msgstr ""
 
 msgid ""
-"`One Point`_: Contains the point on the edge that is ``fraction`` away from "
-"the starting point of the edge."
+"``LINESTRING`` geometry that connects the original **point** to the closest "
+"point of the edge with identifier ``edge_id``"
 msgstr ""
 
-msgid "`Many Points`_: Contains the corresponding **original point**"
+msgid "One point in an edge"
 msgstr ""
 
-msgid ""
-"``LINESTRING`` geometry from the **original point** to the closest point of "
-"the edge with identifier ``edge_id``"
+msgid "The green node is the original point."
 msgstr ""
 
-msgid "One point results"
-msgstr ""
-
-msgid "The green nodes is the **original point**"
+msgid "``geom`` has the value of the original point."
 msgstr ""
 
 msgid ""
-"The geometry ``geom`` is a point on the :math:`sp \\rightarrow ep` edge."
+"The geometry ``edge`` is a line that connects the original point with the "
+"edge :math:`sp \\rightarrow ep` edge."
+msgstr ""
+
+msgid "The point is located at the left of the edge."
+msgstr ""
+
+msgid "One point dry run execution"
+msgstr ""
+
+msgid "Using the query from the previous example:"
+msgstr ""
+
+msgid "Returns ``EMPTY SET``."
+msgstr ""
+
+msgid "``dryrun => true``"
+msgstr ""
+
+msgid "Generates a PostgreSQL ``NOTICE`` with the code used."
 msgstr ""
 
 msgid ""
-"The geometry ``edge`` is a line that connects the **original point** with "
-"``geom``"
+"The generated code can be used as a starting base code for additional "
+"requirements, like taking into consideration the SRID."
 msgstr ""
 
-msgid "Many point results"
+msgid "Many points in an edge"
 msgstr ""
 
 msgid "The green nodes are the **original points**"
@@ -11980,130 +12030,7 @@ msgid ""
 "\\rightarrow ep` edge."
 msgstr ""
 
-msgid "One point examples"
-msgstr ""
-
-msgid "At most two answers"
-msgstr ""
-
-msgid "``cap => 2``"
-msgstr ""
-
-msgid "Maximum two row answer."
-msgstr ""
-
-msgid "Understanding the result"
-msgstr ""
-
-msgid "``NULL`` on ``geom``, ``edge``"
-msgstr ""
-
-msgid "``edge_id`` identifier of the edge close to the **original point**"
-msgstr ""
-
-msgid ""
-"Two edges are withing :math:`0.5` distance units from the **original "
-"point**: :math:`{5, 8}`"
-msgstr ""
-
-msgid "For edge :math:`5`:"
-msgstr ""
-
-msgid ""
-"``fraction``: The closest point from the **original point** is at the :math:"
-"`0.8` fraction of the edge :math:`5`."
-msgstr ""
-
-msgid ""
-"``side``: The **original point** is located to the left side of edge :math:"
-"`5`."
-msgstr ""
-
-msgid ""
-"``distance``: The **original point** is located :math:`0.1` length units "
-"from edge :math:`5`."
-msgstr ""
-
-msgid "For edge :math:`8`:"
-msgstr ""
-
-msgid ""
-"``fraction``: The closest point from the **original point** is at the :math:"
-"`0.89..` fraction of the edge :math:`8`."
-msgstr ""
-
-msgid ""
-"``side``: The **original point** is located to the right side of edge :math:"
-"`8`."
-msgstr ""
-
-msgid ""
-"``distance``: The **original point** is located :math:`0.19..` length units "
-"from edge :math:`8`."
-msgstr ""
-
-msgid "One answer, all columns"
-msgstr ""
-
-msgid "``partial => false``"
-msgstr ""
-
-msgid "Calculate all columns"
-msgstr ""
-
-msgid ""
-"``edge_id`` identifier of the edge **closest** to the **original point**"
-msgstr ""
-
-msgid ""
-"From all edges within :math:`0.5` distance units from the **original "
-"point**: :math:`{5}` is the closest one."
-msgstr ""
-
-msgid ""
-"``geom``: Contains the geometry of the closest point on edge :math:`5` from "
-"the **original point**."
-msgstr ""
-
-msgid ""
-"``edge``: Contains the ``LINESTRING`` geometry of the **original point** to "
-"the closest point on on edge :math:`5` ``geom``"
-msgstr ""
-
-msgid "At most two answers with all columns"
-msgstr ""
-
-msgid "Understanding the result:"
-msgstr ""
-
-msgid ""
-"``geom``: Contains the geometry of the closest point on edge :math:`8` from "
-"the **original point**."
-msgstr ""
-
-msgid ""
-"``edge``: Contains the ``LINESTRING`` geometry of the **original point** to "
-"the closest point on on edge :math:`8` ``geom``"
-msgstr ""
-
-msgid "One point dry run execution"
-msgstr ""
-
-msgid "Returns ``EMPTY SET``."
-msgstr ""
-
-msgid "``partial => true``"
-msgstr ""
-
-msgid "Is ignored"
-msgstr ""
-
-msgid ""
-"Because it is a **dry run** excecution, the code for all calculations are "
-"shown on the PostgreSQL ``NOTICE``."
-msgstr ""
-
-msgid "``dryrun => true``"
+msgid "Many points dry run execution"
 msgstr ""
 
 msgid "Do not process query"
@@ -12111,62 +12038,6 @@ msgstr ""
 
 msgid ""
 "Generate a PostgreSQL ``NOTICE`` with the code used to calculate all columns"
-msgstr ""
-
-msgid "``cap`` and **original point** are used in the code"
-msgstr ""
-
-msgid "Many points examples"
-msgstr ""
-
-msgid "At most two answers per point"
-msgstr ""
-
-msgid "``NULL`` on ``edge``"
-msgstr ""
-
-msgid ""
-"``edge_id`` identifier of the edge close to a **original point** (``geom``)"
-msgstr ""
-
-msgid ""
-"Two edges at most withing :math:`0.5` distance units from each of the "
-"**original points**:"
-msgstr ""
-
-msgid "For ``POINT(1.8 0.4)`` and ``POINT(0.3 1.8)`` only one edge was found."
-msgstr ""
-
-msgid "For the rest of the points two edges were found."
-msgstr ""
-
-msgid "For point ``POINT(2.9 1.8)``"
-msgstr ""
-
-msgid ""
-"Edge :math:`5` is before :math:`8` therefore edge :math:`5` has the shortest "
-"distance to ``POINT(2.9 1.8)``."
-msgstr ""
-
-msgid "One answer per point, all columns"
-msgstr ""
-
-msgid "For the **original point** ``POINT(2.9 1.8)``"
-msgstr ""
-
-msgid "Edge :math:`5` is the closest edge to the **original point**"
-msgstr ""
-
-msgid ""
-"``geom``: Contains the geometry of the **original point** ``POINT(2.9 1.8)``"
-msgstr ""
-
-msgid ""
-"``edge``: Contains the ``LINESTRING`` geometry of the **original point** "
-"(``geom``) to the closest point on on edge."
-msgstr ""
-
-msgid "Many points dry run execution"
 msgstr ""
 
 msgid "Find at most two routes to a given point"
@@ -12203,11 +12074,10 @@ msgstr ""
 msgid "A unique identifier."
 msgstr ""
 
-msgid ""
-"Identifier of the edge nearest edge that allows an arrival to the point."
+msgid "Identifier of the nearest segment."
 msgstr ""
 
-msgid "Is it on the left, right or both sides of the segment ``edge_id``"
+msgid "Is it on the left, right or both sides of the segment ``edge_id``."
 msgstr ""
 
 msgid "Where in the segment is the point located."
@@ -12216,13 +12086,35 @@ msgstr ""
 msgid "The geometry of the points."
 msgstr ""
 
+msgid "The distance between ``geom`` and the segment ``edge_id``."
+msgstr ""
+
+msgid ""
+"A segment that connects the ``geom`` of the point to the closest point on "
+"the segment ``edge_id``."
+msgstr ""
+
 msgid "``newPoint``"
 msgstr ""
 
-msgid "The geometry of the points moved on top of the segment."
+msgid "A point on segment ``edge_id`` that is the closest to ``geom``."
 msgstr ""
 
-msgid "Points of interest fillup"
+msgid "Points of interest fill up"
+msgstr ""
+
+msgid "Inserting the points of interest."
+msgstr ""
+
+msgid "Filling the rest of the table."
+msgstr ""
+
+msgid ""
+"Any other additional modification: In this manual, point :math:`6` can be "
+"reached from both sides."
+msgstr ""
+
+msgid "The points of interest:"
 msgstr ""
 
 msgid "``pgr_floydWarshall``"
@@ -12251,17 +12143,11 @@ msgid ""
 "floyd_warshall_shortest.html>`_"
 msgstr ""
 
-msgid "Queries uses the :doc:`sampledata` network."
-msgstr ""
-
 msgid "``pgr_full_version``"
 msgstr ""
 
 msgid ""
 "``pgr_full_version`` — Get the details of pgRouting version information."
-msgstr ""
-
-msgid "New **official** function"
 msgstr ""
 
 msgid "Get complete details of pgRouting version information"
@@ -12330,16 +12216,15 @@ msgstr ""
 msgid "Git hash of pgRouting build"
 msgstr ""
 
-msgid "``pgr_hawickCircuits - Experimental``"
-msgstr ""
+#, fuzzy
+msgid "``pgr_hawickCircuits`` - Experimental"
+msgstr ":doc:`pgr_hawickCircuits`"
 
+#, fuzzy
 msgid ""
-"``pgr_hawickCircuits`` — Returns the list of cirucits using hawick circuits "
+"``pgr_hawickCircuits`` — Returns the list of ciruits using hawick circuits "
 "algorithm."
-msgstr ""
-
-msgid "``pgr_hawickCircuits``"
-msgstr ""
+msgstr ":doc:`pgr_bdDijkstra` - 최단 경로를 위한 양방향 다익스트라 알고리즘."
 
 msgid ""
 "Hawick Circuit algorithm, is published in 2008 by Ken Hawick and Health A. "
@@ -12463,7 +12348,9 @@ msgid ""
 "blue represent :math:`K_5` subgraph."
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/boyer_myrvold.html"
+msgid ""
+"`Boost: Boyer Myrvold <https://www.boost.org/libs/graph/doc/boyer_myrvold."
+"html>`__"
 msgstr ""
 
 msgid "``pgr_johnson``"
@@ -12516,6 +12403,9 @@ msgstr ""
 msgid ""
 "``pgr_kruskalBFS`` — Kruskal's algorithm for Minimum Spanning Tree with "
 "breadth First Search ordering."
+msgstr ""
+
+msgid "Added ``pred`` result columns."
 msgstr ""
 
 msgid ""
@@ -12593,8 +12483,9 @@ msgstr ""
 msgid "pgr_kruskalDFS(`Edges SQL`_, **root vids**, [``max_depth``])"
 msgstr ""
 
-msgid "pgr_lengauerTarjanDominatorTree -Experimental"
-msgstr ""
+#, fuzzy
+msgid "``pgr_lengauerTarjanDominatorTree`` - Experimental"
+msgstr ":doc:`pgr_lengauerTarjanDominatorTree`"
 
 msgid ""
 "``pgr_lengauerTarjanDominatorTree`` — Returns the immediate dominator of all "
@@ -12651,8 +12542,8 @@ msgid "Dominator tree of another component."
 msgstr ""
 
 msgid ""
-"`Boost: Lengauer-Tarjan dominator tree algorithm <https://www.boost.org/libs/"
-"graph/doc/lengauer_tarjan_dominator.htm>`__"
+"`Boost: Lengauer-Tarjan dominator <https://www.boost.org/libs/graph/doc/"
+"lengauer_tarjan_dominator.htm>`__"
 msgstr ""
 
 msgid ""
@@ -12660,13 +12551,18 @@ msgid ""
 "Dominator_(graph_theory)>`__"
 msgstr ""
 
-msgid "pgr_lineGraph - Proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_lineGraph`` - Proposed"
+msgstr ":doc:`pgr_analyzeGraph`"
 
 msgid ""
 "``pgr_lineGraph`` — Transforms the given graph into its corresponding edge-"
 "based graph."
 msgstr ""
+
+#, fuzzy
+msgid "Works for directed and undirected graphs."
+msgstr ":doc:`pgr_bridges` - 무방향 그래프의 브릿지."
 
 msgid ""
 "Given a graph :math:`G`, its line graph :math:`L(G)` is a graph such that:"
@@ -12711,13 +12607,7 @@ msgstr ""
 msgid "Gives a local identifier for the edge"
 msgstr ""
 
-msgid "Identifier of the source vertex of the current edge."
-msgstr ""
-
 msgid "When `negative`: the source is the reverse edge in the original graph."
-msgstr ""
-
-msgid "Identifier of the target vertex of the current edge."
 msgstr ""
 
 msgid "When `negative`: the target is the reverse edge in the original graph."
@@ -12929,8 +12819,7 @@ msgid "Full line graph of subgraph of edges :math:`\\{4, 7, 8, 10\\}`"
 msgstr ""
 
 msgid ""
-"The examples of this section are based on the :doc:`sampledata` network. The "
-"examples include the subgraph including edges 4, 7, 8, and 10 with "
+"The examples include the subgraph including edges 4, 7, 8, and 10 with "
 "``reverse_cost``."
 msgstr ""
 
@@ -13149,15 +13038,15 @@ msgstr ""
 msgid "Returns set of |result-component-make|"
 msgstr ""
 
+msgid "List of edges that are needed to connect the graph."
+msgstr ""
+
 msgid ""
-"Query done on :doc:`sampledata` network gives the list of edges that are "
-"needed to connect the graph."
+"`Boost: make connected <https://www.boost.org/libs/graph/doc/make_connected."
+"html>`__"
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/make_connected.html"
-msgstr ""
-
-msgid "pgr_maxCardinalityMatch"
+msgid "``pgr_maxCardinalityMatch``"
 msgstr ""
 
 msgid ""
@@ -13165,13 +13054,16 @@ msgid ""
 "graph."
 msgstr ""
 
+msgid "pgr_maxCardinalityMatch(text) returns only ``edge`` column."
+msgstr ""
+
 msgid "Deprecated signature"
 msgstr ""
 
-msgid "``pgr_maxCardinalityMatch(text,boolean)``"
+msgid "pgr_maxCardinalityMatch(text,boolean)"
 msgstr ""
 
-msgid "``directed => false`` when used."
+msgid "directed => ``false`` when used."
 msgstr ""
 
 msgid "Renamed from ``pgr_maximumCardinalityMatching``"
@@ -13222,7 +13114,9 @@ msgstr ""
 msgid "Identifier of the edge in the original query."
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/maximum_matching.html"
+msgid ""
+"`Boost: maximum_matching <https://www.boost.org/libs/graph/doc/"
+"maximum_matching.html>`__"
 msgstr ""
 
 msgid "https://en.wikipedia.org/wiki/Matching_%28graph_theory%29"
@@ -13239,17 +13133,14 @@ msgid ""
 "source(s) to the targets(s) using the Push Relabel algorithm."
 msgstr ""
 
-msgid "``pgr_maxFlow`` (`Combinations`_)"
-msgstr ""
-
-msgid "New **Proposed** function"
-msgstr ""
-
 msgid "Calculates the maximum flow from the sources to the targets."
 msgstr ""
 
 msgid ""
 "When the maximum flow is **0** then there is no flow and **0** is returned."
+msgstr ""
+
+msgid "There is no flow when source has the same vaule as target."
 msgstr ""
 
 msgid "Uses the :doc:`pgr_pushRelabel <pgr_pushRelabel>` algorithm."
@@ -13279,7 +13170,9 @@ msgstr ""
 msgid "Maximum flow possible from the source(s) to the target(s)"
 msgstr ""
 
-msgid "https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html"
+msgid ""
+"`Boost: push relabel max flow <https://www.boost.org/libs/graph/doc/"
+"push_relabel_max_flow.html>`__"
 msgstr ""
 
 msgid ""
@@ -13294,7 +13187,10 @@ msgid ""
 "of the maximum flow on a graph"
 msgstr ""
 
-msgid "``pgr_maxFlowMinCost`` (`Combinations`_)"
+msgid "pgr_maxFlowMinCost(Combinations)"
+msgstr ""
+
+msgid "|boost| graph inside."
 msgstr ""
 
 msgid "**TODO** check which statement is true:"
@@ -13338,11 +13234,6 @@ msgstr ""
 msgid "Returns set of |result-flow-mincost|"
 msgstr ""
 
-msgid ""
-"https://www.boost.org/libs/graph/doc/"
-"successive_shortest_path_nonnegative_weights.html"
-msgstr ""
-
 msgid "``pgr_maxFlowMinCost_Cost`` - Experimental"
 msgstr ""
 
@@ -13351,7 +13242,7 @@ msgid ""
 "maximum flow on a graph"
 msgstr ""
 
-msgid "``pgr_maxFlowMinCost_Cost`` (`Combinations`_)"
+msgid "pgr_maxFlowMinCost_Cost(Combinations)"
 msgstr ""
 
 msgid "**The cost value of all input edges must be nonnegative.**"
@@ -13384,8 +13275,9 @@ msgstr ""
 msgid "Minimum Cost Maximum Flow possible from the source(s) to the target(s)"
 msgstr ""
 
-msgid "pgr_nodeNetwork"
-msgstr ""
+#, fuzzy
+msgid "``pgr_nodeNetwork``"
+msgstr ":doc:`pgr_analyzeGraph`"
 
 msgid "``pgr_nodeNetwork`` - Nodes an network edge table."
 msgstr ""
@@ -13812,7 +13704,7 @@ msgid ""
 "projectweb/top/pdptw/li-lim-benchmark/"
 msgstr ""
 
-msgid "There are 25 vehciles in the problem all with the same characteristics."
+msgid "There are 25 vehicles in the problem all with the same characteristics."
 msgstr ""
 
 msgid "The original orders"
@@ -13823,7 +13715,7 @@ msgid ""
 "order."
 msgstr ""
 
-msgid "The original data needs to be converted to an appropiate table:"
+msgid "The original data needs to be converted to an appropriate table:"
 msgstr ""
 
 msgid "The query"
@@ -13922,9 +13814,6 @@ msgid ""
 "the flow from the sources to the targets using Push Relabel Algorithm."
 msgstr ""
 
-msgid "``pgr_pushRelabel`` (`Combinations`_)"
-msgstr ""
-
 msgid "Renamed from ``pgr_maxFlowPushRelabel``"
 msgstr ""
 
@@ -13943,15 +13832,12 @@ msgstr ""
 msgid "pgr_pushRelabel(`Edges SQL`_, `Combinations SQL`_)"
 msgstr ""
 
-msgid "pgr_sequentialVertexColoring - Proposed"
+msgid "``pgr_sequentialVertexColoring`` - Proposed"
 msgstr ""
 
 msgid ""
 "``pgr_sequentialVertexColoring`` — Returns the vertex coloring of an "
 "undirected graph, using greedy approach."
-msgstr ""
-
-msgid "Promoted to **proposed** signature"
 msgstr ""
 
 msgid ""
@@ -13996,8 +13882,14 @@ msgstr ""
 msgid "pgr_sequentialVertexColoring(`Edges SQL`_)"
 msgstr ""
 
-msgid "pgr_stoerWagner - Experimental"
+msgid ""
+"`Boost: Sequential Vertex Coloring <https://www.boost.org/libs/graph/doc/"
+"sequential_vertex_coloring.html>`__"
 msgstr ""
+
+#, fuzzy
+msgid "``pgr_stoerWagner`` - Experimental"
+msgstr ":doc:`pgr_stoerWagner`"
 
 msgid "``pgr_stoerWagner`` — The min-cut of graph using stoerWagner algorithm."
 msgstr ""
@@ -14080,6 +13972,11 @@ msgstr ""
 msgid "Using :doc:`pgr_connectedComponents`"
 msgstr ""
 
+msgid ""
+"`Boost: Stoer Wagner min cut <https://www.boost.org/libs/graph/doc/"
+"stoer_wagner_min_cut.html>`__"
+msgstr ""
+
 msgid "https://en.wikipedia.org/wiki/Stoer%E2%80%93Wagner_algorithm"
 msgstr ""
 
@@ -14109,7 +14006,7 @@ msgid "The strong components of the graph"
 msgstr ""
 
 msgid ""
-"Boost: `Strong components <https://www.boost.org/libs/graph/doc/"
+"`Boost: Strong components <https://www.boost.org/libs/graph/doc/"
 "strong_components.html>`__"
 msgstr ""
 
@@ -14174,6 +14071,11 @@ msgstr ""
 msgid "Graph is not a DAG"
 msgstr ""
 
+msgid ""
+"`Boost: topological sort <https://www.boost.org/libs/graph/doc/"
+"topological_sort.html>`__"
+msgstr ""
+
 msgid "``pgr_transitiveClosure`` - Experimental"
 msgstr ""
 
@@ -14229,57 +14131,60 @@ msgstr ""
 msgid "Identifiers of the vertices that are reachable from vertex v."
 msgstr ""
 
+msgid ""
+"`Boost: transitive closure <https://www.boost.org/libs/graph/doc/"
+"transitive_closure.html>`__"
+msgstr ""
+
 msgid "https://en.wikipedia.org/wiki/Transitive_closure"
 msgstr ""
 
-msgid "pgr_trsp - Proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_trsp``"
+msgstr ":doc:`pgr_trsp`"
 
 msgid "``pgr_trsp`` - routing vertices with restrictions."
 msgstr ""
 
-msgid "New proposed signatures"
-msgstr ""
+#, fuzzy
+msgid "pgr_trsp(One to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_trsp`` (`One to One`_)"
-msgstr ""
+#, fuzzy
+msgid "pgr_trsp(One to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_trsp`` (`One to Many`_)"
-msgstr ""
+#, fuzzy
+msgid "pgr_trsp(Many to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_trsp`` (`Many to One`_)"
-msgstr ""
+#, fuzzy
+msgid "pgr_trsp(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_trsp`` (`Many to Many`_)"
-msgstr ""
-
-msgid "``pgr_trsp`` (`Combinations`_)"
-msgstr ""
+#, fuzzy
+msgid "pgr_trsp(Combinations)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 msgid "Deprecated signatures"
 msgstr ""
 
-msgid "``pgr_trsp(text,integer,integer,boolean,boolean,text)``"
+msgid "pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)"
 msgstr ""
 
-msgid "``pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)``"
-msgstr ""
-
-msgid "``pgr_trspViaVertices(text,anyarray,boolean,boolean,text)``"
-msgstr ""
-
-msgid ""
-"``pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)``"
+msgid "pgr_trspViaVertices(text,anyarray,boolean,boolean,text)"
 msgstr ""
 
 msgid "New prototypes"
 msgstr ""
 
-msgid "``pgr_trspViaVertices``"
-msgstr ""
+#, fuzzy
+msgid "pgr_trspViaVertices"
+msgstr ":doc:`pgr_extractVertices`"
 
-msgid "``pgr_trspViaEdges``"
-msgstr ""
+#, fuzzy
+msgid "pgr_trspViaEdges"
+msgstr ":doc:`pgr_trspVia`"
 
 msgid ""
 "Turn restricted shortest path (TRSP) is an algorithm that receives turn "
@@ -14351,17 +14256,12 @@ msgid ""
 "`Deprecated documentation <https://docs.pgrouting.org/3.3/en/pgr_trsp.html>`_"
 msgstr ""
 
-msgid "``pgr_trspVia`` - Proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_trspVia``"
+msgstr ":doc:`pgr_trspVia`"
 
 msgid ""
 "``pgr_trspVia`` Route that goes through a list of vertices with restrictions."
-msgstr ""
-
-msgid "New proposed function:"
-msgstr ""
-
-msgid "``pgr_trspVia`` (`One Via`_)"
 msgstr ""
 
 msgid ""
@@ -14441,15 +14341,13 @@ msgstr ""
 msgid ":doc:`via-category`"
 msgstr ":doc:`via-category`"
 
-msgid "``pgr_trspVia_withPoints`` - Proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_trspVia_withPoints``"
+msgstr ":doc:`pgr_trspVia_withPoints`"
 
 msgid ""
 "``pgr_trspVia_withPoints`` - Route that goes through a list of vertices and/"
 "or points with restrictions."
-msgstr ""
-
-msgid "``pgr_trspVia_withPoints`` (`One Via`_)"
 msgstr ""
 
 msgid ""
@@ -14611,28 +14509,10 @@ msgid ""
 "`pgr_trsp` algorithm. In this case a U turn is been done using the same edge."
 msgstr ""
 
-msgid "pgr_trsp_withPoints - Proposed"
+msgid "``pgr_trsp_withPoints``"
 msgstr ""
 
 msgid "``pgr_trsp_withPoints`` Routing Vertex/Point with restrictions."
-msgstr ""
-
-msgid "New proposed signatures:"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`One to One`_)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`One to Many`_)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`Many to One`_)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`Many to Many`_)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (`Combinations`_)"
 msgstr ""
 
 msgid ""
@@ -14743,15 +14623,12 @@ msgid ""
 "`1` on an undirected graph, with details."
 msgstr ""
 
-msgid "pgr_turnRestrictedPath - Experimental"
+msgid "``pgr_turnRestrictedPath`` - Experimental"
 msgstr ""
 
 msgid ""
-"``pgr_turnRestrictedPath`` Using Yen's algorithm Vertex -Vertex routing with "
-"restrictions"
-msgstr ""
-
-msgid "New experimental function"
+"``pgr_turnRestrictedPath`` Using Yen's algorithm Vertex - Vertex routing "
+"with restrictions"
 msgstr ""
 
 msgid ""
@@ -14825,7 +14702,7 @@ msgstr ""
 msgid "pgRouting Version for this documentation"
 msgstr ""
 
-msgid "pgr_vrpOneDepot - Experimental"
+msgid "``pgr_vrpOneDepot`` - Experimental"
 msgstr ""
 
 msgid "**No documentation available**"
@@ -14834,8 +14711,9 @@ msgstr ""
 msgid "**TBD**"
 msgstr ""
 
-msgid "``pgr_withPoints`` - Proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_withPoints``"
+msgstr ":doc:`pgr_withPoints`"
 
 msgid ""
 "``pgr_withPoints`` - Returns the shortest path in a graph with additional "
@@ -14977,8 +14855,9 @@ msgstr ""
 msgid "Passes in front or visits with left side driving."
 msgstr ""
 
-msgid "``pgr_withPointsCost`` - Proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_withPointsCost``"
+msgstr ":doc:`pgr_withPointsCost`"
 
 msgid ""
 "``pgr_withPointsCost`` - Calculates the shortest path and returns only the "
@@ -15121,8 +15000,9 @@ msgstr ""
 msgid "Does not matter driving side driving topology"
 msgstr ""
 
-msgid "``pgr_withPointsCostMatrix`` - proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_withPointsCostMatrix``"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 msgid ""
 "``pgr_withPointsCostMatrix`` - Calculates a cost matrix using :doc:"
@@ -15153,8 +15033,9 @@ msgid ""
 "locations on the graph of point `(2.9, 1.8)`."
 msgstr ""
 
-msgid "``pgr_withPointsDD`` - Proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_withPointsDD``"
+msgstr ":doc:`pgr_withPoints`"
 
 msgid ""
 "``pgr_withPointsDD`` - Returns the driving **distance** from a starting "
@@ -15166,8 +15047,13 @@ msgid ""
 "unnamed compulsory **driving side**."
 msgstr ""
 
-msgid "``pgr_withPointsDD`` (`Single vertex`)"
-msgstr ""
+#, fuzzy
+msgid "pgr_withPointsDD(Single vertex)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
+
+#, fuzzy
+msgid "pgr_withPointsDD(Multiple vertices)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 msgid "Added ``depth``, ``pred`` and ``start_vid`` column."
 msgstr ""
@@ -15184,13 +15070,12 @@ msgid ""
 msgstr ""
 
 msgid ""
-"``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,"
-"boolean)``"
+"pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)"
 msgstr ""
 
 msgid ""
-"``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
-"boolean,boolean)``"
+"pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
+"boolean,boolean)"
 msgstr ""
 
 msgid ""
@@ -15297,8 +15182,9 @@ msgstr ""
 msgid ":doc:`pgr_alphaShape`"
 msgstr ":doc:`pgr_alphaShape`"
 
-msgid "pgr_withPointsKSP - Proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_withPointsKSP``"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 msgid ""
 "``pgr_withPointsKSP`` — Yen's algorithm for K shortest paths using Dijkstra."
@@ -15308,30 +15194,27 @@ msgid "Standarizing output columns to |nksp-result|"
 msgstr ""
 
 #, fuzzy
-msgid "``pgr_withPointsKSP`` (One to One)"
-msgstr ":doc:`pgr_withPointsCostMatrix`"
-
-msgid "New overload functions"
-msgstr ""
-
-#, fuzzy
-msgid "``pgr_withPointsKSP`` (One to Many)"
+msgid "pgr_withPointsKSP(One to One)"
 msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 #, fuzzy
-msgid "``pgr_withPointsKSP`` (Many to One)"
+msgid "pgr_withPointsKSP(One to Many)"
 msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 #, fuzzy
-msgid "``pgr_withPointsKSP`` (Many to Many)"
+msgid "pgr_withPointsKSP(Many to One)"
 msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 #, fuzzy
-msgid "``pgr_withPointsKSP`` (Combinations)"
+msgid "pgr_withPointsKSP(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
+
+#, fuzzy
+msgid "pgr_withPointsKSP(Combinations)"
 msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 msgid ""
-"``pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
+"pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
 "boolean)``"
 msgstr ""
 
@@ -15447,15 +15330,13 @@ msgid ""
 "to point :math:`2` with heap paths and details."
 msgstr ""
 
-msgid "``pgr_withPointsVia`` - Proposed"
-msgstr ""
+#, fuzzy
+msgid "``pgr_withPointsVia``"
+msgstr ":doc:`pgr_withPointsVia`"
 
 msgid ""
 "``pgr_withPointsVia`` - Route that goes through a list of vertices and/or "
 "points."
-msgstr ""
-
-msgid "New **proposed** function ``pgr_withPointsVia`` (`One Via`_)"
 msgstr ""
 
 msgid ""
@@ -15540,43 +15421,15 @@ msgstr ""
 msgid ":doc:`pgr_withPointsVia` - Via routing"
 msgstr ""
 
-msgid "These proposed functions do not modify the database."
-msgstr ""
-
-msgid ""
-":doc:`pgr_degree` - Returns a set of vertices and corresponding count of "
-"incidet edges to the vertex."
-msgstr ""
-
-msgid ""
-":doc:`pgr_extractVertices` - Extracts vertex information based on the edge "
-"table information."
-msgstr ""
-
 msgid ""
 ":doc:`pgr_lineGraph` - Transformation algorithm for generating a Line Graph."
 msgstr ""
-
-msgid ":doc:`pgr_withPointsVia`"
-msgstr ":doc:`pgr_withPointsVia`"
-
-msgid ":doc:`pgr_trspVia`"
-msgstr ":doc:`pgr_trspVia`"
-
-msgid ":doc:`pgr_trspVia_withPoints`"
-msgstr ":doc:`pgr_trspVia_withPoints`"
 
 msgid ":doc:`withPoints-family` - Functions based on Dijkstra algorithm."
 msgstr ""
 
 msgid "From the :doc:`TRSP-family`:"
 msgstr ""
-
-msgid "Utilities"
-msgstr ""
-
-msgid ":doc:`pgr_findCloseEdges`"
-msgstr ":doc:`pgr_findCloseEdges`"
 
 msgid "Reference"
 msgstr ""
@@ -15592,13 +15445,208 @@ msgstr ""
 msgid "Mayors"
 msgstr ""
 
+msgid "pgRouting 4"
+msgstr ""
+
+msgid "Minors 4.x"
+msgstr ""
+
+msgid "pgRouting 4.0"
+msgstr ""
+
 msgid "pgRouting 3"
 msgstr ""
 
 msgid "Minors 3.x"
 msgstr ""
 
+msgid "pgRouting 3.8"
+msgstr ""
+
+msgid "pgRouting 3.8.0 Release Notes"
+msgstr ""
+
+msgid "Promotion to official function of pgRouting."
+msgstr ""
+
+msgid "pgr_extractVertices"
+msgstr ""
+
+msgid "pgr_degree"
+msgstr ""
+
+#, fuzzy
+msgid "pgr_findCloseEdges"
+msgstr ":doc:`pgr_findCloseEdges`"
+
+msgid "Official functions changes"
+msgstr ""
+
+msgid ""
+"`#2786 <https://github.com/pgRouting/pgrouting/issues/2786>`__: "
+"pgr_contraction"
+msgstr ""
+
+#, fuzzy
+msgid "New proposed functions"
+msgstr ":doc:`routingFunctions`"
+
+#, fuzzy
+msgid "Contraction"
+msgstr "소개"
+
+msgid ""
+"`#2790 <https://github.com/pgRouting/pgrouting/issues/2790>`__: "
+"pgr_contractionDeadEnd"
+msgstr ""
+
+msgid ""
+"`#2791 <https://github.com/pgRouting/pgrouting/issues/2791>`__: "
+"pgr_contractionLinear"
+msgstr ""
+
 msgid "pgRouting 3.7"
+msgstr ""
+
+msgid "pgRouting 3.7.3 Release Notes"
+msgstr ""
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.3 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.3%22>`__"
+msgstr ""
+
+msgid ""
+"`#2731 <https://github.com/pgRouting/pgrouting/pull/2731>`__ Build Failure "
+"on Ubuntu 22"
+msgstr ""
+
+msgid "pgRouting 3.7.2 Release Notes"
+msgstr ""
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.2 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.2%22>`__"
+msgstr ""
+
+msgid "Build"
+msgstr ""
+
+msgid ""
+"`#2713 <https://github.com/pgRouting/pgrouting/pull/2713>`__ cmake missing "
+"some policies and min version"
+msgstr ""
+
+msgid "Using OLD policies: CMP0148, CMP0144, CMP0167"
+msgstr ""
+
+msgid "Minimum cmake version 3.12"
+msgstr ""
+
+msgid ""
+"`#2707 <https://github.com/pgRouting/pgrouting/pull/2707>`__ Build failure "
+"in pgRouting 3.7.1 on Alpine"
+msgstr ""
+
+msgid ""
+"`#2706 <https://github.com/pgRouting/pgrouting/pull/2706>`__ winnie crashing "
+"on pgr_betweennessCentrality"
+msgstr ""
+
+msgid "pgRouting 3.7.1 Release Notes"
+msgstr ""
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.1 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.1%22>`__"
+msgstr ""
+
+msgid ""
+"`#2680 <https://github.com/pgRouting/pgrouting/pull/2680>`__ fails to "
+"compile under mingw64 gcc 13.2"
+msgstr ""
+
+msgid ""
+"`#2689 <https://github.com/pgRouting/pgrouting/pull/2689>`__ When point is a "
+"vertex, the withPoints family do not return results."
+msgstr ""
+
+msgid "C/C++ code enhancemet"
+msgstr ""
+
+#, fuzzy
+msgid "TRSP family"
+msgstr ":doc:`TRSP-family`"
+
+msgid "pgRouting 3.7.0 Release Notes"
+msgstr ""
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.0 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.0%22>`__"
+msgstr ""
+
+msgid ""
+"`#2656 <https://github.com/pgRouting/pgrouting/pull/2656>`__ Stop support of "
+"PostgreSQL12 on pgrouting v3.7"
+msgstr ""
+
+#, fuzzy
+msgid "Stopping support of PostgreSQL 12"
+msgstr "PostgreSQL 설정"
+
+msgid "CI does not test for PostgreSQL 12"
+msgstr ""
+
+msgid "New experimental functions"
+msgstr ""
+
+msgid "Metrics"
+msgstr ""
+
+msgid "pgr_betweennessCentrality"
+msgstr ""
+
+msgid ""
+"`#2605 <https://github.com/pgRouting/pgrouting/pull/2605>`__ Standardize "
+"spanning tree functions output"
+msgstr ""
+
+msgid "Functions:"
+msgstr ""
+
+msgid "Experimental promoted to proposed."
+msgstr ""
+
+msgid ""
+"`#2635 <https://github.com/pgRouting/pgrouting/pull/2635>`__ pgr_LineGraph "
+"ignores directed flag and use negative values for identifiers."
+msgstr ""
+
+#, fuzzy
+msgid "``pgr_lineGraph``"
+msgstr ":doc:`pgr_analyzeGraph`"
+
+msgid "Code enhancement"
+msgstr ""
+
+msgid ""
+"`#2599 <https://github.com/pgRouting/pgrouting/pull/2599>`__ Driving "
+"distance cleanup"
+msgstr ""
+
+msgid ""
+"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ Read postgresql "
+"data on C++"
+msgstr ""
+
+msgid ""
+"`#2614 <https://github.com/pgRouting/pgrouting/pull/2614>`__ Clang tidy does "
+"not work"
 msgstr ""
 
 msgid "pgRouting 3.6"
@@ -15611,9 +15659,6 @@ msgid ""
 "To see all issues & pull requests closed by this release see the `Git closed "
 "milestone for 3.6.3 <https://github.com/pgRouting/pgrouting/issues?"
 "utf8=%E2%9C%93&q=milestone%3A%22Release%203.6.3%22>`__"
-msgstr ""
-
-msgid "Build"
 msgstr ""
 
 msgid "Explicit minimum requirements:"
@@ -15719,55 +15764,38 @@ msgid ""
 msgstr ""
 
 msgid ""
-"`#2516 <https://github.com/pgRouting/pgrouting/pull/2516>`__ Standarize "
+"`#2516 <https://github.com/pgRouting/pgrouting/pull/2516>`__ Standardize "
 "output pgr_aStar"
 msgstr ""
 
-msgid ""
-"``pgr_aStar`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
-msgstr ""
-
-msgid "``pgr_aStar`` (`One to Many`) added ``end_vid`` column."
-msgstr ""
-
-msgid "``pgr_aStar`` (`Many to One`) added ``start_vid`` column."
+msgid "Standardize output columns to |short-generic-result|"
 msgstr ""
 
 msgid ""
-"`#2523 <https://github.com/pgRouting/pgrouting/pull/2523>`__ Standarize "
+"`#2523 <https://github.com/pgRouting/pgrouting/pull/2523>`__ Standardize "
 "output pgr_bdAstar"
 msgstr ""
 
 msgid ""
-"``pgr_bdAstar`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
-msgstr ""
-
-msgid "``pgr_bdAstar`` (`One to Many`) added ``end_vid`` column."
-msgstr ""
-
-msgid "``pgr_bdAstar`` (`Many to One`) added ``start_vid`` column."
-msgstr ""
-
-msgid ""
-"`#2547 <https://github.com/pgRouting/pgrouting/pull/2547>`__ Standarize "
+"`#2547 <https://github.com/pgRouting/pgrouting/pull/2547>`__ Standardize "
 "output and modifying signature pgr_KSP"
 msgstr ""
 
 msgid ""
-"`#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ Standarize "
-"output pgr_drivingdistance"
+"`#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ Standardize "
+"output pgr_drivingDistance"
 msgstr ""
 
 msgid "Proposed functions changes"
 msgstr ""
 
 msgid ""
-"`#2544 <https://github.com/pgRouting/pgrouting/pull/2544>`__ Standarize "
+"`#2544 <https://github.com/pgRouting/pgrouting/pull/2544>`__ Standardize "
 "output and modifying signature pgr_withPointsDD"
 msgstr ""
 
 msgid ""
-"`#2546 <https://github.com/pgRouting/pgrouting/pull/2546>`__ Standarize "
+"`#2546 <https://github.com/pgRouting/pgrouting/pull/2546>`__ Standardize "
 "output and modifying signature pgr_withPointsKSP"
 msgstr ""
 
@@ -15811,11 +15839,11 @@ msgid ""
 "history links."
 msgstr ""
 
-msgid "..rubric:: SQL standarization"
+msgid "..rubric:: Standardize SQL"
 msgstr ""
 
 msgid ""
-"`#2555 <https://github.com/pgRouting/pgrouting/pull/2555>`__ standarize "
+"`#2555 <https://github.com/pgRouting/pgrouting/pull/2555>`__ Standardize "
 "deprecated messages"
 msgstr ""
 
@@ -15841,9 +15869,6 @@ msgstr ""
 msgid "Changes on the documentation to the following:"
 msgstr ""
 
-msgid "pgr_degree"
-msgstr ""
-
 msgid "pgr_dijkstra"
 msgstr ""
 
@@ -15861,7 +15886,7 @@ msgstr ""
 
 msgid ""
 "`#2565 <https://github.com/pgRouting/pgrouting/issues/2565>`__ "
-"pgr_pgr_lengauerTarjanDominatorTree triggers an assertion"
+"pgr_lengauerTarjanDominatorTree triggers an assertion"
 msgstr ""
 
 msgid "SQL enhancements"
@@ -15900,16 +15925,6 @@ msgid ""
 msgstr ""
 
 msgid "Dijkstra"
-msgstr ""
-
-msgid ""
-"``pgr_dijkstra`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
-msgstr ""
-
-msgid "``pgr_dijkstra`` (`One to Many`) added ``end_vid`` column."
-msgstr ""
-
-msgid "``pgr_dijkstra`` (`Many to One`) added ``start_vid`` column."
 msgstr ""
 
 msgid "pgRouting 3.4"
@@ -15968,14 +15983,16 @@ msgid ""
 "doesn't give all correct shortest path"
 msgstr ""
 
-msgid "New proposed functions"
-msgstr ""
+#, fuzzy
+msgid "New proposed functions."
+msgstr ":doc:`routingFunctions`"
 
 msgid "With points"
 msgstr ""
 
-msgid "``pgr_withPointsVia`` (One Via)"
-msgstr ""
+#, fuzzy
+msgid "pgr_withPointsVia(One Via)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 msgid "Turn Restrictions"
 msgstr ""
@@ -15983,82 +16000,76 @@ msgstr ""
 msgid "Via with turn restrictions"
 msgstr ""
 
-msgid "``pgr_trspVia`` (One Via)"
+msgid "pgr_trspVia(One Via)"
 msgstr ""
 
-msgid "``pgr_trspVia_withPoints`` (One Via)"
-msgstr ""
+#, fuzzy
+msgid "pgr_trspVia_withPoints(One Via)"
+msgstr ":doc:`pgr_trspVia_withPoints`"
 
-msgid "``pgr_trsp``"
-msgstr ""
+#, fuzzy
+msgid "pgr_trsp_withPoints(One to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_trsp`` (One to One)"
-msgstr ""
+#, fuzzy
+msgid "pgr_trsp_withPoints(One to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_trsp`` (One to Many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_trsp_withPoints(Many to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_trsp`` (Many to One)"
-msgstr ""
+#, fuzzy
+msgid "pgr_trsp_withPoints(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "``pgr_trsp`` (Many to Many)"
-msgstr ""
-
-msgid "``pgr_trsp`` (Combinations)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints``"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (One to One)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (One to Many)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (Many to One)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (Many to Many)"
-msgstr ""
-
-msgid "``pgr_trsp_withPoints`` (Combinations)"
-msgstr ""
+#, fuzzy
+msgid "pgr_trsp_withPoints(Combinations)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 msgid "Topology"
 msgstr ""
 
-msgid "``pgr_degree``"
+msgid "Utilities"
 msgstr ""
 
-msgid "``pgr_findCloseEdges`` (One point)"
-msgstr ""
+#, fuzzy
+msgid "pgr_findCloseEdges(One point)"
+msgstr ":doc:`pgr_findCloseEdges`"
 
-msgid "``pgr_findCloseEdges`` (Many points)"
-msgstr ""
+#, fuzzy
+msgid "pgr_findCloseEdges(Many points)"
+msgstr ":doc:`pgr_findCloseEdges`"
 
 msgid "Ordering"
 msgstr ""
 
-msgid "``pgr_cuthillMckeeOrdering``"
+msgid "pgr_cuthillMckeeOrdering"
 msgstr ""
+
+msgid "Unclassified"
+msgstr ""
+
+#, fuzzy
+msgid "pgr_hawickCircuits"
+msgstr ":doc:`pgr_hawickCircuits`"
 
 msgid "Flow functions"
 msgstr ""
 
-msgid "``pgr_maxCardinalityMatch(text)``"
+msgid "pgr_maxCardinalityMatch(text)"
 msgstr ""
 
-msgid "Deprecating ``pgr_maxCardinalityMatch(text,boolean)``"
+msgid "Deprecating: pgr_maxCardinalityMatch(text,boolean)"
 msgstr ""
 
 msgid "Deprecated Functions"
 msgstr ""
 
-msgid "``pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)``"
+msgid "pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)"
 msgstr ""
 
-msgid "``pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)``"
+msgid "pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)"
 msgstr ""
 
 msgid "pgRouting 3.3"
@@ -16244,9 +16255,6 @@ msgstr ""
 msgid "pgr_sequentialVertexColoring"
 msgstr ""
 
-msgid "pgr_extractVertices"
-msgstr ""
-
 msgid "Traversal"
 msgstr ""
 
@@ -16320,12 +16328,6 @@ msgstr ""
 msgid "Removing support for Boost v1.53, v1.54 & v1.55"
 msgstr ""
 
-msgid "pgr_bellmanFord(Combinations)"
-msgstr ""
-
-msgid "pgr_binaryBreadthFirstSearch(Combinations)"
-msgstr ""
-
 msgid "pgr_bipartite"
 msgstr ""
 
@@ -16333,9 +16335,6 @@ msgid "pgr_depthFirstSearch"
 msgstr ""
 
 msgid "Dijkstra Near"
-msgstr ""
-
-msgid "pgr_edwardMoore(Combinations)"
 msgstr ""
 
 msgid "pgr_isPlanar"
@@ -16347,49 +16346,13 @@ msgstr ""
 msgid "pgr_makeConnected"
 msgstr ""
 
-msgid "pgr_maxFlowMinCost(Combinations)"
-msgstr ""
-
-msgid "pgr_maxFlowMinCost_Cost(Combinations)"
-msgstr ""
-
 msgid "Astar"
-msgstr ""
-
-msgid "pgr_aStar(Combinations)"
-msgstr ""
-
-msgid "pgr_aStarCost(Combinations)"
 msgstr ""
 
 msgid "Bidirectional Astar"
 msgstr ""
 
-msgid "pgr_bdAstar(Combinations)"
-msgstr ""
-
-msgid "pgr_bdAstarCost(Combinations)"
-msgstr ""
-
 msgid "Bidirectional Dijkstra"
-msgstr ""
-
-msgid "pgr_bdDijkstra(Combinations)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCost(Combinations)"
-msgstr ""
-
-msgid "pgr_boykovKolmogorov(Combinations)"
-msgstr ""
-
-msgid "pgr_edmondsKarp(Combinations)"
-msgstr ""
-
-msgid "pgr_maxFlow(Combinations)"
-msgstr ""
-
-msgid "pgr_pushRelabel(Combinations)"
 msgstr ""
 
 msgid "pgRouting 3.1"
@@ -16626,7 +16589,7 @@ msgid ""
 "information"
 msgstr ""
 
-msgid "New functions"
+msgid "New Functions"
 msgstr ""
 
 msgid "Kruskal family"
@@ -16665,149 +16628,120 @@ msgstr ""
 msgid "aStar Family"
 msgstr ""
 
-msgid "pgr_aStar(one to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_aStarCost(One to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_aStar(many to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_aStarCost(One to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_aStar(many to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_aStarCost(Many to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_aStarCost(one to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_aStarCost(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_aStarCost(one to many)"
-msgstr ""
-
-msgid "pgr_aStarCost(many to one)"
-msgstr ""
-
-msgid "pgr_aStarCost(many to many)"
-msgstr ""
-
-msgid "pgr_aStarCostMatrix(one to one)"
-msgstr ""
-
-msgid "pgr_aStarCostMatrix(one to many)"
-msgstr ""
-
-msgid "pgr_aStarCostMatrix(many to one)"
-msgstr ""
-
-msgid "pgr_aStarCostMatrix(many to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_aStarCostMatrix"
+msgstr ":doc:`pgr_aStarCostMatrix`"
 
 msgid "bdAstar Family"
 msgstr ""
 
-msgid "pgr_bdAstar(one to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_bdAstarCost(One to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_bdAstar(many to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_bdAstarCost(One to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_bdAstar(many to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_bdAstarCost(Many to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_bdAstarCost(one to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_bdAstarCost(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_bdAstarCost(one to many)"
-msgstr ""
-
-msgid "pgr_bdAstarCost(many to one)"
-msgstr ""
-
-msgid "pgr_bdAstarCost(many to many)"
-msgstr ""
-
-msgid "pgr_bdAstarCostMatrix(one to one)"
-msgstr ""
-
-msgid "pgr_bdAstarCostMatrix(one to many)"
-msgstr ""
-
-msgid "pgr_bdAstarCostMatrix(many to one)"
-msgstr ""
-
-msgid "pgr_bdAstarCostMatrix(many to many)"
+msgid "pgr_bdAstarCostMatrix"
 msgstr ""
 
 msgid "bdDijkstra Family"
 msgstr ""
 
-msgid "pgr_bdDijkstra(one to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_bdDijkstraCost(One to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_bdDijkstra(many to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_bdDijkstraCost(One to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_bdDijkstra(many to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_bdDijkstraCost(Many to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_bdDijkstraCost(one to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_bdDijkstraCost(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_bdDijkstraCost(one to many)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCost(many to one)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCost(many to many)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCostMatrix(one to one)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCostMatrix(one to many)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCostMatrix(many to one)"
-msgstr ""
-
-msgid "pgr_bdDijkstraCostMatrix(many to many)"
+msgid "pgr_bdDijkstraCostMatrix"
 msgstr ""
 
 msgid "Flow Family"
 msgstr ""
 
-msgid "pgr_pushRelabel(one to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_pushRelabel(One to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_pushRelabel(one to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_pushRelabel(One to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_pushRelabel(many to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_pushRelabel(Many to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_pushRelabel(many to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_pushRelabel(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_edmondsKarp(one to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_edmondsKarp(One to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_edmondsKarp(one to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_edmondsKarp(One to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_edmondsKarp(many to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_edmondsKarp(Many to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_edmondsKarp(many to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_edmondsKarp(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_boykovKolmogorov (one to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_boykovKolmogorov (One to One)"
+msgstr ":doc:`pgr_boykovKolmogorov`"
 
-msgid "pgr_boykovKolmogorov (one to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_boykovKolmogorov (One to Many)"
+msgstr ":doc:`pgr_boykovKolmogorov`"
 
-msgid "pgr_boykovKolmogorov (many to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_boykovKolmogorov (Many to One)"
+msgstr ":doc:`pgr_boykovKolmogorov`"
 
-msgid "pgr_boykovKolmogorov (many to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_boykovKolmogorov (Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 msgid "pgr_maxCardinalityMatching"
 msgstr ""
@@ -16815,19 +16749,26 @@ msgstr ""
 msgid "pgr_maxFlow"
 msgstr ""
 
-msgid "pgr_edgeDisjointPaths(one to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_edgeDisjointPaths(One to One)"
+msgstr ":doc:`pgr_edgeDisjointPaths`"
 
-msgid "pgr_edgeDisjointPaths(one to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_edgeDisjointPaths(One to Many)"
+msgstr ":doc:`pgr_edgeDisjointPaths`"
 
-msgid "pgr_edgeDisjointPaths(many to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_edgeDisjointPaths(Many to One)"
+msgstr ":doc:`pgr_edgeDisjointPaths`"
 
-msgid "pgr_edgeDisjointPaths(many to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_edgeDisjointPaths(Many to Many)"
+msgstr ":doc:`pgr_edgeDisjointPaths`"
 
 msgid "Components family"
+msgstr ""
+
+msgid "pgr_connectedComponents"
 msgstr ""
 
 msgid "pgr_strongComponents"
@@ -17016,7 +16957,7 @@ msgstr ""
 msgid "pgr_johnson"
 msgstr ""
 
-msgid "pgr_astar"
+msgid "pgr_aStar"
 msgstr ""
 
 msgid "pgr_bdAstar"
@@ -17035,6 +16976,9 @@ msgid "pgr_dijkstraCost"
 msgstr ""
 
 msgid "pgr_drivingDistance"
+msgstr ""
+
+msgid "pgr_KSP"
 msgstr ""
 
 msgid "pgr_dijkstraVia (proposed)"
@@ -17235,23 +17179,15 @@ msgstr ""
 msgid "Parameter names changed"
 msgstr ""
 
-msgid "The many version results are the union of the one to one version"
+msgid "The many version results are the union of the One to One version"
 msgstr ""
 
 msgid "New Signatures"
 msgstr ""
 
-msgid "pgr_bdAstar(one to one)"
-msgstr ""
-
-msgid "New Proposed functions"
-msgstr ""
-
-msgid "pgr_bdAstarCostMatrix"
-msgstr ""
-
-msgid "pgr_bdDijkstraCostMatrix"
-msgstr ""
+#, fuzzy
+msgid "pgr_bdAstar(One to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 msgid "pgr_lineGraph"
 msgstr ""
@@ -17333,31 +17269,7 @@ msgstr ""
 msgid "pgr_bdDijkstra"
 msgstr ""
 
-msgid "New Proposed Signatures"
-msgstr ""
-
-msgid "pgr_astar(one to many)"
-msgstr ""
-
-msgid "pgr_astar(many to one)"
-msgstr ""
-
-msgid "pgr_astar(many to many)"
-msgstr ""
-
-msgid "pgr_astarCost(one to one)"
-msgstr ""
-
-msgid "pgr_astarCost(one to many)"
-msgstr ""
-
-msgid "pgr_astarCost(many to one)"
-msgstr ""
-
-msgid "pgr_astarCost(many to many)"
-msgstr ""
-
-msgid "pgr_astarCostMatrix"
+msgid "Deprecated signatures."
 msgstr ""
 
 msgid "pgr_bddijkstra - use pgr_bdDijkstra instead"
@@ -17429,52 +17341,50 @@ msgstr ""
 msgid "pgr_TSP"
 msgstr ""
 
-msgid "pgr_aStar"
-msgstr ""
-
-msgid "New Functions"
-msgstr ""
-
 msgid "pgr_eucledianTSP"
 msgstr ""
 
-msgid "pgr_withPointsCostMatrix"
+msgid "pgr_maxFlowPushRelabel(One to One)"
 msgstr ""
 
-msgid "pgr_maxFlowPushRelabel(one to one)"
+#, fuzzy
+msgid "pgr_maxFlowPushRelabel(One to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
+
+#, fuzzy
+msgid "pgr_maxFlowPushRelabel(Many to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
+
+#, fuzzy
+msgid "pgr_maxFlowPushRelabel(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
+
+#, fuzzy
+msgid "pgr_maxFlowEdmondsKarp(One to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
+
+#, fuzzy
+msgid "pgr_maxFlowEdmondsKarp(One to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
+
+#, fuzzy
+msgid "pgr_maxFlowEdmondsKarp(Many to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
+
+#, fuzzy
+msgid "pgr_maxFlowEdmondsKarp(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
+
+msgid "pgr_maxFlowBoykovKolmogorov (One to One)"
 msgstr ""
 
-msgid "pgr_maxFlowPushRelabel(one to many)"
+msgid "pgr_maxFlowBoykovKolmogorov (One to Many)"
 msgstr ""
 
-msgid "pgr_maxFlowPushRelabel(many to one)"
+msgid "pgr_maxFlowBoykovKolmogorov (Many to One)"
 msgstr ""
 
-msgid "pgr_maxFlowPushRelabel(many to many)"
-msgstr ""
-
-msgid "pgr_maxFlowEdmondsKarp(one to one)"
-msgstr ""
-
-msgid "pgr_maxFlowEdmondsKarp(one to many)"
-msgstr ""
-
-msgid "pgr_maxFlowEdmondsKarp(many to one)"
-msgstr ""
-
-msgid "pgr_maxFlowEdmondsKarp(many to many)"
-msgstr ""
-
-msgid "pgr_maxFlowBoykovKolmogorov (one to one)"
-msgstr ""
-
-msgid "pgr_maxFlowBoykovKolmogorov (one to many)"
-msgstr ""
-
-msgid "pgr_maxFlowBoykovKolmogorov (many to one)"
-msgstr ""
-
-msgid "pgr_maxFlowBoykovKolmogorov (many to many)"
+msgid "pgr_maxFlowBoykovKolmogorov (Many to Many)"
 msgstr ""
 
 msgid "pgr_maximumCardinalityMatching"
@@ -17486,7 +17396,7 @@ msgstr ""
 msgid "pgr_tsp - use pgr_TSP or pgr_eucledianTSP instead"
 msgstr ""
 
-msgid "pgr_astar - use pgr_aStar instead"
+msgid "pgr_aStar - use pgr_aStar instead"
 msgstr ""
 
 msgid "pgr_flip_edges"
@@ -17573,6 +17483,9 @@ msgstr ""
 msgid "Improvements"
 msgstr ""
 
+msgid "pgr_nodeNetwork"
+msgstr ""
+
 msgid "Adding a row_where and outall optional parameters"
 msgstr ""
 
@@ -17585,52 +17498,61 @@ msgstr ""
 msgid "pgr_Johnson"
 msgstr ""
 
-msgid "pgr_dijkstraCost(one to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_dijkstraCost(One to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_dijkstraCost(one to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_dijkstraCost(One to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_dijkstraCost(many to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_dijkstraCost(Many to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_dijkstraCost(many to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_dijkstraCost(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 msgid "Proposed Functionality"
 msgstr ""
 
-msgid "pgr_withPoints(one to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_withPoints(One to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_withPoints(one to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_withPoints(One to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_withPoints(many to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_withPoints(Many to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_withPoints(many to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_withPoints(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_withPointsCost(one to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_withPointsCost(One to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_withPointsCost(one to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_withPointsCost(One to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_withPointsCost(many to one)"
-msgstr ""
+#, fuzzy
+msgid "pgr_withPointsCost(Many to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
-msgid "pgr_withPointsCost(many to many)"
-msgstr ""
+#, fuzzy
+msgid "pgr_withPointsCost(Many to Many)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 msgid "pgr_withPointsDD(single vertex)"
 msgstr ""
 
 msgid "pgr_withPointsDD(multiple vertices)"
-msgstr ""
-
-msgid "pgr_withPointsKSP"
 msgstr ""
 
 msgid "pgr_dijkstraVia"
@@ -17666,26 +17588,12 @@ msgid ""
 "q=is%3Aissue+milestone%3A%22Release+2.1.0%22+is%3Aclosed>`_ on Github."
 msgstr ""
 
-msgid "pgr_dijkstra(one to many)"
-msgstr ""
-
-msgid "pgr_dijkstra(many to one)"
-msgstr ""
-
-msgid "pgr_dijkstra(many to many)"
-msgstr ""
-
-msgid "pgr_drivingDistance(multiple vertices)"
-msgstr ""
-
 msgid "Refactored"
 msgstr ""
 
-msgid "pgr_dijkstra(one to one)"
-msgstr ""
-
-msgid "pgr_drivingDistance(single vertex)"
-msgstr ""
+#, fuzzy
+msgid "pgr_dijkstra(One to One)"
+msgstr ":doc:`pgr_withPointsCostMatrix`"
 
 msgid ""
 "pgr_alphaShape function now can generate better (multi)polygon with holes "
@@ -18023,8 +17931,8 @@ msgstr ""
 
 msgid ""
 "The documentation provides very simple example queries based on a small "
-"sample network that resembles a city. To be able to execute the mayority of "
-"the examples queries, follow the instructions bellow."
+"sample network that resembles a city. To be able to execute the majority of "
+"the examples queries, follow the instructions below."
 msgstr ""
 
 msgid "Main graph"
@@ -18038,7 +17946,8 @@ msgstr ""
 
 msgid ""
 "Information known at this point is the geometry of the edges, cost values, "
-"cpacity values, category values and some locations that are not in the graph."
+"capacity values, category values and some locations that are not in the "
+"graph."
 msgstr ""
 
 msgid ""
@@ -18046,14 +17955,11 @@ msgid ""
 "that everything else is calculated."
 msgstr ""
 
-msgid "Edges"
-msgstr ""
-
 msgid ""
 "The database design for the documentation of pgRouting, keeps in the same "
 "row 2 segments, one in the direction of the geometry and the second in the "
-"oposite direction. Therfore some information has the ``reverse_`` prefix "
-"which corresponds to the segment on the oposite direction of the geometry."
+"opposite direction. Therefore some information has the ``reverse_`` prefix "
+"which corresponds to the segment on the opposite direction of the geometry."
 msgstr ""
 
 msgid "Identifier of the starting vertex of the geometry ``geom``."
@@ -18084,7 +17990,7 @@ msgid ":math:`x` coordinate of the starting vertex of the geometry."
 msgstr ""
 
 msgid ""
-"For convinience it is saved on the table but can be calculated as "
+"For convenience it is saved on the table but can be calculated as "
 "``ST_X(ST_StartPoint(geom))``."
 msgstr ""
 
@@ -18092,7 +17998,7 @@ msgid ":math:`y` coordinate of the ending vertex of the geometry."
 msgstr ""
 
 msgid ""
-"For convinience it is saved on the table but can be calculated as "
+"For convenience it is saved on the table but can be calculated as "
 "``ST_Y(ST_EndPoint(geom))``."
 msgstr ""
 
@@ -18104,8 +18010,8 @@ msgid "Starting on PostgreSQL 12::"
 msgstr "PostgreSQL 설정"
 
 msgid ""
-"Optionally indexes on different columns can be created. The recomendation is "
-"to have"
+"Optionally indexes on different columns can be created. The recommendation "
+"is to have"
 msgstr ""
 
 msgid "``id`` indexed."
@@ -18116,7 +18022,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"``geom`` indexed to speed up gemetry processes that might be needed in the "
+"``geom`` indexed to speed up geometry processes that might be needed in the "
 "front end."
 msgstr ""
 
@@ -18185,7 +18091,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"For convinence of this documentations, some combinations will be stored on a "
+"For convenience of this documentation, some combinations will be stored on a "
 "table:"
 msgstr ""
 
@@ -18395,8 +18301,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"pgRouting suplies some functions to create a routing topology and to analyze "
-"the topology."
+"pgRouting supplies some functions to create a routing topology and to "
+"analyze the topology."
 msgstr ""
 
 msgid "Additional functions to create a graph:"
@@ -18417,7 +18323,7 @@ msgstr ""
 msgid "Traversal - Family of functions"
 msgstr ""
 
-msgid "Aditionaly there are 2 categories under this family"
+msgid "Additionally there are 2 categories under this family"
 msgstr ""
 
 msgid "Via - Category"
@@ -18432,7 +18338,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"In other words, find a continuos route that visits all the vertices in the "
+"In other words, find a continuous route that visits all the vertices in the "
 "order given."
 msgstr ""
 
@@ -18803,3 +18709,22 @@ msgstr ""
 
 msgid "pgr_withPointsvia is pgr_dijkstraVia **with points**"
 msgstr ""
+
+#, fuzzy
+#~ msgid "``pgr_findCloseEdges`` - Proposed"
+#~ msgstr ":doc:`pgr_findCloseEdges`"
+
+#, fuzzy
+#~ msgid "``pgr_trsp_withPoints`` - Proposed"
+#~ msgstr ":doc:`pgr_trspVia_withPoints`"
+
+#~ msgid ":doc:`pgr_topologicalSort`"
+#~ msgstr ":doc:`pgr_topologicalSort`"
+
+#, fuzzy
+#~ msgid "Migrating functions"
+#~ msgstr ":doc:`routingFunctions`"
+
+#, fuzzy
+#~ msgid "**Supported versions**"
+#~ msgstr "짧은 버전"

--- a/locale/zh_Hans/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/zh_Hans/LC_MESSAGES/pgrouting_doc_strings.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-17 00:50+0000\n"
+"POT-Creation-Date: 2025-03-24 14:17+0000\n"
 "PO-Revision-Date: 2024-10-10 19:47+0000\n"
 "Last-Translator: DeepL <noreply-mt-deepl@weblate.org>\n"
 "Language-Team: Chinese (Simplified) <https://weblate.osgeo.org/projects/"
@@ -305,9 +305,6 @@ msgstr ":doc:`pgr_kruskalDFS`"
 msgid ":doc:`pgr_primDFS`"
 msgstr ":doc:`pgr_primDFS`"
 
-msgid "Proposed"
-msgstr "建议"
-
 msgid "Proposed functions for next mayor release."
 msgstr "下一版本的拟议功能。"
 
@@ -376,9 +373,6 @@ msgid ""
 msgstr ""
 "阅读 :doc:`migration` 了解如何从已弃用的 TRSP 功能迁移到新的签名或替换功能。"
 
-msgid "Experimental"
-msgstr "实验性的"
-
 msgid "Possible server crash"
 msgstr "可能服务器崩溃"
 
@@ -421,7 +415,8 @@ msgstr "文档（如果有）可能需要重写。"
 msgid "Documentation examples might need to be automatically generated."
 msgstr "可能需要自动生成文档示例。"
 
-msgid "Might need a lot of feedback from the comunity."
+#, fuzzy
+msgid "Might need a lot of feedback from the community."
 msgstr "可能需要社区的大量反馈。"
 
 msgid "Might depend on a proposed function of pgRouting"
@@ -686,9 +681,10 @@ msgstr "当 ``NOT 0`` 且 ``start_id = 0`` 时，它是第一个和最后一个�
 msgid "References"
 msgstr "参考"
 
+#, fuzzy
 msgid ""
-"`Boost's metric appro's metric approximation <https://www.boost.org/libs/"
-"graph/doc/metric_tsp_approx.html>`__"
+"`Boost: metric TSP approx <https://www.boost.org/libs/graph/doc/"
+"metric_tsp_approx.html>`__"
 msgstr ""
 "`Boost 的 metric appro 的 metric 近似 <https://www.boost.org/libs/graph/doc/"
 "metric_tsp_approx.html>`__"
@@ -705,7 +701,8 @@ msgstr ""
 "`维基百科：旅行商问题 <https://en.wikipedia.org/wiki/"
 "Traveling_salesman_problem>`__"
 
-msgid "Vehicle Routing Functions - Category (Experimental)"
+#, fuzzy
+msgid "Vehicle Routing Functions - Category"
 msgstr "车辆路由功能 - 类别（实验）"
 
 msgid "Pickup and delivery problem"
@@ -1674,8 +1671,8 @@ msgstr ":math:`1km * 0.0277hr/km = 0.0277hr`"
 msgid "https://en.wikipedia.org/wiki/Vehicle_routing_problem"
 msgstr "https://en.wikipedia.org/wiki/Vehicle_routing_problem"
 
-msgid "The queries use the :doc:`sampledata` network."
-msgstr "查询使用 :doc:`sampledata` 网络。"
+msgid ":doc:`sampledata`"
+msgstr ":doc:`sampledata`"
 
 msgid "A* - Family of functions"
 msgstr "A* - 函数族"
@@ -1846,7 +1843,9 @@ msgstr ""
 msgid ":doc:`bdAstar-family`"
 msgstr ":doc:`bdAstar-family`"
 
-msgid "https://www.boost.org/libs/graph/doc/astar_search.html"
+#, fuzzy
+msgid ""
+"`Boost: A* search <https://www.boost.org/libs/graph/doc/astar_search.html>`__"
 msgstr "https://www.boost.org/libs/graph/doc/astar_search.html"
 
 msgid "https://en.wikipedia.org/wiki/A*_search_algorithm"
@@ -2662,14 +2661,12 @@ msgid ""
 "ending vertex:"
 msgstr "对于起始顶点和结束顶点之间存在路径的大型图:"
 
-msgid "It is expected to terminate faster than pgr_astar"
+#, fuzzy
+msgid "It is expected to terminate faster than pgr_aStar"
 msgstr "预计终止速度比 pgr_astar 更快"
 
 msgid ":doc:`aStar-family`"
 msgstr ":doc:`aStar-family`"
-
-msgid "Previous versions of this page"
-msgstr "此页面的先前版本"
 
 msgid "Bidirectional Dijkstra - Family of functions"
 msgstr "双向 Dijkstra - 函数族"
@@ -2814,35 +2811,10 @@ msgstr "``edge_id``"
 msgid "Identifier of the color of the edge."
 msgstr "边颜色的标识符。"
 
+#, fuzzy
 msgid ""
-"`Boost: Sequential Vertex Coloring algorithm documentation <https://www."
-"boost.org/libs/graph/doc/sequential_vertex_coloring.html>`__"
-msgstr ""
-"`Boost：顺序顶点着色算法文档 <https://www.boost.org/libs/graph/doc/"
-"sequential_vertex_coloring.html>`__"
-
-msgid ""
-"`Wikipedia: Graph coloring <https://en.wikipedia.org/wiki/Graph_coloring>`__"
-msgstr "`维基百科：图着色 <https://en.wikipedia.org/wiki/Graph_coloring>`__"
-
-msgid ""
-"`Boost: is_bipartite <https://www.boost.org/libs/graph/doc/is_bipartite."
-"html>`__"
-msgstr ""
-"`Boost: is_bipartite <https://www.boost.org/libs/graph/doc/is_bipartite."
-"html>`__"
-
-msgid ""
-"`Wikipedia: bipartite graph <https://en.wikipedia.org/wiki/"
-"Bipartite_graph>`__"
-msgstr "`维基百科：二分图 <https://en.wikipedia.org/wiki/Bipartite_graph>`__"
-
-msgid ""
-"`Boost: Edge Coloring Algorithm documentation <https://www.boost.org/libs/"
-"graph/doc/edge_coloring.html>`__"
-msgstr ""
-"`Boost：边缘着色算法文档 <https://www.boost.org/libs/graph/doc/edge_coloring."
-"html>`__"
+"`Boost: <https://www.boost.org/libs/graph/doc/table_of_contents.html>`__"
+msgstr "boost: https://www.boost.org/libs/graph/doc/table_of_contents.html"
 
 msgid "Components - Family of functions"
 msgstr "分量 - 函数族"
@@ -2877,6 +2849,10 @@ msgstr "收缩 - 函数族"
 msgid ":doc:`pgr_contraction`"
 msgstr ":doc:`pgr_contraction`"
 
+#, fuzzy
+msgid ":doc:`pgr_contractionDeadEnd`"
+msgstr ":doc:`pgr_contraction`"
+
 msgid ""
 "In large graphs, like the road graphs, or electric networks, graph "
 "contraction can be used to speed up some graph algorithms. Contraction "
@@ -2909,503 +2885,6 @@ msgid ""
 "Decide the order of the contraction algorithms and set the maximum number of "
 "times they are to be executed."
 msgstr "决定收缩算法的顺序并设置它们要执行的最大次数。"
-
-msgid "Contraction of the leaf nodes of the graph."
-msgstr "图的叶节点的收缩。"
-
-msgid "Dead end"
-msgstr "死端"
-
-msgid "A node is considered a **dead end** node when"
-msgstr "当一个节点被认为是 **死端** 节点时"
-
-msgid "On undirected graphs:"
-msgstr "在无向图上："
-
-msgid "The number of adjacent vertices is 1."
-msgstr "相邻顶点的个数为1。"
-
-msgid "On directed graphs:"
-msgstr "在有向图上："
-
-msgid "There are no outgoing edges and has at least one incoming edge."
-msgstr "没有传出边缘，但至少有一个传入边缘。"
-
-msgid "There are no incoming edges and has at least one outgoing edge."
-msgstr "没有传入边缘，但至少有一个传出边缘。"
-
-msgid ""
-"When the conditions are true then the `Operation: Dead End Contraction`_ can "
-"be done."
-msgstr "当条件成立时，可以进行当条件成立时，可以进行 `操作: 死端收缩`_ 。"
-
-msgid "Dead end vertex on undirected graph"
-msgstr "无向图上的死端顶点"
-
-msgid "The green nodes are `dead end`_ nodes"
-msgstr "绿色节点是 `死端`_ 节点"
-
-msgid "The blue nodes have an unlimited number of edges."
-msgstr "蓝色节点具有无限数量的边。"
-
-msgid "Node"
-msgstr "节点"
-
-msgid "Adjecent nodes"
-msgstr "相邻节点"
-
-msgid "Number of adjacent nodes"
-msgstr "相邻节点数"
-
-msgid ":math:`a`"
-msgstr ":math:`a`"
-
-msgid ":math:`\\{u\\}`"
-msgstr ":math:`\\{u\\}`"
-
-msgid ":math:`b`"
-msgstr ":math:`b`"
-
-msgid ":math:`\\{v\\}`"
-msgstr ":math:`\\{v\\}`"
-
-msgid "Dead end vertex on directed graph"
-msgstr "有向图上的死端顶点"
-
-msgid ""
-"The blue nodes have an unlimited number of incoming and/or outgoing edges."
-msgstr "蓝色节点具有无限数量的传入和/或传出边缘。"
-
-msgid "Number of incoming edges"
-msgstr "传入边数"
-
-msgid "Number of outgoing edges"
-msgstr "传出边数"
-
-msgid ":math:`c`"
-msgstr ":math:`c`"
-
-msgid ":math:`\\{v, w\\}`"
-msgstr ":math:`\\{v, w\\}`"
-
-msgid "2"
-msgstr "2"
-
-msgid ":math:`d`"
-msgstr ":math:`d`"
-
-msgid ":math:`\\{x\\}`"
-msgstr ":math:`\\{x\\}`"
-
-msgid ":math:`e`"
-msgstr ":math:`e`"
-
-msgid ":math:`\\{x, y\\}`"
-msgstr ":math:`\\{x, y\\}`"
-
-msgid ""
-"From above, nodes :math:`\\{a, b, d\\}` are dead ends because the number of "
-"adjacent vertices is 1. No further checks are needed for those nodes."
-msgstr ""
-"从上面来看，节点 :math:`\\{a, b, d\\}` 是死端，因为相邻顶点的数量为 1。不需要"
-"对这些节点进行进一步检查。"
-
-msgid ""
-"On the following table, nodes :math:`\\{c, e\\}` because the even that the "
-"number of adjacent vertices is not 1 for"
-msgstr "下表中，节点 :math:`\\{c, e\\}` 因为相邻顶点数不为1的偶数为"
-
-msgid "Operation: Dead End Contraction"
-msgstr "操作：死端收缩"
-
-msgid ""
-"The dead end contraction will stop until there are no more dead end nodes. "
-"For example from the following graph where :math:`w` is the `dead end`_ node:"
-msgstr ""
-"死端收缩将停止，直到不再有死端节点。 例如，从下图中，其中 :math:`w` 是 `死端"
-"`_ 节点："
-
-msgid ""
-"After contracting :math:`w`, node :math:`v` is now a `dead end`_ node and is "
-"contracted:"
-msgstr "收缩 :math:`w` 后，节点 :math:`v` 现在是一个 `死端`_ 节点并且已收缩："
-
-msgid ""
-"After contracting :math:`v`, stop. Node :math:`u` has the information of "
-"nodes that were contrcted."
-msgstr "在收缩 :math:`v` 之后，停止。节点 :math:`u` 有已收缩节点的信息。"
-
-msgid "Node :math:`u` has the information of nodes that were contracted."
-msgstr "节点 :math:`u` 有已收缩节点的信息。"
-
-msgid "In the algorithm, linear contraction is represented by 2."
-msgstr "算法中，线性收缩用2表示。"
-
-msgid "Linear"
-msgstr "线性"
-
-msgid ""
-"In case of an undirected graph, a node is considered a `linear` node when"
-msgstr "在无向图的情况下，当满足以下条件时，节点被视为`线性`节点"
-
-msgid "The number of adjacent vertices is 2."
-msgstr "相邻顶点的数量为2。"
-
-msgid "In case of a directed graph, a node is considered a `linear` node when"
-msgstr "在有向图的情况下，当满足以下条件时，节点被视为`线性`节点"
-
-msgid "Linearity is symmetrical"
-msgstr "线性是对称的"
-
-msgid "Linear vertex on undirected graph"
-msgstr "无向图上的线性顶点"
-
-msgid "The green nodes are `linear`_ nodes"
-msgstr "绿色节点是 `线性`_ 节点"
-
-msgid "The blue nodes have an unlimited number of incoming and outgoing edges."
-msgstr "蓝色节点具有无限数量的传入和传出边缘。"
-
-msgid "Undirected"
-msgstr "无向"
-
-msgid ":math:`v`"
-msgstr ":math:`v`"
-
-msgid ":math:`\\{u, w\\}`"
-msgstr ":math:`\\{u, w\\}`"
-
-msgid "Linear vertex on directed graph"
-msgstr "有向图上的线性顶点"
-
-msgid "The white node is not linear because the linearity is not symetrical."
-msgstr "白色节点不是线性的，因为线性不对称。"
-
-msgid "It is possible to go :math:`y \\rightarrow c \\rightarrow z`"
-msgstr "它是可能去走 :math:`y \\rightarrow c \\rightarrow z`"
-
-msgid "It's not possible to go :math:`z \\rightarrow c \\rightarrow y`"
-msgstr "不可能走 :math:`z \\rightarrow c \\rightarrow y`"
-
-msgid "Is symmetrical?"
-msgstr "是对称的吗？"
-
-msgid ":math:`\\{u, v\\}`"
-msgstr ":math:`\\{u, v\\}`"
-
-msgid "yes"
-msgstr "是"
-
-msgid ":math:`\\{w, x\\}`"
-msgstr ":math:`\\{w, x\\}`"
-
-msgid ":math:`\\{y, z\\}`"
-msgstr ":math:`\\{y, z\\}`"
-
-msgid "no"
-msgstr "否"
-
-msgid "Operation: Linear Contraction"
-msgstr "操作：线性收缩"
-
-msgid ""
-"The linear contraction will stop when there are no more linear nodes. For "
-"example from the following graph where :math:`v` and :math:`w` are `linear`_ "
-"nodes:"
-msgstr ""
-"当不再有线性节点时，线性收缩将停止。 例如，在下图中，其中 :math:`v` 和 :math:"
-"`w` 是 `线性`_ 节点："
-
-msgid "Contracting :math:`w`,"
-msgstr "收缩 :math:`w`，"
-
-msgid "The vertex :math:`w` is removed from the graph"
-msgstr "顶点 :math:`w` 已从图中移除"
-
-msgid ""
-"The edges :math:`v \\rightarrow w` and :math:`w \\rightarrow z` are removed "
-"from the graph."
-msgstr "从图中删除边 :math:`v \\rightarrow w` 和 :math:`w \\rightarrow z`。"
-
-msgid ""
-"A new edge :math:`v \\rightarrow z` is inserted represented with red color."
-msgstr "插入一条新边 :math:`v \\rightarrow z`，以红色表示。"
-
-msgid "Contracting :math:`v`:"
-msgstr "收缩 :math:`v`："
-
-msgid "The vertex :math:`v` is removed from the graph"
-msgstr "顶点 :math:`v` 已从图中移除"
-
-msgid ""
-"The edges :math:`u \\rightarrow v` and :math:`v \\rightarrow z` are removed "
-"from the graph."
-msgstr "从图中删除边 :math:`u \\rightarrow v` 和 :math:`v \\rightarrow z`。"
-
-msgid ""
-"A new edge :math:`u \\rightarrow z` is inserted represented with red color."
-msgstr "插入一条新边 :math:`u \\rightarrow z`，以红色表示。"
-
-msgid ""
-"Edge :math:`u \\rightarrow z` has the information of nodes that were "
-"contracted."
-msgstr "边 :math:`u \\rightarrow z` 有收缩点的信息。"
-
-msgid "The cycle"
-msgstr "循环"
-
-msgid ""
-"Contracting a graph, can be done with more than one operation. The order of "
-"the operations affect the resulting contracted graph, after applying one "
-"operation, the set of vertices that can be contracted by another operation "
-"changes."
-msgstr ""
-"收缩一张图可以通过多个操作来完成。 操作的顺序会影响生成的收缩图，在应用一个操"
-"作后，可以由另一操作收缩的顶点集会发生变化。"
-
-msgid ""
-"This implementation, cycles ``max_cycles`` times through "
-"``operations_order`` ."
-msgstr "此实现通过 ``operations_order``循环 ``max_cycles`` 次。"
-
-msgid "Contracting sample data"
-msgstr "收缩示例数据"
-
-msgid ""
-"In this section, building and using a contracted graph will be shown by "
-"example."
-msgstr "在本节中，将通过示例展示构建和使用收缩图。"
-
-msgid "The :doc:`sampledata` for an undirected graph is used"
-msgstr "使用无向图的 :doc:`sampledata`"
-
-msgid "a dead end operation first followed by a linear operation."
-msgstr "首先是死端操作，然后是线性操作。"
-
-msgid "Construction of the graph in the database"
-msgstr "数据库中图的构建"
-
-msgid "Original Data"
-msgstr "原始数据"
-
-msgid ""
-"The following query shows the original data involved in the contraction "
-"operation."
-msgstr "以下查询显示了收缩操作所涉及的原始数据。"
-
-msgid "The original graph:"
-msgstr "原始图："
-
-msgid "Contraction results"
-msgstr "收缩结果"
-
-msgid ""
-"The results do not represent the contracted graph. They represent the "
-"changes done to the graph after applying the contraction algorithm."
-msgstr "结果不代表收缩图。 它们表示应用收缩算法后对图所做的更改。"
-
-msgid ""
-"Observe that vertices, for example, :math:`6` do not appear in the results "
-"because it was not affected by the contraction algorithm."
-msgstr ""
-"例如，观察到顶点 :math:`6` 没有出现在结果中，因为它不受收缩算法的影响。"
-
-msgid "After doing the dead end contraction operation:"
-msgstr "进行死端收缩操作后："
-
-msgid "After doing the linear contraction operation to the graph above:"
-msgstr "对上图进行线性收缩运算后："
-
-msgid "The process to create the contraction graph on the database:"
-msgstr "在数据库上创建收缩图的过程："
-
-msgid "Add additional columns"
-msgstr "添加附加列"
-
-msgid ""
-"Adding extra columns to the ``edge_table`` and ``edge_table_vertices_pgr`` "
-"tables, where:"
-msgstr "向 ``edge_table`` 和``edge_table_vertices_pgr`` 表添加额外的列，其中："
-
-msgid "``contracted_vertices``"
-msgstr "``contracted_vertices``"
-
-msgid "The vertices set belonging to the vertex/edge"
-msgstr "属于顶点/边的顶点集"
-
-msgid "``is_contracted``"
-msgstr "``is_contracted``"
-
-msgid "On the vertex table"
-msgstr "在顶点表上"
-
-msgid ""
-"when ``true`` the vertex is contracted, its not part of the contracted graph."
-msgstr "当 ``true`` 时，顶点收缩，它不是收缩图的一部分。"
-
-msgid ""
-"when ``false`` the vertex is not contracted, its part of the contracted "
-"graph."
-msgstr "当 ``false`` 时，顶点不收缩，它是收缩图的一部分。"
-
-msgid "``is_new``"
-msgstr "``is_new``"
-
-msgid "On the edge table"
-msgstr "在边表上"
-
-msgid ""
-"when ``true`` the edge was generated by the contraction algorithm. its part "
-"of the contracted graph."
-msgstr "当 ``true`` 时，边缘由收缩算法生成。 它是收缩图的一部分。"
-
-msgid ""
-"when ``false`` the edge is an original edge, might be or not part of the "
-"contracted graph."
-msgstr "当 ``false`` 时，边是原始边，可能是也可能不是收缩图的一部分。"
-
-msgid "Store contraction information"
-msgstr "存储收缩信息"
-
-msgid "Store the `contraction results`_ in a table"
-msgstr "将 `收缩结果`_ 存储在表中"
-
-msgid "The vertex table update"
-msgstr "顶点表更新"
-
-msgid ""
-"Use ``is_contracted`` column to indicate the vertices that are contracted."
-msgstr "使用 ``is_contracted`` 列来指示收缩的顶点。"
-
-msgid ""
-"Fill ``contracted_vertices`` with the information from the results tha "
-"belong to the vertices."
-msgstr "使用属于顶点的结果中的信息填充 ``contracted_vertices``。"
-
-msgid "The modified vertices table:"
-msgstr "修改后的顶点表："
-
-msgid "The edge table update"
-msgstr "边缘表更新"
-
-msgid "Insert the new edges generated by pgr_contraction."
-msgstr "插入由 pgr_contraction 生成的新边。"
-
-msgid "The modified ``edge_table``."
-msgstr "修改后的 ``edge_table``。"
-
-msgid "The contracted graph"
-msgstr "收缩图"
-
-msgid "Vertices that belong to the contracted graph."
-msgstr "属于收缩图的顶点。"
-
-msgid "Edges that belong to the contracted graph."
-msgstr "属于收缩图的边。"
-
-msgid "Contracted graph"
-msgstr "收缩图"
-
-msgid "Using the contracted graph"
-msgstr "使用收缩图"
-
-msgid "Using the contracted graph with ``pgr_dijkstra``"
-msgstr "将收缩图与 ``pgr_dijkstra`` 一起使用"
-
-msgid ""
-"There are three cases when calculating the shortest path between a given "
-"source and target in a contracted graph:"
-msgstr "计算收缩图中给定源和目标之间的最短路径时，存在三种情况："
-
-msgid "Case 1: Both source and target belong to the contracted graph."
-msgstr "情况1：源和目标都属于收缩图。"
-
-msgid "Case 2: Source and/or target belong to an edge subgraph."
-msgstr "情况 2：源和/或目标属于边缘子图。"
-
-msgid "Case 3: Source and/or target belong to a vertex."
-msgstr "情况 3：源和/或目标属于一个顶点。"
-
-msgid ""
-"Using the `Edges that belong to the contracted graph.`_ on lines 11 to 20."
-msgstr "使用 `属于收缩图的边。`_ 第 11 至 20 行。"
-
-msgid "Case 1"
-msgstr "情况1"
-
-msgid ""
-"When both source and target belong to the contracted graph, a path is found."
-msgstr "当源和目标都属于收缩图时，就找到了一条路径。"
-
-msgid "Case 2"
-msgstr "情况2"
-
-msgid ""
-"When source and/or target belong to an edge subgraph then a path is not "
-"found."
-msgstr "当源和/或目标属于边缘子图时，则找不到路径。"
-
-msgid ""
-"In this case, the contracted graph do not have an edge connecting with node :"
-"math:`4`."
-msgstr "在这种情况下，收缩图没有与节点 :math:`4` 相连的边。"
-
-msgid "Case 3"
-msgstr "情况3"
-
-msgid "When source and/or target belong to a vertex then a path is not found."
-msgstr "当源和/或目标属于顶点时，则找不到路径。"
-
-msgid ""
-"In this case, the contracted graph do not have an edge connecting with node :"
-"math:`7` and of node :math:`4` of the second case."
-msgstr ""
-"在这种情况下，收缩图没有与第二种情况的节点 :math:`7` 和节点 :math:`4` 连接的"
-"边。"
-
-msgid "Refining the above function to include nodes that belong to an edge."
-msgstr "改进上述函数以包含属于边的节点。"
-
-msgid "The vertices that need to be expanded are calculated on lines 11 to 17."
-msgstr "需要扩展的顶点在第 11 至 17 行计算。"
-
-msgid ""
-"Adding to the contracted graph that additional section on lines 26 to 28."
-msgstr "将第 26 至 28 行的附加部分添加到收缩图中。"
-
-msgid ""
-"When source and/or target belong to an edge subgraph, now, a path is found."
-msgstr "当源和目标都属于收缩图时，就找到了一条路径。"
-
-msgid "The routing graph now has an edge connecting with node :math:`4`."
-msgstr "路由图现在有一条与节点 :math:`4` 连接的边。"
-
-msgid ""
-"In this case, the contracted graph do not have an edge connecting with node :"
-"math:`7`."
-msgstr "在这种情况下，收缩图没有与节点 :math:`7` 相连的边。"
-
-msgid "The vertices that need to be expanded are calculated on lines 19 to 24."
-msgstr "需要扩展的顶点在第19到24行计算。"
-
-msgid ""
-"Adding to the contracted graph that additional section on lines 38 to 40."
-msgstr "将第 38 至 40 行的附加部分添加到收缩图中。"
-
-msgid ""
-"The code change do not affect this case so when source and/or target belong "
-"to an edge subgraph, a path is still found."
-msgstr ""
-"代码更改不会影响这种情况，因此当源和/或目标属于边缘子图时，仍然会找到路径。"
-
-msgid "When source and/or target belong to a vertex, now, a path is found."
-msgstr "当源和/或目标属于一个顶点时，现在就找到了一条路径。"
-
-msgid "Now, the routing graph has an edge connecting with node :math:`7`."
-msgstr "现在，路由图有一条与节点 :math:`7` 连接的边。"
-
-msgid ":doc:`sampledata`"
-msgstr ":doc:`sampledata`"
 
 msgid ""
 "https://www.cs.cmu.edu/afs/cs/academic/class/15210-f12/www/lectures/"
@@ -3487,9 +2966,6 @@ msgstr ":doc:`pgr_bdAstarCostMatrix`"
 
 msgid ":doc:`pgr_bdDijkstraCostMatrix`"
 msgstr ":doc:`pgr_bdDijkstraCostMatrix`"
-
-msgid "proposed"
-msgstr "建议的"
 
 msgid ":doc:`pgr_withPointsCostMatrix`"
 msgstr ":doc:`pgr_withPointsCostMatrix`"
@@ -3669,7 +3145,8 @@ msgid ""
 "paths."
 msgstr ":doc:`pgr_KSP` - 使用 Yen 算法和 pgr_dijkstra 来获得 K 条最短路径。"
 
-msgid ":doc:`pgr_dijkstraVia` - Get a route of a seuence of vertices."
+#, fuzzy
+msgid ":doc:`pgr_dijkstraVia` - Get a route of a sequence of vertices."
 msgstr ":doc:`pgr_dijkstraVia` - 获取一系列顶点的路径。"
 
 msgid ":doc:`pgr_dijkstraNear` - Get the route to the nearest vertex."
@@ -3758,8 +3235,8 @@ msgstr "图定义如下："
 msgid "Directed graph"
 msgstr "有向图"
 
-msgid "The weighted directed graph, :math:`G_d(V,E)`, is definied by:"
-msgstr "加权有向图， :math:`G_d(V,E)` 的定义如下："
+msgid "The weighted directed graph, :math:`G_d(V,E)`, is defined by:"
+msgstr "加权有向图， :math:`G_d(V,E)`， 定义如下："
 
 msgid "the set of vertices :math:`V`"
 msgstr "顶点集 :math:`V`"
@@ -3790,7 +3267,8 @@ msgstr ""
 msgid "Undirected graph"
 msgstr "无向图"
 
-msgid "The weighted undirected graph, :math:`G_u(V,E)`, is definied by:"
+#, fuzzy
+msgid "The weighted undirected graph, :math:`G_u(V,E)`, is defined by:"
 msgstr "加权无向图， :math:`G_u(V,E)` 的定义如下："
 
 msgid ":math:`V = source \\cup target \\cup {start_v{vid}} \\cup  {end_{vid}}`"
@@ -3930,7 +3408,8 @@ msgstr ":doc:`pgr_primDD` - 基于Prim算法的行驶距离"
 msgid ":doc:`pgr_kruskalDD` - Driving Distance based on Kruskal's algorithm"
 msgstr ":doc:`pgr_kruskalDD` - 基于Kruskal算法的行驶距离"
 
-msgid "Post pocessing"
+#, fuzzy
+msgid "Post processing"
 msgstr "后期处理"
 
 msgid ":doc:`pgr_alphaShape` - Alpha shape computation"
@@ -4053,13 +3532,18 @@ msgid ""
 "an undirected graph."
 msgstr ":doc:`pgr_cuthillMckeeOrdering` -返回无向图的反向 Cuthill-McKee 排序。"
 
+msgid ""
+":doc:`pgr_topologicalSort` - Linear ordering of the vertices for directed "
+"acyclic graph."
+msgstr ":doc:`pgr_topologicalSort` — 有向无环图 (DAG) 的顶点的线性排序。"
+
 msgid ":doc:`metrics-family`"
 msgstr ":doc:`metrics-family`"
 
 msgid ""
 ":doc:`pgr_betweennessCentrality` - Calculates relative betweenness "
 "centrality using Brandes Algorithm"
-msgstr ""
+msgstr ":doc:`pgr_betweennessCentrality` - 使用布兰德斯算法计算相对介度中心性"
 
 msgid ":doc:`TRSP-family`"
 msgstr ":doc:`TRSP-family`"
@@ -4070,8 +3554,9 @@ msgstr "类别"
 msgid ":doc:`VRP-category`"
 msgstr ":doc:`VRP-category`"
 
-msgid "Unclassified"
-msgstr "未分类"
+#, fuzzy
+msgid "Shortest Path Category"
+msgstr "K最短路径 - 类别"
 
 msgid ":doc:`pgr_bellmanFord`"
 msgstr ":doc:`pgr_bellmanFord`"
@@ -4082,20 +3567,24 @@ msgstr ":doc:`pgr_dagShortestPath`"
 msgid ":doc:`pgr_edwardMoore`"
 msgstr ":doc:`pgr_edwardMoore`"
 
+#, fuzzy
+msgid "Planar Family"
+msgstr "aStar族"
+
 msgid ":doc:`pgr_isPlanar`"
 msgstr ":doc:`pgr_isPlanar`"
+
+msgid "Miscellaneous Algorithms"
+msgstr ""
+
+msgid ":doc:`pgr_lengauerTarjanDominatorTree`"
+msgstr ":doc:`pgr_lengauerTarjanDominatorTree`"
 
 msgid ":doc:`pgr_stoerWagner`"
 msgstr ":doc:`pgr_stoerWagner`"
 
-msgid ":doc:`pgr_topologicalSort`"
-msgstr ":doc:`pgr_topologicalSort`"
-
 msgid ":doc:`pgr_transitiveClosure`"
 msgstr ":doc:`pgr_transitiveClosure`"
-
-msgid ":doc:`pgr_lengauerTarjanDominatorTree`"
-msgstr ":doc:`pgr_lengauerTarjanDominatorTree`"
 
 msgid ":doc:`pgr_hawickCircuits`"
 msgstr ":doc:`pgr_hawickCircuits`"
@@ -4151,10 +3640,9 @@ msgid ""
 msgstr "当最大流量为0时则没有流量并返回 **EMPTY SET** 。"
 
 #, fuzzy
-msgid "There is no flow when source has the same vaule as target."
-msgstr "当 source与 target相同时，就没有流量。"
+msgid "There is no flow when source has the same value as target."
+msgstr "当 source与 target相同时，没有流量。"
 
-#, fuzzy
 msgid "Any duplicated values in source or target are ignored."
 msgstr "source或target 中的任何重复值都将被忽略。"
 
@@ -4165,13 +3653,13 @@ msgid "Edges with zero flow are omitted."
 msgstr "流量为零的边被忽略。"
 
 msgid "Creates"
-msgstr ""
+msgstr "创建"
 
 msgid "a **super source** and edges from it to all the sources,"
-msgstr ""
+msgstr "一个**超级源**和从它到所有源的边，"
 
 msgid "a **super target** and edges from it to all the targetss."
-msgstr ""
+msgstr "一个**超级目标**和从它到所有目标的边。"
 
 msgid ""
 "The maximum flow through the graph is guaranteed to be the value returned "
@@ -4472,6 +3960,12 @@ msgstr ":doc:`pgr_kruskal`"
 msgid ":doc:`pgr_kruskalDD`"
 msgstr ":doc:`pgr_kruskalDD`"
 
+#, fuzzy
+msgid ""
+":doc:`pgr_degree` - Returns a set of vertices and corresponding count of "
+"incident edges to the vertex."
+msgstr ":doc:`pgr_degree` -返回一组顶点以及该顶点对应的关联边数。"
+
 msgid ":doc:`prim-family`"
 msgstr ":doc:`prim-family`"
 
@@ -4518,8 +4012,20 @@ msgstr ":doc:`pgr_analyzeOneWay` - 分析边的方向性。"
 msgid ":doc:`pgr_nodeNetwork` - to create nodes to a not noded edge table."
 msgstr ":doc:`pgr_nodeNetwork` - 为无节点边表创建节点。"
 
+msgid ""
+":doc:`pgr_extractVertices` - Extracts vertex information based on the edge "
+"table information."
+msgstr ":doc:`pgr_extractVertices` - 根据边表信息提取顶点信息。"
+
 msgid ":doc:`pgr_trsp` - Turn Restriction Shortest Path (TRSP)"
 msgstr ":doc:`pgr_trsp` - 转弯限制最短路径 (TRSP)"
+
+#, fuzzy
+msgid "Utilities family"
+msgstr "实用程序"
+
+msgid ":doc:`pgr_findCloseEdges`"
+msgstr ":doc:`pgr_findCloseEdges`"
 
 msgid "Functions by categories"
 msgstr "按类别划分的函数"
@@ -4536,7 +4042,8 @@ msgstr ":doc:`drivingDistance-category`"
 msgid ":doc:`KSP-category`"
 msgstr ":doc:`KSP-category`"
 
-msgid ":doc:`spanningTree-family`"
+#, fuzzy
+msgid ":doc:`spanningTree-category`"
 msgstr ":doc:`spanningTree-family`"
 
 msgid ":doc:`BFS-category`"
@@ -4557,131 +4064,199 @@ msgstr ":doc:`experimental`"
 msgid ":doc:`release_notes`"
 msgstr ":doc:`release_notes`"
 
-msgid "pgRouting 3.7.0 Release Notes"
-msgstr "pgRouting 3.7.0 发布说明"
+msgid "pgRouting 4.0.0 Release Notes"
+msgstr "pgRouting 4.0.0 发布说明"
 
+#, fuzzy
 msgid ""
 "To see all issues & pull requests closed by this release see the `Git closed "
-"milestone for 3.7.0 <https://github.com/pgRouting/pgrouting/issues?"
+"milestone for 4.0.0 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%204.0.0%22>`__"
+msgstr ""
+"要查看此版本关闭的所有问题和拉取请求，请参阅 `Git closed milestone for 3.7.0 "
+"<https://github.com/pgRouting/pgrouting/issues?"
 "utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.0%22>`__"
-msgstr ""
-"要查看此版本关闭的所有问题和拉取请求，请参阅 `3.7.0 <https://github.com/"
-"pgRouting/pgrouting/issues?"
-"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.0%22>`__ 的 Git 关闭里程碑"
-
-msgid "Support"
-msgstr "支持"
 
 #, fuzzy
-msgid ""
-"`#2656 <https://github.com/pgRouting/pgrouting/pull/2656>`__ Stop support of "
-"PostgreSQL12 on pgrouting v3.7"
+msgid "Functions promoted to official"
+msgstr "实验性的功能被提升为提议的。"
+
+msgid "pgr_trsp"
+msgstr "pgr_trsp"
+
+msgid "pgr_trspVia"
+msgstr "pgr_trspVia"
+
+msgid "pgr_trspVia_withPoints"
+msgstr "pgr_trspVia_withPoints"
+
+msgid "pgr_trsp_withPoints"
+msgstr "pgr_trsp_withPoints"
+
+msgid "pgr_withPoints"
+msgstr "pgr_withPoints"
+
+msgid "pgr_withPointsCost"
+msgstr "pgr_withPointsCost"
+
+msgid "pgr_withPointsCostMatrix"
+msgstr "pgr_withPointsCostMatrix"
+
+msgid "pgr_withPointsDD"
+msgstr "pgr_withPointsDD"
+
+msgid "pgr_withPointsKSP"
+msgstr "pgr_withPointsKSP"
+
+msgid "pgr_withPointsVia"
+msgstr "pgr_withPointsVia"
+
+msgid "Signatures promoted to official"
 msgstr ""
-"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ 在 C++ 上读取 "
-"postgresql 数据"
+
+msgid "pgr_aStar(Combinations)"
+msgstr "pgr_aStar(组合)"
+
+msgid "pgr_aStarCost(Combinations)"
+msgstr "pgr_aStarCost(组合)"
+
+msgid "pgr_bdAstar(Combinations)"
+msgstr "pgr_bdAstar(组合)"
+
+msgid "pgr_bdAstarCost(Combinations)"
+msgstr "pgr_bdAstarCost(组合)"
+
+msgid "pgr_bdDijkstra(Combinations)"
+msgstr "pgr_bdDijkstra(组合)"
+
+msgid "pgr_bdDijkstraCost(Combinations)"
+msgstr "pgr_bdDijkstraCost(组合)"
+
+msgid "pgr_dijkstra(Combinations)"
+msgstr "pgr_dijkstra(组合)"
+
+msgid "pgr_dijkstraCost(Combinations)"
+msgstr "pgr_dijkstraCost(组合)"
 
 #, fuzzy
-msgid "Stopping support of PostgreSQL 12"
-msgstr "从 PostgreSQL 12 开始：："
+msgid "pgr_KSP(All signatures)"
+msgstr "TSP 旧签名"
+
+msgid "pgr_boykovKolmogorov(Combinations)"
+msgstr "pgr_boykovKolmogorov (组合)"
+
+msgid "pgr_edmondsKarp(Combinations)"
+msgstr "pgr_edmondsKarp(组合)"
+
+msgid "pgr_maxFlow(Combinations)"
+msgstr "pgr_maxFlow(组合)"
+
+msgid "pgr_pushRelabel(Combinations)"
+msgstr "pgr_pushRelabel(组合)"
+
+msgid "code enhancements:"
+msgstr "代码改进："
+
+msgid "Removal of unused C/C++ code"
+msgstr ""
 
 #, fuzzy
-msgid "CI does not test for PostgreSQL 12"
-msgstr "适用于 postgreSQL 10"
+msgid "Removal of SQL deprecated functions"
+msgstr "移除已弃用的函数和签名"
 
-msgid "New experimental functions"
-msgstr "新的实验函数"
+msgid ""
+"pgr_trsp(text,integer,double precision,integer,double precision,boolean,"
+"boolean,text)"
+msgstr ""
+"pgr_trsp(text,integer,double precision,integer,double precision,boolean,"
+"boolean,text)"
+
+msgid "pgr_trsp(text,integer,integer,boolean,boolean,text)"
+msgstr "pgr_trsp(text,integer,integer,boolean,boolean,text)"
+
+msgid ""
+"pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)"
+msgstr ""
+"pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)"
+
+msgid "pgr_trspviavertices(text,anyarray,boolean,boolean,text)"
+msgstr "pgr_trspviavertices(text,anyarray,boolean,boolean,text)"
 
 #, fuzzy
-msgid "Metrics"
-msgstr "限制"
+msgid "Removal of SQL deprecated internal functions"
+msgstr "移除已弃用的函数和签名"
 
-msgid "pgr_betweennessCentrality"
-msgstr ""
+msgid "_pgr_dijkstranear(text,anyarray,anyarray,bigint,boolean)"
+msgstr "_pgr_dijkstranear(text,anyarray,anyarray,bigint,boolean)"
 
-msgid "Official functions changes"
-msgstr "官方功能变更"
+msgid "_pgr_dijkstranear(text,anyarray,bigint,bigint,boolean)"
+msgstr "_pgr_dijkstranear(text,anyarray,bigint,bigint,boolean)"
+
+msgid "_pgr_dijkstranear(text,bigint,anyarray,bigint,boolean)"
+msgstr "_pgr_dijkstranear(text,bigint,anyarray,bigint,boolean)"
+
+msgid "_pgr_dijkstra(text,anyarray,anyarray,boolean,boolean,boolean,bigint)"
+msgstr "_pgr_dijkstra(text,anyarray,anyarray,boolean,boolean,boolean,bigint)"
+
+msgid "_pgr_dijkstra(text,text,boolean,boolean,boolean)"
+msgstr "_pgr_dijkstra(text,text,boolean,boolean,boolean)"
+
+msgid "_pgr_drivingdistance(text,anyarray,double precision,boolean,boolean)"
+msgstr "_pgr_drivingdistance(text,anyarray,double precision,boolean,boolean)"
+
+msgid "_pgr_kruskal(text,anyarray,text,bigint,double precision)"
+msgstr "_pgr_kruskal(text,anyarray,text,bigint,double precision)"
+
+msgid "_pgr_prim(text,anyarray,text,bigint,double precision)"
+msgstr "_pgr_prim(text,anyarray,text,bigint,double precision)"
 
 msgid ""
-"`#2605 <https://github.com/pgRouting/pgrouting/pull/2605>`__ Standarize "
-"spanning tree functions output"
+"_pgr_trsp(text,integer,double precision,integer,double precision,boolean,"
+"boolean,text)"
 msgstr ""
+"_pgr_trsp(text,integer,double precision,integer,double precision,boolean,"
+"boolean,text)"
 
-msgid "Functions:"
-msgstr "新函数:"
+msgid "_pgr_trsp(text,text,anyarray,anyarray,boolean)"
+msgstr "_pgr_trsp(text,text,anyarray,anyarray,boolean)"
 
-msgid "``pgr_kruskalDD``"
-msgstr "``pgr_kruskalDD``"
+msgid "_pgr_trsp(text,text,anyarray,bigint,boolean)"
+msgstr "_pgr_trsp(text,text,anyarray,bigint,boolean)"
 
-msgid "``pgr_kruskalDFS``"
-msgstr "``pgr_kruskalDFS``"
+msgid "_pgr_trsp(text,text,bigint,anyarray,boolean)"
+msgstr "_pgr_trsp(text,text,bigint,anyarray,boolean)"
 
-msgid "``pgr_kruskalBFS``"
-msgstr "``pgr_kruskalBFS``"
+msgid "_pgr_trsp(text,text,bigint,bigint,boolean)"
+msgstr "_pgr_trsp(text,text,bigint,bigint,boolean)"
 
-msgid "``pgr_primDD``"
-msgstr "``pgr_primDD``"
+msgid "_pgr_trspviavertices(text,integer[],boolean,boolean,text)"
+msgstr "_pgr_trspviavertices(text,integer[],boolean,boolean,text)"
 
-msgid "``pgr_primDFS``"
-msgstr "``pgr_primDFS``"
+msgid "_pgr_withpointsvia(text,bigint[],double precision[],boolean)"
+msgstr "_pgr_withpointsvia(text,bigint[],double precision[],boolean)"
 
-msgid "``pgr_primBFS``"
-msgstr "``pgr_primBFS``"
+msgid "_trsp(text,text,anyarray,anyarray,boolean)"
+msgstr "_trsp(text,text,anyarray,anyarray,boolean)"
 
-msgid "Standarizing output columns to |result-spantree|"
-msgstr "将输出列标准化为 |result-spantree|"
+msgid "_v4trsp(text,text,anyarray,anyarray,boolean)"
+msgstr "_v4trsp(text,text,anyarray,anyarray,boolean)"
+
+msgid "_v4trsp(text,text,text,boolean)"
+msgstr "_v4trsp(text,text,text,boolean)"
 
 #, fuzzy
-msgid "Added ``pred`` result columns."
-msgstr "添加了 ``depth`` 和``pred`` 结果列。"
+msgid "Deprecation of internal C/C++ functions"
+msgstr "已废弃的函数"
 
-msgid "Experimental promoted to proposed."
-msgstr "实验提升为拟议。"
-
-msgid ""
-"`#2635 <https://github.com/pgRouting/pgrouting/pull/2635>`__ pgr_LineGraph "
-"ignores directed flag and use negative values for identifiers."
-msgstr ""
-
-msgid "``pgr_lineGraph``"
-msgstr "``pgr_lineGraph``"
-
-msgid "Promoted to **proposed** signature."
-msgstr "晋升为 **拟议** 签名。"
-
-msgid "Works for directed and undirected graphs."
-msgstr "适用于有向和无向图。"
-
-msgid "Code enhancement"
-msgstr "代码改进"
-
-msgid ""
-"`#2599 <https://github.com/pgRouting/pgrouting/pull/2599>`__ Driving "
-"distance cleanup"
-msgstr ""
-"`#2599 <https://github.com/pgRouting/pgrouting/pull/2599>`__ 行车距离清理"
-
-msgid ""
-"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ Read postgresql "
-"data on C++"
-msgstr ""
-"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ 在 C++ 上读取 "
-"postgresql 数据"
-
-msgid ""
-"`#2614 <https://github.com/pgRouting/pgrouting/pull/2614>`__ Clang tidy does "
-"not work"
-msgstr ""
-"`#2614 <https://github.com/pgRouting/pgrouting/pull/2614>`__ Clang tidy 不工"
-"作"
+#, fuzzy
+msgid "Internal C/C++ functions in legacy"
+msgstr "已废弃的函数"
 
 msgid "All releases"
 msgstr "所有版本"
 
 msgid "Kruskal - Family of functions"
 msgstr "Kruskal - 函数族"
-
-msgid "Boost Graph Inside"
-msgstr "Boost 图内部"
 
 msgid ""
 "Kruskal's algorithm is a greedy minimum spanning tree algorithm that in each "
@@ -4701,7 +4276,7 @@ msgid "Kruskal's running time: :math:`O(E * log E)`"
 msgstr "克鲁斯卡尔的运行时间： :math:`O(E * log E)`"
 
 msgid "Metrics - Family of functions"
-msgstr ""
+msgstr "度量 - 功能系列"
 
 msgid "Migration guide"
 msgstr "迁移指南"
@@ -4716,12 +4291,6 @@ msgstr "结果可能会因变化而不同。"
 
 msgid "All deprecated functions will be removed on next mayor version 4.0.0"
 msgstr "所有已弃用的函数将在下一个主要版本 4.0.0 中被移除"
-
-msgid "Migration of functions"
-msgstr "函数迁移"
-
-msgid "Migrating functions"
-msgstr "迁移函数"
 
 msgid "Migration of ``pgr_aStar``"
 msgstr "``pgr_aStar`` 迁移"
@@ -4766,9 +4335,8 @@ msgstr "``pgr_aStar`` (`多对一`)没有 ``end_vid``。"
 msgid "Migration"
 msgstr "迁移"
 
-#, fuzzy
 msgid "Be aware of the existence of the additional columns."
-msgstr "请注意附加列的存在。"
+msgstr "注意附加栏的存在。"
 
 msgid "In ``pgr_aStar`` (`One to One`)"
 msgstr "在 ``pgr_aStar`` (`一对一`)中"
@@ -4885,7 +4453,8 @@ msgstr "在 ``pgr_dijkstra`` (`多对一`)中"
 msgid "If needed add the new columns, for example:"
 msgstr "如果需要，过滤掉添加的列，例如："
 
-msgid "Migration of ``pgr_drivingdistance``"
+#, fuzzy
+msgid "Migration of ``pgr_drivingDistance``"
 msgstr "迁移 ``pgr_drivingdistance``"
 
 msgid ""
@@ -4907,11 +4476,13 @@ msgstr "到"
 msgid "|result-spantree|"
 msgstr "|result-spantree|"
 
-msgid "``pgr_drivingdistance`` (Single vertex)"
-msgstr "``pgr_drivingdistance`` (单个顶点)"
+#, fuzzy
+msgid "pgr_drivingDistance(Single vertex)"
+msgstr "pgr_drivingDistance （单顶点）"
 
-msgid "``pgr_drivingdistance`` (Multiple vertices)"
-msgstr "``pgr_drivingdistance`` (多个顶点)"
+#, fuzzy
+msgid "pgr_drivingDistance(Multiple vertices)"
+msgstr "pgr_drivingDistance （多顶点）"
 
 msgid "Output columns were |result-dij-dd|"
 msgstr "输出列是 |result-dij-dd|"
@@ -4925,9 +4496,8 @@ msgstr "有 ``from_v`` 而不是 ``start_vid`` 结果列。"
 msgid "does not have ``depth`` result column."
 msgstr "没有 ``depth`` 结果列。"
 
-#, fuzzy
 msgid "Be aware of the existence and name change of the result columns."
-msgstr "请注意结果列的存在和名称更改。"
+msgstr "注意结果列的存在和名称变化。"
 
 msgid ""
 "Using `this <https://docs.pgrouting.org/3.5/en/pgr_drivingDistance."
@@ -4957,24 +4527,29 @@ msgstr ""
 msgid "The ``from_v`` result column name changes to ``start_vid``."
 msgstr "``from_v`结果列名称更改为 ``start_vid``。"
 
-#, fuzzy
 msgid ""
 "If needed filter out and rename columns, for example, to return the original "
 "columns:"
-msgstr "如果需要，过滤掉并重命名列，例如，返回原始列："
+msgstr "如有需要，可过滤掉列并重新命名列，例如，返回原始列："
 
 msgid ""
 "Migration of ``pgr_kruskalDD`` / ``pgr_kruskalBFS`` / ``pgr_kruskalDFS``"
-msgstr ""
+msgstr "`pgr_kruskalDD`` / `pgr_kruskalBFS`` / `pgr_kruskalDFS`` 的迁移"
 
 msgid ""
 "Starting from `v3.7.0 <https://docs.pgrouting.org/3.7/en/migration.html>`__ :"
 "doc:`pgr_kruskalDD`, :doc:`pgr_kruskalBFS` and :doc:`pgr_kruskalDFS` result "
 "columns are being standardized."
 msgstr ""
+"Starting from `v3.7.0 <https://docs.pgrouting.org/3.7/en/migration.html>`__ :"
+"doc:`pgr_kruskalDD`, :doc:`pgr_kruskalBFS` and :doc:`pgr_kruskalDFS` result "
+"columns are being standardized."
 
 msgid "|result-bfs|"
 msgstr "|result-bfs|"
+
+msgid "``pgr_kruskalDD``"
+msgstr "``pgr_kruskalDD``"
 
 msgid "Single vertex"
 msgstr "单顶点"
@@ -4982,68 +4557,65 @@ msgstr "单顶点"
 msgid "Multiple vertices"
 msgstr "多个顶点"
 
-msgid "Output columns were |result-bfs|"
-msgstr ""
+msgid "``pgr_kruskalDFS``"
+msgstr "``pgr_kruskalDFS``"
 
-#, fuzzy
+msgid "``pgr_kruskalBFS``"
+msgstr "``pgr_kruskalBFS``"
+
+msgid "Output columns were |result-bfs|"
+msgstr "输出列为 |result-bfs|"
+
 msgid "Single vertex and Multiple vertices"
-msgstr "多个顶点"
+msgstr "单顶点和多顶点"
 
 msgid "Do not have ``pred`` result column."
-msgstr ""
+msgstr "没有 ``pred`` 结果列。"
 
-#, fuzzy
 msgid "Be aware of the existence of `pred` result columns."
-msgstr "注意附加结果列的存在。"
+msgstr "注意`pred`结果列的存在。"
 
-#, fuzzy
 msgid "If needed filter out the added columns"
-msgstr "如果需要，过滤掉添加的列，例如"
+msgstr "如果需要，可过滤掉添加的列"
 
-#, fuzzy
 msgid "Kruskal single vertex"
-msgstr "单顶点"
+msgstr "Kruskal 单顶点"
 
 msgid ""
 "Using ``pgr_KruskalDD`` as example. Migration is similar to al the affected "
 "functions."
-msgstr ""
+msgstr "以 ``pgr_KruskalDD`` 为例。迁移与所有受影响的函数类似。"
 
-#, fuzzy
 msgid ""
 "Comparing with `this <https://docs.pgrouting.org/3.6/en/pgr_kruskalDD."
 "html#single-vertex>`__ example."
 msgstr ""
-"使用`这个 <https://docs.pgrouting.org/3.5/en/pgr_withPointsDD.html#single-"
-"vertex>`__ 示例。"
+"与 `this <https://docs.pgrouting.org/3.6/en/pgr_kruskalDD.html#single-"
+"vertex>`__ 示例比较。"
 
-#, fuzzy
 msgid ""
 "Now column ``pred`` exists and contains the predecessor of the ``node``."
-msgstr "``pred`` 包含``node`` 的前驱。"
+msgstr "现在列 ``pred`` 已经存在，并包含了 ``node`` 的前置节点。"
 
-#, fuzzy
 msgid "Kruskal multiple vertices"
-msgstr "多个顶点"
+msgstr "Kruskal 多顶点"
 
-#, fuzzy
 msgid ""
 "Comparing with `this <https://docs.pgrouting.org/3.6/en/pgr_kruskalDD."
 "html#multiple-vertex>`__ example."
 msgstr ""
-"使用`这个 <https://docs.pgrouting.org/3.5/en/pgr_withPointsDD.html#multiple-"
-"vertices>`__ 示例。"
+"与 `this <https://docs.pgrouting.org/3.6/en/pgr_kruskalDD.html#multiple-"
+"vertex>`__ 示例比较。"
 
 msgid "Migration of ``pgr_KSP``"
 msgstr "迁移 ``pgr_KSP``"
 
-#, fuzzy
 msgid ""
 "Starting from `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__ :"
 "doc:`pgr_KSP` result columns are being standardized."
 msgstr ""
-"从 `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__ 开始， :doc:"
-"`pgr_KSP`结果列正在标准化。"
+"从 `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__ :doc:"
+"`pgr_KSP` 开始，结果列被标准化。"
 
 msgid "|ksp-result|"
 msgstr "|ksp-result|"
@@ -5063,12 +4635,11 @@ msgstr "``start_vid`` 和 ``end_vid`` 列不存在。"
 msgid "``pgr_KSP`` (One to One) does not have ``start_vid`` and ``end_vid``."
 msgstr "``pgr_KSP`` (一对一) 没有 ``start_vid`` 和``end_vid``。"
 
-#, fuzzy
 msgid ""
 "Using `this <https://docs.pgrouting.org/3.5/en/pgr_KSP.html#signatures>`__ "
 "example."
 msgstr ""
-"使用`这个 <https://docs.pgrouting.org/3.5/en/pgr_KSP.html#signatures>`__ 示"
+"使用 `this <https://docs.pgrouting.org/3.5/en/pgr_KSP.html#signatures>`__ 示"
 "例。"
 
 msgid ""
@@ -5146,7 +4717,7 @@ msgid "In the query returns only ``edge`` column."
 msgstr "查询中仅返回 ``边`` 列。"
 
 msgid "Migration of ``pgr_primDD`` / ``pgr_primBFS`` / ``pgr_primDFS``"
-msgstr ""
+msgstr "`pgr_primDD`` / `pgr_primBFS`` / `pgr_primDFS`` 的迁移"
 
 #, fuzzy
 msgid ""
@@ -5157,45 +4728,49 @@ msgstr ""
 "从 `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__ 开始， :doc:"
 "`pgr_drivingDistance`结果列正在标准化。"
 
-#, fuzzy
+msgid "``pgr_primDD``"
+msgstr "``pgr_primDD``"
+
+msgid "``pgr_primDFS``"
+msgstr "``pgr_primDFS``"
+
+msgid "``pgr_primBFS``"
+msgstr "``pgr_primBFS``"
+
 msgid "Prim single vertex"
-msgstr "单顶点"
+msgstr "Prim 单一节点"
 
 msgid ""
 "Using ``pgr_primDD`` as example. Migration is similar to al the affected "
 "functions."
-msgstr ""
+msgstr "以 ``pgr_primDD`` 为例。迁移与所有受影响的函数类似。"
 
-#, fuzzy
 msgid ""
 "Comparing with `this <https://docs.pgrouting.org/3.6/en/pgr_primDD."
 "html#single-vertex>`__ example."
 msgstr ""
-"使用`这个 <https://docs.pgrouting.org/3.5/en/pgr_withPointsDD.html#single-"
-"vertex>`__ 示例。"
+"与 `this <https://docs.pgrouting.org/3.6/en/pgr_primDD.html#single-"
+"vertex>`__ 例子比较。"
 
-#, fuzzy
 msgid "Prim multiple vertices"
-msgstr "多个顶点"
+msgstr "Prim 多个顶点"
 
-#, fuzzy
 msgid ""
 "Comparing with `this <https://docs.pgrouting.org/3.6/en/pgr_primDD."
 "html#multiple-vertex>`__ example."
 msgstr ""
-"使用`这个 <https://docs.pgrouting.org/3.5/en/pgr_withPointsDD.html#multiple-"
-"vertices>`__ 示例。"
+"与 `this <https://docs.pgrouting.org/3.6/en/pgr_primDD.html#multiple-"
+"vertex>`__ 例子比较。"
 
 msgid "Migration of ``pgr_withPointsDD``"
 msgstr "迁移 ``pgr_withPointsDD``"
 
-#, fuzzy
 msgid ""
 "Starting from `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__ :"
 "doc:`pgr_withPointsDD` result columns are being standardized."
 msgstr ""
-"从`v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__ 开始 :doc:"
-"`pgr_withPointsDD`结果列正在标准化。"
+"从 `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__ :doc:"
+"`pgr_withPointsDD` 结果列开始标准化。"
 
 msgid "|result-generic-no-seq|"
 msgstr "|result-generic-no-seq|"
@@ -5220,10 +4795,9 @@ msgstr "输出列为 |result-1-1-no-seq|"
 msgid "Does not have ``start_vid``, ``pred`` and ``depth`` result columns."
 msgstr "没有 ``start_vid``，``pred`` 和``depth`` 结果列。"
 
-#, fuzzy
 msgid ""
 "``driving_side`` parameter was named optional now it is compulsory unnamed."
-msgstr "``driving_side`` 参数被命名为可选，现在强制未命名。"
+msgstr "``driving_side`` 参数以前被命名为可选，现在是强制性的未命名参数。"
 
 msgid "``pgr_withPointsDD`` (`Multiple vertices`)"
 msgstr "``pgr_withPointsDD`` (`多个顶点`)"
@@ -5273,7 +4847,6 @@ msgstr "此外， ``l`` 也可用作 **驾驶侧**"
 msgid "After Migration"
 msgstr "迁移后"
 
-#, fuzzy
 msgid "Be aware of the existence of the additional result Columns."
 msgstr "注意附加结果列的存在。"
 
@@ -5342,13 +4915,12 @@ msgstr "过滤掉额外的列"
 msgid "Migration of ``pgr_withPointsKSP``"
 msgstr "迁移 ``pgr_withPointsKSP``"
 
-#, fuzzy
 msgid ""
 "Starting from `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__ :"
 "doc:`pgr_withPointsKSP` result columns are being standardized."
 msgstr ""
-"从`v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__ 开始 ， :doc:"
-"`pgr_withPointsKSP`结果列正在标准化。"
+"从 `v3.6.0 <https://docs.pgrouting.org/3.6/en/migration.html>`__ :doc:"
+"`pgr_withPointsKSP` 开始对结果列进行标准化。"
 
 msgid ""
 "And ``driving side`` parameter changed from named optional to unnamed "
@@ -5379,8 +4951,137 @@ msgid ""
 "original columns:"
 msgstr "如果需要，过滤掉附加列，例如，返回原始列："
 
-msgid "Migration of turn restrictions"
-msgstr "转弯限制的迁移"
+msgid "Migration of ``pgr_trsp`` (Vertices)"
+msgstr "迁移 ``pgr_trsp`` （顶点）"
+
+msgid "Signature:"
+msgstr "标识："
+
+#, fuzzy
+msgid "Deprecated"
+msgstr "已废弃的功能"
+
+msgid "`v3.4.0 <https://docs.pgrouting.org/3.4>`__"
+msgstr "`v3.4.0 <https://docs.pgrouting.org/3.4>`__"
+
+msgid "Removed"
+msgstr ""
+
+msgid "`v4.0.0 <https://docs.pgrouting.org/4.0>`__"
+msgstr "`v4.0.0 <https://docs.pgrouting.org/4.0>`__"
+
+msgid ":doc:`pgr_dijkstra`"
+msgstr ":doc:`pgr_dijkstra`"
+
+msgid ":doc:`pgr_trsp`"
+msgstr ":doc:`pgr_trsp`"
+
+#, fuzzy
+msgid "`Migration of restrictions`_"
+msgstr "限制迁移"
+
+#, fuzzy
+msgid "Use ``pgr_dijkstra`` when there are no restrictions."
+msgstr ":doc:`pgr_dijkstra` 当没有限制时，"
+
+msgid "Use :doc:`pgr_dijkstra` instead."
+msgstr "请改用 :doc:`pgr_dijkstra`。"
+
+#, fuzzy
+msgid "To get the original column names:"
+msgstr "要获取图的连通性："
+
+msgid "``id1`` is the node"
+msgstr "``id1`` 是节点"
+
+msgid "``id2`` is the edge"
+msgstr "``id2`` 是边"
+
+#, fuzzy
+msgid "Use ``pgr_trsp`` when there are restrictions."
+msgstr ":doc:`pgr_trspVia` 当有限制时。"
+
+msgid "Use :doc:`pgr_trsp` (One to One) instead."
+msgstr "请改用 :doc:`pgr_trsp` (一对一）。"
+
+msgid "Migration of ``pgr_trsp`` (Edges)"
+msgstr "迁移 ``pgr_trsp`` （边）"
+
+msgid ":doc:`pgr_withPoints`"
+msgstr ":doc:`pgr_withPoints`"
+
+msgid ":doc:`pgr_trsp_withPoints`"
+msgstr ":doc:`pgr_trsp_withPoints`"
+
+#, fuzzy
+msgid "Use ``pgr_withPoints`` when there are no restrictions."
+msgstr ":doc:`pgr_withPoints` 当没有任何限制的时候，"
+
+#, fuzzy
+msgid "Use :doc:`pgr_withPoints` (One to One) instead."
+msgstr "请改用 :doc:`pgr_trsp` (一对一）。"
+
+#, fuzzy
+msgid "Use ``pgr_trsp_withPoints`` when there are restrictions."
+msgstr ":doc:`pgr_trspVia_withPoints` 当有限制时。"
+
+msgid "Use :doc:`pgr_trsp_withPoints` instead."
+msgstr "请使用 :doc:`pgr_trsp_withPoints`。"
+
+msgid "Migration of ``pgr_trspViaVertices``"
+msgstr "迁移 ``pgr_trspViaVertices``"
+
+msgid ":doc:`pgr_dijkstraVia`"
+msgstr ":doc:`pgr_dijkstraVia`"
+
+msgid ":doc:`pgr_trspVia`"
+msgstr ":doc:`pgr_trspVia`"
+
+#, fuzzy
+msgid "Use ``pgr_dijkstraVia`` when there are no restrictions"
+msgstr ":doc:`pgr_dijkstraVia` 当无限制时，"
+
+msgid "Use :doc:`pgr_dijkstraVia` instead."
+msgstr "请使用 :doc:`pgr_dijkstraVia`。"
+
+msgid "``id1`` is the path identifier"
+msgstr "``id1`` 是路径标识符"
+
+msgid "``id2`` is the node"
+msgstr "``id2`` 是节点"
+
+msgid "``id3`` is the edge"
+msgstr "``id3`` 是边"
+
+#, fuzzy
+msgid "Use ``pgr_trspVia`` when there are restrictions"
+msgstr ":doc:`pgr_trspVia` 当有限制时。"
+
+msgid "Use :doc:`pgr_trspVia` instead."
+msgstr "使用 :doc:`pgr_trspVia`。"
+
+msgid "Migration of ``pgr_trspViaEdges``"
+msgstr "迁移 ``pgr_trspViaEdges``"
+
+msgid ":doc:`pgr_withPointsVia`"
+msgstr ":doc:`pgr_withPointsVia`"
+
+msgid ":doc:`pgr_trspVia_withPoints`"
+msgstr ":doc:`pgr_trspVia_withPoints`"
+
+#, fuzzy
+msgid "Use ``pgr_withPointsVia`` when there are no restrictions"
+msgstr ":doc:`pgr_withPointsVia` 当没有限制时，"
+
+msgid "Use :doc:`pgr_withPointsVia` instead."
+msgstr "请使用 :doc:`pgr_withPointsVia`。"
+
+#, fuzzy
+msgid "Use ``pgr_trspVia_withPoints`` when there are restrictions"
+msgstr ":doc:`pgr_trspVia_withPoints` 当有限制时。"
+
+msgid "Use :doc:`pgr_trspVia_withPoints` instead."
+msgstr "使用 :doc:`pgr_trspVia_withPoints` 代替。"
 
 msgid "Migration of restrictions"
 msgstr "限制迁移"
@@ -5528,245 +5229,6 @@ msgstr "将在下一个正式版本 4.0.0 中删除"
 
 msgid "The migrated table contents:"
 msgstr "迁移后的表内容："
-
-msgid "Migration of ``pgr_trsp`` (Vertices)"
-msgstr "迁移 ``pgr_trsp`` （顶点）"
-
-msgid ""
-":doc:`pgr_trsp` signatures have changed and many issues have been fixed in "
-"the new signatures. This section will show how to migrate from the old "
-"signatures to the new replacement functions. This also affects the "
-"restrictions."
-msgstr ""
-":doc:`pgr_trsp` 的签名已更改，并且新签名中已修复许多问题。 本节将展示如何从旧"
-"签名迁移到新的替换函数。 这也会影响限制。"
-
-msgid "The integral type of the ``Edges SQL`` can only be ``INTEGER``."
-msgstr "``Edges SQL`` 的整数类型只能是 ``INTEGER``。"
-
-msgid "The floating point type of the ``Edges SQL`` can only be ``FLOAT``."
-msgstr "``Edges SQL`` 的浮点类型只能是 ``FLOAT``。"
-
-msgid "``directed`` flag is compulsory."
-msgstr "``directed`` 标志是强制性的。"
-
-msgid "Does not autodetect if ``reverse_cost`` column exist."
-msgstr "不自动检测 ``reverse_cost`` 列是否存在。"
-
-msgid ""
-"User must be careful to match the existence of the column with the value of "
-"``has_rcost`` parameter."
-msgstr "用户必须小心地将列的存在与 ``has_rcost`` 参数的值相匹配。"
-
-msgid "The restrictions inner query is optional."
-msgstr "内部查询的限制是可选的。"
-
-msgid "The output column names are meaningless"
-msgstr "输出列名没有意义"
-
-msgid "Migrate by using:"
-msgstr "使用以下方式迁移："
-
-msgid ":doc:`pgr_dijkstra` when there are no restrictions,"
-msgstr ":doc:`pgr_dijkstra` 当没有限制时，"
-
-msgid ":doc:`pgr_trsp` (One to One) when there are restrictions."
-msgstr ":doc:`pgr_trsp` (一对一)当有限制时。"
-
-msgid "Migrating ``pgr_trsp`` (Vertices) using ``pgr_dijkstra``"
-msgstr "使用 ``pgr_dijkstra`` 迁移 ``pgr_trsp`` （顶点）"
-
-msgid "The following query does not have restrictions."
-msgstr "以下查询没有限制。"
-
-msgid "A message about deprecation is shown"
-msgstr "显示有关弃用的消息"
-
-msgid "Deprecated functions will be removed on the next mayor version 4.0.0"
-msgstr "已弃用的功能将在下一个正式版本 4.0.0 中删除"
-
-msgid "Use :doc:`pgr_dijkstra` instead."
-msgstr "请改用 :doc:`pgr_dijkstra`。"
-
-msgid "The types casting has been removed."
-msgstr "类型强制转换已被删除。"
-
-msgid ":doc:`pgr_dijkstra`:"
-msgstr ":doc:`pgr_dijkstra`:"
-
-msgid "Autodetects if ``reverse_cost`` column is in the edges SQL."
-msgstr "自动检测 ``reverse_cost`` 列是否在边SQL中。"
-
-msgid "Accepts ``ANY-INTEGER`` on integral types"
-msgstr "接受整数类型 ``ANY-INTEGER``"
-
-msgid "Accepts ``ANY-NUMERICAL`` on floating point types"
-msgstr "接受浮点类型 ``ANY-NUMERICAL``"
-
-msgid "``directed`` flag has a default value of ``true``."
-msgstr "``directed`` 标志的默认值为``true``。"
-
-msgid "Use the same value that on the original query."
-msgstr "使用与原始查询相同的值。"
-
-msgid "In this example it is ``true`` which is the default value."
-msgstr "在此示例中，默认值为 ``true``。"
-
-msgid "The flag has been omitted and the default is been used."
-msgstr "该标志已被省略，并使用默认值。"
-
-msgid ""
-"When the need of using strictly the same (meaningless) names and types of "
-"the function been migrated then:"
-msgstr "当需要使用严格相同（无意义）的函数名称和类型进行迁移时："
-
-msgid "``id1`` is the node"
-msgstr "``id1`` 是节点"
-
-msgid "``id2`` is the edge"
-msgstr "``id2`` 是边"
-
-msgid "Migrating ``pgr_trsp`` (Vertices) using ``pgr_trsp``"
-msgstr "使用 ``pgr_trsp``迁移 ``pgr_trsp`` （顶点）"
-
-msgid "The following query has restrictions."
-msgstr "以下查询有限制。"
-
-msgid "The restrictions are the last parameter of the function"
-msgstr "限制是函数的最后一个参数"
-
-msgid "Using the old structure of restrictions"
-msgstr "使用旧的限制结构"
-
-msgid "Use :doc:`pgr_trsp` (One to One) instead."
-msgstr "请改用 :doc:`pgr_trsp` (一对一）。"
-
-msgid "The new structure of restrictions is been used."
-msgstr "使用了新的限制结构。"
-
-msgid "It is the second parameter."
-msgstr "这是第二个参数。"
-
-msgid ":doc:`pgr_trsp`:"
-msgstr ":doc:`pgr_trsp`:"
-
-msgid "Migration of ``pgr_trsp`` (Edges)"
-msgstr "迁移 ``pgr_trsp`` （边）"
-
-msgid "The integral types of the ``sql`` can only be ``INTEGER``."
-msgstr "``sql`` 的整型类型只能是 ``INTEGER``。"
-
-msgid "The floating point type of the ``sql`` can only be ``FLOAT``."
-msgstr "``sql`` 的浮点类型只能是 ``FLOAT``。"
-
-msgid "For these migration guide the following points will be used:"
-msgstr "对于这些迁移指南，将使用以下几点："
-
-msgid ":doc:`pgr_withPoints` when there are no restrictions,"
-msgstr ":doc:`pgr_withPoints` 当没有任何限制的时候，"
-
-msgid ":doc:`pgr_trsp_withPoints` (One to One) when there are restrictions."
-msgstr ":doc:`pgr_trsp_withPoints` (一对一) 当有限制时。"
-
-msgid "Migrating ``pgr_trsp`` (Edges) using ``pgr_withPoints``"
-msgstr "使用 ``pgr_withPoints``迁移 ``pgr_trsp`` （边）"
-
-msgid "Use :doc:`pgr_withPoints` instead."
-msgstr "请使用 :doc:`pgr_withPoints`。"
-
-msgid "Do not show details, as the deprecated function does not show details."
-msgstr "不显示详细信息，因为已弃用的函数不显示详细信息。"
-
-msgid ":doc:`pgr_withPoints`:"
-msgstr ":doc:`pgr_withPoints`:"
-
-msgid "On the points query do not include the ``side`` column."
-msgstr "在点查询中不包括 ``side`` 列。"
-
-msgid ""
-"When the need of using strictly the same (meaningless) names and types, and "
-"node values of the function been migrated then:"
-msgstr "当需要使用严格相同（无意义）的名称和类型，并且函数的节点值被迁移时："
-
-msgid "Migrating ``pgr_trsp`` (Edges) using ``pgr_trsp_withPoints``"
-msgstr "使用 ``pgr_trsp_withPoints`` 迁移 ``pgr_trsp`` （边）"
-
-msgid "Use :doc:`pgr_trsp_withPoints` instead."
-msgstr "请使用 :doc:`pgr_trsp_withPoints`。"
-
-msgid ":doc:`pgr_trsp_withPoints`:"
-msgstr ":doc:`pgr_trsp_withPoints`:"
-
-msgid "Migration of ``pgr_trspViaVertices``"
-msgstr "迁移 ``pgr_trspViaVertices``"
-
-msgid "The integral types of the ``Edges SQL`` can only be ``INTEGER``."
-msgstr "``Edges SQL`` 的整数类型只能是 ``INTEGER``。"
-
-msgid ":doc:`pgr_dijkstraVia` when there are no restrictions,"
-msgstr ":doc:`pgr_dijkstraVia` 当无限制时，"
-
-msgid ":doc:`pgr_trspVia` when there are restrictions."
-msgstr ":doc:`pgr_trspVia` 当有限制时。"
-
-msgid "Migrating ``pgr_trspViaVertices`` using ``pgr_dijkstraVia``"
-msgstr "使用 ``pgr_dijkstraVia``迁移 ``pgr_trspViaVertices``"
-
-msgid "Use :doc:`pgr_dijkstraVia` instead."
-msgstr "请使用 :doc:`pgr_dijkstraVia`。"
-
-msgid ":doc:`pgr_dijkstraVia`:"
-msgstr ":doc:`pgr_dijkstraVia`:"
-
-msgid "``id1`` is the path identifier"
-msgstr "``id1`` 是路径标识符"
-
-msgid "``id2`` is the node"
-msgstr "``id2`` 是节点"
-
-msgid "``id3`` is the edge"
-msgstr "``id3`` 是边"
-
-msgid "Migrating ``pgr_trspViaVertices`` using ``pgr_trspVia``"
-msgstr "使用 ``pgr_trspVia``迁移 ``pgr_trspViaVertices``"
-
-msgid "Use :doc:`pgr_trspVia` instead."
-msgstr "使用 :doc:`pgr_trspVia`。"
-
-msgid ":doc:`pgr_trspVia`:"
-msgstr ":doc:`pgr_trspVia`:"
-
-msgid "Migration of ``pgr_trspViaEdges``"
-msgstr "迁移 ``pgr_trspViaEdges``"
-
-msgid ""
-"And will travel thru the following Via points :math:"
-"`4\\rightarrow3\\rightarrow6`"
-msgstr "并将途经以下途经点： :math:`4\\rightarrow3\\rightarrow6`"
-
-msgid ":doc:`pgr_withPointsVia` when there are no restrictions,"
-msgstr ":doc:`pgr_withPointsVia` 当没有限制时，"
-
-msgid ":doc:`pgr_trspVia_withPoints` when there are restrictions."
-msgstr ":doc:`pgr_trspVia_withPoints` 当有限制时。"
-
-msgid "Migrating ``pgr_trspViaEdges`` using ``pgr_withPointsVia``"
-msgstr "使用 ``pgr_withPointsVia`` 迁移 ``pgr_trspViaEdges``"
-
-msgid "Use :doc:`pgr_withPointsVia` instead."
-msgstr "请使用 :doc:`pgr_withPointsVia`。"
-
-msgid ":doc:`pgr_withPointsVia`:"
-msgstr ":doc:`pgr_withPointsVia`:"
-
-msgid "Migrating ``pgr_trspViaEdges`` using ``pgr_trspVia_withPoints``"
-msgstr "使用 ``pgr_trspVia_withPoints``迁移``pgr_trspViaEdges``"
-
-msgid "Use :doc:`pgr_trspVia_withPoints` instead."
-msgstr "使用 :doc:`pgr_trspVia_withPoints` 代替。"
-
-msgid ":doc:`pgr_trspVia_withPoints`:"
-msgstr ":doc:`pgr_trspVia_withPoints`:"
 
 msgid ":doc:`withPoints-category`"
 msgstr ":doc:`withPoints-category`"
@@ -5938,9 +5400,6 @@ msgstr "边 :math:`2` (:math:`1 \\frac{\\;\\;\\;\\;\\;}{} 3`) 不是图的一部
 
 msgid "Graph with ``cost`` and ``reverse_cost``"
 msgstr "带有 ``cost`` 和``reverse_cost`` 的图"
-
-msgid "The weighted directed graph, :math:`G_d(V,E)`, is defined by:"
-msgstr "加权有向图， :math:`G_d(V,E)`， 定义如下："
 
 msgid "``SELECT id, source, target, cost, reverse_cost FROM edges``"
 msgstr "``SELECT id, source, target, cost, reverse_cost FROM edges``"
@@ -6668,19 +6127,30 @@ msgstr "死端"
 msgid "To get the dead ends:"
 msgstr "获取死端："
 
-msgid ""
-"That information is correct, for example, when the dead end is on the limit "
-"of the imported graph."
-msgstr "例如，当死端位于导入图的极限时，该信息是正确的。"
-
-msgid ""
-"Visually node :math:`4` looks to be as start/ending of 3 edges, but it is "
-"not."
+msgid "A dead end happens when"
 msgstr ""
-"从视觉上看，节点 :math:`4` 看起来是 3 条边的开始/结束，但事实并非如此。"
 
-msgid "Is that correct?"
-msgstr "那是对的吗？"
+msgid ""
+"The vertex is the limit of a cul-de-sac, a no-through road or a no-exit road."
+msgstr ""
+
+#, fuzzy
+msgid "The vertex is on the limit of the imported graph."
+msgstr "当 ``true`` 时，顶点收缩，它不是收缩图的一部分。"
+
+msgid "If a larger graph is imported then the vertex might not be a dead end"
+msgstr ""
+
+msgid ""
+"Node :math:`4`, is a dead end on the query, even that it visually looks like "
+"an end point of 3 edges."
+msgstr ""
+
+msgid "Is node :math:`4` a dead end or not?"
+msgstr ""
+
+msgid "The answer to that question will depend on the application."
+msgstr ""
 
 msgid "Is there such a small curb:"
 msgstr "有这么小的路边吗："
@@ -6703,9 +6173,14 @@ msgid ""
 "the segment?"
 msgstr "是否有一个大悬崖，从鹰的角度看，死胡同靠近该路段？"
 
+#, fuzzy
+msgid "Depending on the answer, modification of the data might be needed."
+msgstr "根据函数需要一个或多个内部查询。"
+
+#, fuzzy
 msgid ""
-"When there are many dead ends, to speed up, the :doc:`contraction-family` "
-"functions can be used to divide the problem."
+"When there are many dead ends, to speed up processing, the :doc:`contraction-"
+"family` functions can be used to contract the graph."
 msgstr ""
 "当有很多死端时，为了加快速度，可以使用 :doc:`contraction-family` 函数来划分问"
 "题。"
@@ -6717,13 +6192,15 @@ msgid "To get the linear edges:"
 msgstr "要获得线性边："
 
 msgid ""
-"This information is correct, for example, when the application is taking "
-"into account speed bumps, stop signals."
-msgstr "例如，当应用程序考虑减速带、停止信号时，此信息是正确的。"
+"These linear vertices are correct, for example, when those the vertices are "
+"speed bumps, stop signals and the application is taking them into account."
+msgstr ""
 
+#, fuzzy
 msgid ""
-"When there are many linear edges, to speed up, the :doc:`contraction-family` "
-"functions can be used to divide the problem."
+"When there are many linear vertices, that need not to be taken into account, "
+"to speed up the processing, the :doc:`contraction-family` functions can be "
+"used to contract the problem."
 msgstr ""
 "当线性边较多时，为了加快速度，可以使用 :doc:`contraction-family` 函数来划分问"
 "题。"
@@ -6902,15 +6379,14 @@ msgstr "用户可以根据需要定义组合。"
 msgid "Needs a `Combinations SQL`_"
 msgstr "需要 `Combinations SQL`_"
 
-#, fuzzy
 msgid ""
 "There are several kinds of valid inner queries and also the columns returned "
 "are depending of the function. Which kind of inner query will depend on the "
 "function's requirements. To simplify the variety of types, **ANY-INTEGER** "
 "and **ANY-NUMERICAL** is used."
 msgstr ""
-"有多种有效的内部查询，返回的列也取决于函数。 哪种内部查询取决于函数的要求。 "
-"为了简化各种类型，使用 **ANY-INTEGER** 和 **ANY-NUMERICAL** 。"
+"有几种有效的内部查询类型，返回的列也取决于函数。哪种类型的内部查询将取决于函"
+"数的要求。为了简化类型的种类，使用了 **ANY-INTEGER**和**ANY-NUMERICAL**。"
 
 msgid "Edges SQL for"
 msgstr "边 SQL"
@@ -6996,9 +6472,6 @@ msgstr ""
 msgid "Parameters for the Via functions"
 msgstr "Via 函数的参数"
 
-msgid ":doc:`pgr_dijkstraVia`"
-msgstr ":doc:`pgr_dijkstraVia`"
-
 msgid "SQL query as described."
 msgstr "如所述的 SQL 查询。"
 
@@ -7041,9 +6514,6 @@ msgstr ""
 
 msgid "For the TRSP functions"
 msgstr "对于 TRSP 函数"
-
-msgid ":doc:`pgr_trsp`"
-msgstr ":doc:`pgr_trsp`"
 
 msgid "Array of identifiers of destination vertices."
 msgstr "目标顶点的标识符数组。"
@@ -7099,9 +6569,6 @@ msgstr "从使用 ``edge`` 的 ``node`` 遍历到路径序列中的下一个节�
 
 msgid "Used in functions the following:"
 msgstr "用于以下函数："
-
-msgid ":doc:`pgr_withPoints`"
-msgstr ":doc:`pgr_withPoints`"
 
 msgid ""
 "Returns set of ``(seq, path_seq [, start_pid] [, end_pid], node, edge, cost, "
@@ -7262,6 +6729,14 @@ msgstr ""
 "在此示例中，使用内部查询 SQL，该 SQL 不包括路由函数中的某些边并且位于结果区域"
 "内。"
 
+#, fuzzy
+msgid "Given this area:"
+msgstr "给定车辆："
+
+#, fuzzy
+msgid "Calculate a route:"
+msgstr "计算所有列"
+
 msgid "How to contribute"
 msgstr "如何贡献"
 
@@ -7295,7 +6770,8 @@ msgstr ""
 "`示例 <https://github.com/pgRouting/pgrouting/wiki/How-to:-Handle-parallel-"
 "edges-(KSP)>`__"
 
-msgid "Adding Functionaity to pgRouting"
+#, fuzzy
+msgid "Adding Functionality to pgRouting"
 msgstr "向 pgRouting 添加功能"
 
 msgid ""
@@ -7414,9 +6890,9 @@ msgid "Upgrading the database"
 msgstr "升级数据库"
 
 msgid ""
-"To upgrade pgRouting in the database to version 3.7.0 use the following "
+"To upgrade pgRouting in the database to version 4.0.0 use the following "
 "command:"
-msgstr "要将数据库中的 pgRouting 升级到版本3.7.0，请使用以下命令："
+msgstr "要将数据库中的 pgRouting 升级到 4.0.0 版本，请使用以下命令："
 
 msgid ""
 "More information can be found in https://www.postgresql.org/docs/current/sql-"
@@ -7708,15 +7184,14 @@ msgstr ""
 "`Georepublic <https://georepublic.info>`__ 、`Paragon Corporation <https://"
 "www.paragoncorporation.com/>`__ 和广大用户社区的支持和维护。"
 
-#, fuzzy
 msgid ""
 "pgRouting is part of `OSGeo Community Projects <https://wiki.osgeo.org/wiki/"
 "OSGeo_Community_Projects>`__ from the `OSGeo Foundation <https://www.osgeo."
 "org>`__ and included on `OSGeoLive <http://live.osgeo.org/>`__."
 msgstr ""
-"pgRouting 是 `OSGeo 基金会 <https://www.osgeo.org>`__ `OSGeo 社区项目 "
-"<https://wiki.osgeo.org/wiki/OSGeo_Community_Projects>`__ 的一部分，并包含在 "
-"`OSGeoLive <http://live.osgeo.org/>`__ 中。"
+"pgRouting 是 `OSGeo Community Projects <https://wiki.osgeo.org/wiki/"
+"OSGeo_Community_Projects>`__的一部分，隶属于`OSGeo Foundation <https://www."
+"osgeo.org>`__，并被包含在`OSGeoLive <http://live.osgeo.org/>`__。"
 
 msgid "Licensing"
 msgstr "许可"
@@ -7903,8 +7378,8 @@ msgstr "Boost C++ 源库位于 https://www.boost.org。"
 msgid ":doc:`migration`"
 msgstr ":doc:`migration`"
 
-msgid "pgr_KSP"
-msgstr "pgr_KSP"
+msgid "``pgr_KSP``"
+msgstr "``pgr_KSP``"
 
 msgid "``pgr_KSP`` — Yen's algorithm for K shortest paths using Dijkstra."
 msgstr "``pgr_KSP`` — Yen 使用 Dijkstra 计算 K 最短路径的算法。"
@@ -7912,32 +7387,39 @@ msgstr "``pgr_KSP`` — Yen 使用 Dijkstra 计算 K 最短路径的算法。"
 msgid "Availability"
 msgstr "可用性"
 
+#, fuzzy
+msgid "Version 4.0.0"
+msgstr "版本2.0.0"
+
+msgid "All signatures promoted to official."
+msgstr ""
+
 msgid "Version 3.6.0"
 msgstr "版本3.6.0"
 
 msgid "Result columns standarized to: |nksp-result|"
 msgstr "结果列标准化为 |nksp-result|"
 
-msgid "``pgr_ksp`` (One to One)"
-msgstr "``pgr_ksp`` (一对一)"
+msgid "pgr_ksp(One to One)"
+msgstr "pgr_ksp(一对一)"
 
 msgid "Added ``start_vid`` and ``end_vid`` result columns."
 msgstr "增加 ``start_vid`` 和 ``end_vid`` 结果列。"
 
-msgid "New overload functions:"
-msgstr "新的重载函数："
+msgid "New proposed signatures:"
+msgstr "新拟议的签名："
 
-msgid "``pgr_ksp`` (One to Many)"
-msgstr "``pgr_ksp`` (一对多)"
+msgid "pgr_ksp(One to Many)"
+msgstr "pgr_ksp(一对多)"
 
-msgid "``pgr_ksp`` (Many to One)"
-msgstr "``pgr_ksp`` (多对一)"
+msgid "pgr_ksp(Many to One)"
+msgstr "pgr_ksp(多对一)"
 
-msgid "``pgr_ksp`` (Many to Many)"
-msgstr "``pgr_ksp`` (多对多)"
+msgid "pgr_ksp(Many to Many)"
+msgstr "pgr_ksp(多对多)"
 
-msgid "``pgr_ksp`` (Combinations)"
-msgstr "``pgr_ksp`` (组合)"
+msgid "pgr_ksp(Combinations)"
+msgstr "pgr_ksp(组合)"
 
 msgid "Version 2.1.0"
 msgstr "版本2.1.0"
@@ -7951,13 +7433,19 @@ msgstr "不再支持旧签名"
 msgid "Version 2.0.0"
 msgstr "版本2.0.0"
 
-msgid "**Official** function"
-msgstr "**官方** 函数"
+msgid "Official function."
+msgstr "官方 函数"
 
 msgid ""
 "The K shortest path routing algorithm based on Yen's algorithm. \"K\" is the "
 "number of shortest paths desired."
 msgstr "基于Yen算法的K最短路径路由算法。 “K”是所需的最短路径的数量。"
+
+msgid "|Boost| Boost Graph Inside"
+msgstr "|Boost| Boost 图内部"
+
+msgid "Boost Graph Inside"
+msgstr "Boost 图内部"
 
 msgid "Signatures"
 msgstr "签名"
@@ -8092,7 +7580,8 @@ msgstr "https://en.wikipedia.org/wiki/K_shortest_path_routing"
 msgid "``pgr_TSP``"
 msgstr "``pgr_TSP``"
 
-msgid "``pgr_TSP`` - Aproximation using *metric* algorithm."
+#, fuzzy
+msgid "``pgr_TSP`` - Approximation using *metric* algorithm."
 msgstr "``pgr_TSP`` -使用*metric*算法的近似方法。"
 
 msgid "Availability:"
@@ -8323,8 +7812,17 @@ msgstr ""
 msgid "``pgr_TSPeuclidean``"
 msgstr "``pgr_TSPeuclidean``"
 
-msgid "``pgr_TSPeuclidean`` - Aproximation using *metric* algorithm."
+#, fuzzy
+msgid "``pgr_TSPeuclidean`` - Approximation using *metric* algorithm."
 msgstr "``pgr_TSPeuclidean`` -使用*metric*算法进行近似。"
+
+#, fuzzy
+msgid ""
+"Using `Boost: metric TSP approx <https://www.boost.org/libs/graph/doc/"
+"metric_tsp_approx.html>`__"
+msgstr ""
+"`Boost 的 metric appro 的 metric 近似 <https://www.boost.org/libs/graph/doc/"
+"metric_tsp_approx.html>`__"
 
 msgid ""
 "The Simulated Annealing Algorithm related parameters are ignored: "
@@ -8343,8 +7841,9 @@ msgstr "版本3.0.0"
 msgid "Name change from pgr_eucledianTSP"
 msgstr "pgr_eucledianTSP 的名称更改"
 
-msgid "New **Official** function"
-msgstr "**官方** 新函数"
+#, fuzzy
+msgid "New official function."
+msgstr "新函数 official。"
 
 msgid ""
 "Any duplicated identifier will be ignored. The coordinates that will be kept"
@@ -8361,9 +7860,8 @@ msgid ""
 "The coordinates are quite different for the same identifier, for example ::"
 msgstr "对于相同的标识符，坐标有很大不同，例如::"
 
-#, fuzzy
 msgid "pgr_TSPeuclidean(`Coordinates SQL`_, ``[start_id, end_id]``)"
-msgstr "pgr_TSPeuclidean(`Coordinates SQL`_ , ``[start_id, end_id]``)"
+msgstr "pgr_TSPeuclidean(`Coordinates SQL`_, ``[start_id, end_id]``)"
 
 msgid "With default values"
 msgstr "有默认值"
@@ -8430,57 +7928,53 @@ msgstr ""
 "从视觉上看，第一幅图像是 `最优解 <https://www.math.uwaterloo.ca/tsp/world/"
 "witour.html>`__ ，第二幅图像是使用 ``pgr_TSPeuclidean`` 获得的解。"
 
-msgid ":doc:`sampledata` network."
-msgstr ":doc:`sampledata` 网络。"
-
 msgid "``pgr_aStar``"
 msgstr "``pgr_aStar``"
 
 msgid "``pgr_aStar`` — Shortest path using the A* algorithm."
 msgstr "``pgr_aStar`` —使用 A* 算法的最短路径。"
 
+msgid "Combinations signature promoted to official."
+msgstr ""
+
 msgid "Standarizing output columns to |short-generic-result|"
 msgstr "标准输出列|short-generic-result|"
 
-msgid ""
-"``pgr_aStar`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
-msgstr "``pgr_aStar`` (`一对一`_) 增加 ``start_vid`` 和 ``end_vid`` 列."
+#, fuzzy
+msgid "pgr_aStar(One to One) added ``start_vid`` and ``end_vid`` columns."
+msgstr "``pgr_aStar`` （`一对一`）增加了 ``start_vid`` 和 ``end_vid`` 列。"
 
-msgid "``pgr_aStar`` (`One to Many`_) added ``end_vid`` column."
-msgstr "``pgr_aStar`` (`一对多`_) 增加 ``end_vid`` 列."
+msgid "pgr_aStar(One to Many) added ``end_vid`` column."
+msgstr "pgr_aStar(一对多）添加了 ``end_vid`` 列。"
 
-msgid "``pgr_aStar`` (`Many to One`_) added ``start_vid`` column."
-msgstr "``pgr_aStar`` (`多对一`_) 增加 ``start_vid`` 列."
+msgid "pgr_aStar(Many to One) added ``start_vid`` column."
+msgstr "pgr_aStar(多对一）添加了 ``start_vid`` 列。"
 
 msgid "Version 3.2.0"
 msgstr "版本3.2.0"
 
-msgid "New **proposed** signature:"
-msgstr "新 **拟议** 的签名："
+#, fuzzy
+msgid "New proposed signature:"
+msgstr "新拟议的签名："
 
-msgid "``pgr_aStar`` (`Combinations`_)"
-msgstr "``pgr_aStar`` (`组合`_)"
+msgid "Function promoted to official."
+msgstr ""
 
 msgid "Version 2.4.0"
 msgstr "版本2.4.0"
 
-msgid "New **Proposed** signatures:"
-msgstr "新 **拟议** 签名："
+msgid "pgr_aStar(One to Many)"
+msgstr "pgr_aStar(一对多）"
 
-msgid "``pgr_aStar`` (`One to Many`_)"
-msgstr "``pgr_aStar`` (`一对多`_)"
+msgid "pgr_aStar(Many to One)"
+msgstr "pgr_aStar(多对一）"
 
-msgid "``pgr_aStar`` (`Many to One`_)"
-msgstr "``pgr_aStar`` (`多对一`_)"
+msgid "pgr_aStar(Many to Many)"
+msgstr "pgr_aStar(多对多）"
 
-msgid "``pgr_aStar`` (`Many to Many`_)"
-msgstr "``pgr_aStar`` (`多对多`_)"
-
-msgid "Signature change on ``pgr_astar`` (`One to One`_)"
-msgstr "签名更改 ``pgr_astar`` (`一对一`_)"
-
-msgid "**Official** ``pgr_aStar`` (`One to One`_)"
-msgstr "**官方** ``pgr_aStar`` (`一对一`_)"
+#, fuzzy
+msgid "Signature change on pgr_aStar(One to One)"
+msgstr "签名更改 pgr_aStar(一对一)"
 
 msgid ""
 "The results are equivalent to the union of the results of the `pgr_aStar(` "
@@ -8561,25 +8055,20 @@ msgstr "示例3"
 msgid "Manually assigned vertex combinations."
 msgstr "手动指定的顶点组合。"
 
-msgid "pgr_aStarCost"
-msgstr "pgr_aStarCost"
+msgid "``pgr_aStarCost``"
+msgstr "``pgr_aStarCost``"
 
-#, fuzzy
 msgid ""
 "``pgr_aStarCost`` - Total cost of the shortest path using the A* algorithm."
-msgstr "``pgr_aStarCost`` -使用 A* 算法的最短路径的总成本。"
+msgstr "``pgr_aStarCost`` - 使用 A* 算法计算最短路径的总成本。"
 
-msgid "``pgr_aStarCost`` (`Combinations`_)"
-msgstr "``pgr_aStarCost`` (`组合`_)"
+msgid "New proposed function."
+msgstr "新提议的函数。"
 
-msgid "New **proposed** function"
-msgstr "新 **拟议** 函数"
-
-#, fuzzy
 msgid ""
 "The ``pgr_aStarCost`` function sumarizes of the cost of the shortest path "
 "using the A* algorithm."
-msgstr "``pgr_aStarCost`` 函数使用 A* 算法汇总最短路径的成本。"
+msgstr "``pgr_aStarCost`` 函数总结了使用 A* 算法计算最短路径的成本。"
 
 msgid ""
 "Let be the case the values returned are stored in a table, so the unique "
@@ -8698,6 +8187,9 @@ msgstr "支持返回多个外/内圈"
 msgid "Renamed from version 1.x"
 msgstr "从版本1.X重命名"
 
+msgid "Support"
+msgstr "支持"
+
 msgid "Returns the polygon part of an alpha shape."
 msgstr "返回 alpha 形状的多边形部分。"
 
@@ -8772,8 +8264,8 @@ msgstr ":doc:`pgr_drivingDistance`"
 msgid "`ST_ConcaveHull <https://postgis.net/docs/ST_ConcaveHull.html>`__"
 msgstr "`ST_ConcaveHull <https://postgis.net/docs/ST_ConcaveHull.html>`__"
 
-msgid "pgr_analyzeGraph"
-msgstr "pgr_analyzeGraph"
+msgid "``pgr_analyzeGraph``"
+msgstr "``pgr_analyzeGraph``"
 
 msgid "``pgr_analyzeGraph`` — Analyzes the network topology."
 msgstr "``pgr_analyzeGraph`` —分析网络拓扑。"
@@ -9048,9 +8540,6 @@ msgstr ""
 "选择几何图形靠近表 ``othertable`` 的 place='myhouse' 的行。 （注意 "
 "quote_literal 的使用）"
 
-msgid "The examples use the :doc:`sampledata` network."
-msgstr "这些示例使用 :doc:`sampledata` 网络。"
-
 msgid ":doc:`pgr_analyzeOneWay`"
 msgstr ":doc:`pgr_analyzeOneWay`"
 
@@ -9060,8 +8549,8 @@ msgstr ":doc:`pgr_createVerticesTable`"
 msgid ":doc:`pgr_nodeNetwork` to create nodes to a not noded edge table."
 msgstr ":doc:`pgr_nodeNetwork` 创建节点到非节点边表。"
 
-msgid "pgr_analyzeOneWay"
-msgstr "pgr_analyzeOneWay"
+msgid "``pgr_analyzeOneWay``"
+msgstr "``pgr_analyzeOneWay``"
 
 msgid ""
 "``pgr_analyzeOneWay`` — Analyzes oneway Sstreets and identifies flipped "
@@ -9236,8 +8725,8 @@ msgstr "结果列更改：删除了 ``seq``"
 msgid "Version 2.5.0"
 msgstr "版本2.5.0"
 
-msgid "New **experimental** function"
-msgstr "新 **实验** 函数"
+msgid "New experimental function."
+msgstr "新实验功能。"
 
 msgid ""
 "Those vertices that belong to more than one biconnected component are called "
@@ -9269,8 +8758,9 @@ msgstr "图表的连接点"
 msgid "Nodes in red are the articulation points."
 msgstr "红色节点是关节点。"
 
+#, fuzzy
 msgid ""
-"Boost: `Biconnected components & articulation points <https://www.boost.org/"
+"`Boost: Biconnected components & articulation points <https://www.boost.org/"
 "libs/graph/doc/biconnected_components.html>`__"
 msgstr ""
 "Boost: `双连通分量和关节点 <https://www.boost.org/libs/graph/doc/"
@@ -9289,38 +8779,33 @@ msgstr "``pgr_bdAstar``"
 msgid "``pgr_bdAstar`` — Shortest path using the bidirectional A* algorithm."
 msgstr "``pgr_bdAstar`` — 使用双向 A* 算法的最短路径。"
 
-msgid ""
-"``pgr_bdAstar`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
-msgstr "``pgr_bdAstar`` (`一对一`_) 增加 ``start_vid`` 和 ``end_vid`` 列。"
+msgid "pgr_bdAstar(One to One) added ``start_vid`` and ``end_vid`` columns."
+msgstr "pgr_bdAstar(一对一）增加了 ``start_vid`` 和``end_vid`` 列。"
 
-msgid "``pgr_bdAstar`` (`One to Many`_) added ``end_vid`` column."
-msgstr "``pgr_bdAstar`` (`一对多`_) 增加 ``end_vid`` 列。"
+msgid "pgr_bdAstar(One to Many) added ``end_vid`` column."
+msgstr "pgr_bdAstar(一对多）添加了``end_vid`` 列。"
 
-msgid "``pgr_bdAstar`` (`Many to One`_) added ``start_vid`` column."
-msgstr "``pgr_bdAstar`` (`多对一`_) 增加 ``start_vid`` 列。"
+msgid "pgr_bdAstar(Many to One) added ``start_vid`` column."
+msgstr "pgr_bdAstar(多对一）添加了``start_vid`` 列。"
 
-msgid "``pgr_bdAstar`` (`Combinations`_)"
-msgstr "``pgr_bdAstar`` (`组合`_)"
+msgid "pgr_bdAstar(One to Many)"
+msgstr "pgr_bdAstar（一对多）"
 
-msgid "``pgr_bdAstar`` (`One to Many`_)"
-msgstr "``pgr_bdAstar`` (`一对多`_)"
+msgid "pgr_bdAstar(Many to One)"
+msgstr "pgr_bdAstar（多对一）"
 
-msgid "``pgr_bdAstar`` (`Many to One`_)"
-msgstr "``pgr_bdAstar`` (`多对一`_)"
+msgid "pgr_bdAstar(Many to Many)"
+msgstr "pgr_bdAstar（多对多）"
 
-msgid "``pgr_bdAstar`` (`Many to Many`_)"
-msgstr "``pgr_bdAstar`` (`多对多`_)"
-
-msgid "Signature change on ``pgr_bdAstar`` (`One to One`_)"
+#, fuzzy
+msgid "Signature change on pgr_bdAstar(One to One)"
 msgstr "在 ``pgr_bdAstar`` (`一对一`_)上的签名更改"
 
-msgid "**Official** ``pgr_bdAstar`` (`One to One`_)"
-msgstr "**官方** ``pgr_bdAstar`` (`一对一`_)"
-
+#, fuzzy
 msgid ""
-"The results are equivalent to the union of the results of the `pgr_bdAStar(` "
-"`One to One`_ `)` on the:"
-msgstr "结果相当于`pgr_bdAStar(` `一对一`_ `)` 结果的并集："
+"The results are equivalent to the union of the results of the "
+"pgr_bdAStar(One to One) on the:"
+msgstr "结果相当于pgr_bdAStar(一对一) 结果的并集："
 
 msgid "pgr_bdAstar(`Edges SQL`_, **start vid**, **end vid**, [**options**])"
 msgstr "pgr_bdAstar(`Edges SQL`_, **start vid**, **end vid**, [**options**])"
@@ -9337,23 +8822,18 @@ msgstr "pgr_bdAstar(`Edges SQL`_, **start vids**, **end vids**, [**options**])"
 msgid "pgr_bdAstar(`Edges SQL`_, `Combinations SQL`_, [**options**])"
 msgstr "pgr_bdAstar(`Edges SQL`_, `Combinations SQL`_, [**options**])"
 
-msgid "pgr_bdAstarCost"
-msgstr "pgr_bdAstarCost"
+msgid "``pgr_bdAstarCost``"
+msgstr "``pgr_bdAstarCost``"
 
-#, fuzzy
 msgid ""
 "``pgr_bdAstarCost`` - Total cost of the shortest path using the "
 "bidirectional A* algorithm."
-msgstr "``pgr_bdAstarCost`` -使用双向 A* 算法的最短路径的总成本。"
+msgstr "``pgr_bdAstarCost`` - 使用双向 A* 算法计算的最短路径的总成本。"
 
-msgid "``pgr_bdAstarCost`` (`Combinations`_)"
-msgstr "``pgr_bdAstarCost`` (`组合`_)"
-
-#, fuzzy
 msgid ""
 "The ``pgr_bdAstarCost`` function sumarizes of the cost of the shortest path "
 "using the bidirectional A* algorithm."
-msgstr "``pgr_bdAstarCost`` 函数使用双向 A* 算法汇总最短路径的成本。"
+msgstr "``pgr_bdAstarCost`` 函数总结了使用双向 A* 算法计算最短路径的成本。"
 
 msgid ""
 "pgr_bdAstarCost(`Edges SQL`_, **start vid**, **end vid**, [**options**])"
@@ -9395,32 +8875,24 @@ msgstr "pgr_bdAstarCostMatrix(`Edges SQL`_, **start vids**, [**options**])"
 msgid "``pgr_bdDijkstra``"
 msgstr "``pgr_bdDijkstra``"
 
-#, fuzzy
 msgid ""
 "``pgr_bdDijkstra`` — Returns the shortest path using Bidirectional Dijkstra "
 "algorithm."
-msgstr "``pgr_bdDijkstra`` — 使用双向 Dijkstra 算法返回最短路径。"
+msgstr "``pgr_bdDijkstra`` — 返回使用双向 Dijkstra 算法计算的最短路径。"
 
-msgid "pgr_bdDijkstra(`Combinations`_)"
-msgstr "pgr_bdDijkstra(`组合`_)"
+#, fuzzy
+msgid "pgr_bdDijkstra(One to Many)"
+msgstr "pgr_bdDijkstra（一对多）"
 
-msgid "New **Proposed** functions:"
-msgstr "新 **拟议** 函数："
+msgid "pgr_bdDijkstra(Many to One)"
+msgstr "pgr_bdDijkstra（多对一）"
 
-msgid "``pgr_bdDijkstra`` (`One to Many`_)"
-msgstr "``pgr_bdDijkstra`` (`一对多`_)"
+msgid "pgr_bdDijkstra(Many to Many)"
+msgstr "pgr_bdDijkstra（多对多）"
 
-msgid "``pgr_bdDijkstra`` (`Many to One`_)"
-msgstr "``pgr_bdDijkstra`` (`多对一`_)"
-
-msgid "``pgr_bdDijkstra`` (`Many to Many`_)"
-msgstr "``pgr_bdDijkstra`` (`多对多`_)"
-
-msgid "Signature change on ``pgr_bdDijsktra`` (`One to One`_)"
+#, fuzzy
+msgid "Signature change on pgr_bdDijsktra(One to One)"
 msgstr "``pgr_bdDijsktra`` (`一对一`_)上的签名更改"
-
-msgid "**Official** ``pgr_bdDijkstra`` (`One to One`_)"
-msgstr "**官方** ``pgr_bdDijkstra`` (`一对一`_)"
 
 msgid ""
 "pgr_bdDijkstra(`Edges SQL`_, **start vid**, **end vid**, [``directed``])"
@@ -9477,27 +8949,16 @@ msgstr "在 **无向** 图上从顶点 :math:`\\{6, 1\\}` 到顶点 :math:`\\{10
 msgid "Using a combinations table on an **undirected** graph"
 msgstr "在 **无向** 图上使用组合表"
 
-msgid ""
-"https://www.cs.princeton.edu/courses/archive/spr06/cos423/Handouts/"
-"EPP%20shortest%20path%20algorithms.pdf"
-msgstr ""
-"https://www.cs.princeton.edu/courses/archive/spr06/cos423/Handouts/"
-"EPP%20shortest%20path%20algorithms.pdf"
-
 msgid "https://en.wikipedia.org/wiki/Bidirectional_search"
 msgstr "https://en.wikipedia.org/wiki/Bidirectional_search"
 
 msgid "``pgr_bdDijkstraCost``"
 msgstr "``pgr_bdDijkstraCost``"
 
-#, fuzzy
 msgid ""
 "``pgr_bdDijkstraCost`` — Returns the shortest path's cost using "
 "Bidirectional Dijkstra algorithm."
-msgstr "``pgr_bdDijkstraCost`` — 使用双向 Dijkstra 算法返回最短路径的成本。"
-
-msgid "``pgr_bdDijkstraCost`` (`Combinations`_)"
-msgstr "``pgr_bdDijkstraCost`` (`组合`_)"
+msgstr "``pgr_bdDijkstraCost`` —返回使用双向 Dijkstra 算法计算最短路径的成本。"
 
 msgid ""
 "The ``pgr_bdDijkstraCost`` function sumarizes of the cost of the shortest "
@@ -9562,30 +9023,14 @@ msgstr "与 :doc:`pgr_TSP` 一起使用。"
 msgid "``pgr_bellmanFord - Experimental``"
 msgstr "``pgr_bellmanFord - 实验``"
 
-#, fuzzy
 msgid "``pgr_bellmanFord`` — Shortest path using Bellman-Ford algorithm."
-msgstr "``pgr_bellmanFord`` — 使用 Bellman-Ford 算法的最短路径。"
+msgstr "``pgr_bellmanFord`` — 使用 Bellman-Ford 算法计算的最短路径。"
 
-msgid "New **experimental** signature:"
-msgstr "新 **实验性** 签名："
+msgid "New experimental signature:"
+msgstr "新 实验性*签名："
 
-msgid "``pgr_bellmanFord`` (`Combinations`_)"
-msgstr "``pgr_bellmanFord`` (`组合`_)"
-
-msgid "New **experimental** signatures:"
-msgstr "新 **实验** 签名："
-
-msgid "``pgr_bellmanFord`` (`One to One`_)"
-msgstr "``pgr_bellmanFord`` (`一对一`_)"
-
-msgid "``pgr_bellmanFord`` (`One to Many`_)"
-msgstr "``pgr_bellmanFord`` (`一对多`_)"
-
-msgid "``pgr_bellmanFord`` (`Many to One`_)"
-msgstr "``pgr_bellmanFord`` (`多对一`_)"
-
-msgid "``pgr_bellmanFord`` (`Many to Many`_)"
-msgstr "``pgr_bellmanFord`` (`多对多`_)"
+msgid "pgr_bellmanFord(Combinations)"
+msgstr "pgr_bellmanFord(组合)"
 
 msgid ""
 "Bellman-Ford's algorithm, is named after Richard Bellman and Lester Ford, "
@@ -9666,37 +9111,43 @@ msgstr ""
 msgid "pgr_bellmanFord(`Edges SQL`_, `Combinations SQL`_, [``directed``])"
 msgstr "pgr_bellmanFord(`Edges SQL`_, `Combinations SQL`_, [``directed``])"
 
-#, fuzzy
 msgid ""
 "From vertex :math:`6` to vertices :math:`\\{ 10, 17\\}` on a **directed** "
 "graph"
-msgstr "在 **有向** 图上从顶点 :math:`6` 到顶点 :math:`\\{10, 17\\}`"
+msgstr ""
+"从节点 :math:`6`到节点:math:`\\{ 10, 17\\}`的最短路径，基于一个**directed**图"
 
 msgid "Using a combinations table on an **undirected** graph."
 msgstr "在 **无向** 图上使用组合表。"
 
+#, fuzzy
+msgid ""
+"`Boost: Bellman Ford <https://www.boost.org/libs/graph/doc/"
+"bellman_ford_shortest.html>`__"
+msgstr ""
+"`Boost: Belman Ford <https://www.boost.org/libs/graph/doc/"
+"bellman_ford_shortest.html>`__"
+
 msgid "https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm"
 msgstr "https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm"
 
-msgid "``pgr_betweennessCentrality``"
-msgstr ""
-
-msgid ""
-"``pgr_betweennessCentrality`` - Calculates the relative betweeness "
-"centrality using Brandes Algorithm"
-msgstr ""
+#, fuzzy
+msgid "``pgr_betweennessCentrality`` - Experimental"
+msgstr "``pgr_betweennessCentrality``"
 
 #, fuzzy
-msgid "Version 3.7.0"
-msgstr "版本3.6.0"
+msgid ""
+"``pgr_betweennessCentrality`` - Calculates the relative betweenness "
+"centrality using Brandes Algorithm"
+msgstr "``pgr_betweennessCentrality`` - 使用 Brandes 算法计算相对介数中心度"
 
-msgid "New **experimental** function:"
-msgstr "新的 **实验** 函数："
+msgid "Version 3.7.0"
+msgstr "版本 3.7.0"
 
 msgid ""
 "The Brandes Algorithm takes advantage of the sparse graphs for evaluating "
 "the betweenness centrality score of all vertices."
-msgstr ""
+msgstr "Brandes 算法利用稀疏图来评估所有顶点的中心度得分。"
 
 msgid ""
 "Betweenness centrality measures the extent to which a vertex lies on the "
@@ -9704,83 +9155,75 @@ msgid ""
 "betweenness centrality score may have considerable influence in a network by "
 "the virtue of their control over the shortest paths passing between them."
 msgstr ""
+"Betweenness centrality（介数中心性）衡量的是一个顶点在所有其他顶点对之间的最"
+"短路径中的重要性。具有较高介数中心性得分的顶点，通常能够对网络产生显著的影"
+"响，因为它们控制了通过它们的最短路径。"
 
 msgid ""
 "The removal of these vertices will affect the network by disrupting the it, "
 "as most of the shortest paths between vertices pass through them."
 msgstr ""
+"这些顶点的移除会影响网络，因为大多数顶点之间的最短路径都经过它们，从而破坏了"
+"网络的连接性。"
 
-#, fuzzy
 msgid "This implementation work for both directed and undirected graphs."
-msgstr "该实现适用于 **有向** 图和 **无向** 图。"
+msgstr "该实现适用于directed 和undirected。"
 
-#, fuzzy
 msgid "Running time:  :math:`\\Theta(VE)`"
-msgstr "运行时间： :math:`O(V + E)`"
+msgstr "运行时间: :math:`Theta(VE)`"
 
-#, fuzzy
 msgid "Running space: :math:`\\Theta(VE)`"
-msgstr "运行时间： :math:`O(V + E)`"
+msgstr "运行空间: :math:`\\Theta(VE)`"
 
-#, fuzzy
 msgid "Throws when there are no edges in the graph"
-msgstr "当图中没有边时，返回 EMPTY SET。"
+msgstr "当图形中没有边时抛出"
 
 msgid "pgr_betweennessCentrality(`Edges SQL`_, [``directed``])"
 msgstr "pgr_betweennessCentrality(`Edges SQL`_, [``directed``])"
 
-#, fuzzy
 msgid "Returns set of ``(vid, centrality)``"
-msgstr "返回集合 ``(edge, cost)``"
+msgstr "返回 ``(vid, centrality)`` 的集合"
 
-#, fuzzy
 msgid "For a directed graph with edges :math:`\\{1, 2, 3, 4\\}`."
-msgstr "对于有边 :math:`\\{1, 2, 3, 4\\}` 的有向子图。"
+msgstr "对于带边的directed graph:math:`\\{1, 2, 3, 4\\}`."
 
-#, fuzzy
 msgid "Explanation"
-msgstr "应用"
+msgstr "说明"
 
 msgid "The betweenness centrality are between parenthesis."
-msgstr ""
+msgstr "介数中心性值位于括号内。"
 
 msgid "The leaf vertices have betweenness centrality :math:`0`."
-msgstr ""
+msgstr "叶子节点的介数中心性为 :math:`0`。"
 
-#, fuzzy
 msgid ""
 "Betweenness centrality of vertex :math:`6` is higher than of vertex :math:"
 "`10`."
-msgstr "从顶点 :math:`11` 到顶点 :math:`12`"
+msgstr "顶点 :math:`6` 的间隔中心度高于顶点 :math:`10` 的间隔中心度。"
 
-#, fuzzy
 msgid "Removing vertex :math:`6` will create three graph components."
-msgstr "顶点 :math:`w` 已从图中移除"
+msgstr "移除顶点 :math:`6` 将创建三个图形组件。"
 
 msgid "Removing vertex :math:`10` will create two graph components."
-msgstr ""
+msgstr "移除节点 :math:`10` 将会产生两个图形组件。"
 
 msgid "``vid``"
 msgstr "``vid``"
 
-#, fuzzy
 msgid "``centrality``"
 msgstr "``capacity``"
 
 msgid ""
 "Relative betweenness centrality score of the vertex (will be in range [0,1])"
-msgstr ""
+msgstr "该节点的相对介数中心性得分（范围为 [0,1]）"
 
 #, fuzzy
 msgid ""
-"Boost's `betweenness_centrality <https://www.boost.org/doc/libs/1_84_0/libs/"
-"graph/doc/betweenness_centrality.html>`_"
+"`Boost: betweenness centrality <https://www.boost.org/libs/graph/doc/"
+"betweenness_centrality.html>`_"
 msgstr ""
-"`Boost：Hawick 电路算法 <https://www.boost.org/doc/libs/1_78_0/libs/graph/"
-"doc/hawick_circuits.html>`__"
-
-msgid "Queries use the :doc:`sampledata` network."
-msgstr "查询使用 :doc:`sampledata` 网络。"
+"`Boost: betweenness centrality <https://www.boost.org/doc/libs/1_84_0/libs/"
+"graph/doc/betweenness_centrality.html>`_"
 
 msgid "``pgr_biconnectedComponents``"
 msgstr "``pgr_biconnectedComponents``"
@@ -9841,41 +9284,21 @@ msgstr "具有组件中最小边标识符的值。"
 msgid "Identifier of the edge that belongs to the ``component``."
 msgstr "属于该 ``分量`` 的边的标识符。"
 
-msgid ""
-"Boost: `Biconnected components <https://www.boost.org/libs/graph/doc/"
-"biconnected_components.html>`__"
-msgstr ""
-"Boost: `双连通分量 <https://www.boost.org/libs/graph/doc/"
-"biconnected_components.html>`__"
-
 msgid "``pgr_binaryBreadthFirstSearch`` - Experimental"
 msgstr "``pgr_binaryBreadthFirstSearch`` - 实验"
 
-#, fuzzy
 msgid ""
 "``pgr_binaryBreadthFirstSearch`` — Returns the shortest path in a binary "
 "graph."
-msgstr "``pgr_binaryBreadthFirstSearch`` — 返回二元图中的最短路径。"
+msgstr "``pgr_binaryBreadthFirstSearch`` — 返回二进制图中的最短路径。"
 
 msgid ""
 "Any graph whose edge-weights belongs to the set {0,X}, where 'X' is any non-"
 "negative integer, is termed as a 'binary graph'."
 msgstr "任何边权属于集合 {0,X} 的图（其中“X”是任何非负整数）都被称为“二元图”。"
 
-msgid "pgr_binaryBreadthFirstSearch(`Combinations`_)"
-msgstr "pgr_binaryBreadthFirstSearch(`组合`_)"
-
-msgid "pgr_binaryBreadthFirstSearch(`One to One`_)"
-msgstr "pgr_binaryBreadthFirstSearch(`一对一`_)"
-
-msgid "pgr_binaryBreadthFirstSearch(`One to Many`_)"
-msgstr "pgr_binaryBreadthFirstSearch(`一对多`_)"
-
-msgid "pgr_binaryBreadthFirstSearch(`Many to One`_)"
-msgstr "pgr_binaryBreadthFirstSearch(`多对一`_)"
-
-msgid "pgr_binaryBreadthFirstSearch(`Many to Many`_)"
-msgstr "pgr_binaryBreadthFirstSearch(`多对多`_)"
+msgid "pgr_binaryBreadthFirstSearch(Combinations)"
+msgstr "pgr_binaryBreadthFirstSearch(组合)"
 
 msgid ""
 "It is well-known that the shortest paths between a single source and all "
@@ -9958,6 +9381,14 @@ msgid ""
 msgstr ""
 "**注意:** 使用 :doc:`sampledata` 网络，因为所有权重都相同（即为 :math:`1`）"
 
+#, fuzzy
+msgid ""
+"`Boost: Breadth First Search <https://www.boost.org/libs/graph/doc/"
+"breadth_first_search.html>`__"
+msgstr ""
+"`Boost：广度优先搜索算法文档 <https://www.boost.org/libs/graph/doc/"
+"breadth_first_search.html>`__"
+
 msgid "https://cp-algorithms.com/graph/01_bfs.html"
 msgstr "https://cp-algorithms.com/graph/01_bfs.html"
 
@@ -9966,16 +9397,14 @@ msgid ""
 msgstr ""
 "https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm#Specialized_variants"
 
-msgid "pgr_bipartite -Experimental"
+#, fuzzy
+msgid "``pgr_bipartite`` - Experimental"
 msgstr "pgr_bipartite -实验"
 
 msgid ""
 "``pgr_bipartite`` — Disjoint sets of vertices such that no two vertices "
 "within the same set are adjacent."
 msgstr "`pgr_bipartite` - 不相邻的顶点集合，同一集合中没有两个顶点相邻。"
-
-msgid "New **experimental** signature"
-msgstr "新的 **实验** 签名"
 
 msgid ""
 "A bipartite graph is a graph with two sets of vertices which are connected "
@@ -10030,6 +9459,18 @@ msgstr ""
 msgid "Edges in blue represent odd length cycle subgraph."
 msgstr "蓝色边代表奇数长度循环子图。"
 
+msgid ""
+"`Boost: is_bipartite <https://www.boost.org/libs/graph/doc/is_bipartite."
+"html>`__"
+msgstr ""
+"`Boost: is_bipartite <https://www.boost.org/libs/graph/doc/is_bipartite."
+"html>`__"
+
+msgid ""
+"`Wikipedia: bipartite graph <https://en.wikipedia.org/wiki/"
+"Bipartite_graph>`__"
+msgstr "`维基百科：二分图 <https://en.wikipedia.org/wiki/Bipartite_graph>`__"
+
 msgid "``pgr_boykovKolmogorov``"
 msgstr "``pgr_boykovKolmogorov``"
 
@@ -10041,20 +9482,12 @@ msgstr ""
 "`pgr_boykovKolmogorov`` - 使用 Boykov Kolmogorov 算法计算图边的流量，使从源到"
 "目标的流量最大。"
 
-msgid "New **proposed** signature"
-msgstr "新的 **拟议** 签名"
-
-msgid "``pgr_boykovKolmogorov`` (`Combinations`_)"
-msgstr "``pgr_boykovKolmogorov`` (`组合`_)"
-
 msgid "Renamed from ``pgr_maxFlowBoykovKolmogorov``"
 msgstr "从 ``pgr_maxFlowBoykovKolmogorov`` 更名而来"
 
-msgid "**Proposed** function"
-msgstr "**拟议** 函数"
-
-msgid "New **Experimental** function"
-msgstr "新的 **实验** 函数"
+#, fuzzy
+msgid "Function promoted to proposed."
+msgstr "实验性的功能被提升为提议的。"
 
 msgid "Running time: Polynomial"
 msgstr "运行时间：多项式时间"
@@ -10097,7 +9530,10 @@ msgstr ""
 "使用组合表，相当于计算从顶点 :math:`\\{5, 6\\}` 到顶点 :math:`{\\10, 15, "
 "14\\}` 的结果。"
 
-msgid "https://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html"
+#, fuzzy
+msgid ""
+"`Boost: Boykov Kolmogorov max flow <https://www.boost.org/libs/graph/doc/"
+"boykov_kolmogorov_max_flow.html>`__"
 msgstr "https://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html"
 
 msgid "``pgr_breadthFirstSearch`` - Experimental"
@@ -10107,12 +9543,6 @@ msgid ""
 "``pgr_breadthFirstSearch`` — Returns the traversal order(s) using Breadth "
 "First Search algorithm."
 msgstr "``pgr_breadthFirstSearch`` —使用广度优先搜索算法返回遍历顺序。"
-
-msgid "``pgr_breadthFirstSearch`` (`Single Vertex`_)"
-msgstr "``pgr_breadthFirstSearch`` (`单顶点搜索`_)"
-
-msgid "``pgr_breadthFirstSearch`` (`Multiple Vertices`_)"
-msgstr "``pgr_breadthFirstSearch`` (`多顶点搜索`_)"
 
 msgid ""
 "Provides the Breadth First Search traversal order from a root vertex to a "
@@ -10183,13 +9613,6 @@ msgid "descending"
 msgstr "降序"
 
 msgid ""
-"`Boost: Breadth First Search algorithm documentation <https://www.boost.org/"
-"libs/graph/doc/breadth_first_search.html>`__"
-msgstr ""
-"`Boost：广度优先搜索算法文档 <https://www.boost.org/libs/graph/doc/"
-"breadth_first_search.html>`__"
-
-msgid ""
 "`Wikipedia: Breadth First Search algorithm <https://en.wikipedia.org/wiki/"
 "Breadth-first_search>`__"
 msgstr ""
@@ -10231,8 +9654,13 @@ msgstr "作为桥的边的标识符。"
 msgid "https://en.wikipedia.org/wiki/Bridge_%28graph_theory%29"
 msgstr "https://en.wikipedia.org/wiki/Bridge_%28graph_theory%29"
 
-msgid "**Supported versions**"
-msgstr "**支持版本**"
+#, fuzzy
+msgid ""
+"`Boost: Connected components <https://www.boost.org/libs/graph/doc/"
+"connected_components.html>`__"
+msgstr ""
+"Boost: ` 已连接组件 <https://www.boost.org/libs/graph/doc/"
+"connected_components.html>`__"
 
 msgid "``pgr_chinesePostman`` - Experimental"
 msgstr "``pgr_chinesePostman`` - 实验"
@@ -10295,8 +9723,8 @@ msgstr "``pgr_chinesepostmancost``"
 msgid "Minimum costs of a circuit path."
 msgstr "一个回路路径的最小成本。"
 
-msgid "pgr_connectedComponents"
-msgstr "pgr_connectedComponents"
+msgid "``pgr_connectedComponents``"
+msgstr "``pgr_connectedComponents``"
 
 msgid ""
 "``pgr_connectedComponents`` — Connected components of an undirected graph "
@@ -10335,13 +9763,6 @@ msgid "Connecting disconnected components"
 msgstr "连接不连通的组件"
 
 msgid ""
-"Boost: `Connected components <https://www.boost.org/libs/graph/doc/"
-"connected_components.html>`__"
-msgstr ""
-"Boost: ` 已连接组件 <https://www.boost.org/libs/graph/doc/"
-"connected_components.html>`__"
-
-msgid ""
 "wikipedia: `Connected component <https://en.wikipedia.org/wiki/"
 "Connected_component_(graph_theory)>`__"
 msgstr ""
@@ -10355,6 +9776,28 @@ msgid ""
 "``pgr_contraction`` — Performs graph contraction and returns the contracted "
 "vertices and edges."
 msgstr "``pgr_contraction`` — 执行图收缩操作并返回收缩后的顶点和边。"
+
+#, fuzzy
+msgid "Version 3.8.0"
+msgstr "版本3.6.0"
+
+#, fuzzy
+msgid "New signature:"
+msgstr "新签名"
+
+msgid ""
+"Previously compulsory parameter **Contraction order** is now optional with "
+"name ``methods``."
+msgstr ""
+
+#, fuzzy
+msgid "New name and order of optional parameters."
+msgstr "接近可选参数"
+
+#, fuzzy
+msgid ""
+"Deprecated signature pgr_contraction(text,bigint[],integer,bigint[],boolean)"
+msgstr "_pgr_dijkstranear(text,bigint,anyarray,bigint,boolean)"
 
 msgid "Name change from ``pgr_contractGraph``"
 msgstr "``pgr_contractGraph`` 的名称更改"
@@ -10370,58 +9813,77 @@ msgstr ""
 "收缩通过移除部分顶点和边来减小图的大小，例如，可以添加代表原始边序列的边，从"
 "而减少图算法所用的总时间和空间。"
 
-msgid "Does not return the full contracted graph"
+#, fuzzy
+msgid "Does not return the full contracted graph."
 msgstr "不返回完整的收缩图"
 
-msgid "Only changes on the graph are returned"
+#, fuzzy
+msgid "Only changes on the graph are returned."
 msgstr "仅返回图上的更改"
 
-msgid "Currnetly there are two types of contraction methods"
-msgstr "目前有两种类型的收缩方法"
-
-msgid "Dead End Contraction"
-msgstr "死端收缩"
-
-msgid "Linear Contraction"
-msgstr "线性收缩"
-
-msgid "The returned values include"
+#, fuzzy
+msgid "The returned values include:"
 msgstr "返回值包括"
 
-msgid "the added edges by linear contraction."
-msgstr "由线性收缩添加的边。"
+#, fuzzy
+msgid "The new edges generated by linear contraction."
+msgstr "插入由 pgr_contraction 生成的新边。"
 
-msgid "the modified vertices by dead end contraction."
+#, fuzzy
+msgid "The modified vertices generated by dead end contraction."
 msgstr "通过死端收缩修改顶点。"
 
 msgid "The returned values are ordered as follows:"
 msgstr "返回值的排序如下："
 
-msgid "column ``id`` ascending when type is ``v``"
+#, fuzzy
+msgid "column ``id`` ascending when its a modified vertex."
 msgstr "当类型为 ``v``时，按列 ``id`` 升序"
 
-msgid "column ``id`` descending when type is ``e``"
+#, fuzzy
+msgid "column ``id`` with negative numbers descending when its a new edge."
 msgstr "当类型为 ``e`` 时，按列``id`` 降序"
 
-msgid "The pgr_contraction function has the following signature:"
-msgstr "pgr_contraction 函数具有以下签名："
+#, fuzzy
+msgid ""
+"Currently there are two types of contraction methods included in this "
+"function:"
+msgstr "目前有两种类型的收缩方法"
 
-msgid "pgr_contraction(`Edges SQL`_, **contraction order**, [**options**])"
+msgid "Dead End Contraction. See :doc:`pgr_contractionDeadEnd`."
+msgstr ""
+
+msgid "Linear Contraction. See :doc:`pgr_contractionLinear`."
+msgstr ""
+
+#, fuzzy
+msgid "pgr_contraction(`Edges SQL`_, [**options**])"
 msgstr "pgr_contraction(`Edges SQL`_, **contraction order**, [**options**])"
 
-msgid "**options:** ``[ max_cycles, forbidden_vertices, directed]``"
-msgstr "**options:** ``[ max_cycles, forbidden_vertices, directed]``"
+#, fuzzy
+msgid "**options:** ``[directed, methods, cycles, forbidden]``"
+msgstr "**options:** ``[directed, details]``"
 
 msgid "Returns set of |result-contract|"
 msgstr "Returns set of |result-contract|"
 
-msgid ""
-"Making a dead end and linear contraction in that order on an undirected "
-"graph."
+#, fuzzy
+msgid "Dead end and linear contraction in that order on an undirected graph."
 msgstr "在无向图上按顺序进行死端和线性收缩。"
 
-msgid "**contraction Order**"
-msgstr "**contraction Order**"
+msgid "Contraction optional parameters"
+msgstr "可选收缩参数"
+
+msgid "``methods``"
+msgstr ""
+
+#, fuzzy
+msgid "``INTEGER[]``"
+msgstr "``INTEGER``"
+
+#, fuzzy
+msgid "``ARRAY[1,2]``"
+msgstr "``ARRAY[BIGINT]``"
 
 msgid "Ordered contraction operations."
 msgstr "有序收缩操作。"
@@ -10432,25 +9894,30 @@ msgstr "1 = 死端收缩"
 msgid "2 = Linear contraction"
 msgstr "2 = 线性收缩"
 
-msgid "Contraction optional parameters"
-msgstr "可选收缩参数"
-
-msgid "``forbidden_vertices``"
-msgstr "``forbidden_vertices``"
-
-msgid "**Empty**"
-msgstr "**Empty**"
-
-msgid "Identifiers of vertices forbidden for contraction."
-msgstr "禁止收缩的顶点标识符。"
+#, fuzzy
+msgid "``cycles``"
+msgstr "``max_cycles``"
 
 msgid ":math:`1`"
 msgstr ":math:`1`"
 
-msgid ""
-"Number of times the contraction operations on ``contraction_order`` will be "
-"performed."
+#, fuzzy
+msgid "Number of times the contraction methods will be performed."
 msgstr "对 ``contraction_order`` 执行收缩操作的次数。"
+
+#, fuzzy
+msgid "``forbidden``"
+msgstr "``forbidden_vertices``"
+
+msgid "``BIGINT[]``"
+msgstr "``BIGINT[]``"
+
+#, fuzzy
+msgid "``ARRAY[]::BIGINT[]``"
+msgstr "``ARRAY[BIGINT]``"
+
+msgid "Identifiers of vertices forbidden for contraction."
+msgstr "禁止收缩的顶点标识符。"
 
 msgid "The function returns a single row. The columns of the row are:"
 msgstr "该函数返回一行数据。该行的列包括："
@@ -10458,19 +9925,22 @@ msgstr "该函数返回一行数据。该行的列包括："
 msgid "``type``"
 msgstr "``type``"
 
-msgid "Type of the ``id``."
+#, fuzzy
+msgid "Type of the row."
 msgstr "``id`` 的类型。"
 
 msgid "``v`` when the row is a vertex."
 msgstr "当该行表示一个顶点时，列为 ``v``。"
 
-msgid "Column ``id`` has a positive value"
+#, fuzzy
+msgid "Column ``id`` has a positive value."
 msgstr "列 ``id`` 具有正值"
 
 msgid "``e`` when the row is an edge."
 msgstr "当行是边时，则为 ``e``。"
 
-msgid "Column ``id`` has a negative value"
+#, fuzzy
+msgid "Column ``id`` has a negative value."
 msgstr "列 ``id`` 具有负值"
 
 msgid "All numbers on this column are ``DISTINCT``"
@@ -10492,6 +9962,9 @@ msgid ""
 "Representing a pseudo `id` as is not incorporated in the set of original "
 "edges."
 msgstr "表示未包含在原始边集中的伪`id` 。"
+
+msgid "``contracted_vertices``"
+msgstr "``contracted_vertices``"
 
 msgid "Array of contracted vertex identifiers."
 msgstr "收缩顶点标识符数组。"
@@ -10522,8 +9995,613 @@ msgstr "仅死端收缩"
 msgid "Only linear contraction"
 msgstr "仅线性收缩"
 
-msgid "pgr_createTopology"
-msgstr "pgr_createTopology"
+msgid "The cycle"
+msgstr "循环"
+
+#, fuzzy
+msgid ""
+"Contracting a graph can be done with more than one operation. The order of "
+"the operations affect the resulting contracted graph, after applying one "
+"operation, the set of vertices that can be contracted by another operation "
+"changes."
+msgstr ""
+"收缩一张图可以通过多个操作来完成。 操作的顺序会影响生成的收缩图，在应用一个操"
+"作后，可以由另一操作收缩的顶点集会发生变化。"
+
+#, fuzzy
+msgid "This implementation cycles ``cycles`` times through the ``methods`` ."
+msgstr "此实现通过 ``operations_order``循环 ``max_cycles`` 次。"
+
+msgid "Contracting sample data"
+msgstr "收缩示例数据"
+
+msgid ""
+"In this section, building and using a contracted graph will be shown by "
+"example."
+msgstr "在本节中，将通过示例展示构建和使用收缩图。"
+
+msgid "The :doc:`sampledata` for an undirected graph is used"
+msgstr "使用无向图的 :doc:`sampledata`"
+
+msgid "a dead end operation first followed by a linear operation."
+msgstr "首先是死端操作，然后是线性操作。"
+
+msgid "Construction of the graph in the database"
+msgstr "数据库中图的构建"
+
+msgid "The original graph:"
+msgstr "原始图："
+
+#, fuzzy
+msgid ""
+"The results do not represent the contracted graph. They represent the "
+"changes that need to be done to the graph after applying the contraction "
+"methods."
+msgstr "结果不代表收缩图。 它们表示应用收缩算法后对图所做的更改。"
+
+msgid ""
+"Observe that vertices, for example, :math:`6` do not appear in the results "
+"because it was not affected by the contraction algorithm."
+msgstr ""
+"例如，观察到顶点 :math:`6` 没有出现在结果中，因为它不受收缩算法的影响。"
+
+msgid "After doing the dead end contraction operation:"
+msgstr "进行死端收缩操作后："
+
+msgid "After doing the linear contraction operation to the graph above:"
+msgstr "对上图进行线性收缩运算后："
+
+msgid "The process to create the contraction graph on the database:"
+msgstr "在数据库上创建收缩图的过程："
+
+msgid "Add additional columns"
+msgstr "添加附加列"
+
+msgid ""
+"Adding extra columns to the edges and vertices tables. In this documentation "
+"the following will be used:"
+msgstr ""
+
+#, fuzzy
+msgid "Column."
+msgstr "列"
+
+msgid "The vertices set belonging to the vertex/edge"
+msgstr "属于顶点/边的顶点集"
+
+msgid "``is_contracted``"
+msgstr "``is_contracted``"
+
+msgid "On the vertex table"
+msgstr "在顶点表上"
+
+msgid ""
+"when ``true`` the vertex is contracted, its not part of the contracted graph."
+msgstr "当 ``true`` 时，顶点收缩，它不是收缩图的一部分。"
+
+msgid ""
+"when ``false`` the vertex is not contracted, its part of the contracted "
+"graph."
+msgstr "当 ``false`` 时，顶点不收缩，它是收缩图的一部分。"
+
+msgid "``is_new``"
+msgstr "``is_new``"
+
+msgid "On the edge table"
+msgstr "在边表上"
+
+msgid ""
+"when ``true`` the edge was generated by the contraction algorithm. its part "
+"of the contracted graph."
+msgstr "当 ``true`` 时，边缘由收缩算法生成。 它是收缩图的一部分。"
+
+msgid ""
+"when ``false`` the edge is an original edge, might be or not part of the "
+"contracted graph."
+msgstr "当 ``false`` 时，边是原始边，可能是也可能不是收缩图的一部分。"
+
+msgid "Store contraction information"
+msgstr "存储收缩信息"
+
+#, fuzzy
+msgid "Store the contraction results in a table."
+msgstr "将 `收缩结果`_ 存储在表中"
+
+#, fuzzy
+msgid "Update the edges and vertices tables"
+msgstr "创建顶点表"
+
+msgid ""
+"Use ``is_contracted`` column to indicate the vertices that are contracted."
+msgstr "使用 ``is_contracted`` 列来指示收缩的顶点。"
+
+#, fuzzy
+msgid ""
+"Fill ``contracted_vertices`` with the information from the results that "
+"belong to the vertices."
+msgstr "使用属于顶点的结果中的信息填充 ``contracted_vertices``。"
+
+msgid "Insert the new edges generated by pgr_contraction."
+msgstr "插入由 pgr_contraction 生成的新边。"
+
+msgid "The contracted graph"
+msgstr "收缩图"
+
+msgid "Vertices that belong to the contracted graph."
+msgstr "属于收缩图的顶点。"
+
+msgid "Edges that belong to the contracted graph."
+msgstr "属于收缩图的边。"
+
+#, fuzzy
+msgid "Visually:"
+msgstr "视觉效果"
+
+msgid "Using the contracted graph"
+msgstr "使用收缩图"
+
+msgid ""
+"Depending on the final application the graph is to be prepared. In this "
+"example the final application will be to calculate the cost from two "
+"vertices in the original graph by using the contracted graph with "
+"``pgr_dijkstraCost``"
+msgstr ""
+
+msgid ""
+"There are three cases when calculating the shortest path between a given "
+"source and target in a contracted graph:"
+msgstr "计算收缩图中给定源和目标之间的最短路径时，存在三种情况："
+
+msgid "Case 1: Both source and target belong to the contracted graph."
+msgstr "情况1：源和目标都属于收缩图。"
+
+msgid "Case 2: Source and/or target belong to an edge subgraph."
+msgstr "情况 2：源和/或目标属于边缘子图。"
+
+msgid "Case 3: Source and/or target belong to a vertex."
+msgstr "情况 3：源和/或目标属于一个顶点。"
+
+msgid "The final application should consider all of those cases."
+msgstr ""
+
+#, fuzzy
+msgid "Create a view (or table) of the contracted graph:"
+msgstr "属于收缩图的顶点。"
+
+#, fuzzy
+msgid "Create the function that will use the contracted graph."
+msgstr "情况1：源和目标都属于收缩图。"
+
+#, fuzzy
+msgid ""
+"Case 2: Source and/or target belong to an edge that has contracted vertices."
+msgstr "情况 2：源和/或目标属于边缘子图。"
+
+#, fuzzy
+msgid ""
+"Case 3: Source and/or target belong to a vertex that has been contracted."
+msgstr "情况 3：源和/或目标属于一个顶点。"
+
+#, fuzzy
+msgid "``pgr_contractionDeadEnd`` - Proposed"
+msgstr "``pgr_trspVia`` - 拟议"
+
+#, fuzzy
+msgid ""
+"``pgr_contractionDeadEnd`` — Performs graph contraction and returns the "
+"contracted vertices and edges."
+msgstr "``pgr_contraction`` — 执行图收缩操作并返回收缩后的顶点和边。"
+
+#, fuzzy
+msgid "A node is considered a dead end node when:"
+msgstr "当一个节点被认为是 **死端** 节点时"
+
+msgid "On undirected graphs:"
+msgstr "在无向图上："
+
+msgid "The number of adjacent vertices is 1."
+msgstr "相邻顶点的个数为1。"
+
+msgid "On directed graphs:"
+msgstr "在有向图上："
+
+#, fuzzy
+msgid "When there is only one adjacent vertex or"
+msgstr "当没有路径时："
+
+msgid ""
+"When all edges are incoming regardless of the number of adjacent vertices."
+msgstr ""
+
+#, fuzzy
+msgid "pgr_contractionDeadEnd(`Edges SQL`_, [**options**])"
+msgstr "pgr_contraction(`Edges SQL`_, **contraction order**, [**options**])"
+
+#, fuzzy
+msgid "**options:** ``[directed, forbidden_vertices]``"
+msgstr "**options:** ``[directed, details]``"
+
+#, fuzzy
+msgid "Dead end contraction on an undirected graph."
+msgstr "无向图上的死端顶点"
+
+#, fuzzy
+msgid "The green nodes are dead end nodes."
+msgstr "绿色节点是 `死端`_ 节点"
+
+#, fuzzy
+msgid "Node :math:`3` is a dead end node after node :math:`1` is contracted."
+msgstr "节点 :math:`u` 有已收缩节点的信息。"
+
+msgid "``forbidden_vertices``"
+msgstr "``forbidden_vertices``"
+
+#, fuzzy
+msgid "``ARRAY[`` |ANY-INTEGER| ``]``"
+msgstr "``ARRAY[`` **ANY-INTEGER** ``]``"
+
+msgid "**Empty**"
+msgstr "**Empty**"
+
+#, fuzzy
+msgid "Value = ``e`` indicating the row is an edge."
+msgstr "当行是边时，则为 ``e``。"
+
+#, fuzzy
+msgid "A pseudo `id` of the edge."
+msgstr "边的几何形状。"
+
+msgid "Identifier of the source vertex of the current edge."
+msgstr "当前边的源顶点的标识符。"
+
+msgid "Identifier of the target vertex of the current edge."
+msgstr "当前边的目标顶点的标识符。"
+
+#, fuzzy
+msgid "Weight of the current edge."
+msgstr "当前边的源顶点的标识符。"
+
+msgid "Dead end vertex on undirected graph"
+msgstr "无向图上的死端顶点"
+
+msgid "They have only one adjacent node."
+msgstr ""
+
+msgid "Dead end vertex on directed graph"
+msgstr "有向图上的死端顶点"
+
+#, fuzzy
+msgid "The green nodes are dead end nodes"
+msgstr "绿色节点是 `死端`_ 节点"
+
+msgid ""
+"The blue nodes have an unlimited number of incoming and/or outgoing edges."
+msgstr "蓝色节点具有无限数量的传入和/或传出边缘。"
+
+msgid "Node"
+msgstr "节点"
+
+msgid "Adjacent nodes"
+msgstr "相邻节点"
+
+msgid "Dead end"
+msgstr "死端"
+
+msgid "Reason"
+msgstr ""
+
+#, fuzzy
+msgid ":math:`6`"
+msgstr ":math:`a`"
+
+#, fuzzy
+msgid ":math:`\\{1\\}`"
+msgstr ":math:`\\{u\\}`"
+
+#, fuzzy
+msgid "Yes"
+msgstr "是"
+
+#, fuzzy
+msgid "Has only one adjacent node."
+msgstr "相邻节点数"
+
+#, fuzzy
+msgid ":math:`7`"
+msgstr ":math:`a`"
+
+#, fuzzy
+msgid ":math:`\\{2\\}`"
+msgstr ":math:`\\{u\\}`"
+
+#, fuzzy
+msgid ":math:`8`"
+msgstr ":math:`a`"
+
+#, fuzzy
+msgid ":math:`\\{2, 3\\}`"
+msgstr ":math:`\\{v, w\\}`"
+
+msgid "Has more than one adjacent node and all edges are incoming."
+msgstr ""
+
+#, fuzzy
+msgid ":math:`\\{4\\}`"
+msgstr ":math:`\\{u\\}`"
+
+#, fuzzy
+msgid ":math:`10`"
+msgstr ":math:`1`"
+
+#, fuzzy
+msgid ":math:`\\{4, 5\\}`"
+msgstr ":math:`\\{v, w\\}`"
+
+#, fuzzy
+msgid "No"
+msgstr "节点"
+
+msgid "Has more than one adjacent node and all edges are outgoing."
+msgstr ""
+
+#, fuzzy
+msgid ":math:`1,2,3,4,5`"
+msgstr ":math:`1`"
+
+#, fuzzy
+msgid "Many adjacent nodes."
+msgstr "相邻节点"
+
+msgid ""
+"Has more than one adjacent node and some edges are incoming and some are "
+"outgoing."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"From above, nodes :math:`\\{6, 7, 9\\}` are dead ends because the total "
+"number of adjacent vertices is one."
+msgstr ""
+"从上面来看，节点 :math:`\\{a, b, d\\}` 是死端，因为相邻顶点的数量为 1。不需要"
+"对这些节点进行进一步检查。"
+
+msgid ""
+"When there are more than one adjacent vertex, all edges need to be all "
+"incoming edges otherwise it is not a dead end."
+msgstr ""
+
+#, fuzzy
+msgid "Step by step dead end contraction"
+msgstr "仅死端收缩"
+
+#, fuzzy
+msgid ""
+"The dead end contraction will stop until there are no more dead end nodes. "
+"For example, from the following graph where :math:`3` is the dead end node:"
+msgstr ""
+"死端收缩将停止，直到不再有死端节点。 例如，从下图中，其中 :math:`w` 是 `死端"
+"`_ 节点："
+
+#, fuzzy
+msgid ""
+"After contracting :math:`3`, node :math:`2` is now a dead end node and is "
+"contracted:"
+msgstr "收缩 :math:`w` 后，节点 :math:`v` 现在是一个 `死端`_ 节点并且已收缩："
+
+#, fuzzy
+msgid ""
+"After contracting :math:`2`, stop. Node :math:`1` has the information of "
+"nodes that were contracted."
+msgstr "在收缩 :math:`v` 之后，停止。节点 :math:`u` 有已收缩节点的信息。"
+
+#, fuzzy
+msgid "Creating the contracted graph"
+msgstr "使用收缩图"
+
+#, fuzzy
+msgid "Steps for the creation of the contracted graph"
+msgstr "属于收缩图的边。"
+
+#, fuzzy
+msgid "Add additional columns."
+msgstr "添加附加列"
+
+#, fuzzy
+msgid "Save results into a table."
+msgstr "将 `收缩结果`_ 存储在表中"
+
+#, fuzzy
+msgid "The contracted vertices are not part of the contracted graph."
+msgstr "当 ``true`` 时，顶点收缩，它不是收缩图的一部分。"
+
+#, fuzzy
+msgid "Using when departure and destination are in the contracted graph"
+msgstr "情况1：源和目标都属于收缩图。"
+
+#, fuzzy
+msgid "Using when departure/destination is not in the contracted graph"
+msgstr "当 ``true`` 时，顶点收缩，它不是收缩图的一部分。"
+
+#, fuzzy
+msgid "Using when departure and destination are not in the contracted graph"
+msgstr "情况1：源和目标都属于收缩图。"
+
+#, fuzzy
+msgid "``pgr_contractionLinear`` - Proposed"
+msgstr "``pgr_dijkstraNear`` - 拟议"
+
+#, fuzzy
+msgid ""
+"``pgr_contractionLinear`` — Performs graph contraction and returns the "
+"contracted vertices and edges."
+msgstr "``pgr_contraction`` — 执行图收缩操作并返回收缩后的顶点和边。"
+
+#, fuzzy
+msgid "pgr_contractionLinear(`Edges SQL`_, [**options**])"
+msgstr "pgr_contraction(`Edges SQL`_, **contraction order**, [**options**])"
+
+#, fuzzy
+msgid "**options:** ``[directed, max_cycles, forbidden_vertices]``"
+msgstr "**options:** ``[ max_cycles, forbidden_vertices, directed]``"
+
+#, fuzzy
+msgid "Linear contraction on an undirected graph."
+msgstr "在无向图上使用组合表。"
+
+#, fuzzy
+msgid ""
+"The green nodes are linear nodes and will not be part of the contracted "
+"graph."
+msgstr "当 ``true`` 时，顶点收缩，它不是收缩图的一部分。"
+
+#, fuzzy
+msgid "All edges adjacent will not be part of the contracted graph."
+msgstr "属于收缩图的边。"
+
+#, fuzzy
+msgid "The red lines will be new edges of the contracted graph."
+msgstr "属于收缩图的顶点。"
+
+msgid "**contraction Order**"
+msgstr "**contraction Order**"
+
+msgid ""
+"Number of times the contraction operations on ``contraction_order`` will be "
+"performed."
+msgstr "对 ``contraction_order`` 执行收缩操作的次数。"
+
+msgid "A node connects two (or more) `linear` edges when"
+msgstr ""
+
+msgid "The number of adjacent vertices is 2."
+msgstr "相邻顶点的数量为2。"
+
+msgid "In case of a directed graph, a node is considered a `linear` node when"
+msgstr "在有向图的情况下，当满足以下条件时，节点被视为`线性`节点"
+
+#, fuzzy
+msgid "Linearity is symmetrical."
+msgstr "线性是对称的"
+
+#, fuzzy
+msgid "Linearity is not symmetrical"
+msgstr "线性是对称的"
+
+#, fuzzy
+msgid "Graph where linearity is not symmetrical."
+msgstr "线性是对称的"
+
+msgid ""
+"When the graph is processed as a directed graph, linearity is not "
+"symmetrical, therefore the graph can not be contracted."
+msgstr ""
+
+msgid ""
+"When the same graph is processed as an undirected graph, linearity is "
+"symmetrical, therefore the graph can be contracted."
+msgstr ""
+
+#, fuzzy
+msgid "The three edges can be replaced by one undirected edge"
+msgstr "图可以是有向或无向的。"
+
+#, fuzzy
+msgid "Edge :math:`1 - 3`."
+msgstr ":math:`1`"
+
+#, fuzzy
+msgid "With cost: :math:`4`."
+msgstr "使用 ``cost``"
+
+#, fuzzy
+msgid "Contracted vertices in the edge: :math:`\\{2\\}`."
+msgstr "对于带边的directed graph:math:`\\{1, 2, 3, 4\\}`."
+
+msgid "Linearity is symmetrical"
+msgstr "线性是对称的"
+
+#, fuzzy
+msgid "Graph where linearity is symmetrical."
+msgstr "线性是对称的"
+
+#, fuzzy
+msgid "The four edges can be replaced by two directed edges."
+msgstr "图可以是有向或无向的。"
+
+#, fuzzy
+msgid "Edge :math:`3 - 1`."
+msgstr ":math:`-1`"
+
+#, fuzzy
+msgid "With cost: :math:`6`."
+msgstr "使用 ``cost``"
+
+#, fuzzy
+msgid "The four edges can be replaced by one undirected edge."
+msgstr "图可以是有向或无向的。"
+
+#, fuzzy
+msgid "Step by step linear contraction"
+msgstr "仅线性收缩"
+
+#, fuzzy
+msgid ""
+"The linear contraction will stop when there are no more linear edges. For "
+"example from the following graph there are linear edges"
+msgstr ""
+"当不再有线性节点时，线性收缩将停止。 例如，在下图中，其中 :math:`v` 和 :math:"
+"`w` 是 `线性`_ 节点："
+
+#, fuzzy
+msgid "Contracting vertex :math:`3`,"
+msgstr "收缩 :math:`w`，"
+
+#, fuzzy
+msgid "The vertex :math:`3` is removed from the graph"
+msgstr "顶点 :math:`w` 已从图中移除"
+
+#, fuzzy
+msgid ""
+"The edges :math:`2 \\rightarrow 3` and :math:`w \\rightarrow z` are removed "
+"from the graph."
+msgstr "从图中删除边 :math:`v \\rightarrow w` 和 :math:`w \\rightarrow z`。"
+
+#, fuzzy
+msgid ""
+"A new edge :math:`2 \\rightarrow 4` is inserted represented with red color."
+msgstr "插入一条新边 :math:`v \\rightarrow z`，以红色表示。"
+
+#, fuzzy
+msgid "Contracting vertex :math:`2`:"
+msgstr "收缩 :math:`v`："
+
+#, fuzzy
+msgid "The vertex :math:`2` is removed from the graph"
+msgstr "顶点 :math:`w` 已从图中移除"
+
+#, fuzzy
+msgid ""
+"The edges :math:`1 \\rightarrow 2` and :math:`2 \\rightarrow 3` are removed "
+"from the graph."
+msgstr "从图中删除边 :math:`v \\rightarrow w` 和 :math:`w \\rightarrow z`。"
+
+#, fuzzy
+msgid ""
+"A new edge :math:`1 \\rightarrow 3` is inserted represented with red color."
+msgstr "插入一条新边 :math:`v \\rightarrow z`，以红色表示。"
+
+#, fuzzy
+msgid ""
+"Edge :math:`1 \\rightarrow 3` has the information of cost and the nodes that "
+"were contracted."
+msgstr "边 :math:`u \\rightarrow z` 有收缩点的信息。"
+
+#, fuzzy
+msgid "Create the contracted graph."
+msgstr "收缩图"
+
+msgid "``pgr_createTopology``"
+msgstr "``pgr_createTopology``"
 
 msgid ""
 "``pgr_createTopology`` — Builds a network topology based on the geometry "
@@ -10742,11 +10820,8 @@ msgid ""
 "to the rest of the edges."
 msgstr "该示例以 5 条边的简洁拓扑结构为起点，然后递增到其余的边。"
 
-msgid "The example uses the :doc:`sampledata` network."
-msgstr "本例使用 :doc:`sampledata` 网络。"
-
-msgid "pgr_createVerticesTable"
-msgstr "pgr_createVerticesTable"
+msgid "``pgr_createVerticesTable``"
+msgstr "``pgr_createVerticesTable``"
 
 msgid ""
 "``pgr_createVerticesTable`` — Reconstructs the vertices table based on the "
@@ -10985,17 +11060,17 @@ msgstr ""
 "`Wikipedia: Cuthill-McKee 排序 <https://en.wikipedia.org/wiki/"
 "Cuthill%E2%80%93McKee_algorithm>`__"
 
-msgid "pgr_dagShortestPath - Experimental"
+#, fuzzy
+msgid "``pgr_dagShortestPath`` - Experimental"
 msgstr "pgr_dagShortestPath - 实验"
 
-#, fuzzy
 msgid ""
 "``pgr_dagShortestPath`` — Returns the shortest path for weighted directed "
 "acyclic graphs(DAG). In particular, the DAG shortest paths algorithm "
 "implemented by Boost.Graph."
 msgstr ""
-"``pgr_dagShortestPath`` — 返回加权有向无环图（DAG）的最短路径（path）。特别"
-"是，由Boost.Graph实现的DAG最短路径算法。"
+"``pgr_dagShortestPath`` — 返回加权有向无环图（DAG）中的最短路径。特别是使用 "
+"Boost.Graph 实现的 DAG 最短路径算法。"
 
 msgid "pgr_dagShortestPath(Combinations)"
 msgstr "pgr_dagShortestPath(组合)"
@@ -11072,39 +11147,111 @@ msgstr "返回列"
 msgid "Making **start_vids** the same as **end_vids**"
 msgstr "使 **start_vids** 与 **end_vids** 相同"
 
+#, fuzzy
+msgid ""
+"`Boost: DAG shortest paths <https://www.boost.org/libs/graph/doc/"
+"dag_shortest_paths.html>`__"
+msgstr ""
+"`Boost: is_bipartite <https://www.boost.org/libs/graph/doc/is_bipartite."
+"html>`__"
+
 msgid "https://en.wikipedia.org/wiki/Topological_sorting"
 msgstr "https://en.wikipedia.org/wiki/Topological_sorting"
 
-msgid "``pgr_degree`` -- Proposed"
-msgstr "``pgr_degree`` -- 拟议"
+msgid "``pgr_degree``"
+msgstr "``pgr_degree``"
 
 msgid ""
 "``pgr_degree`` — For each vertex in an undirected graph, return the count of "
 "edges incident to the vertex."
 msgstr "``pgr_degree`` —对于无向图中的每个顶点，返回与该顶点关联的边的计数。"
 
-msgid "Calculates the degree of the vertices of an **undirected** graph"
+msgid "Error messages adjustment."
+msgstr ""
+
+msgid "New signature with only Edges SQL."
+msgstr ""
+
+#, fuzzy
+msgid "Calculates the degree of the vertices of an undirected graph"
 msgstr "计算 **无向** 图顶点的度数"
 
 #, fuzzy
+msgid ""
+"The degree (or valency) of a vertex of a graph is the number of edges that "
+"are incident to the vertex."
+msgstr "``pgr_degree`` —对于无向图中的每个顶点，返回与该顶点关联的边的计数。"
+
+msgid "A loop contributes 2 to a vertex's degree."
+msgstr ""
+
+msgid "A vertex with degree 0 is called an isolated vertex."
+msgstr ""
+
+#, fuzzy
+msgid "Isolated vertex is not part of the result"
+msgstr "修复顶点不在图中时的行驶距离问题"
+
+msgid ""
+"Vertex not participating on the subgraph is considered and isolated vertex."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"There can be a ``dryrun`` execution and the code used to get the answer will "
+"be shown in a PostgreSQL ``NOTICE``."
+msgstr ""
+"由于这是一次 **模拟** 执行，所有计算的代码都显示在 PostgreSQL 的 ``NOTICE`` "
+"中。"
+
+msgid ""
+"The code can be used as base code for the particular application "
+"requirements."
+msgstr ""
+
+#, fuzzy
+msgid "No ordering is performed."
+msgstr "不进行排序"
+
+#, fuzzy
+msgid "pgr_degree(`Edges SQL`_ , [``dryrun``])"
+msgstr "pgr_degree(`Edges SQL`_ , `Vertex SQL`_, [``dryrun``])"
+
 msgid "pgr_degree(`Edges SQL`_ , `Vertex SQL`_, [``dryrun``])"
-msgstr "pgr_degree(`Edges SQL`_ , `Vertex SQL`_ , [``dryrun``])"
+msgstr "pgr_degree(`Edges SQL`_ , `Vertex SQL`_, [``dryrun``])"
 
 msgid "RETURNS SETOF |result-degree|"
 msgstr "RETURNS SETOF |result-degree|"
 
+msgid "Edges"
+msgstr "边"
+
+#, fuzzy
+msgid "example"
+msgstr "示例"
+
+#, fuzzy
+msgid "Get the degree of the vertices defined on the edges table"
+msgstr ":math:`m` 是图中顶点的最大度数。"
+
+#, fuzzy
+msgid "Edges and Vertices"
+msgstr "添加新的顶点"
+
 msgid "Extracting the vertex information"
 msgstr "提取顶点信息"
 
-msgid ""
-"pgr_degree can utilize output from `pgr_extractVertices` or can have "
-"`pgr_extractVertices` embedded in the call. For decent size networks, it is "
-"best to prep your vertices table before hand and use that vertices table for "
-"pgr_degree calls."
+msgid "``pgr_degree`` can use :doc:`pgr_extractVertices` embedded in the call."
 msgstr ""
-"`pgr_degree`可以利用 `pgr_extractVertices` 的输出，或者可以在调用中嵌入"
-"`pgr_extractVertices`。对于较大规模的网络，最好提前准备好顶点表并在"
-"`pgr_degree`调用中使用该顶点表。"
+
+msgid ""
+"For decent size networks, it is best to prepare your vertices table before "
+"hand and use it on ``pgr_degree`` calls. (See `Using a vertex table`_)"
+msgstr ""
+
+#, fuzzy
+msgid "Calculate the degree of the nodes:"
+msgstr "计算 **无向** 图顶点的度数"
 
 msgid "`Vertex SQL`_"
 msgstr "`Vertex SQL`_"
@@ -11118,14 +11265,19 @@ msgstr "``dryrun``"
 msgid "When true do not process and get in a NOTICE the resulting query."
 msgstr "当为真时，不要处理查询，而是获取一个通知（NOTICE）来显示查询的结果。"
 
+#, fuzzy
+msgid "For the `Edges and Vertices`_ signature:"
+msgstr "关于已弃用的签名："
+
+#, fuzzy
+msgid "For the `Edges`_ signature:"
+msgstr "关于已弃用的签名："
+
 msgid "Vertex SQL"
 msgstr "Vertex SQL"
 
 msgid "``in_edges``"
 msgstr "``in_edges``"
-
-msgid "``BIGINT[]``"
-msgstr "``BIGINT[]``"
 
 msgid ""
 "Array of identifiers of the edges that have the vertex ``id`` as *first end "
@@ -11155,8 +11307,55 @@ msgstr "``degree``"
 msgid "Number of edges that are incident to the vertex ``id``"
 msgstr "与顶点 ``id`` 关联的边数"
 
+#, fuzzy
+msgid "Degree of a loop"
+msgstr "子图的度数"
+
+#, fuzzy
+msgid "Using the `Edges`_ signature."
+msgstr "关于已弃用的签名："
+
+msgid "Using the `Edges and Vertices`_ signature."
+msgstr ""
+
 msgid "Degree of a sub graph"
 msgstr "子图的度数"
+
+#, fuzzy
+msgid "For the following is a subgraph of the :doc:`sampledata`:"
+msgstr "pgRouting :doc:`sampledata` 的图形着色"
+
+msgid ":math:`E = \\{(1, 5 \\leftrightarrow 6), (1, 6 \\leftrightarrow 10)\\}`"
+msgstr ""
+
+msgid ":math:`V = \\{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17\\}`"
+msgstr ""
+
+msgid "The vertices not participating on the edge are considered isolated"
+msgstr ""
+
+msgid "their degree is 0 in the subgraph and"
+msgstr ""
+
+msgid "their degree is not shown in the output."
+msgstr ""
+
+#, fuzzy
+msgid "Using a vertex table"
+msgstr "在顶点表上"
+
+#, fuzzy
+msgid ""
+"For decent size networks, it is best to prepare your vertices table before "
+"hand and use it on ``pgr_degree`` calls."
+msgstr ""
+"`pgr_degree`可以利用 `pgr_extractVertices` 的输出，或者可以在调用中嵌入"
+"`pgr_extractVertices`。对于较大规模的网络，最好提前准备好顶点表并在"
+"`pgr_degree`调用中使用该顶点表。"
+
+#, fuzzy
+msgid "Extract the vertex information and save into a table:"
+msgstr "提取顶点信息"
 
 msgid "Dry run execution"
 msgstr "模拟执行"
@@ -11171,17 +11370,37 @@ msgid ""
 "backend development needs."
 msgstr "结果可作为基础代码，根据后台开发需要进行改进。"
 
-msgid "Degree from an existing table"
-msgstr "来自现有表的度数"
+#, fuzzy
+msgid "Finding dead ends"
+msgstr "死端"
 
+#, fuzzy
 msgid ""
-"If you have a vertices table already built using ``pgr_extractVertices`` and "
-"want the degree of the whole graph rather than a subset, you can forgo using "
-"pgr_degree and work with the ``in_edges`` and ``out_edges`` columns directly."
+"If there is a vertices table already built using ``pgr_extractVertices`` and "
+"want the degree of the whole graph rather than a subset, it can be forgo "
+"using ``pgr_degree`` and work with the ``in_edges`` and ``out_edges`` "
+"columns directly."
 msgstr ""
 "如果您已经使用 ``pgr_extractVertices`` 构建了一个顶点表，并且想要整个图的度而"
 "不是子集，则可以放弃使用 pgr_degree 并直接使用 ``in_edges`` 和 ``out_edges`` "
 "列。"
+
+#, fuzzy
+msgid "The degree of a dead end is 1."
+msgstr "绿色节点是 `死端`_ 节点"
+
+#, fuzzy
+msgid "Finding linear vertices"
+msgstr "添加新的顶点"
+
+#, fuzzy
+msgid "The degree of a linear vertex is 2."
+msgstr "相邻顶点的数量为2。"
+
+#, fuzzy
+msgid ""
+"If there is a vertices table already built using the ``pgr_extractVertices``"
+msgstr "要获取顶点信息，请使用 :doc:`pgr_extractVertices`"
 
 msgid ":doc:`pgr_extractVertices`"
 msgstr ":doc:`pgr_extractVertices`"
@@ -11198,15 +11417,6 @@ msgstr ""
 
 msgid "Version 3.3.0"
 msgstr "版本 3.3.0"
-
-msgid "Promoted to **proposed** function"
-msgstr "升级至 **拟议** 函数"
-
-msgid "``pgr_depthFirstSearch`` (`Single Vertex`_)"
-msgstr "``pgr_depthFirstSearch`` (`单个顶点`_)"
-
-msgid "``pgr_depthFirstSearch`` (`Multiple Vertices`_)"
-msgstr "``pgr_depthFirstSearch`` (`多个顶点`_)"
 
 msgid ""
 "Depth First Search algorithm is a traversal algorithm which starts from a "
@@ -11263,16 +11473,18 @@ msgstr "**options:** ``[directed, max_depth]``"
 msgid "Same as `Single vertex`_ but with edges in descending order of ``id``."
 msgstr "与 `单顶点`_ 相同，但边按 ``id`` 降序排列。"
 
+#, fuzzy
 msgid ""
-"`Boost: Depth First Search algorithm documentation <https://www.boost.org/"
-"libs/graph/doc/depth_first_search.html>`__"
+"`Boost: Depth First Search <https://www.boost.org/libs/graph/doc/"
+"depth_first_search.html>`__"
 msgstr ""
 "`Boost：深度优先搜索算法文档 <https://www.boost.org/libs/graph/doc/"
 "depth_first_search.html>`__"
 
+#, fuzzy
 msgid ""
-"`Boost: Undirected DFS algorithm documentation <https://www.boost.org/libs/"
-"graph/doc/undirected_dfs.html>`__"
+"`Boost: Undirected DFS <https://www.boost.org/libs/graph/doc/undirected_dfs."
+"html>`__"
 msgstr ""
 "`Boost：非定向 DFS 算法文档 <https://www.boost.org/libs/graph/doc/"
 "undirected_dfs.html>`__"
@@ -11287,52 +11499,39 @@ msgstr ""
 msgid "``pgr_dijkstra``"
 msgstr "`pgr_dijkstra``"
 
-#, fuzzy
 msgid "``pgr_dijkstra`` — Shortest path using Dijkstra algorithm."
-msgstr "`pgr_dijkstra`` - 使用 Dijkstra 算法的最短路径。"
+msgstr "`pgr_dijkstra`` - 使用 Dijkstra 算法计算的最短路径。"
 
 msgid "Version 3.5.0"
 msgstr "版本 3.5.0"
 
-msgid ""
-"``pgr_dijkstra`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
-msgstr "``pgr_dijkstra`` (`一对一`_)增加``start_vid`` 和``end_vid`` 列。"
+msgid "pgr_dijkstra(One to One) added ``start_vid`` and ``end_vid`` columns."
+msgstr "pgr_dijkstra（一对一）增加了``start_vid`` 和``end_vid`` 列。"
 
-msgid "``pgr_dijkstra`` (`One to Many`_) added ``end_vid`` column."
-msgstr "``pgr_dijkstra`` (`一对多`_) 增加``end_vid`` 列。"
+msgid "pgr_dijkstra(One to Many) added ``end_vid`` column."
+msgstr "pgr_dijkstra（一对多）添加了 ``end_vid`` 列。"
 
-msgid "``pgr_dijkstra`` (`Many to One`_) added ``start_vid`` column."
-msgstr "``pgr_dijkstra`` (`多对一`_) 增加 ``start_vid`` 列。"
+msgid "pgr_dijkstra(Many to One) added ``start_vid`` column."
+msgstr "pgr_dijkstra（多对一）添加了 ``start_vid`` 列。"
 
 msgid "Version 3.1.0"
 msgstr "版本 3.1.0"
 
-msgid "``pgr_dijkstra`` (`Combinations`_)"
-msgstr "``pgr_dijkstra`` (`组合`_)"
-
-msgid "**Official** functions"
-msgstr "**官方** 函数"
-
 msgid "Version 2.2.0"
 msgstr "版本 2.2.0"
 
-msgid "New **proposed** functions:"
-msgstr "新的 **拟议** 函数："
+msgid "pgr_dijkstra(One to Many)"
+msgstr "pgr_dijkstra(一对多)"
 
-msgid "``pgr_dijkstra`` (`One to Many`_)"
-msgstr "``pgr_dijkstra`` (`一对多`_)"
+msgid "pgr_dijkstra(Many to One)"
+msgstr "pgr_dijkstra(多对一)"
 
-msgid "``pgr_dijkstra`` (`Many to One`_)"
-msgstr "``pgr_dijkstra`` (`多对一`_)"
+msgid "pgr_dijkstra(Many to Many)"
+msgstr "pgr_dijkstra（多对多）"
 
-msgid "``pgr_dijkstra`` (`Many to Many`_)"
-msgstr "``pgr_dijkstra`` (`多对多`_)"
-
-msgid "Signature change on ``pgr_dijkstra`` (`One to One`_)"
+#, fuzzy
+msgid "Signature change on pgr_dijkstra(One to One)"
 msgstr "``pgr_dijkstra`` (`一对一`_)的签名更改"
-
-msgid "**Official** ``pgr_dijkstra`` (`One to One`_)"
-msgstr "**官方** ``pgr_dijkstra`` (`一对一`_)"
 
 msgid "pgr_dijkstra(`Edges SQL`_, **start vid**, **end vid**, [``directed``])"
 msgstr "pgr_dijkstra(`Edges SQL`_, **start vid**, **end vid**, [``directed``])"
@@ -11519,26 +11718,29 @@ msgstr "36) 使用 `多对多`_"
 msgid "37) Using `Combinations`_"
 msgstr "37) 使用 `组合`_"
 
+#, fuzzy
+msgid ""
+"`Boost: Dijkstra shortest paths <https://www.boost.org/libs/graph/doc/"
+"dijkstra_shortest_paths.html>`__"
+msgstr ""
+"`Boost: is_bipartite <https://www.boost.org/libs/graph/doc/is_bipartite."
+"html>`__"
+
 msgid "https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm"
 msgstr "https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm"
 
 msgid "``pgr_dijkstraCost``"
 msgstr "`pgr_dijkstraCost``"
 
-#, fuzzy
 msgid ""
 "``pgr_dijkstraCost`` - Total cost of the shortest path using Dijkstra "
 "algorithm."
-msgstr "`pgr_dijkstraCost`` - 使用 Dijkstra 算法计算的最短路径总成本。"
+msgstr "`pgr_dijkstraCost`` - 使用 Dijkstra 算法计算最短路径的总成本。"
 
-msgid "``pgr_dijkstraCost`` (`Combinations`_)"
-msgstr "``pgr_dijkstraCost`` (`组合`_)"
-
-#, fuzzy
 msgid ""
 "The ``pgr_dijkstraCost`` function sumarizes of the cost of the shortest path "
 "using Dijkstra Algorithm."
-msgstr "``pgr_dijkstraCost`` 函数总结了使用Dijkstra算法的最短路径的成本。"
+msgstr "``pgr_dijkstraCost`` 函数总结了使用 Dijkstra 算法计算最短路径的成本。"
 
 msgid ""
 "pgr_dijkstraCost(`Edges SQL`_, **start vid**, **end vid**, [``directed``])"
@@ -11847,9 +12049,6 @@ msgstr "``true`` 时：仅返回 ``cap`` 结果"
 msgid "When ``false``: ``cap`` limit per ``Start vid`` will be returned"
 msgstr "当 ``false`` 时：将返回每个 ``Start vid`` 的 ``cap`` 限值"
 
-msgid "boost: https://www.boost.org/libs/graph/doc/table_of_contents.html"
-msgstr "boost: https://www.boost.org/libs/graph/doc/table_of_contents.html"
-
 msgid "Wikipedia: https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm"
 msgstr "维基百科：https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm"
 
@@ -11966,11 +12165,11 @@ msgstr "**选项：** ``[directed, strict, U_turn_on_edge]``"
 msgid "Returns set of |via-result|"
 msgstr "返回 |via-result| 的集合"
 
-#, fuzzy
 msgid ""
 "Find the route that visits the vertices :math:`\\{5, 1, 8\\}` in that order "
 "on an directed graph."
-msgstr "在有向图上查找按顺序访问顶点 :math:`\\{ 5, 1, 8\\}` 的路线。"
+msgstr ""
+"在一个directed graph中，找到按顺序访问顶点 :math:`\\ {5, 1, 8\\}` 的路径。"
 
 msgid "Via optional parameters"
 msgstr "Via可选参数"
@@ -12033,6 +12232,9 @@ msgid ""
 "``pgr_drivingDistance`` - Returns the driving distance from a start node."
 msgstr "``pgr_drivingDistance`` - 返回起始节点的行驶距离。"
 
+msgid "Standarizing output columns to |result-spantree|"
+msgstr "将输出列标准化为 |result-spantree|"
+
 msgid "Added ``depth`` and ``start_vid`` result columns."
 msgstr "添加了 ``depth`` 和 ``start_vid`` 结果列。"
 
@@ -12042,14 +12244,17 @@ msgstr "结果列名称更改： ``from_v``改为 ``start_vid``。"
 msgid "Added ``depth`` and ``pred`` result columns."
 msgstr "添加了 ``depth`` 和``pred`` 结果列。"
 
-msgid "Signature change pgr_drivingDistance(single vertex)"
-msgstr "签名更改 pgr_drivingDistance（单顶点）"
+msgid "Signature change:"
+msgstr "签名变更："
 
-msgid "New **Official** pgr_drivingDistance(multiple vertices)"
-msgstr "新 **官方** pgr_drivingDistance(多顶点)"
+msgid "pgr_drivingDistance(single vertex)"
+msgstr "pgr_drivingDistance （单顶点）"
 
-msgid "Official:: pgr_drivingDistance(single vertex)"
-msgstr "官方:: pgr_drivingDistance(单顶点)"
+msgid "New official signature:"
+msgstr "新签名："
+
+msgid "pgr_drivingDistance(multiple vertices)"
+msgstr "pgr_drivingDistance （多顶点）"
 
 msgid ""
 "Using the Dijkstra algorithm, extracts all the nodes that have costs less "
@@ -12109,7 +12314,8 @@ msgid ""
 "undirected graph"
 msgstr "在无向图上，从顶点 :math:`{11, 16\\}` 开始的距离为 :math:`3.0`"
 
-msgid "pgr_edgeColoring - Experimental"
+#, fuzzy
+msgid "``pgr_edgeColoring`` - Experimental"
 msgstr "pgr_edgeColoring - 实验"
 
 msgid ""
@@ -12189,6 +12395,18 @@ msgstr "Returns set of |result-edge-color|"
 msgid "Graph coloring of pgRouting :doc:`sampledata`"
 msgstr "pgRouting :doc:`sampledata` 的图形着色"
 
+#, fuzzy
+msgid ""
+"`Boost: Edge Coloring <https://www.boost.org/libs/graph/doc/edge_coloring."
+"html>`__"
+msgstr ""
+"`Boost：边缘着色算法文档 <https://www.boost.org/libs/graph/doc/edge_coloring."
+"html>`__"
+
+msgid ""
+"`Wikipedia: Graph coloring <https://en.wikipedia.org/wiki/Graph_coloring>`__"
+msgstr "`维基百科：图着色 <https://en.wikipedia.org/wiki/Graph_coloring>`__"
+
 msgid "``pgr_edgeDisjointPaths``"
 msgstr "``pgr_edgeDisjointPaths``"
 
@@ -12196,9 +12414,6 @@ msgid ""
 "``pgr_edgeDisjointPaths`` — Calculates edge disjoint paths between two "
 "groups of vertices."
 msgstr "``pgr_edgeDisjointPaths`` - 计算两组顶点之间的边不相交路径。"
-
-msgid "New **proposed** function:"
-msgstr "新的 **拟议** 函数："
 
 msgid "pgr_edgeDisjointPaths(Combinations)"
 msgstr "pgr_edgeDisjointPaths(组合)"
@@ -12294,9 +12509,6 @@ msgstr ""
 "``pgr_edmondsKarp`` —使用 Edmonds Karp 算法计算图边上的流量，以最大化从源到目"
 "标的流量。"
 
-msgid "``pgr_edmondsKarp`` (`Combinations`_)"
-msgstr "``pgr_edmondsKarp`` (`组合`_)"
-
 msgid "Renamed from ``pgr_maxFlowEdmondsKarp``"
 msgstr "从 ``pgr_maxFlowEdmondsKarp`` 更名而来"
 
@@ -12318,33 +12530,25 @@ msgstr "pgr_edmondsKarp(`Edges SQL`_, **start vids**, **end vids**)"
 msgid "pgr_edmondsKarp(`Edges SQL`_, `Combinations SQL`_)"
 msgstr "pgr_edmondsKarp(`Edges SQL`_, `Combinations SQL`_)"
 
-msgid "https://www.boost.org/libs/graph/doc/edmonds_karp_max_flow.html"
+#, fuzzy
+msgid ""
+"`Boost: Edmonds Karp max flow <https://www.boost.org/libs/graph/doc/"
+"edmonds_karp_max_flow.html>`__"
 msgstr "https://www.boost.org/libs/graph/doc/edmonds_karp_max_flow.html"
 
 msgid "https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm"
 msgstr "https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm"
 
-msgid "``pgr_edwardMoore - Experimental``"
-msgstr "``pgr_edwardMoore - 实验``"
+#, fuzzy
+msgid "``pgr_edwardMoore`` - Experimental"
+msgstr "``pgr_edwardMoore`` - 实验"
 
 msgid ""
 "``pgr_edwardMoore`` — Returns the shortest path using Edward-Moore algorithm."
 msgstr "`pgr_edwardMoore`` - 使用 Edward-Moore 算法返回最短路径。"
 
-msgid "``pgr_edwardMoore`` (`Combinations`_)"
-msgstr "``pgr_edwardMoore`` (`组合`_)"
-
-msgid "``pgr_edwardMoore`` (`One to One`_)"
-msgstr "``pgr_edwardMoore`` (`一对一`_)"
-
-msgid "``pgr_edwardMoore`` (`One to Many`_)"
-msgstr "``pgr_edwardMoore`` (`一对多`_)"
-
-msgid "``pgr_edwardMoore`` (`Many to One`_)"
-msgstr "``pgr_edwardMoore`` (`多对一`_)"
-
-msgid "``pgr_edwardMoore`` (`Many to Many`_)"
-msgstr "``pgr_edwardMoore`` (`多对多`_)"
+msgid "pgr_edwardMoore(Combinations)"
+msgstr "pgr_edwardMoore(组合)"
 
 msgid ""
 "Edward Moore’s Algorithm is an improvement of the Bellman-Ford Algorithm. It "
@@ -12417,14 +12621,12 @@ msgstr "pgr_edwardMoore(`Edges SQL`_, `Combinations SQL`_, [``directed``])"
 msgid "https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm"
 msgstr "https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm"
 
-msgid "pgr_extractVertices -- Proposed"
-msgstr "pgr_extractVertices -- 拟议"
+#, fuzzy
+msgid "``pgr_extractVertices``"
+msgstr "pgr_extractVertices"
 
 msgid "``pgr_extractVertices`` — Extracts the vertices information"
 msgstr "``pgr_extractVertices`` — 提取顶点信息"
-
-msgid "Classified as **proposed** function"
-msgstr "列为 **拟议** 函数"
 
 msgid ""
 "This is an auxiliary function for extracting the vertex information of the "
@@ -12530,14 +12732,9 @@ msgstr "``pgr_findCloseEdges``"
 msgid "``pgr_findCloseEdges`` - Finds the close edges to a point geometry."
 msgstr "``pgr_findCloseEdges`` -查找点几何图形的闭合边。"
 
-msgid "New **proposed** signatures:"
-msgstr "新的 **拟议** 签名："
-
-msgid "``pgr_findCloseEdges`` (`One point`_)"
-msgstr "``pgr_findCloseEdges`` (`一个点`_)"
-
-msgid "``pgr_findCloseEdges`` (`Many points`_)"
-msgstr "``pgr_findCloseEdges`` (`多个点`_)"
+#, fuzzy
+msgid "``partial`` option is removed."
+msgstr "``n_seq`` 被删除"
 
 msgid ""
 "``pgr_findCloseEdges`` - An utility function that finds the closest edge to "
@@ -12553,7 +12750,8 @@ msgid ""
 "adjustments needed by the application."
 msgstr "可以获取计算代码，以便根据应用需要进行进一步的具体调整。"
 
-msgid "``EMTPY SET`` is returned on dryrun executions"
+#, fuzzy
+msgid "``EMPTY SET`` is returned on dryrun executions"
 msgstr "空运行执行时返回 ``EMTPY SET``"
 
 msgid ""
@@ -12566,7 +12764,8 @@ msgid ""
 msgstr ""
 "pgr_findCloseEdges(`Edges SQL`_, **points**, **tolerance**, [**options**])"
 
-msgid "**options:** ``[cap, partial, dryrun]``"
+#, fuzzy
+msgid "**options:** ``[cap, dryrun]``"
 msgstr "**options:** ``[cap, partial, dryrun]``"
 
 msgid "Returns set of |result-find|"
@@ -12575,53 +12774,17 @@ msgstr "返回集合 |result-find|"
 msgid "One point"
 msgstr "一个点"
 
-msgid "Default: ``cap => 1``"
-msgstr "默认： ``cap => 1``"
+msgid "Get two close edges to points of interest with :math:`pid = 5`"
+msgstr ""
 
-msgid "Maximum one row answer."
-msgstr "最多回答一行。"
-
-msgid "Default: ``partial => true``"
-msgstr "默认： ``partial => true``"
-
-msgid "With less calculations as possible."
-msgstr "尽可能减少计算。"
-
-msgid "Default: ``dryrun => false``"
-msgstr "默认： ``dryrun => false``"
-
-msgid "Process query"
-msgstr "过程查询"
-
-msgid "Returns"
-msgstr "返回"
-
-msgid "values on ``edge_id``, ``fraction``, ``side`` columns."
-msgstr "``edge_id``, ``fraction``, ``side`` 列的值。"
-
-msgid "``NULL`` on ``distance``, ``geom``, ``edge`` columns."
-msgstr "``distance``, ``geom``, ``edge``列上为``NULL``。"
+msgid "``cap => 2``"
+msgstr "``cap => 2``"
 
 msgid "Many points"
 msgstr "多点"
 
-msgid ""
-"Find at most :math:`2` edges close to all vertices on the points of interest "
-"table."
-msgstr "最多找出 :math:`2` 接近兴趣点表上所有顶点的边。"
-
-msgid "One answer per point, as small as possible."
-msgstr "每点一个答案，越小越好。"
-
-msgid ""
-"Columns ``edge_id``, ``fraction``, ``side`` and ``geom`` are returned with "
-"values."
-msgstr "返回了带有值的列 ``edge_id``, ``fraction``, ``side`` 和 ``geom``。"
-
-msgid ""
-"``geom`` contains the original point geometry to assist on deterpartialing "
-"to which point geometry the row belongs to."
-msgstr "``geom`` 包含原始的点几何信息，以帮助确定该行属于哪个点几何。"
+msgid "For each points of interests, find the closest edge."
+msgstr ""
 
 msgid "**point**"
 msgstr "**point**"
@@ -12647,17 +12810,6 @@ msgstr "几何图形之间的最大距离"
 msgid "Limit output rows"
 msgstr "限制输出行数"
 
-msgid "``partial``"
-msgstr "``partial``"
-
-msgid ""
-"When ``true`` only columns needed for :doc:`withPoints-category` are "
-"calculated."
-msgstr "当为 ``true`` 时，只计算 :doc:`withPoints-category` 需要的列。"
-
-msgid "When ``false`` all columns are calculated"
-msgstr "当为 ``false`` 时，所有的列都计算"
-
 msgid "When ``false`` calculations are performed."
 msgstr "当为 ``false`` 时，执行计算。"
 
@@ -12674,66 +12826,93 @@ msgstr "边的 ``LINESTRING`` 几何。"
 msgid "When :math:`cap = 1`, it is the closest edge."
 msgstr "当 :math:`cap = 1` 时，它是最近的边。"
 
+#, fuzzy
 msgid ""
-"Value in <0,1> that indicates the relative postition from the first end-"
-"point of the edge."
+"Value in <0,1> that indicates the relative position from the first end-point "
+"of the edge."
 msgstr "在 <0,1> 范围内的值，表示相对于边的第一个端点的相对位置。"
 
 msgid "Value in ``[r, l]`` indicating if the point is:"
 msgstr "``[r, l]`` 中的值指示该点是否为："
 
-msgid "In the right ``r``."
-msgstr "在右边的 ``r``。"
-
-msgid "In the left ``l``."
-msgstr "在左边的 ``l``。"
+#, fuzzy
+msgid "At the right ``r`` of the segment."
+msgstr "分段的几何形状。"
 
 msgid "When the point is on the line it is considered to be on the right."
 msgstr "当点在直线上时，它被认为是在右边。"
 
+#, fuzzy
+msgid "At the left ``l`` of the segment."
+msgstr "位于该段的两侧。"
+
 msgid "``distance``"
 msgstr "``distance``"
 
-msgid "Distance from point to edge."
+#, fuzzy
+msgid "Distance from the point to the edge."
 msgstr "点到边缘的距离。"
 
-msgid "``NULL`` when ``cap = 1`` on the `One point`_ signature"
-msgstr "``NULL`` 当在 `一个点`_ 签名，``cap = 1`` 时"
-
-msgid "``POINT`` geometry"
+#, fuzzy
+msgid "Original ``POINT`` geometry."
 msgstr "``POINT`` 几何"
 
+#, fuzzy
 msgid ""
-"`One Point`_: Contains the point on the edge that is ``fraction`` away from "
-"the starting point of the edge."
-msgstr "`一个点`_：包含边缘上距边缘起点一小部分的点。"
-
-msgid "`Many Points`_: Contains the corresponding **original point**"
-msgstr "`多个点`_：包含对应的 **原始点**"
-
-msgid ""
-"``LINESTRING`` geometry from the **original point** to the closest point of "
-"the edge with identifier ``edge_id``"
+"``LINESTRING`` geometry that connects the original **point** to the closest "
+"point of the edge with identifier ``edge_id``"
 msgstr ""
 "从 **原始点** 到具有标识符 ``edge_id`` 的边的最近点的 ``LINESTRING`` 几何图形"
 
-msgid "One point results"
-msgstr "单一点的结果"
+#, fuzzy
+msgid "One point in an edge"
+msgstr "单点模拟执行"
 
-msgid "The green nodes is the **original point**"
+#, fuzzy
+msgid "The green node is the original point."
 msgstr "绿色节点是 **原始点**"
 
+#, fuzzy
+msgid "``geom`` has the value of the original point."
+msgstr "边 :math:`5` 是距离 **原始点** 最近的边"
+
+#, fuzzy
 msgid ""
-"The geometry ``geom`` is a point on the :math:`sp \\rightarrow ep` edge."
-msgstr "几何 ``geom`` 是 :math:`sp \\rightarrow ep` 边上的一个点。"
+"The geometry ``edge`` is a line that connects the original point with the "
+"edge :math:`sp \\rightarrow ep` edge."
+msgstr ""
+"标为 **edge1** 和 **edge2** 的几何图形 ``edge`` 是一条连接 ** 原始点** 和 :"
+"math:`sp \\rightarrow ep` 边上最近点的线。"
+
+#, fuzzy
+msgid "The point is located at the left of the edge."
+msgstr "``side``： **原始点** 位于边 :math:`5` 的左侧。"
+
+msgid "One point dry run execution"
+msgstr "单点模拟执行"
+
+#, fuzzy
+msgid "Using the query from the previous example:"
+msgstr "本示例使用此表设计："
+
+msgid "Returns ``EMPTY SET``."
+msgstr "返回 ``EMPTY SET``。"
+
+msgid "``dryrun => true``"
+msgstr "``dryrun => true``"
+
+#, fuzzy
+msgid "Generates a PostgreSQL ``NOTICE`` with the code used."
+msgstr "生成一个包含用于计算所有列的代码的 PostgreSQL ``NOTICE``"
 
 msgid ""
-"The geometry ``edge`` is a line that connects the **original point** with "
-"``geom``"
-msgstr "几何 ``edge`` 是连接 **original point** 和 ``geom`` 的线"
+"The generated code can be used as a starting base code for additional "
+"requirements, like taking into consideration the SRID."
+msgstr ""
 
-msgid "Many point results"
-msgstr "多点成果"
+#, fuzzy
+msgid "Many points in an edge"
+msgstr "多点示例"
 
 msgid "The green nodes are the **original points**"
 msgstr "绿色节点为 **原始点**"
@@ -12751,144 +12930,8 @@ msgstr ""
 "标为 **edge1** 和 **edge2** 的几何图形 ``edge`` 是一条连接 ** 原始点** 和 :"
 "math:`sp \\rightarrow ep` 边上最近点的线。"
 
-msgid "One point examples"
-msgstr "单点示例"
-
-msgid "At most two answers"
-msgstr "最多两个答案"
-
-msgid "``cap => 2``"
-msgstr "``cap => 2``"
-
-msgid "Maximum two row answer."
-msgstr "最多回答两行。"
-
-msgid "Understanding the result"
-msgstr "了解结果"
-
-msgid "``NULL`` on ``geom``, ``edge``"
-msgstr "``NULL`` 在 ``geom``, ``edge`` 上"
-
-msgid "``edge_id`` identifier of the edge close to the **original point**"
-msgstr "``edge_id`` 靠近 **原始点** 的边的标识符"
-
-msgid ""
-"Two edges are withing :math:`0.5` distance units from the **original "
-"point**: :math:`{5, 8}`"
-msgstr "有两条边与 **原始点** : :math:`{5, 8}` 的距离在 :math:`0.5` 单位范围内"
-
-msgid "For edge :math:`5`:"
-msgstr "对于边 :math:`5`:"
-
-msgid ""
-"``fraction``: The closest point from the **original point** is at the :math:"
-"`0.8` fraction of the edge :math:`5`."
-msgstr ""
-"``fraction``：离 **原始点** 最近的点位于边 :math:`5` 处的 :math:`0.8` 分数位"
-"置。"
-
-msgid ""
-"``side``: The **original point** is located to the left side of edge :math:"
-"`5`."
-msgstr "``side``： **原始点** 位于边 :math:`5` 的左侧。"
-
-msgid ""
-"``distance``: The **original point** is located :math:`0.1` length units "
-"from edge :math:`5`."
-msgstr "``distance``： **原始点** 位于边 :math:`5` 的 :math:`0.1` 长度单位处。"
-
-msgid "For edge :math:`8`:"
-msgstr "对于边 :math:`8`："
-
-msgid ""
-"``fraction``: The closest point from the **original point** is at the :math:"
-"`0.89..` fraction of the edge :math:`8`."
-msgstr ""
-"``fraction``：离 **原始点** 最近的点位于边 :math:`8` 的 :math:`0.89..` 分数位"
-"置。"
-
-msgid ""
-"``side``: The **original point** is located to the right side of edge :math:"
-"`8`."
-msgstr "``side``： **原始点** 位于边 :math:`8` 的右侧。"
-
-msgid ""
-"``distance``: The **original point** is located :math:`0.19..` length units "
-"from edge :math:`8`."
-msgstr ""
-"``distance``： **原始点** 距离边 :math:`8` 有 :math:`0.19..` 长度单位。"
-
-msgid "One answer, all columns"
-msgstr "一个答案，所有列"
-
-msgid "``partial => false``"
-msgstr "``partial => false``"
-
-msgid "Calculate all columns"
-msgstr "计算所有列"
-
-msgid ""
-"``edge_id`` identifier of the edge **closest** to the **original point**"
-msgstr "``edge_id`` 与 **原始点** 最 **接近** 的边的标识符"
-
-msgid ""
-"From all edges within :math:`0.5` distance units from the **original "
-"point**: :math:`{5}` is the closest one."
-msgstr ""
-"从距离 **原始点** 不超过 :math:`0.5` 距离单位的所有边中，边 :math:`{5}` 是最"
-"近的一条。"
-
-msgid ""
-"``geom``: Contains the geometry of the closest point on edge :math:`5` from "
-"the **original point**."
-msgstr "``geom``:包含了从 **原始点** 到边 :math:`5` 上最近点的几何形状。"
-
-msgid ""
-"``edge``: Contains the ``LINESTRING`` geometry of the **original point** to "
-"the closest point on on edge :math:`5` ``geom``"
-msgstr ""
-"``edge``：包含了从 **原始点** 到边 :math:`5` ``geom`` 上最近点的 "
-"``LINESTRING`` 几何形状"
-
-msgid "At most two answers with all columns"
-msgstr "所有列最多有两个答案"
-
-msgid "Understanding the result:"
-msgstr "了解结果："
-
-msgid ""
-"``geom``: Contains the geometry of the closest point on edge :math:`8` from "
-"the **original point**."
-msgstr "``geom``：包含了从 **原始点** 到边 :math:`8` 上最近点的几何形状。"
-
-msgid ""
-"``edge``: Contains the ``LINESTRING`` geometry of the **original point** to "
-"the closest point on on edge :math:`8` ``geom``"
-msgstr ""
-"``edge``：包含了从 **原始点** 到边 :math:`8` ``geom`` 上最近点的 "
-"``LINESTRING`` 几何形状"
-
-msgid "One point dry run execution"
-msgstr "单点模拟执行"
-
-msgid "Returns ``EMPTY SET``."
-msgstr "返回 ``EMPTY SET``。"
-
-msgid "``partial => true``"
-msgstr "``partial => true``"
-
-msgid "Is ignored"
-msgstr "被忽略"
-
-msgid ""
-"Because it is a **dry run** excecution, the code for all calculations are "
-"shown on the PostgreSQL ``NOTICE``."
-msgstr ""
-"由于这是一次 **模拟** 执行，所有计算的代码都显示在 PostgreSQL 的 ``NOTICE`` "
-"中。"
-
-msgid "``dryrun => true``"
-msgstr "``dryrun => true``"
+msgid "Many points dry run execution"
+msgstr "多点模拟执行"
 
 msgid "Do not process query"
 msgstr "不处理查询"
@@ -12896,67 +12939,6 @@ msgstr "不处理查询"
 msgid ""
 "Generate a PostgreSQL ``NOTICE`` with the code used to calculate all columns"
 msgstr "生成一个包含用于计算所有列的代码的 PostgreSQL ``NOTICE``"
-
-msgid "``cap`` and **original point** are used in the code"
-msgstr "代码中使用了 ``cap`` 和 **原始点**"
-
-msgid "Many points examples"
-msgstr "多点示例"
-
-msgid "At most two answers per point"
-msgstr "每个点最多两个答案"
-
-msgid "``NULL`` on ``edge``"
-msgstr "``edge``为``NULL``"
-
-msgid ""
-"``edge_id`` identifier of the edge close to a **original point** (``geom``)"
-msgstr "``edge_id``是与一个 **原始点** （``geom``）靠近的边的标识符"
-
-msgid ""
-"Two edges at most withing :math:`0.5` distance units from each of the "
-"**original points**:"
-msgstr ""
-"每个 **原始点** 中，最多有两条边位于距离不超过 :math:`0.5` 距离单位的范围内："
-
-msgid "For ``POINT(1.8 0.4)`` and ``POINT(0.3 1.8)`` only one edge was found."
-msgstr "对于 ``POINT(1.8 0.4)`` 和 ``POINT(0.3 1.8)`` ，只找到一条边。"
-
-msgid "For the rest of the points two edges were found."
-msgstr "其余的点有两条边。"
-
-msgid "For point ``POINT(2.9 1.8)``"
-msgstr "对于点 ``POINT(2.9 1.8)``"
-
-msgid ""
-"Edge :math:`5` is before :math:`8` therefore edge :math:`5` has the shortest "
-"distance to ``POINT(2.9 1.8)``."
-msgstr ""
-"边 :math:`5` 在 :math:`8` 之前，因此边 :math:`5` 到 ``POINT(2.9 1.8)`` 的距离"
-"最短。"
-
-msgid "One answer per point, all columns"
-msgstr "每点一个答案，所有列"
-
-msgid "For the **original point** ``POINT(2.9 1.8)``"
-msgstr "对于 **原始点** ``POINT(2.9 1.8)``"
-
-msgid "Edge :math:`5` is the closest edge to the **original point**"
-msgstr "边 :math:`5` 是距离 **原始点** 最近的边"
-
-msgid ""
-"``geom``: Contains the geometry of the **original point** ``POINT(2.9 1.8)``"
-msgstr "``geom``：包含了 **原始点** 的几何形状，即 ``POINT(2.9 1.8)``"
-
-msgid ""
-"``edge``: Contains the ``LINESTRING`` geometry of the **original point** "
-"(``geom``) to the closest point on on edge."
-msgstr ""
-"``edge``：包含了 **原始点** （``geom``）到最接近的边上的 ``LINESTRING`` 几何"
-"形状。"
-
-msgid "Many points dry run execution"
-msgstr "多点模拟执行"
 
 msgid "Find at most two routes to a given point"
 msgstr "最多找到两条到达给定点的路线"
@@ -12994,11 +12976,12 @@ msgstr "在这份文档中，将有6个固定的兴趣点，并且它们将被�
 msgid "A unique identifier."
 msgstr "唯一标识符。"
 
-msgid ""
-"Identifier of the edge nearest edge that allows an arrival to the point."
-msgstr "允许到达该点的最近边的标识符。"
+#, fuzzy
+msgid "Identifier of the nearest segment."
+msgstr "顶点的标识符。"
 
-msgid "Is it on the left, right or both sides of the segment ``edge_id``"
+#, fuzzy
+msgid "Is it on the left, right or both sides of the segment ``edge_id``."
 msgstr "它位于边 ``edge_id`` 的左侧、右侧还是两侧"
 
 msgid "Where in the segment is the point located."
@@ -13007,14 +12990,42 @@ msgstr "该点位于边的哪个位置。"
 msgid "The geometry of the points."
 msgstr "点的几何形状。"
 
+#, fuzzy
+msgid "The distance between ``geom`` and the segment ``edge_id``."
+msgstr "它位于边 ``edge_id`` 的左侧、右侧还是两侧"
+
+#, fuzzy
+msgid ""
+"A segment that connects the ``geom`` of the point to the closest point on "
+"the segment ``edge_id``."
+msgstr "它位于边 ``edge_id`` 的左侧、右侧还是两侧"
+
 msgid "``newPoint``"
 msgstr "``newPoint``"
 
-msgid "The geometry of the points moved on top of the segment."
-msgstr "在线段顶部移动的点的几何形状。"
+msgid "A point on segment ``edge_id`` that is the closest to ``geom``."
+msgstr ""
 
-msgid "Points of interest fillup"
+#, fuzzy
+msgid "Points of interest fill up"
 msgstr "兴趣点填充"
+
+#, fuzzy
+msgid "Inserting the points of interest."
+msgstr "兴趣点"
+
+#, fuzzy
+msgid "Filling the rest of the table."
+msgstr "填写映射表"
+
+msgid ""
+"Any other additional modification: In this manual, point :math:`6` can be "
+"reached from both sides."
+msgstr ""
+
+#, fuzzy
+msgid "The points of interest:"
+msgstr "兴趣点"
 
 msgid "``pgr_floydWarshall``"
 msgstr "``pgr_floydWarshall``"
@@ -13049,18 +13060,12 @@ msgstr ""
 "Boost `floyd-Warshall <https://www.boost.org/libs/graph/doc/"
 "floyd_warshall_shortest.html>`_"
 
-msgid "Queries uses the :doc:`sampledata` network."
-msgstr "查询使用 :doc:`sampledata` 网络。"
-
 msgid "``pgr_full_version``"
 msgstr "``pgr_full_version``"
 
 msgid ""
 "``pgr_full_version`` — Get the details of pgRouting version information."
 msgstr "``pgr_full_version`` — 获取pgRouting版本信息的详细信息。."
-
-msgid "New **official** function"
-msgstr "**官方** 新功能"
 
 msgid "Get complete details of pgRouting version information"
 msgstr "获取 pgRouting 版本信息的完整详细信息"
@@ -13128,16 +13133,15 @@ msgstr "``hash``"
 msgid "Git hash of pgRouting build"
 msgstr "pgRouting 构建的 Git 哈希"
 
-msgid "``pgr_hawickCircuits - Experimental``"
+#, fuzzy
+msgid "``pgr_hawickCircuits`` - Experimental"
 msgstr "``pgr_hawickCircuits - 实验``"
 
+#, fuzzy
 msgid ""
-"``pgr_hawickCircuits`` — Returns the list of cirucits using hawick circuits "
+"``pgr_hawickCircuits`` — Returns the list of ciruits using hawick circuits "
 "algorithm."
 msgstr "``pgr_hawickCircuits`` — 使用 Hawick 回路算法返回回路列表。"
-
-msgid "``pgr_hawickCircuits``"
-msgstr "``pgr_hawickCircuits``"
 
 msgid ""
 "Hawick Circuit algorithm, is published in 2008 by Ken Hawick and Health A. "
@@ -13279,7 +13283,10 @@ msgstr ""
 "新图不是平面图，因为它具有一个 :math:`K_5` 子图。蓝色的边代表 :math:`K_5` 子"
 "图。"
 
-msgid "https://www.boost.org/libs/graph/doc/boyer_myrvold.html"
+#, fuzzy
+msgid ""
+"`Boost: Boyer Myrvold <https://www.boost.org/libs/graph/doc/boyer_myrvold."
+"html>`__"
 msgstr "https://www.boost.org/libs/graph/doc/boyer_myrvold.html"
 
 msgid "``pgr_johnson``"
@@ -13338,6 +13345,9 @@ msgid ""
 "``pgr_kruskalBFS`` — Kruskal's algorithm for Minimum Spanning Tree with "
 "breadth First Search ordering."
 msgstr "``pgr_kruskalBFS`` — Kruskal 的最小生成树算法，具有广度优先搜索排序。"
+
+msgid "Added ``pred`` result columns."
+msgstr "添加了 ``pred`` 结果列。"
 
 msgid ""
 "Visits and extracts the nodes information in Breath First Search ordering of "
@@ -13421,8 +13431,9 @@ msgstr "pgr_kruskalDFS(`Edges SQL`_, **root vid**, [``max_depth``])"
 msgid "pgr_kruskalDFS(`Edges SQL`_, **root vids**, [``max_depth``])"
 msgstr "pgr_kruskalDFS(`Edges SQL`_, **root vids**, [``max_depth``])"
 
-msgid "pgr_lengauerTarjanDominatorTree -Experimental"
-msgstr "pgr_lengauerTarjanDominatorTree -实验"
+#, fuzzy
+msgid "``pgr_lengauerTarjanDominatorTree`` - Experimental"
+msgstr "``pgr_lengauerTarjanDominatorTree`` - 实验"
 
 msgid ""
 "``pgr_lengauerTarjanDominatorTree`` — Returns the immediate dominator of all "
@@ -13480,11 +13491,12 @@ msgstr "顶点的直接支配者。"
 msgid "Dominator tree of another component."
 msgstr "另一个组件的支配树。"
 
+#, fuzzy
 msgid ""
-"`Boost: Lengauer-Tarjan dominator tree algorithm <https://www.boost.org/libs/"
-"graph/doc/lengauer_tarjan_dominator.htm>`__"
+"`Boost: Lengauer-Tarjan dominator <https://www.boost.org/libs/graph/doc/"
+"lengauer_tarjan_dominator.htm>`__"
 msgstr ""
-"`BOOST：Languer-Tarzan 支配树算法 <https://www.boost.org/libs/graph/doc/"
+"`Boost：Languer-Tarjan 支配树算法 <https://www.boost.org/libs/graph/doc/"
 "lengauer_tarjan_dominator.htm>`__"
 
 msgid ""
@@ -13493,51 +13505,50 @@ msgid ""
 msgstr ""
 "`维基百科:支配树 <https://en.wikipedia.org/wiki/Dominator_(graph_theory)>`__"
 
-#, fuzzy
-msgid "pgr_lineGraph - Proposed"
-msgstr "pgr_trsp - 拟议"
+msgid "``pgr_lineGraph`` - Proposed"
+msgstr "``pgr_lineGraph`` - 提议"
 
 msgid ""
 "``pgr_lineGraph`` — Transforms the given graph into its corresponding edge-"
 "based graph."
 msgstr "``pgr_lineGraph`` — 将给定图转换为其相应的基于边的图。"
 
-#, fuzzy
+msgid "Works for directed and undirected graphs."
+msgstr "适用于有向和无向图。"
+
 msgid ""
 "Given a graph :math:`G`, its line graph :math:`L(G)` is a graph such that:"
-msgstr "给定一个图 G，它的线图 L(G) 是这样的图："
+msgstr "给定一个图 :math:`G`，其线图 :math:`L(G)` 是一个图，满足以下条件："
 
-#, fuzzy
 msgid "Each vertex of :math:`L(G)` represents an edge of :math:`G`."
 msgstr ":math:`L(G)` 的每个顶点代表 :math:`G` 的一条边。"
 
-#, fuzzy
 msgid ""
 "Two vertices of :math:`L(G)` are adjacent if and only if their corresponding "
 "edges share a common endpoint in :math:`G`"
 msgstr ""
-":math:`L(G)` 的两个顶点相邻当且仅当它们对应的边共享 :math:`G` 中的公共端点"
+":math:`L(G)` 的两个顶点相邻，当且仅当它们对应的边在 :math:`G` 中共享一个共同"
+"端点时"
 
-#, fuzzy
 msgid ""
 "The ``cost`` and ``reverse_cost`` columns of the result represent existence "
 "of the edge."
-msgstr "使用 ``cost`` 和 ``reverse_cost`` 列来表示边的存在。"
+msgstr "结果中的 ``cost`` 和 ``reverse_cost`` 列表示边的存在性。"
 
-#, fuzzy
 msgid "When the graph is directed the result is directed."
-msgstr "当图无向时，成本矩阵是对称的。"
+msgstr "当图形是有向的，结果也是有向的。"
 
 msgid ""
 "To get the complete Line Graph use unique identifiers on the double way "
 "edges (See `Additional Examples`_)."
 msgstr ""
+"要获取完整的线图，请在双向边上使用唯一标识符 (See `Additional Examples`_)."
 
 msgid "When the graph is undirected the result is undirected."
 msgstr "当图无向时，成本矩阵是对称的。"
 
 msgid "The ``reverse_cost`` is always :math:`-1`."
-msgstr ""
+msgstr "``reverse_cost`` 始终为 :math:`-1`。"
 
 msgid "pgr_lineGraph(`Edges SQL`_, [``directed``])"
 msgstr "pgr_lineGraph(`Edges SQL`_, [``directed``])"
@@ -13545,21 +13556,14 @@ msgstr "pgr_lineGraph(`Edges SQL`_, [``directed``])"
 msgid "Returns set of |result-lineg|"
 msgstr "Returns set of |result-lineg|"
 
-#, fuzzy
 msgid "For an undirected graph with edges :math:'{2,4,5,8}'"
-msgstr "对于有边 :math:`\\{1, 2, 3, 4\\}` 的有向子图"
+msgstr "对于一个undirected graph(无向图)，其边为 :math:'{2,4,5,8}'"
 
 msgid "Gives a local identifier for the edge"
 msgstr "给出边的本地标识符"
 
-msgid "Identifier of the source vertex of the current edge."
-msgstr "当前边的源顶点的标识符。"
-
 msgid "When `negative`: the source is the reverse edge in the original graph."
 msgstr "为负时：源是原始图中的反向边。"
-
-msgid "Identifier of the target vertex of the current edge."
-msgstr "当前边的目标顶点的标识符。"
 
 msgid "When `negative`: the target is the reverse edge in the original graph."
 msgstr "为负时：目标是原始图中的反向边。"
@@ -13580,152 +13584,146 @@ msgid ""
 "it’s not part of the graph."
 msgstr "当为负时：边(``target``, ``source``)不存在，因此它不是图的一部分。"
 
-#, fuzzy
 msgid "Given the following directed graph"
-msgstr "给出以下查询"
+msgstr "给定以下有向图"
 
 msgid ""
 ":math:`G(V,E) = G(\\{1,2,3,4\\},\\{ 1 \\rightarrow 2, 1 \\rightarrow 4, 2 "
 "\\rightarrow 3, 3 \\rightarrow 1, 3 \\rightarrow 2, 3 \\rightarrow 4, 4 "
 "\\rightarrow 3\\})`"
 msgstr ""
+":math:`G(V,E) = G(\\{1,2,3,4\\},\\{ 1 \\rightarrow 2, 1 \\rightarrow 4, 2 "
+"\\rightarrow 3, 3 \\rightarrow 1, 3 \\rightarrow 2, 3 \\rightarrow 4, 4 "
+"\\rightarrow 3\\})`"
 
 msgid "Representation as directed with shared edge identifiers"
-msgstr ""
+msgstr "用共享边标识符定向表示"
 
 msgid ""
 "For the simplicity, the design of the edges table on the database, has the "
 "edge's identifiers are represented with 3 digits:"
-msgstr ""
+msgstr "为了简化数据库中边表的设计，边的标识符采用3位数字表示："
 
 msgid "hundreds"
-msgstr ""
+msgstr "百位"
 
-#, fuzzy
 msgid "the source vertex"
-msgstr "获取最近的顶点"
+msgstr "源点"
 
 msgid "tens"
-msgstr ""
+msgstr "十位"
 
 msgid "always 0, acts as a separator"
-msgstr ""
+msgstr "始终为 0，用作分隔符"
 
-#, fuzzy
 msgid "units"
-msgstr "单位"
+msgstr "个位"
 
-#, fuzzy
 msgid "the target vertex"
-msgstr "获取最近的顶点"
+msgstr "目标顶点"
 
 msgid "In this image,"
-msgstr ""
+msgstr "在这张图片中，"
 
 msgid ""
 "Single or double head arrows represent one edge (row) on the edges table."
-msgstr ""
+msgstr "单向或双向箭头表示边表中的一条边（行）。"
 
-#, fuzzy
 msgid "The numbers in the yellow shadow are the edge identifiers."
-msgstr "返回的行按边标识符升序排列。"
+msgstr "黄色阴影中的数字是边缘标识符。"
 
 msgid ""
 "Two pair of edges share the same identifier when the ``reverse_cost`` column "
 "is used."
-msgstr ""
+msgstr "当使用 ``reverse_cost`` 列时，两个边对会共享相同的标识符。"
 
-#, fuzzy
 msgid ""
 "Edges :math:`{2 \\rightarrow 3, 3 \\rightarrow 2}` are represented with one "
 "edge row with :math:`id=203`."
-msgstr "从图中删除边 :math:`v \\rightarrow w` 和 :math:`w \\rightarrow z`。"
+msgstr ""
+"边 :math:`{2 \\rightarrow 3, 3 \\rightarrow 2}` 用一条边行表示，标识符其 :"
+"math:`id=203` 。"
 
-#, fuzzy
 msgid ""
 "Edges :math:`{3 \\rightarrow 4, 4 \\rightarrow 3}` are represented with one "
 "edge row with :math:`id=304`."
-msgstr "从图中删除边 :math:`v \\rightarrow w` 和 :math:`w \\rightarrow z`。"
+msgstr ""
+"边 :math:`{3 \\rightarrow 4, 4 \\rightarrow 3}` 用一条边的行表示，标识符为 :"
+"math:`id=304` 。"
 
-#, fuzzy
 msgid "The graph can be created as follows:"
-msgstr "图定义如下："
+msgstr "图表的创建过程如下："
 
-#, fuzzy
 msgid "Line Graph of a directed graph represented with shared edges"
-msgstr "就有向图而言，就像有四个边"
+msgstr "用共享边表示的有向图的线图"
 
-#, fuzzy
 msgid "The result is a directed graph."
-msgstr "有向图。"
+msgstr "结果就是一个有向图。"
 
-#, fuzzy
 msgid ""
 "For :math:`seq=4` from :math:`203 \\leftrightarrow 304` represent two edges"
-msgstr "边 :math:`2` (:math:`1 \\rightarrow 3`) 不是图的一部分"
+msgstr "对于 :math:`seq=4` ，从:math:`203 \\leftrightarrow 304` 表示两条边"
 
 msgid "For all the other values of ``seq`` represent one edge."
-msgstr ""
+msgstr "所有其他的 ``seq`` 值都代表一条边。"
 
-#, fuzzy
 msgid ""
 "The ``cost`` and ``reverse_cost`` values represent the existence of the edge."
-msgstr "使用 ``cost`` 和 ``reverse_cost`` 列来表示边的存在。"
+msgstr "``cost`` 和 ``reverse_cost`` 的值表示边的存在。"
 
-#, fuzzy
 msgid "When positive: the edge exists."
-msgstr "当正数时是顶点的标识符。"
+msgstr "当为正数时：边缘存在。"
 
-#, fuzzy
 msgid "When negative: the edge does not exist."
-msgstr "为负数时抛出错误。"
+msgstr "负数时：边缘不存在。"
 
 msgid "Representation as directed with unique edge identifiers"
-msgstr ""
+msgstr "作为有向图表示，并使用唯一的边标识符"
 
-#, fuzzy
 msgid "Single head arrows represent one edge (row) on the edges table."
-msgstr "红色箭头对应边表中 ``cost`` > 0的情况。"
+msgstr "单头箭头代表边表中的一条边（行）。"
 
 msgid "There are no double head arrows"
-msgstr ""
+msgstr "没有双向头箭"
 
 msgid ""
 "Two pair of edges share the same ending nodes and the ``reverse_cost`` "
 "column is not used."
-msgstr ""
+msgstr "两对边共享相同的结束节点，不使用 ``reverse_cost`` 列。"
 
 msgid ""
 "Edges :math:`{2 \\rightarrow 3, 3 \\rightarrow 2}` are represented with two "
 "edges :math:`id=203` and :math:`id=302` respectively."
 msgstr ""
+"边 :math:`{2 \\rightarrow 3, 3 \\rightarrow 2}`分别用两条边表示，边标识符为 :"
+"math:`id=203` 和:math:`id=302` 。"
 
 msgid ""
 "Edges :math:`{3 \\rightarrow 4, 4 \\rightarrow 3}` are represented with two "
 "edges :math:`id=304` and :math:`id=403` respectively."
 msgstr ""
+"边 :math:`{3 \\rightarrow 4, 4 \\rightarrow 3}`分别用两条边表示，边标识符为 :"
+"math:`id=304` 和 :math:`id=403` 。"
 
-#, fuzzy
 msgid "Line Graph of a directed graph represented with unique edges"
-msgstr "就有向图而言，就像有四个边"
+msgstr "用唯一边表示的有向图的线图"
 
-#, fuzzy
 msgid ""
 "For :math:`seq=7` from :math:`203 \\leftrightarrow 302` represent two edges."
-msgstr "边 :math:`2` (:math:`1 \\rightarrow 3`) 不是图的一部分。"
+msgstr "对于 :math:`seq=7` 从 :math:`203 \\leftrightarrow 302` 代表两条边。"
 
-#, fuzzy
 msgid ""
 "For :math:`seq=8` from :math:`304 \\leftrightarrow 403` represent two edges."
-msgstr "边 :math:`2` (:math:`1 \\rightarrow 3`) 不是图的一部分。"
+msgstr "对于 :math:`seq=8` ，从 :math:`304 \\leftrightarrow 403` 表示两条边。"
 
-#, fuzzy
 msgid "wikipedia: `Line Graph <https://en.wikipedia.org/wiki/Line_graph>`__"
-msgstr "`维基百科：二分图 <https://en.wikipedia.org/wiki/Bipartite_graph>`__"
+msgstr "维基百科: `Line Graph <https://en.wikipedia.org/wiki/Line_graph>`__"
 
 msgid ""
 "mathworld: `Line Graph <https://mathworld.wolfram.com/LineGraph.html>`__"
 msgstr ""
+"MathWorld在线数学资源: `Line Graph <https://mathworld.wolfram.com/LineGraph."
+"html>`__"
 
 msgid "``pgr_lineGraphFull`` - Experimental"
 msgstr "``pgr_lineGraphFull`` - 实验"
@@ -13792,9 +13790,9 @@ msgstr "返回 |result-linegf| 的集合"
 msgid "Full line graph of subgraph of edges :math:`\\{4, 7, 8, 10\\}`"
 msgstr "边 :math:`\\{4, 7, 8, 10\\}` 子图的全线图"
 
+#, fuzzy
 msgid ""
-"The examples of this section are based on the :doc:`sampledata` network. The "
-"examples include the subgraph including edges 4, 7, 8, and 10 with "
+"The examples include the subgraph including edges 4, 7, 8, and 10 with "
 "``reverse_cost``."
 msgstr ""
 "本节的示例基于 :doc:`sampledata` 网络。 这些示例包括包含具有 "
@@ -14028,30 +14026,36 @@ msgstr "pgr_makeConnected(`Edges SQL`_)"
 msgid "Returns set of |result-component-make|"
 msgstr "Returns set of |result-component-make|"
 
-msgid ""
-"Query done on :doc:`sampledata` network gives the list of edges that are "
-"needed to connect the graph."
+#, fuzzy
+msgid "List of edges that are needed to connect the graph."
 msgstr "在 :doc:`sampledata` 网络上完成的查询给出了连接图所需的边列表。"
 
-msgid "https://www.boost.org/libs/graph/doc/make_connected.html"
+#, fuzzy
+msgid ""
+"`Boost: make connected <https://www.boost.org/libs/graph/doc/make_connected."
+"html>`__"
 msgstr "https://www.boost.org/libs/graph/doc/make_connected.html"
 
-msgid "pgr_maxCardinalityMatch"
-msgstr "pgr_maxCardinalityMatch"
+msgid "``pgr_maxCardinalityMatch``"
+msgstr "``pgr_maxCardinalityMatch``"
 
 msgid ""
 "``pgr_maxCardinalityMatch`` — Calculates a maximum cardinality matching in a "
 "graph."
 msgstr "``pgr_maxCardinalityMatch`` — 计算图中的最大基数匹配。."
 
+#, fuzzy
+msgid "pgr_maxCardinalityMatch(text) returns only ``edge`` column."
+msgstr "``pgr_maxCardinalityMatch(text)`` 仅仅返回``边`` 列."
+
 msgid "Deprecated signature"
 msgstr "已弃用的签名"
 
-msgid "``pgr_maxCardinalityMatch(text,boolean)``"
-msgstr "``pgr_maxCardinalityMatch(text,boolean)``"
+msgid "pgr_maxCardinalityMatch(text,boolean)"
+msgstr "pgr_maxCardinalityMatch(text,boolean)"
 
-msgid "``directed => false`` when used."
-msgstr "使用时 ``directed => false``。"
+msgid "directed => ``false`` when used."
+msgstr "使用时 directed => ``false``。"
 
 msgid "Renamed from ``pgr_maximumCardinalityMatching``"
 msgstr "从 ``pgr_maximumCardinalityMatching`` 重命名"
@@ -14101,7 +14105,10 @@ msgstr "正值表示存在边(``target``, ``source``)"
 msgid "Identifier of the edge in the original query."
 msgstr "原始查询中边的标识符。"
 
-msgid "https://www.boost.org/libs/graph/doc/maximum_matching.html"
+#, fuzzy
+msgid ""
+"`Boost: maximum_matching <https://www.boost.org/libs/graph/doc/"
+"maximum_matching.html>`__"
 msgstr "https://www.boost.org/libs/graph/doc/maximum_matching.html"
 
 msgid "https://en.wikipedia.org/wiki/Matching_%28graph_theory%29"
@@ -14119,19 +14126,15 @@ msgid ""
 msgstr ""
 "``pgr_maxFlow`` —使用 Push Relabel 算法计算有向图中从源到目标的最大流量。"
 
-msgid "``pgr_maxFlow`` (`Combinations`_)"
-msgstr "``pgr_maxFlow`` (`组合`_)"
-
-msgid "New **Proposed** function"
-msgstr "新 **拟议** 的函数"
-
-#, fuzzy
 msgid "Calculates the maximum flow from the sources to the targets."
-msgstr "计算从 `source(s)` 到 `target(s)` 的最大流量。"
+msgstr "计算从源头到目标的最大流量。"
 
 msgid ""
 "When the maximum flow is **0** then there is no flow and **0** is returned."
 msgstr "当最大流量为 **0** 时则没有流量，返回 **0** 。"
+
+msgid "There is no flow when source has the same vaule as target."
+msgstr "当 source与 target相同时，没有流量。"
 
 msgid "Uses the :doc:`pgr_pushRelabel <pgr_pushRelabel>` algorithm."
 msgstr "使用 :doc:`pgr_pushRelabel <pgr_pushRelabel>` 算法。"
@@ -14160,7 +14163,10 @@ msgstr "RETURNS ``BIGINT``"
 msgid "Maximum flow possible from the source(s) to the target(s)"
 msgstr "从 source(s)到 target(s)的可能最大流量"
 
-msgid "https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html"
+#, fuzzy
+msgid ""
+"`Boost: push relabel max flow <https://www.boost.org/libs/graph/doc/"
+"push_relabel_max_flow.html>`__"
 msgstr "https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html"
 
 msgid ""
@@ -14176,8 +14182,11 @@ msgid ""
 "of the maximum flow on a graph"
 msgstr "``pgr_maxFlowMinCost`` — 计算图上最大流的总成本最小化的边"
 
-msgid "``pgr_maxFlowMinCost`` (`Combinations`_)"
-msgstr "``pgr_maxFlowMinCost`` (`组合`_)"
+msgid "pgr_maxFlowMinCost(Combinations)"
+msgstr "pgr_maxFlowMinCost(组合)"
+
+msgid "|boost| graph inside."
+msgstr "|boost| 图内部。"
 
 msgid "**TODO** check which statement is true:"
 msgstr "**TODO** 检查哪个陈述是正确的："
@@ -14222,13 +14231,6 @@ msgstr "pgr_maxFlowMinCost(`Edges SQL`_, `Combinations SQL`_)"
 msgid "Returns set of |result-flow-mincost|"
 msgstr "返回 |result-flow-mincost| 的集合"
 
-msgid ""
-"https://www.boost.org/libs/graph/doc/"
-"successive_shortest_path_nonnegative_weights.html"
-msgstr ""
-"https://www.boost.org/libs/graph/doc/"
-"successive_shortest_path_nonnegative_weights.html"
-
 msgid "``pgr_maxFlowMinCost_Cost`` - Experimental"
 msgstr "``pgr_maxFlowMinCost_Cost`` - 实验"
 
@@ -14237,8 +14239,8 @@ msgid ""
 "maximum flow on a graph"
 msgstr "``pgr_maxFlowMinCost_Cost`` — 计算图上最大流量的最小总成本"
 
-msgid "``pgr_maxFlowMinCost_Cost`` (`Combinations`_)"
-msgstr "``pgr_maxFlowMinCost_Cost`` (`组合`_)"
+msgid "pgr_maxFlowMinCost_Cost(Combinations)"
+msgstr "pgr_maxFlowMinCost_Cost(组合)"
 
 msgid "**The cost value of all input edges must be nonnegative.**"
 msgstr "**所有输入边的成本值必须是非负的。**"
@@ -14270,8 +14272,8 @@ msgstr "RETURNS FLOAT"
 msgid "Minimum Cost Maximum Flow possible from the source(s) to the target(s)"
 msgstr "从source(s) 到target(s)的最小成本最大流量"
 
-msgid "pgr_nodeNetwork"
-msgstr "pgr_nodeNetwork"
+msgid "``pgr_nodeNetwork``"
+msgstr "``pgr_nodeNetwork``"
 
 msgid "``pgr_nodeNetwork`` - Nodes an network edge table."
 msgstr "``pgr_nodeNetwork`` - 网络边表的节点。"
@@ -14341,9 +14343,8 @@ msgstr "``bigint`` 表的唯一标识符"
 msgid "old_id"
 msgstr "old_id"
 
-#, fuzzy
 msgid "``bigint`` Identifier of the edge in original table"
-msgstr "``bigint`` 原表中边的标识符"
+msgstr "``bigint`` 是原始表中边的标识符"
 
 msgid "sub_id"
 msgstr "sub_id"
@@ -14437,9 +14438,8 @@ msgstr "仅具有进行拓扑分析的基本字段"
 msgid "Edges with 1 dead end: 1,6,24"
 msgstr "有 1 个死端的边：1、6、24"
 
-#, fuzzy
 msgid "Edges with 2 dead ends: 17,18"
-msgstr "有两个死端的边：17，18"
+msgstr "边缘有 2 个死角：17,18"
 
 msgid ""
 "Edge 17's right node is a dead end because there is no other edge sharing "
@@ -14452,9 +14452,8 @@ msgstr "有 1 个死端的边：1-1 ,6-1,14-2, 18-1 17-1 18-2"
 msgid "Isolated segments"
 msgstr "孤立的片段"
 
-#, fuzzy
 msgid "two isolated segments: 17 and 18 both they have 2 dead ends"
-msgstr "两个孤立的段：17 和 18 都有 2 个死端"
+msgstr "两个孤立的段：17 和 18，它们都有两个死端"
 
 msgid "No Isolated segments"
 msgstr "无孤立段"
@@ -14723,7 +14722,8 @@ msgstr ""
 "此数据示例 **lc101** 来自 https://www.sintef.no/projectweb/top/pdptw/li-lim-"
 "benchmark/ 上发布的数据"
 
-msgid "There are 25 vehciles in the problem all with the same characteristics."
+#, fuzzy
+msgid "There are 25 vehicles in the problem all with the same characteristics."
 msgstr "问题中有 25 辆车都具有相同的特征。"
 
 msgid "The original orders"
@@ -14734,7 +14734,8 @@ msgid ""
 "order."
 msgstr "对于同一订单的取货和配送，数据位于不同的行中。"
 
-msgid "The original data needs to be converted to an appropiate table:"
+#, fuzzy
+msgid "The original data needs to be converted to an appropriate table:"
 msgstr "需要将原始数据转换为合适的表格："
 
 msgid "The query"
@@ -14787,12 +14788,12 @@ msgid ""
 "First Search ordering."
 msgstr "``pgr_primBFS`` — Prim 的深度优先搜索排序最小生成树算法。"
 
-#, fuzzy
 msgid ""
 "Visits and extracts the nodes information in Breath First Search ordering of "
 "the Minimum Spanning Tree created using Prims's algorithm."
 msgstr ""
-"访问并提取使用 Prims 算法创建的最小生成树的深度优先搜索顺序中的节点信息。"
+"访问并提取使用 Prims 算法创建的最小生成树的 Breath First Search 排序中的节点"
+"信息。"
 
 msgid "pgr_primBFS(`Edges SQL`_, **root vid**, [``max_depth``])"
 msgstr "pgr_primBFS(`Edges SQL`_, **root vid**, [``max_depth``])"
@@ -14803,14 +14804,13 @@ msgstr "pgr_primBFS(`Edges SQL`_, **root vids**, [``max_depth``])"
 msgid "``pgr_primDD`` — Catchament nodes using Prim's algorithm."
 msgstr "``pgr_primDD`` — 使用 Prim 算法的集水区节点。"
 
-#, fuzzy
 msgid ""
 "Using Prim's algorithm, extracts the nodes that have aggregate costs less "
 "than or equal to a distance from a root vertex (or vertices) within the "
 "calculated minimum spanning tree."
 msgstr ""
-"使用 Prim 算法，在计算的最小生成树中提取总成本小于或等于距根顶点（或多个顶"
-"点）距离的节点。"
+"使用 Prim 算法，从计算出最小生成树中提取出那些与根节点（或根节点组）之间的聚"
+"合成本小于或等于某个距离的节点。"
 
 msgid "pgr_primDD(`Edges SQL`_, **root vid**, **distance**)"
 msgstr "pgr_primDD(`Edges SQL`_, **root vid**, **distance**)"
@@ -14845,9 +14845,6 @@ msgstr ""
 "``pgr_pushRelabel`` — 使用 Push Relabel 算法计算图边上的流量，以最大化从源到"
 "目标的流量。"
 
-msgid "``pgr_pushRelabel`` (`Combinations`_)"
-msgstr "``pgr_pushRelabel`` (`组合`_)"
-
 msgid "Renamed from ``pgr_maxFlowPushRelabel``"
 msgstr "由 ``pgr_maxFlowPushRelabel`` 重命名"
 
@@ -14866,16 +14863,13 @@ msgstr "pgr_pushRelabel(`Edges SQL`_, **start vids**, **end vids**)"
 msgid "pgr_pushRelabel(`Edges SQL`_, `Combinations SQL`_)"
 msgstr "pgr_pushRelabel(`Edges SQL`_, `Combinations SQL`_)"
 
-msgid "pgr_sequentialVertexColoring - Proposed"
-msgstr "pgr_sequentialVertexColoring - 拟议"
+msgid "``pgr_sequentialVertexColoring`` - Proposed"
+msgstr "``pgr_sequentialVertexColoring`` - 拟议"
 
 msgid ""
 "``pgr_sequentialVertexColoring`` — Returns the vertex coloring of an "
 "undirected graph, using greedy approach."
 msgstr "``pgr_sequentialVertexColoring`` — 使用贪婪方法返回无向图的顶点着色。"
-
-msgid "Promoted to **proposed** signature"
-msgstr "晋升为 **拟议** 签名"
 
 msgid ""
 "Sequential vertex coloring algorithm is a graph coloring algorithm in which "
@@ -14923,8 +14917,16 @@ msgstr ":math:`k` 是使用的颜色数量。"
 msgid "pgr_sequentialVertexColoring(`Edges SQL`_)"
 msgstr "pgr_sequentialVertexColoring(`Edges SQL`_)"
 
-msgid "pgr_stoerWagner - Experimental"
-msgstr "pgr_stoerWagner - 实验"
+#, fuzzy
+msgid ""
+"`Boost: Sequential Vertex Coloring <https://www.boost.org/libs/graph/doc/"
+"sequential_vertex_coloring.html>`__"
+msgstr ""
+"`Boost：顺序顶点着色算法文档 <https://www.boost.org/libs/graph/doc/"
+"sequential_vertex_coloring.html>`__"
+
+msgid "``pgr_stoerWagner`` - Experimental"
+msgstr "``pgr_stoerWagner`` - 实验"
 
 msgid "``pgr_stoerWagner`` — The min-cut of graph using stoerWagner algorithm."
 msgstr "``pgr_stoerWagner`` — 使用 stoerWagner 算法对图进行最小分割。"
@@ -15017,6 +15019,14 @@ msgstr "边的最小割"
 msgid "Using :doc:`pgr_connectedComponents`"
 msgstr "使用 :doc:`pgr_connectedComponents`"
 
+#, fuzzy
+msgid ""
+"`Boost: Stoer Wagner min cut <https://www.boost.org/libs/graph/doc/"
+"stoer_wagner_min_cut.html>`__"
+msgstr ""
+"Boost: `强大组件 <https://www.boost.org/libs/graph/doc/strong_components."
+"html>`__"
+
 msgid "https://en.wikipedia.org/wiki/Stoer%E2%80%93Wagner_algorithm"
 msgstr "https://en.wikipedia.org/wiki/Stoer%E2%80%93Wagner_algorithm"
 
@@ -15047,8 +15057,9 @@ msgstr "pgr_strongComponents(`Edges SQL`_)"
 msgid "The strong components of the graph"
 msgstr "图的重要组成部分"
 
+#, fuzzy
 msgid ""
-"Boost: `Strong components <https://www.boost.org/libs/graph/doc/"
+"`Boost: Strong components <https://www.boost.org/libs/graph/doc/"
 "strong_components.html>`__"
 msgstr ""
 "Boost: `强大组件 <https://www.boost.org/libs/graph/doc/strong_components."
@@ -15119,6 +15130,14 @@ msgstr "对单向段进行拓扑排序"
 msgid "Graph is not a DAG"
 msgstr "图不是 DAG"
 
+#, fuzzy
+msgid ""
+"`Boost: topological sort <https://www.boost.org/libs/graph/doc/"
+"topological_sort.html>`__"
+msgstr ""
+"`Boost: is_bipartite <https://www.boost.org/libs/graph/doc/is_bipartite."
+"html>`__"
+
 msgid "``pgr_transitiveClosure`` - Experimental"
 msgstr "``pgr_transitiveClosure`` - 实验"
 
@@ -15176,58 +15195,55 @@ msgstr "边目标的标识符"
 msgid "Identifiers of the vertices that are reachable from vertex v."
 msgstr "从顶点 v 可到达的顶点的标识符。"
 
+#, fuzzy
+msgid ""
+"`Boost: transitive closure <https://www.boost.org/libs/graph/doc/"
+"transitive_closure.html>`__"
+msgstr ""
+"`Boost: is_bipartite <https://www.boost.org/libs/graph/doc/is_bipartite."
+"html>`__"
+
 msgid "https://en.wikipedia.org/wiki/Transitive_closure"
 msgstr "https://en.wikipedia.org/wiki/Transitive_closure"
 
-msgid "pgr_trsp - Proposed"
-msgstr "pgr_trsp - 拟议"
+msgid "``pgr_trsp``"
+msgstr "``pgr_trsp``"
 
 msgid "``pgr_trsp`` - routing vertices with restrictions."
 msgstr "``pgr_trsp`` -有限制的路由顶点。"
 
-msgid "New proposed signatures"
-msgstr "新拟议的签名"
+msgid "pgr_trsp(One to One)"
+msgstr "pgr_trsp （一对一）"
 
-msgid "``pgr_trsp`` (`One to One`_)"
-msgstr "``pgr_trsp`` (`一对一`_)"
+msgid "pgr_trsp(One to Many)"
+msgstr "pgr_trsp （一对多）"
 
-msgid "``pgr_trsp`` (`One to Many`_)"
-msgstr "``pgr_trsp`` (`一对多`_)"
+msgid "pgr_trsp(Many to One)"
+msgstr "pgr_trsp （多对一）"
 
-msgid "``pgr_trsp`` (`Many to One`_)"
-msgstr "``pgr_trsp`` (`多对一`_)"
+msgid "pgr_trsp(Many to Many)"
+msgstr "pgr_trsp （多对多）"
 
-msgid "``pgr_trsp`` (`Many to Many`_)"
-msgstr "``pgr_trsp`` (`多对多`_)"
-
-msgid "``pgr_trsp`` (`Combinations`_)"
-msgstr "``pgr_trsp`` (`组合`_)"
+msgid "pgr_trsp(Combinations)"
+msgstr "pgr_trsp （组合）"
 
 msgid "Deprecated signatures"
 msgstr "弃用签名"
 
-msgid "``pgr_trsp(text,integer,integer,boolean,boolean,text)``"
-msgstr "``pgr_trsp(text,integer,integer,boolean,boolean,text)``"
+msgid "pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)"
+msgstr "pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)"
 
-msgid "``pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)``"
-msgstr "``pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)``"
-
-msgid "``pgr_trspViaVertices(text,anyarray,boolean,boolean,text)``"
-msgstr "``pgr_trspViaVertices(text,anyarray,boolean,boolean,text)``"
-
-msgid ""
-"``pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)``"
-msgstr ""
-"``pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,text)``"
+msgid "pgr_trspViaVertices(text,anyarray,boolean,boolean,text)"
+msgstr "pgr_trspViaVertices(text,anyarray,boolean,boolean,text)"
 
 msgid "New prototypes"
 msgstr "新原型"
 
-msgid "``pgr_trspViaVertices``"
-msgstr "``pgr_trspViaVertices``"
+msgid "pgr_trspViaVertices"
+msgstr "pgr_trspViaVertices"
 
-msgid "``pgr_trspViaEdges``"
-msgstr "``pgr_trspViaEdges``"
+msgid "pgr_trspViaEdges"
+msgstr "pgr_trspViaEdges"
 
 msgid ""
 "Turn restricted shortest path (TRSP) is an algorithm that receives turn "
@@ -15311,18 +15327,12 @@ msgid ""
 "`Deprecated documentation <https://docs.pgrouting.org/3.3/en/pgr_trsp.html>`_"
 msgstr "` 已弃用文档 <https://docs.pgrouting.org/3.3/en/pgr_trsp.html>`_"
 
-msgid "``pgr_trspVia`` - Proposed"
-msgstr "``pgr_trspVia`` - 拟议"
+msgid "``pgr_trspVia``"
+msgstr "``pgr_trspVia``"
 
 msgid ""
 "``pgr_trspVia`` Route that goes through a list of vertices with restrictions."
 msgstr "``pgr_trspVia`` 穿过有限制的顶点列表的路线。"
-
-msgid "New proposed function:"
-msgstr "新提议的函数："
-
-msgid "``pgr_trspVia`` (`One Via`_)"
-msgstr "``pgr_trspVia`` (`One Via`_)"
 
 msgid ""
 "Given a list of vertices and a graph, this function is equivalent to finding "
@@ -15416,16 +15426,13 @@ msgstr "因此，当设置为 ``false`` 时，结果会忽略 ``U_turn_on_edge``
 msgid ":doc:`via-category`"
 msgstr ":doc:`via-category`"
 
-msgid "``pgr_trspVia_withPoints`` - Proposed"
-msgstr "``pgr_trspVia_withPoints`` - 拟议"
+msgid "``pgr_trspVia_withPoints``"
+msgstr "``pgr_trspVia_withPoints``"
 
 msgid ""
 "``pgr_trspVia_withPoints`` - Route that goes through a list of vertices and/"
 "or points with restrictions."
 msgstr "``pgr_trspVia_withPoints`` - 经过一系列具有限制的顶点和/或点的路线。"
-
-msgid "``pgr_trspVia_withPoints`` (`One Via`_)"
-msgstr "``pgr_trspVia_withPoints`` (`One Via`_)"
 
 msgid ""
 "Given a graph, a set of restriction on the graph edges, a set of points on "
@@ -15610,35 +15617,17 @@ msgstr ""
 "`pgr_withPointsVia` 结果中，它删除了冲突路径，并使用 :doc:`pgr_trsp` 算法的结"
 "果构建解决方案。 在这种情况下，使用相同的边缘完成 U 形转弯。"
 
-msgid "pgr_trsp_withPoints - Proposed"
-msgstr "pgr_trsp_withPoints - 拟议"
+msgid "``pgr_trsp_withPoints``"
+msgstr "``pgr_trsp_withPoints``"
 
 msgid "``pgr_trsp_withPoints`` Routing Vertex/Point with restrictions."
 msgstr "``pgr_trsp_withPoints`` 有限制的路由顶点/点。"
 
-msgid "New proposed signatures:"
-msgstr "新拟议的签名："
-
-msgid "``pgr_trsp_withPoints`` (`One to One`_)"
-msgstr "``pgr_trsp_withPoints`` (`一对一`_)"
-
-msgid "``pgr_trsp_withPoints`` (`One to Many`_)"
-msgstr "``pgr_trsp_withPoints`` (`一对多`_)"
-
-msgid "``pgr_trsp_withPoints`` (`Many to One`_)"
-msgstr "``pgr_trsp_withPoints`` (`多对一`_)"
-
-msgid "``pgr_trsp_withPoints`` (`Many to Many`_)"
-msgstr "``pgr_trsp_withPoints`` (`多对多`_)"
-
-msgid "``pgr_trsp_withPoints`` (`Combinations`_)"
-msgstr "``pgr_trsp_withPoints`` (`组合`_)"
-
-#, fuzzy
 msgid ""
 "Modify the graph to include points defined by points_sql. Using Dijkstra "
 "algorithm, find the shortest path"
-msgstr "修改图以包括由points_sql 定义的点。 使用 Dijkstra 算法，找到最短路径"
+msgstr ""
+"修改图形，使其包含由 points_sql 定义的点。使用 Dijkstra 算法找出最短路径"
 
 msgid "Characteristics:"
 msgstr "特征："
@@ -15759,16 +15748,14 @@ msgstr ""
 "无向图上从点 :math:`1` 和顶点 :math:`6` 到点 :math:`3`到顶点 :math:`1` 的详细"
 "信息。"
 
-msgid "pgr_turnRestrictedPath - Experimental"
-msgstr "pgr_turnRestrictedPath - 实验性"
+msgid "``pgr_turnRestrictedPath`` - Experimental"
+msgstr "``pgr_turnRestrictedPath`` - 实验性"
 
+#, fuzzy
 msgid ""
-"``pgr_turnRestrictedPath`` Using Yen's algorithm Vertex -Vertex routing with "
-"restrictions"
+"``pgr_turnRestrictedPath`` Using Yen's algorithm Vertex - Vertex routing "
+"with restrictions"
 msgstr "``pgr_turnRestrictedPath`` 使用 Yen 算法顶点- 带限制的顶点路由"
-
-msgid "New experimental function"
-msgstr "新实验功能"
 
 msgid ""
 "Using Yen's algorithm to obtain K shortest paths and analyze the paths to "
@@ -15843,8 +15830,8 @@ msgstr "pgr_version()"
 msgid "pgRouting Version for this documentation"
 msgstr "本文档的 pgRouting 版本"
 
-msgid "pgr_vrpOneDepot - Experimental"
-msgstr "pgr_vrpOneDepot -实验"
+msgid "``pgr_vrpOneDepot`` - Experimental"
+msgstr "``pgr_vrpOneDepot`` - 实验"
 
 msgid "**No documentation available**"
 msgstr "**无可用文档**"
@@ -15852,8 +15839,8 @@ msgstr "**无可用文档**"
 msgid "**TBD**"
 msgstr "**TBD**"
 
-msgid "``pgr_withPoints`` - Proposed"
-msgstr "``pgr_withPoints`` -拟议"
+msgid "``pgr_withPoints``"
+msgstr "``pgr_withPoints``"
 
 msgid ""
 "``pgr_withPoints`` - Returns the shortest path in a graph with additional "
@@ -16011,28 +15998,25 @@ msgstr "对于点 :math:`6` 和顶点 :math:`11`。"
 msgid "Passes in front or visits with left side driving."
 msgstr "从前方超车或以左侧驾驶方式行驶。"
 
-msgid "``pgr_withPointsCost`` - Proposed"
-msgstr "``pgr_withPointsCost`` -拟议"
+msgid "``pgr_withPointsCost``"
+msgstr "``pgr_withPointsCost``"
 
-#, fuzzy
 msgid ""
 "``pgr_withPointsCost`` - Calculates the shortest path and returns only the "
 "aggregate cost of the shortest path found, for the combination of points "
 "given."
 msgstr ""
-"``pgr_withPointsCost`` -对于给定的点组合，计算最短路径并仅返回找到的最短路径"
-"的总成本。"
+"``pgr_withPointsCost`` - 计算最短路径，并只返回所给点组合的最短路径的总成本。"
 
 msgid "pgr_withPointsCost(Combinations)"
 msgstr "pgr_withPointsCost（组合）"
 
-#, fuzzy
 msgid ""
 "Modify the graph to include points defined by points_sql. Using Dijkstra "
 "algorithm, return only the aggregate cost of the shortest path found."
 msgstr ""
-"修改图以包括由points_sql 定义的点。 使用 Dijkstra 算法，仅返回找到的最短路径"
-"的总成本。"
+"修改图形以包含由 points_sql 定义的点。使用 Dijkstra 算法，只返回找到的最短路"
+"径的总成本。"
 
 msgid ""
 "Returns the sum of the costs of the shortest path for pair combination of "
@@ -16182,8 +16166,8 @@ msgstr "左侧驾驶拓扑"
 msgid "Does not matter driving side driving topology"
 msgstr "与驱动端驱动拓扑无关"
 
-msgid "``pgr_withPointsCostMatrix`` - proposed"
-msgstr "``pgr_withPointsCostMatrix`` - 拟议"
+msgid "``pgr_withPointsCostMatrix``"
+msgstr "``pgr_withPointsCostMatrix``"
 
 msgid ""
 "``pgr_withPointsCostMatrix`` - Calculates a cost matrix using :doc:"
@@ -16219,8 +16203,8 @@ msgid ""
 msgstr ""
 "求从顶点 :math:`1` 到图上点 `(2.9, 1.8)` 的两个最近位置的路线的矩阵成本。"
 
-msgid "``pgr_withPointsDD`` - Proposed"
-msgstr "``pgr_withPointsDD`` - 拟议"
+msgid "``pgr_withPointsDD``"
+msgstr "``pgr_withPointsDD``"
 
 msgid ""
 "``pgr_withPointsDD`` - Returns the driving **distance** from a starting "
@@ -16234,8 +16218,11 @@ msgstr ""
 "签名更改： ``driving_side`` 参数从已命名的可选参数改为未命名的必选参数 "
 "**driving side**。"
 
-msgid "``pgr_withPointsDD`` (`Single vertex`)"
-msgstr "``pgr_withPointsDD`` （`单顶点`）"
+msgid "pgr_withPointsDD(Single vertex)"
+msgstr "pgr_withPointsDD （单顶点）"
+
+msgid "pgr_withPointsDD(Multiple vertices)"
+msgstr "pgr_withPointsDD（多顶点）"
 
 msgid "Added ``depth``, ``pred`` and ``start_vid`` column."
 msgstr "添加了 ``depth``、``pred`` 和 ``start_vid`` 列。"
@@ -16243,9 +16230,8 @@ msgstr "添加了 ``depth``、``pred`` 和 ``start_vid`` 列。"
 msgid "Added ``depth``, ``pred`` columns."
 msgstr "添加了 ``depth``，``pred`` 列。"
 
-#, fuzzy
 msgid "When ``details`` is ``false``:"
-msgstr "当 ``details`` 为``false`` 时："
+msgstr "当 ``details`` 为 ``false`` 时："
 
 msgid ""
 "Only points that are visited are removed, that is, points reached within the "
@@ -16255,18 +16241,16 @@ msgstr ""
 "被包含在内"
 
 msgid ""
-"``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,"
-"boolean)``"
+"pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)"
 msgstr ""
-"``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,"
-"boolean)``"
+"pgr_withpointsdd(text,text,bigint,double precision,boolean,character,boolean)"
 
 msgid ""
-"``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
-"boolean,boolean)``"
+"pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
+"boolean,boolean)"
 msgstr ""
-"``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
-"boolean,boolean)``"
+"pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
+"boolean,boolean)"
 
 msgid ""
 "Modify the graph to include points and using Dijkstra algorithm, extracts "
@@ -16387,8 +16371,8 @@ msgstr ""
 msgid ":doc:`pgr_alphaShape`"
 msgstr ":doc:`pgr_alphaShape`"
 
-msgid "pgr_withPointsKSP - Proposed"
-msgstr "pgr_withPointsKSP -拟议"
+msgid "``pgr_withPointsKSP``"
+msgstr "``pgr_withPointsKSP``"
 
 msgid ""
 "``pgr_withPointsKSP`` — Yen's algorithm for K shortest paths using Dijkstra."
@@ -16397,29 +16381,26 @@ msgstr "``pgr_withPointsKSP`` — Yen 使用 Dijkstra 计算 K 最短路径的�
 msgid "Standarizing output columns to |nksp-result|"
 msgstr "标准化输出列为 |nksp-result|"
 
-msgid "``pgr_withPointsKSP`` (One to One)"
-msgstr "``pgr_withPointsKSP`` (一对一)"
+msgid "pgr_withPointsKSP(One to One)"
+msgstr "pgr_withPointsKSP(一对一)"
 
-msgid "New overload functions"
-msgstr "新的重载函数"
+msgid "pgr_withPointsKSP(One to Many)"
+msgstr "pgr_withPointsKSP (一对多)"
 
-msgid "``pgr_withPointsKSP`` (One to Many)"
-msgstr "``pgr_withPointsKSP`` (一对多)"
+msgid "pgr_withPointsKSP(Many to One)"
+msgstr "pgr_withPointsKSP(多对一)"
 
-msgid "``pgr_withPointsKSP`` (Many to One)"
-msgstr "``pgr_withPointsKSP`` (多对一)"
+msgid "pgr_withPointsKSP(Many to Many)"
+msgstr "pgr_withPointsKSP(多对多)"
 
-msgid "``pgr_withPointsKSP`` (Many to Many)"
-msgstr "``pgr_withPointsKSP`` (多对多)"
-
-msgid "``pgr_withPointsKSP`` (Combinations)"
-msgstr "``pgr_withPointsKSP`` (组合)"
+msgid "pgr_withPointsKSP(Combinations)"
+msgstr "pgr_withPointsKSP（组合）"
 
 msgid ""
-"``pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
+"pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
 "boolean)``"
 msgstr ""
-"``pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
+"pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
 "boolean)``"
 
 msgid ""
@@ -16556,16 +16537,13 @@ msgstr ""
 "使用右侧驾驶拓扑，从点 :math:`1` 到点 :math:`2` 获取 :math:`2` 条路径，同时使"
 "用堆路径（heap paths）并包含详细信息。"
 
-msgid "``pgr_withPointsVia`` - Proposed"
-msgstr "``pgr_withPointsVia`` - 拟议"
+msgid "``pgr_withPointsVia``"
+msgstr "``pgr_withPointsVia``"
 
 msgid ""
 "``pgr_withPointsVia`` - Route that goes through a list of vertices and/or "
 "points."
 msgstr "``pgr_withPointsVia`` - 经过一系列顶点和/或点的路线。"
-
-msgid "New **proposed** function ``pgr_withPointsVia`` (`One Via`_)"
-msgstr "新 **拟议** 的函数 ``pgr_withPointsVia`` (`One Via`_)"
 
 msgid ""
 "Given a graph, a set of points on the graphs edges and a list of vertices, "
@@ -16669,43 +16647,15 @@ msgstr ":doc:`pgr_withPointsDD` -行驶距离。"
 msgid ":doc:`pgr_withPointsVia` - Via routing"
 msgstr ":doc:`pgr_withPointsVia` - 通过路由"
 
-msgid "These proposed functions do not modify the database."
-msgstr "这些拟议的功能不会修改数据库。"
-
-msgid ""
-":doc:`pgr_degree` - Returns a set of vertices and corresponding count of "
-"incidet edges to the vertex."
-msgstr ":doc:`pgr_degree` -返回一组顶点以及该顶点对应的关联边数。"
-
-msgid ""
-":doc:`pgr_extractVertices` - Extracts vertex information based on the edge "
-"table information."
-msgstr ":doc:`pgr_extractVertices` - 根据边表信息提取顶点信息。"
-
 msgid ""
 ":doc:`pgr_lineGraph` - Transformation algorithm for generating a Line Graph."
 msgstr ":doc:`pgr_lineGraph` - 用于生成折线图的转换算法。"
-
-msgid ":doc:`pgr_withPointsVia`"
-msgstr ":doc:`pgr_withPointsVia`"
-
-msgid ":doc:`pgr_trspVia`"
-msgstr ":doc:`pgr_trspVia`"
-
-msgid ":doc:`pgr_trspVia_withPoints`"
-msgstr ":doc:`pgr_trspVia_withPoints`"
 
 msgid ":doc:`withPoints-family` - Functions based on Dijkstra algorithm."
 msgstr ":doc:`withPoints-family` -基于 Dijkstra 算法的函数。"
 
 msgid "From the :doc:`TRSP-family`:"
 msgstr "来自 :doc:`TRSP-family`:"
-
-msgid "Utilities"
-msgstr "实用程序"
-
-msgid ":doc:`pgr_findCloseEdges`"
-msgstr ":doc:`pgr_findCloseEdges`"
 
 msgid "Reference"
 msgstr "参考"
@@ -16723,74 +16673,312 @@ msgstr ""
 msgid "Mayors"
 msgstr "主要版本"
 
+msgid "pgRouting 4"
+msgstr "pgRouting 4"
+
+msgid "Minors 4.x"
+msgstr "Minors 4.x"
+
+msgid "pgRouting 4.0"
+msgstr "pgRouting 4.0"
+
 msgid "pgRouting 3"
 msgstr "pgRouting 3"
 
 msgid "Minors 3.x"
 msgstr "3.x小版本"
 
+#, fuzzy
+msgid "pgRouting 3.8"
+msgstr "pgRouting 3.7"
+
+#, fuzzy
+msgid "pgRouting 3.8.0 Release Notes"
+msgstr "pgRouting 3.7.0 发布说明"
+
+#, fuzzy
+msgid "Promotion to official function of pgRouting."
+msgstr "pgRouting 中的拟议已升级为正式版本"
+
+msgid "pgr_extractVertices"
+msgstr "pgr_extractVertices"
+
+msgid "pgr_degree"
+msgstr "pgr_degree"
+
+#, fuzzy
+msgid "pgr_findCloseEdges"
+msgstr "``pgr_findCloseEdges``"
+
+msgid "Official functions changes"
+msgstr "官方功能变更"
+
+#, fuzzy
+msgid ""
+"`#2786 <https://github.com/pgRouting/pgrouting/issues/2786>`__: "
+"pgr_contraction"
+msgstr ""
+"`#2266 <https://github.com/pgRouting/pgrouting/issues/2266>`__：错误处理限制"
+
+msgid "New proposed functions"
+msgstr "新的拟议函数"
+
+#, fuzzy
+msgid "Contraction"
+msgstr "收缩："
+
+#, fuzzy
+msgid ""
+"`#2790 <https://github.com/pgRouting/pgrouting/issues/2790>`__: "
+"pgr_contractionDeadEnd"
+msgstr ""
+"`#2087 <https://github.com/pgRouting/pgrouting/issues/2087>`__:拟议的 "
+"pgr_extractVertices"
+
+#, fuzzy
+msgid ""
+"`#2791 <https://github.com/pgRouting/pgrouting/issues/2791>`__: "
+"pgr_contractionLinear"
+msgstr ""
+"`#1002 <https://github.com/pgRouting/pgrouting/issues/1002>`__：修复收缩问"
+"题："
+
 msgid "pgRouting 3.7"
 msgstr "pgRouting 3.7"
+
+msgid "pgRouting 3.7.3 Release Notes"
+msgstr "pgRouting 3.7.3 发布说明"
+
+#, fuzzy
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.3 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.3%22>`__"
+msgstr ""
+"要查看此版本关闭的所有问题和拉取请求，请参阅 `Git closed milestone for 3.7.1 "
+"<https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.1%22>`__"
+
+#, fuzzy
+msgid ""
+"`#2731 <https://github.com/pgRouting/pgrouting/pull/2731>`__ Build Failure "
+"on Ubuntu 22"
+msgstr ""
+"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ 在 C++ 上读取 "
+"postgresql 数据"
+
+msgid "pgRouting 3.7.2 Release Notes"
+msgstr "pgRouting 3.7.2 发布说明"
+
+#, fuzzy
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.2 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.2%22>`__"
+msgstr ""
+"要查看此版本关闭的所有问题和拉取请求，请参阅 `Git closed milestone for 3.7.1 "
+"<https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.1%22>`__"
+
+msgid "Build"
+msgstr "构建"
+
+#, fuzzy
+msgid ""
+"`#2713 <https://github.com/pgRouting/pgrouting/pull/2713>`__ cmake missing "
+"some policies and min version"
+msgstr ""
+"`#2517 <https://github.com/pgRouting/pgrouting/pull/2517>`__ Astar 代码简化。"
+
+msgid "Using OLD policies: CMP0148, CMP0144, CMP0167"
+msgstr ""
+
+msgid "Minimum cmake version 3.12"
+msgstr ""
+
+#, fuzzy
+msgid ""
+"`#2707 <https://github.com/pgRouting/pgrouting/pull/2707>`__ Build failure "
+"in pgRouting 3.7.1 on Alpine"
+msgstr ""
+"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ 在 C++ 上读取 "
+"postgresql 数据"
+
+#, fuzzy
+msgid ""
+"`#2706 <https://github.com/pgRouting/pgrouting/pull/2706>`__ winnie crashing "
+"on pgr_betweennessCentrality"
+msgstr ""
+"`#2505 <https://github.com/pgRouting/pgrouting/pull/2505>`__ 使用命名空间。"
+
+msgid "pgRouting 3.7.1 Release Notes"
+msgstr "pgRouting 3.7.1 发布说明"
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.1 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.1%22>`__"
+msgstr ""
+"要查看此版本关闭的所有问题和拉取请求，请参阅 `Git closed milestone for 3.7.1 "
+"<https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.1%22>`__"
+
+msgid ""
+"`#2680 <https://github.com/pgRouting/pgrouting/pull/2680>`__ fails to "
+"compile under mingw64 gcc 13.2"
+msgstr ""
+"`#2680 <https://github.com/pgRouting/pgrouting/pull/2680>`__ 在 mingw64 gcc "
+"13.2 下编译失败"
+
+msgid ""
+"`#2689 <https://github.com/pgRouting/pgrouting/pull/2689>`__ When point is a "
+"vertex, the withPoints family do not return results."
+msgstr ""
+"`#2689 <https://github.com/pgRouting/pgrouting/pull/2689>`__ 当 point 是顶点"
+"时，withPoints 系列不返回结果。"
+
+#, fuzzy
+msgid "C/C++ code enhancemet"
+msgstr "C/C++ 代码增强"
+
+#, fuzzy
+msgid "TRSP family"
+msgstr "Prim族"
+
+msgid "pgRouting 3.7.0 Release Notes"
+msgstr "pgRouting 3.7.0 发布说明"
+
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git closed "
+"milestone for 3.7.0 <https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.0%22>`__"
+msgstr ""
+"要查看此版本关闭的所有问题和拉取请求，请参阅 `3.7.0 <https://github.com/"
+"pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.0%22>`__ 的 Git 关闭里程碑"
+
+msgid ""
+"`#2656 <https://github.com/pgRouting/pgrouting/pull/2656>`__ Stop support of "
+"PostgreSQL12 on pgrouting v3.7"
+msgstr ""
+"`#2656 <https://github.com/pgRouting/pgrouting/pull/2656>`__ 在 pgrouting "
+"v3.7 上停止支持 PostgreSQL12"
+
+msgid "Stopping support of PostgreSQL 12"
+msgstr "停止支持 PostgreSQL 12"
+
+msgid "CI does not test for PostgreSQL 12"
+msgstr "CI 不测试 PostgreSQL 12"
+
+msgid "New experimental functions"
+msgstr "新的实验函数"
+
+msgid "Metrics"
+msgstr "Metrics"
+
+msgid "pgr_betweennessCentrality"
+msgstr "pgr_betweennessCentrality"
+
+#, fuzzy
+msgid ""
+"`#2605 <https://github.com/pgRouting/pgrouting/pull/2605>`__ Standardize "
+"spanning tree functions output"
+msgstr ""
+"`#2605 <https://github.com/pgRouting/pgrouting/pull/2605>`__ 将生成树函数输出"
+"标准化"
+
+msgid "Functions:"
+msgstr "新函数:"
+
+msgid "Experimental promoted to proposed."
+msgstr "实验提升为拟议。"
+
+msgid ""
+"`#2635 <https://github.com/pgRouting/pgrouting/pull/2635>`__ pgr_LineGraph "
+"ignores directed flag and use negative values for identifiers."
+msgstr ""
+"`#2635 <https://github.com/pgRouting/pgrouting/pull/2635>`__ pgr_LineGraph 忽"
+"略了有向标志，并使用负值作为标识符。"
+
+msgid "``pgr_lineGraph``"
+msgstr "``pgr_lineGraph``"
+
+msgid "Code enhancement"
+msgstr "代码改进"
+
+msgid ""
+"`#2599 <https://github.com/pgRouting/pgrouting/pull/2599>`__ Driving "
+"distance cleanup"
+msgstr ""
+"`#2599 <https://github.com/pgRouting/pgrouting/pull/2599>`__ 行车距离清理"
+
+msgid ""
+"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ Read postgresql "
+"data on C++"
+msgstr ""
+"`#2607 <https://github.com/pgRouting/pgrouting/pull/2607>`__ 在 C++ 上读取 "
+"postgresql 数据"
+
+msgid ""
+"`#2614 <https://github.com/pgRouting/pgrouting/pull/2614>`__ Clang tidy does "
+"not work"
+msgstr ""
+"`#2614 <https://github.com/pgRouting/pgrouting/pull/2614>`__ Clang tidy 不工"
+"作"
 
 msgid "pgRouting 3.6"
 msgstr "pgRouting 3.6"
 
-#, fuzzy
 msgid "pgRouting 3.6.3 Release Notes"
-msgstr "pgRouting 3.6.1 发布说明"
+msgstr "pgRouting 3.6.3 发布说明"
 
-#, fuzzy
 msgid ""
 "To see all issues & pull requests closed by this release see the `Git closed "
 "milestone for 3.6.3 <https://github.com/pgRouting/pgrouting/issues?"
 "utf8=%E2%9C%93&q=milestone%3A%22Release%203.6.3%22>`__"
 msgstr ""
-"要查看此版本关闭的所有问题和拉取请求，请参阅 `3.6.1Git 关闭里程碑 <https://"
-"github.com/pgRouting/pgrouting/issues?"
-"utf8=%E2%9C%93&q=milestone%3A%22Release%203.6.1%22>`_"
-
-msgid "Build"
-msgstr "构建"
+"要查看此版本关闭的所有问题和拉取请求，请参阅 `Git closed milestone for 3.6.3 "
+"<https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.6.3%22>`__"
 
 msgid "Explicit minimum requirements:"
-msgstr ""
+msgstr "最低要求："
 
 msgid "postgres 11.0.0"
-msgstr ""
+msgstr "postgres 11.0.0"
 
-#, fuzzy
 msgid "postgis 3.0.0"
-msgstr "版本3.0.0"
+msgstr "postgis 3.0.0"
 
 msgid "g++ 13+ is supported"
-msgstr ""
+msgstr "支持 g++ 13+"
 
 msgid "Code fixes"
 msgstr "代码修正"
 
 msgid "Fix warnings from cpplint."
-msgstr ""
+msgstr "修复来自 cpplint 的警告。"
 
 msgid "Fix warnings from clang 18."
-msgstr ""
+msgstr "修复来自 clang 18 的警告。"
 
-#, fuzzy
 msgid "CI tests"
-msgstr "pgtap 测试"
+msgstr "CI tests"
 
 msgid "Add a clang tidy test on changed files."
-msgstr ""
+msgstr "为已更改的文件添加 clang tidy 测试。"
 
 msgid ""
 "Update test not done on versions: 3.0.1, 3.0.2, 3.0.3, 3.0.4, 3.1.0, 3.1.1, "
 "3.1.2"
 msgstr ""
+"未对以下版本进行更新测试3.0.1, 3.0.2, 3.0.3, 3.0.4, 3.1.0, 3.1.1, 3.1.2"
 
 msgid "Documentation"
 msgstr "文档"
 
 msgid "Results of documentation queries adujsted to boost 1.83.0 version:"
-msgstr ""
+msgstr "根据 boost 1.83.0 版本进行的文档查询结果："
 
 msgid "pgr_edgeDisjointPaths"
 msgstr "pgr_edgeDisjointPaths"
@@ -16801,32 +16989,29 @@ msgstr "pgr_stoerWagner"
 msgid "pgtap tests"
 msgstr "pgtap 测试"
 
-#, fuzzy
 msgid "bug fixes"
-msgstr "Bug修复"
+msgstr "bug fixes"
 
-#, fuzzy
 msgid "pgRouting 3.6.2 Release Notes"
-msgstr "pgRouting 3.6.1 发布说明"
+msgstr "pgRouting 3.6.2 发布说明"
 
-#, fuzzy
 msgid ""
 "To see all issues & pull requests closed by this release see the `Git closed "
 "milestone for 3.6.2 <https://github.com/pgRouting/pgrouting/issues?"
 "utf8=%E2%9C%93&q=milestone%3A%22Release%203.6.2%22>`__"
 msgstr ""
-"要查看此版本关闭的所有问题和拉取请求，请参阅 `3.6.1Git 关闭里程碑 <https://"
-"github.com/pgRouting/pgrouting/issues?"
-"utf8=%E2%9C%93&q=milestone%3A%22Release%203.6.1%22>`_"
+"要查看此版本关闭的所有问题和拉取请求，请参阅 `Git closed milestone for 3.6.2 "
+"<https://github.com/pgRouting/pgrouting/issues?"
+"utf8=%E2%9C%93&q=milestone%3A%22Release%203.6.2%22>`__"
 
 msgid "Upgrade fix"
-msgstr ""
+msgstr "升级修复"
 
 msgid "The upgrade was failing for same minor"
-msgstr ""
+msgstr "升级失败的主要原因是"
 
 msgid "Fix warnings from cpplint"
-msgstr ""
+msgstr "修复来自 cpplint 的警告"
 
 msgid "Others"
 msgstr "其他"
@@ -16868,50 +17053,38 @@ msgstr ""
 "拉取请求 <https://github.com/pgRouting/pgrouting/issues?"
 "utf8=%E2%9C%93&q=milestone%3A%22Release%203.6.0%22>`_"
 
+#, fuzzy
 msgid ""
-"`#2516 <https://github.com/pgRouting/pgrouting/pull/2516>`__ Standarize "
+"`#2516 <https://github.com/pgRouting/pgrouting/pull/2516>`__ Standardize "
 "output pgr_aStar"
 msgstr ""
 "`#2516 <https://github.com/pgRouting/pgrouting/pull/2516>`__ 标准化输出"
 "pgr_aStar"
 
+#, fuzzy
+msgid "Standardize output columns to |short-generic-result|"
+msgstr "标准输出列|short-generic-result|"
+
+#, fuzzy
 msgid ""
-"``pgr_aStar`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
-msgstr "``pgr_aStar`` （`一对一`）增加了 ``start_vid`` 和 ``end_vid`` 列。"
-
-msgid "``pgr_aStar`` (`One to Many`) added ``end_vid`` column."
-msgstr "``pgr_aStar``（`一对多`）添加了 ``end_vid`` 列。"
-
-msgid "``pgr_aStar`` (`Many to One`) added ``start_vid`` column."
-msgstr "``pgr_aStar``（`多对一`）添加了 ``start_vid`` 列。"
-
-msgid ""
-"`#2523 <https://github.com/pgRouting/pgrouting/pull/2523>`__ Standarize "
+"`#2523 <https://github.com/pgRouting/pgrouting/pull/2523>`__ Standardize "
 "output pgr_bdAstar"
 msgstr ""
 "`#2523 <https://github.com/pgRouting/pgrouting/pull/2523>`__ 标准化输出 "
 "pgr_bdAstar"
 
+#, fuzzy
 msgid ""
-"``pgr_bdAstar`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
-msgstr "``pgr_bdAstar``（`一对一`）增加了 ``start_vid`` 和``end_vid`` 列。"
-
-msgid "``pgr_bdAstar`` (`One to Many`) added ``end_vid`` column."
-msgstr "``pgr_bdAstar``（`一对多）添加了``end_vid`` 列。"
-
-msgid "``pgr_bdAstar`` (`Many to One`) added ``start_vid`` column."
-msgstr "``pgr_bdAstar``（`多对一`）添加了``start_vid`` 列。"
-
-msgid ""
-"`#2547 <https://github.com/pgRouting/pgrouting/pull/2547>`__ Standarize "
+"`#2547 <https://github.com/pgRouting/pgrouting/pull/2547>`__ Standardize "
 "output and modifying signature pgr_KSP"
 msgstr ""
 "`#2547 <https://github.com/pgRouting/pgrouting/pull/2547>`__ 标准化输出并修改"
 "签名 pgr_KSP"
 
+#, fuzzy
 msgid ""
-"`#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ Standarize "
-"output pgr_drivingdistance"
+"`#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ Standardize "
+"output pgr_drivingDistance"
 msgstr ""
 "`#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ 标准化输出 "
 "pgr_drivingdistance"
@@ -16919,15 +17092,17 @@ msgstr ""
 msgid "Proposed functions changes"
 msgstr "拟议函数改变"
 
+#, fuzzy
 msgid ""
-"`#2544 <https://github.com/pgRouting/pgrouting/pull/2544>`__ Standarize "
+"`#2544 <https://github.com/pgRouting/pgrouting/pull/2544>`__ Standardize "
 "output and modifying signature pgr_withPointsDD"
 msgstr ""
 "`#2544 <https://github.com/pgRouting/pgrouting/pull/2544>`__ 标准化输出并修改"
 "签名 pgr_withPointsDD"
 
+#, fuzzy
 msgid ""
-"`#2546 <https://github.com/pgRouting/pgrouting/pull/2546>`__ Standarize "
+"`#2546 <https://github.com/pgRouting/pgrouting/pull/2546>`__ Standardize "
 "output and modifying signature pgr_withPointsKSP"
 msgstr ""
 "`#2546 <https://github.com/pgRouting/pgrouting/pull/2546>`__ 标准化输出并修改"
@@ -16985,11 +17160,13 @@ msgstr ""
 "`#2490 <https://github.com/pgRouting/pgrouting/pull/2490>`__ 自动页面历史链"
 "接。"
 
-msgid "..rubric:: SQL standarization"
+#, fuzzy
+msgid "..rubric:: Standardize SQL"
 msgstr "..rubric::SQL 标准化"
 
+#, fuzzy
 msgid ""
-"`#2555 <https://github.com/pgRouting/pgrouting/pull/2555>`__ standarize "
+"`#2555 <https://github.com/pgRouting/pgrouting/pull/2555>`__ Standardize "
 "deprecated messages"
 msgstr ""
 "`#2555 <https://github.com/pgRouting/pgrouting/pull/2555>`__ 标准化已弃用的消"
@@ -17020,9 +17197,6 @@ msgstr "文档修复"
 msgid "Changes on the documentation to the following:"
 msgstr "将文件修改如下："
 
-msgid "pgr_degree"
-msgstr "pgr_degree"
-
 msgid "pgr_dijkstra"
 msgstr "pgr_dijkstra"
 
@@ -17040,7 +17214,7 @@ msgstr "问题修复"
 
 msgid ""
 "`#2565 <https://github.com/pgRouting/pgrouting/issues/2565>`__ "
-"pgr_pgr_lengauerTarjanDominatorTree triggers an assertion"
+"pgr_lengauerTarjanDominatorTree triggers an assertion"
 msgstr ""
 "`#2565 <https://github.com/pgRouting/pgrouting/issues/2565>`__ "
 "pgr_pgr_lengauerTarjanDominatorTree 触发了一个断言"
@@ -17088,16 +17262,6 @@ msgstr ""
 
 msgid "Dijkstra"
 msgstr "Dijkstra"
-
-msgid ""
-"``pgr_dijkstra`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
-msgstr "``pgr_dijkstra``（`一对一`）增加了``start_vid`` 和``end_vid`` 列。"
-
-msgid "``pgr_dijkstra`` (`One to Many`) added ``end_vid`` column."
-msgstr "``pgr_dijkstra``（`一对多`）添加了 ``end_vid`` 列。"
-
-msgid "``pgr_dijkstra`` (`Many to One`) added ``start_vid`` column."
-msgstr "``pgr_dijkstra`` （`多对一`）添加了 ``start_vid`` 列。"
 
 msgid "pgRouting 3.4"
 msgstr "pgRouting 3.4"
@@ -17174,14 +17338,15 @@ msgstr ""
 "`#1891 <https://github.com/pgRouting/pgrouting/issues/1891>`__: pgr_ksp 没有"
 "给出所有正确的最短路径"
 
-msgid "New proposed functions"
-msgstr "新的拟议函数"
+msgid "New proposed functions."
+msgstr "新的拟议函数。"
 
 msgid "With points"
 msgstr "带点"
 
-msgid "``pgr_withPointsVia`` (One Via)"
-msgstr "``pgr_withPointsVia`` (One Via)"
+#, fuzzy
+msgid "pgr_withPointsVia(One Via)"
+msgstr "pgr_withPointsVia (One Via)"
 
 msgid "Turn Restrictions"
 msgstr "转弯限制"
@@ -17189,83 +17354,70 @@ msgstr "转弯限制"
 msgid "Via with turn restrictions"
 msgstr "有转弯限制的通道"
 
-msgid "``pgr_trspVia`` (One Via)"
-msgstr "``pgr_trspVia`` (One Via)"
+#, fuzzy
+msgid "pgr_trspVia(One Via)"
+msgstr "pgr_trspVia(One Via)"
 
-msgid "``pgr_trspVia_withPoints`` (One Via)"
-msgstr "pgr_trspVia_withPoints``（一次通过）"
+msgid "pgr_trspVia_withPoints(One Via)"
+msgstr "pgr_trspVia_withPoints（一次通过）"
 
-msgid "``pgr_trsp``"
-msgstr "``pgr_trsp``"
+msgid "pgr_trsp_withPoints(One to One)"
+msgstr "pgr_trsp_withPoints（一对一）"
 
-msgid "``pgr_trsp`` (One to One)"
-msgstr "``pgr_trsp`` （一对一）"
+msgid "pgr_trsp_withPoints(One to Many)"
+msgstr "pgr_trsp_withPoints（一对多）"
 
-msgid "``pgr_trsp`` (One to Many)"
-msgstr "``pgr_trsp`` （一对多）"
+msgid "pgr_trsp_withPoints(Many to One)"
+msgstr "pgr_trsp_withPoints（多对一）"
 
-msgid "``pgr_trsp`` (Many to One)"
-msgstr "``pgr_trsp`` （多对一）"
+msgid "pgr_trsp_withPoints(Many to Many)"
+msgstr "pgr_trsp_withPoints（多对多）"
 
-msgid "``pgr_trsp`` (Many to Many)"
-msgstr "``pgr_trsp`` （多对多）"
-
-msgid "``pgr_trsp`` (Combinations)"
-msgstr "``pgr_trsp`` （组合）"
-
-msgid "``pgr_trsp_withPoints``"
-msgstr "``pgr_trsp_withPoints``"
-
-msgid "``pgr_trsp_withPoints`` (One to One)"
-msgstr "``pgr_trsp_withPoints`` （一对一）"
-
-msgid "``pgr_trsp_withPoints`` (One to Many)"
-msgstr "``pgr_trsp_withPoints`` （一对多）"
-
-msgid "``pgr_trsp_withPoints`` (Many to One)"
-msgstr "pgr_trsp_withPoints``（多对一）"
-
-msgid "``pgr_trsp_withPoints`` (Many to Many)"
-msgstr "``pgr_trsp_withPoints`` （多对多）"
-
-msgid "``pgr_trsp_withPoints`` (Combinations)"
-msgstr "``pgr_trsp_withPoints`` （组合）"
+msgid "pgr_trsp_withPoints(Combinations)"
+msgstr "pgr_trsp_withPoints（组合）"
 
 msgid "Topology"
 msgstr "拓扑结构"
 
-msgid "``pgr_degree``"
-msgstr "``pgr_degree``"
+msgid "Utilities"
+msgstr "实用程序"
 
-msgid "``pgr_findCloseEdges`` (One point)"
-msgstr "``pgr_findCloseEdges`` （单点）"
+msgid "pgr_findCloseEdges(One point)"
+msgstr "pgr_findCloseEdges（单点）"
 
-msgid "``pgr_findCloseEdges`` (Many points)"
-msgstr "``pgr_findCloseEdges`` （多点）"
+msgid "pgr_findCloseEdges(Many points)"
+msgstr "pgr_findCloseEdges（多点）"
 
 msgid "Ordering"
 msgstr "排序"
 
-msgid "``pgr_cuthillMckeeOrdering``"
-msgstr "``pgr_cuthillMckeeOrdering``"
+msgid "pgr_cuthillMckeeOrdering"
+msgstr "pgr_cuthillMckeeOrdering"
+
+msgid "Unclassified"
+msgstr "未分类"
+
+msgid "pgr_hawickCircuits"
+msgstr "pgr_hawickCircuits"
 
 msgid "Flow functions"
 msgstr "流程函数"
 
-msgid "``pgr_maxCardinalityMatch(text)``"
-msgstr "``pgr_maxCardinalityMatch(text)``"
+msgid "pgr_maxCardinalityMatch(text)"
+msgstr "pgr_maxCardinalityMatch(text)"
 
-msgid "Deprecating ``pgr_maxCardinalityMatch(text,boolean)``"
+#, fuzzy
+msgid "Deprecating: pgr_maxCardinalityMatch(text,boolean)"
 msgstr "弃用 ``pgr_maxCardinalityMatch(text,boolean)``"
 
 msgid "Deprecated Functions"
 msgstr "已废弃的函数"
 
-msgid "``pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)``"
-msgstr "``pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)``"
+msgid "pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)"
+msgstr "pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)"
 
-msgid "``pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)``"
-msgstr "``pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)``"
+msgid "pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)"
+msgstr "pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)"
 
 msgid "pgRouting 3.3"
 msgstr "pgRouting 3.3"
@@ -17486,9 +17638,6 @@ msgstr "pgr_dijkstraNearCost(一对多)"
 msgid "pgr_sequentialVertexColoring"
 msgstr "pgr_sequentialVertexColoring"
 
-msgid "pgr_extractVertices"
-msgstr "pgr_extractVertices"
-
 msgid "Traversal"
 msgstr "遍历"
 
@@ -17579,12 +17728,6 @@ msgstr ""
 msgid "Removing support for Boost v1.53, v1.54 & v1.55"
 msgstr "删除对 Boost v1.53、v1.54 和 v1.55 的支持"
 
-msgid "pgr_bellmanFord(Combinations)"
-msgstr "pgr_bellmanFord(组合)"
-
-msgid "pgr_binaryBreadthFirstSearch(Combinations)"
-msgstr "pgr_binaryBreadthFirstSearch(组合)"
-
 msgid "pgr_bipartite"
 msgstr "pgr_bipartite"
 
@@ -17593,9 +17736,6 @@ msgstr "pgr_depthFirstSearch"
 
 msgid "Dijkstra Near"
 msgstr "Dijkstra Near"
-
-msgid "pgr_edwardMoore(Combinations)"
-msgstr "pgr_edwardMoore(组合)"
 
 msgid "pgr_isPlanar"
 msgstr "pgr_isPlanar"
@@ -17606,50 +17746,14 @@ msgstr "pgr_lengauerTarjanDominatorTree"
 msgid "pgr_makeConnected"
 msgstr "pgr_makeConnected"
 
-msgid "pgr_maxFlowMinCost(Combinations)"
-msgstr "pgr_maxFlowMinCost(组合)"
-
-msgid "pgr_maxFlowMinCost_Cost(Combinations)"
-msgstr "pgr_maxFlowMinCost_Cost(组合)"
-
 msgid "Astar"
 msgstr "Astar"
-
-msgid "pgr_aStar(Combinations)"
-msgstr "pgr_aStar(组合)"
-
-msgid "pgr_aStarCost(Combinations)"
-msgstr "pgr_aStarCost(组合)"
 
 msgid "Bidirectional Astar"
 msgstr "双向Astar"
 
-msgid "pgr_bdAstar(Combinations)"
-msgstr "pgr_bdAstar(组合)"
-
-msgid "pgr_bdAstarCost(Combinations)"
-msgstr "pgr_bdAstarCost(组合)"
-
 msgid "Bidirectional Dijkstra"
 msgstr "双向 Dijkstra"
-
-msgid "pgr_bdDijkstra(Combinations)"
-msgstr "pgr_bdDijkstra(组合)"
-
-msgid "pgr_bdDijkstraCost(Combinations)"
-msgstr "pgr_bdDijkstraCost(组合)"
-
-msgid "pgr_boykovKolmogorov(Combinations)"
-msgstr "pgr_boykovKolmogorov (组合)"
-
-msgid "pgr_edmondsKarp(Combinations)"
-msgstr "pgr_edmondsKarp(组合)"
-
-msgid "pgr_maxFlow(Combinations)"
-msgstr "pgr_maxFlow(组合)"
-
-msgid "pgr_pushRelabel(Combinations)"
-msgstr "pgr_pushRelabel(组合)"
 
 msgid "pgRouting 3.1"
 msgstr "pgRouting 3.1"
@@ -17958,7 +18062,7 @@ msgid ""
 msgstr ""
 "`#1006 <https://github.com/pgRouting/pgrouting/issues/1006>`__：无信息丢失"
 
-msgid "New functions"
+msgid "New Functions"
 msgstr "新函数"
 
 msgid "Kruskal family"
@@ -17997,148 +18101,119 @@ msgstr "pgRouting 中的拟议已升级为正式版本"
 msgid "aStar Family"
 msgstr "aStar族"
 
-msgid "pgr_aStar(one to many)"
-msgstr "pgr_aStar（一对多）"
-
-msgid "pgr_aStar(many to one)"
-msgstr "pgr_aStar（多对一）"
-
-msgid "pgr_aStar(many to many)"
-msgstr "pgr_aStar（多对多）"
-
-msgid "pgr_aStarCost(one to one)"
+#, fuzzy
+msgid "pgr_aStarCost(One to One)"
 msgstr "pgr_aStarCost(一对一)"
 
-msgid "pgr_aStarCost(one to many)"
+#, fuzzy
+msgid "pgr_aStarCost(One to Many)"
 msgstr "pgr_aStarCost(一对多)"
 
-msgid "pgr_aStarCost(many to one)"
+#, fuzzy
+msgid "pgr_aStarCost(Many to One)"
 msgstr "pgr_aStarCost(多对一)"
 
-msgid "pgr_aStarCost(many to many)"
+#, fuzzy
+msgid "pgr_aStarCost(Many to Many)"
 msgstr "pgr_aStarCost（多对多）"
 
-msgid "pgr_aStarCostMatrix(one to one)"
-msgstr "pgr_aStarCostMatrix(一对一)"
-
-msgid "pgr_aStarCostMatrix(one to many)"
-msgstr "pgr_aStarCostMatrix (一对多)"
-
-msgid "pgr_aStarCostMatrix(many to one)"
-msgstr "pgr_aStarCostMatrix (多对一)"
-
-msgid "pgr_aStarCostMatrix(many to many)"
-msgstr "pgr_aStarCostMatrix（多对多）"
+#, fuzzy
+msgid "pgr_aStarCostMatrix"
+msgstr "pgr_astarCostMatrix"
 
 msgid "bdAstar Family"
 msgstr "bdAstar 族"
 
-msgid "pgr_bdAstar(one to many)"
-msgstr "pgr_bdAstar（一对多）"
-
-msgid "pgr_bdAstar(many to one)"
-msgstr "pgr_bdAstar（多对一）"
-
-msgid "pgr_bdAstar(many to many)"
-msgstr "pgr_bdAstar（多对多）"
-
-msgid "pgr_bdAstarCost(one to one)"
+#, fuzzy
+msgid "pgr_bdAstarCost(One to One)"
 msgstr "pgr_bdAstarCost(一对一)"
 
-msgid "pgr_bdAstarCost(one to many)"
+#, fuzzy
+msgid "pgr_bdAstarCost(One to Many)"
 msgstr "pgr_bdAstarCost(一对多)"
 
-msgid "pgr_bdAstarCost(many to one)"
+#, fuzzy
+msgid "pgr_bdAstarCost(Many to One)"
 msgstr "pgr_bdAstarCost （多对一）"
 
-msgid "pgr_bdAstarCost(many to many)"
+#, fuzzy
+msgid "pgr_bdAstarCost(Many to Many)"
 msgstr "pgr_bdAstarCost (多对多)"
 
-msgid "pgr_bdAstarCostMatrix(one to one)"
-msgstr "pgr_bdAstarCostMatrix(一对一)"
-
-msgid "pgr_bdAstarCostMatrix(one to many)"
-msgstr "pgr_bdAstarCostMatrix(一对多)"
-
-msgid "pgr_bdAstarCostMatrix(many to one)"
-msgstr "pgr_bdAstarCostMatrix （多对一）"
-
-msgid "pgr_bdAstarCostMatrix(many to many)"
-msgstr "pgr_bdAstarCostMatrix （多对多）"
+msgid "pgr_bdAstarCostMatrix"
+msgstr "pgr_bdAstarCostMatrix"
 
 msgid "bdDijkstra Family"
 msgstr "bdDijkstra族"
 
-msgid "pgr_bdDijkstra(one to many)"
-msgstr "pgr_bdDijkstra（一对多）"
-
-msgid "pgr_bdDijkstra(many to one)"
-msgstr "pgr_bdDijkstra（多对一）"
-
-msgid "pgr_bdDijkstra(many to many)"
-msgstr "pgr_bdDijkstra（多对多）"
-
-msgid "pgr_bdDijkstraCost(one to one)"
+#, fuzzy
+msgid "pgr_bdDijkstraCost(One to One)"
 msgstr "pgr_bdDijkstraCost (一对一)"
 
-msgid "pgr_bdDijkstraCost(one to many)"
+#, fuzzy
+msgid "pgr_bdDijkstraCost(One to Many)"
 msgstr "pgr_bdDijkstraCost(一对多)"
 
-msgid "pgr_bdDijkstraCost(many to one)"
+#, fuzzy
+msgid "pgr_bdDijkstraCost(Many to One)"
 msgstr "pgr_bdDijkstraCost (多对一)"
 
-msgid "pgr_bdDijkstraCost(many to many)"
+#, fuzzy
+msgid "pgr_bdDijkstraCost(Many to Many)"
 msgstr "pgr_bdDijkstraCost（多对多）"
 
-msgid "pgr_bdDijkstraCostMatrix(one to one)"
-msgstr "pgr_bdDijkstraCostMatrix(一对一)"
-
-msgid "pgr_bdDijkstraCostMatrix(one to many)"
-msgstr "pgr_bdDijkstraCostMatrix(一对多)"
-
-msgid "pgr_bdDijkstraCostMatrix(many to one)"
-msgstr "pgr_bdDijkstraCostMatrix (多对一)"
-
-msgid "pgr_bdDijkstraCostMatrix(many to many)"
-msgstr "pgr_bdDijkstraCostMatrix（多对多）"
+msgid "pgr_bdDijkstraCostMatrix"
+msgstr "pgr_bdDijkstraCostMatrix"
 
 msgid "Flow Family"
 msgstr "Flow族"
 
-msgid "pgr_pushRelabel(one to one)"
+#, fuzzy
+msgid "pgr_pushRelabel(One to One)"
 msgstr "pgr_pushRelabel(一对一)"
 
-msgid "pgr_pushRelabel(one to many)"
+#, fuzzy
+msgid "pgr_pushRelabel(One to Many)"
 msgstr "pgr_pushRelabel(一对多)"
 
-msgid "pgr_pushRelabel(many to one)"
+#, fuzzy
+msgid "pgr_pushRelabel(Many to One)"
 msgstr "pgr_pushRelabel(多对一)"
 
-msgid "pgr_pushRelabel(many to many)"
+#, fuzzy
+msgid "pgr_pushRelabel(Many to Many)"
 msgstr "pgr_pushRelabel(多对多)"
 
-msgid "pgr_edmondsKarp(one to one)"
+#, fuzzy
+msgid "pgr_edmondsKarp(One to One)"
 msgstr "pgr_edmondsKarp（一对一）"
 
-msgid "pgr_edmondsKarp(one to many)"
+#, fuzzy
+msgid "pgr_edmondsKarp(One to Many)"
 msgstr "pgr_edmondsKarp（一对多）"
 
-msgid "pgr_edmondsKarp(many to one)"
+#, fuzzy
+msgid "pgr_edmondsKarp(Many to One)"
 msgstr "pgr_edmondsKarp（多对一）"
 
-msgid "pgr_edmondsKarp(many to many)"
+#, fuzzy
+msgid "pgr_edmondsKarp(Many to Many)"
 msgstr "pgr_edmondsKarp（多对多）"
 
-msgid "pgr_boykovKolmogorov (one to one)"
+#, fuzzy
+msgid "pgr_boykovKolmogorov (One to One)"
 msgstr "pgr_boykovKolmogorov (一对一)"
 
-msgid "pgr_boykovKolmogorov (one to many)"
+#, fuzzy
+msgid "pgr_boykovKolmogorov (One to Many)"
 msgstr "pgr_boykovKolmogorov (一对多)"
 
-msgid "pgr_boykovKolmogorov (many to one)"
+#, fuzzy
+msgid "pgr_boykovKolmogorov (Many to One)"
 msgstr "pgr_boykovKolmogorov (多对一)"
 
-msgid "pgr_boykovKolmogorov (many to many)"
+#, fuzzy
+msgid "pgr_boykovKolmogorov (Many to Many)"
 msgstr "pgr_boykovKolmogorov (多对多)"
 
 msgid "pgr_maxCardinalityMatching"
@@ -18147,20 +18222,27 @@ msgstr "pgr_maxCardinalityMatching"
 msgid "pgr_maxFlow"
 msgstr "pgr_maxFlow"
 
-msgid "pgr_edgeDisjointPaths(one to one)"
+#, fuzzy
+msgid "pgr_edgeDisjointPaths(One to One)"
 msgstr "pgr_edgeDisjointPaths (一对一)"
 
-msgid "pgr_edgeDisjointPaths(one to many)"
+#, fuzzy
+msgid "pgr_edgeDisjointPaths(One to Many)"
 msgstr "pgr_edgeDisjointPaths （一对多）"
 
-msgid "pgr_edgeDisjointPaths(many to one)"
+#, fuzzy
+msgid "pgr_edgeDisjointPaths(Many to One)"
 msgstr "pgr_edgeDisjointPaths (多对一)"
 
-msgid "pgr_edgeDisjointPaths(many to many)"
+#, fuzzy
+msgid "pgr_edgeDisjointPaths(Many to Many)"
 msgstr "pgr_edgeDisjointPaths （多对多）"
 
 msgid "Components family"
 msgstr "分量族"
+
+msgid "pgr_connectedComponents"
+msgstr "pgr_connectedComponents"
 
 msgid "pgr_strongComponents"
 msgstr "pgr_strongComponents"
@@ -18369,8 +18451,8 @@ msgstr "pgr_floydWarshall"
 msgid "pgr_johnson"
 msgstr "pgr_johnson"
 
-msgid "pgr_astar"
-msgstr "pgr_astar"
+msgid "pgr_aStar"
+msgstr "pgr_aStar"
 
 msgid "pgr_bdAstar"
 msgstr "pgr_bdAstar"
@@ -18389,6 +18471,9 @@ msgstr "pgr_dijkstraCost"
 
 msgid "pgr_drivingDistance"
 msgstr "pgr_drivingDistance"
+
+msgid "pgr_KSP"
+msgstr "pgr_KSP"
 
 msgid "pgr_dijkstraVia (proposed)"
 msgstr "pgr_dijkstraVia (拟议)"
@@ -18611,23 +18696,16 @@ msgstr "在结果中添加了 path_id、cost 和 agg_cost 列"
 msgid "Parameter names changed"
 msgstr "更改参数名称"
 
-msgid "The many version results are the union of the one to one version"
+#, fuzzy
+msgid "The many version results are the union of the One to One version"
 msgstr "多版本结果是一对一版本的并集"
 
 msgid "New Signatures"
 msgstr "新签名"
 
-msgid "pgr_bdAstar(one to one)"
+#, fuzzy
+msgid "pgr_bdAstar(One to One)"
 msgstr "pgr_bdAstar（一对一）"
-
-msgid "New Proposed functions"
-msgstr "新的拟议函数"
-
-msgid "pgr_bdAstarCostMatrix"
-msgstr "pgr_bdAstarCostMatrix"
-
-msgid "pgr_bdDijkstraCostMatrix"
-msgstr "pgr_bdDijkstraCostMatrix"
 
 msgid "pgr_lineGraph"
 msgstr "pgr_lineGraph"
@@ -18717,32 +18795,8 @@ msgstr ""
 msgid "pgr_bdDijkstra"
 msgstr "pgr_bdDijkstra"
 
-msgid "New Proposed Signatures"
-msgstr "新的拟议签名"
-
-msgid "pgr_astar(one to many)"
-msgstr "pgr_astar（一对多）"
-
-msgid "pgr_astar(many to one)"
-msgstr "pgr_astar（多对一）"
-
-msgid "pgr_astar(many to many)"
-msgstr "pgr_astar（多对多）"
-
-msgid "pgr_astarCost(one to one)"
-msgstr "pgr_astarCost(一对一)"
-
-msgid "pgr_astarCost(one to many)"
-msgstr "pgr_astarCost(一对多)"
-
-msgid "pgr_astarCost(many to one)"
-msgstr "pgr_astarCost(多对一)"
-
-msgid "pgr_astarCost(many to many)"
-msgstr "pgr_astarCost（多对多）"
-
-msgid "pgr_astarCostMatrix"
-msgstr "pgr_astarCostMatrix"
+msgid "Deprecated signatures."
+msgstr "弃用签名。"
 
 msgid "pgr_bddijkstra - use pgr_bdDijkstra instead"
 msgstr "pgr_bddijkstra - 使用 pgr_bdDijkstra代替"
@@ -18822,52 +18876,55 @@ msgstr ""
 msgid "pgr_TSP"
 msgstr "pgr_TSP"
 
-msgid "pgr_aStar"
-msgstr "pgr_aStar"
-
-msgid "New Functions"
-msgstr "新函数"
-
 msgid "pgr_eucledianTSP"
 msgstr "pgr_eucledianTSP"
 
-msgid "pgr_withPointsCostMatrix"
-msgstr "pgr_withPointsCostMatrix"
-
-msgid "pgr_maxFlowPushRelabel(one to one)"
+#, fuzzy
+msgid "pgr_maxFlowPushRelabel(One to One)"
 msgstr "pgr_maxFlowPushRelabel(一对一)"
 
-msgid "pgr_maxFlowPushRelabel(one to many)"
+#, fuzzy
+msgid "pgr_maxFlowPushRelabel(One to Many)"
 msgstr "pgr_maxFlowPushRelabel(一对多)"
 
-msgid "pgr_maxFlowPushRelabel(many to one)"
+#, fuzzy
+msgid "pgr_maxFlowPushRelabel(Many to One)"
 msgstr "pgr_maxFlowPushRelabel(多对一)"
 
-msgid "pgr_maxFlowPushRelabel(many to many)"
+#, fuzzy
+msgid "pgr_maxFlowPushRelabel(Many to Many)"
 msgstr "pgr_maxFlowPushRelabel(多对多)"
 
-msgid "pgr_maxFlowEdmondsKarp(one to one)"
+#, fuzzy
+msgid "pgr_maxFlowEdmondsKarp(One to One)"
 msgstr "pgr_maxFlowEdmondsKarp（一对一）"
 
-msgid "pgr_maxFlowEdmondsKarp(one to many)"
+#, fuzzy
+msgid "pgr_maxFlowEdmondsKarp(One to Many)"
 msgstr "pgr_maxFlowEdmondsKarp（一对多）"
 
-msgid "pgr_maxFlowEdmondsKarp(many to one)"
+#, fuzzy
+msgid "pgr_maxFlowEdmondsKarp(Many to One)"
 msgstr "pgr_maxFlowEdmondsKarp（多对一）"
 
-msgid "pgr_maxFlowEdmondsKarp(many to many)"
+#, fuzzy
+msgid "pgr_maxFlowEdmondsKarp(Many to Many)"
 msgstr "pgr_maxFlowEdmondsKarp（多对多）"
 
-msgid "pgr_maxFlowBoykovKolmogorov (one to one)"
+#, fuzzy
+msgid "pgr_maxFlowBoykovKolmogorov (One to One)"
 msgstr "pgr_maxFlowBoykovKolmogorov （一对一）"
 
-msgid "pgr_maxFlowBoykovKolmogorov (one to many)"
+#, fuzzy
+msgid "pgr_maxFlowBoykovKolmogorov (One to Many)"
 msgstr "pgr_maxFlowBoykovKolmogorov （一对多）"
 
-msgid "pgr_maxFlowBoykovKolmogorov (many to one)"
+#, fuzzy
+msgid "pgr_maxFlowBoykovKolmogorov (Many to One)"
 msgstr "pgr_maxFlowBoykovKolmogorov （多对一）"
 
-msgid "pgr_maxFlowBoykovKolmogorov (many to many)"
+#, fuzzy
+msgid "pgr_maxFlowBoykovKolmogorov (Many to Many)"
 msgstr "pgr_maxFlowBoykovKolmogorov （多对多）"
 
 msgid "pgr_maximumCardinalityMatching"
@@ -18879,7 +18936,8 @@ msgstr "pgr_contractGraph"
 msgid "pgr_tsp - use pgr_TSP or pgr_eucledianTSP instead"
 msgstr "pgr_tsp - 使用 pgr_TSP 或 pgr_eucledianTSP 代替"
 
-msgid "pgr_astar - use pgr_aStar instead"
+#, fuzzy
+msgid "pgr_aStar - use pgr_aStar instead"
 msgstr "pgr_astar - 使用 pgr_aStar 代替"
 
 msgid "pgr_flip_edges"
@@ -18980,6 +19038,9 @@ msgstr ""
 msgid "Improvements"
 msgstr "改进"
 
+msgid "pgr_nodeNetwork"
+msgstr "pgr_nodeNetwork"
+
 msgid "Adding a row_where and outall optional parameters"
 msgstr "添加 row_where 和 outall 可选参数"
 
@@ -18992,43 +19053,55 @@ msgstr "pgr_dijkstra -- 与文档中的内容相匹配"
 msgid "pgr_Johnson"
 msgstr "pgr_Johnson"
 
-msgid "pgr_dijkstraCost(one to one)"
+#, fuzzy
+msgid "pgr_dijkstraCost(One to One)"
 msgstr "pgr_dijkstraCost(一对一)"
 
-msgid "pgr_dijkstraCost(one to many)"
-msgstr "pgr_dijkstraCost(一对多)"
+#, fuzzy
+msgid "pgr_dijkstraCost(One to Many)"
+msgstr "pgr_dijkstraNearCost(一对多)"
 
-msgid "pgr_dijkstraCost(many to one)"
-msgstr "pgr_dijkstraCost（多对一）"
+#, fuzzy
+msgid "pgr_dijkstraCost(Many to One)"
+msgstr "pgr_dijkstraNearCost(多对一)"
 
-msgid "pgr_dijkstraCost(many to many)"
-msgstr "pgr_dijkstraCost（多对多）"
+#, fuzzy
+msgid "pgr_dijkstraCost(Many to Many)"
+msgstr "pgr_dijkstraNearCost (多对多)"
 
 msgid "Proposed Functionality"
 msgstr "建议的功能"
 
-msgid "pgr_withPoints(one to one)"
-msgstr "pgr_withPoints(一对一)"
+#, fuzzy
+msgid "pgr_withPoints(One to One)"
+msgstr "pgr_withPointsKSP(一对一)"
 
-msgid "pgr_withPoints(one to many)"
-msgstr "pgr_withPoints（一对多）"
+#, fuzzy
+msgid "pgr_withPoints(One to Many)"
+msgstr "pgr_withPointsKSP (一对多)"
 
-msgid "pgr_withPoints(many to one)"
-msgstr "pgr_withPoints(多对一)"
+#, fuzzy
+msgid "pgr_withPoints(Many to One)"
+msgstr "pgr_withPointsKSP(多对一)"
 
-msgid "pgr_withPoints(many to many)"
-msgstr "pgr_withPoints(多对多)"
+#, fuzzy
+msgid "pgr_withPoints(Many to Many)"
+msgstr "pgr_withPointsKSP(多对多)"
 
-msgid "pgr_withPointsCost(one to one)"
+#, fuzzy
+msgid "pgr_withPointsCost(One to One)"
 msgstr "pgr_withPointsCost(一对一)"
 
-msgid "pgr_withPointsCost(one to many)"
+#, fuzzy
+msgid "pgr_withPointsCost(One to Many)"
 msgstr "pgr_withPointsCost(一对多)"
 
-msgid "pgr_withPointsCost(many to one)"
+#, fuzzy
+msgid "pgr_withPointsCost(Many to One)"
 msgstr "pgr_withPointsCost(多对一)"
 
-msgid "pgr_withPointsCost(many to many)"
+#, fuzzy
+msgid "pgr_withPointsCost(Many to Many)"
 msgstr "pgr_withPointsCost(多对多)"
 
 msgid "pgr_withPointsDD(single vertex)"
@@ -19036,9 +19109,6 @@ msgstr "pgr_withPointsDD （单顶点）"
 
 msgid "pgr_withPointsDD(multiple vertices)"
 msgstr "pgr_withPointsDD（多顶点）"
-
-msgid "pgr_withPointsKSP"
-msgstr "pgr_withPointsKSP"
 
 msgid "pgr_dijkstraVia"
 msgstr "pgr_dijkstraVia"
@@ -19076,26 +19146,12 @@ msgstr ""
 "github.com/pgRouting/pgrouting/issues?"
 "q=is%3Aissue+milestone%3A%22Release+2.1.0%22+is%3Aclosed>`_ 。"
 
-msgid "pgr_dijkstra(one to many)"
-msgstr "pgr_dijkstra（一对多）"
-
-msgid "pgr_dijkstra(many to one)"
-msgstr "pgr_dijkstra（多对一）"
-
-msgid "pgr_dijkstra(many to many)"
-msgstr "pgr_dijkstra（多对多）"
-
-msgid "pgr_drivingDistance(multiple vertices)"
-msgstr "pgr_drivingDistance （多顶点）"
-
 msgid "Refactored"
 msgstr "重构"
 
-msgid "pgr_dijkstra(one to one)"
+#, fuzzy
+msgid "pgr_dijkstra(One to One)"
 msgstr "pgr_dijkstra（一对一）"
-
-msgid "pgr_drivingDistance(single vertex)"
-msgstr "pgr_drivingDistance （单顶点）"
 
 msgid ""
 "pgr_alphaShape function now can generate better (multi)polygon with holes "
@@ -19445,10 +19501,11 @@ msgstr "函数族"
 msgid "Sample Data"
 msgstr "示例数据"
 
+#, fuzzy
 msgid ""
 "The documentation provides very simple example queries based on a small "
-"sample network that resembles a city. To be able to execute the mayority of "
-"the examples queries, follow the instructions bellow."
+"sample network that resembles a city. To be able to execute the majority of "
+"the examples queries, follow the instructions below."
 msgstr ""
 "该文档提供了基于类似于城市的小型示例网络的非常简单的示例查询。 为了能够执行大"
 "部分示例查询，请按照以下说明进行操作。"
@@ -19462,9 +19519,11 @@ msgstr "图由一组边和一组顶点组成。"
 msgid "The following city is to be inserted into the database:"
 msgstr "要在数据库中插入以下城市："
 
+#, fuzzy
 msgid ""
 "Information known at this point is the geometry of the edges, cost values, "
-"cpacity values, category values and some locations that are not in the graph."
+"capacity values, category values and some locations that are not in the "
+"graph."
 msgstr ""
 "此时已知的信息是边的几何形状、成本值、容量值、类别值和一些不在图中的位置。"
 
@@ -19473,14 +19532,12 @@ msgid ""
 "that everything else is calculated."
 msgstr "拓扑结构的工作流程从插入边开始。然后再计算其他所有内容。"
 
-msgid "Edges"
-msgstr "边"
-
+#, fuzzy
 msgid ""
 "The database design for the documentation of pgRouting, keeps in the same "
 "row 2 segments, one in the direction of the geometry and the second in the "
-"oposite direction. Therfore some information has the ``reverse_`` prefix "
-"which corresponds to the segment on the oposite direction of the geometry."
+"opposite direction. Therefore some information has the ``reverse_`` prefix "
+"which corresponds to the segment on the opposite direction of the geometry."
 msgstr ""
 "pgRouting文档的数据库设计将同一行中的两段保留在一个方向上，其中一个是与几何形"
 "状相同方向的，另一个是与几何形状相反方向的。因此，一些信息具有 ``reverse_`` "
@@ -19513,8 +19570,9 @@ msgstr "``reverse_category``"
 msgid ":math:`x` coordinate of the starting vertex of the geometry."
 msgstr ":math:`x` 几何图形起始顶点的坐标。"
 
+#, fuzzy
 msgid ""
-"For convinience it is saved on the table but can be calculated as "
+"For convenience it is saved on the table but can be calculated as "
 "``ST_X(ST_StartPoint(geom))``."
 msgstr ""
 "为了方便起见，它被保存在表格中，但也可以计算为 "
@@ -19523,8 +19581,9 @@ msgstr ""
 msgid ":math:`y` coordinate of the ending vertex of the geometry."
 msgstr ":math:`y` 几何图形结束顶点的坐标。"
 
+#, fuzzy
 msgid ""
-"For convinience it is saved on the table but can be calculated as "
+"For convenience it is saved on the table but can be calculated as "
 "``ST_Y(ST_EndPoint(geom))``."
 msgstr ""
 "为方便起见，它保存在表格中，但也可以计算为 ``ST_Y(ST_EndPoint(geom))``。"
@@ -19535,9 +19594,10 @@ msgstr "分段的几何形状。"
 msgid "Starting on PostgreSQL 12::"
 msgstr "从 PostgreSQL 12 开始：："
 
+#, fuzzy
 msgid ""
-"Optionally indexes on different columns can be created. The recomendation is "
-"to have"
+"Optionally indexes on different columns can be created. The recommendation "
+"is to have"
 msgstr "可以选择在不同的列上创建索引。建议的做法是"
 
 msgid "``id`` indexed."
@@ -19547,8 +19607,9 @@ msgid ""
 "``source`` and ``target`` columns indexed to speed up pgRouting queries."
 msgstr "``source`` 和 ``target`` 列建立索引以加快 pgRouting 查询。"
 
+#, fuzzy
 msgid ""
-"``geom`` indexed to speed up gemetry processes that might be needed in the "
+"``geom`` indexed to speed up geometry processes that might be needed in the "
 "front end."
 msgstr "``geom`` 列建立索引以加快前端可能需要的 gemetry 处理。"
 
@@ -19622,8 +19683,9 @@ msgstr ""
 "当需要从 ``source`` 到 ``target`` 的路由时，许多函数都可以与 ``(source, "
 "target)`` 对组合使用。"
 
+#, fuzzy
 msgid ""
-"For convinence of this documentations, some combinations will be stored on a "
+"For convenience of this documentation, some combinations will be stored on a "
 "table:"
 msgstr "为便于阅读，某些组合将存储在一个表中："
 
@@ -19772,15 +19834,14 @@ msgid ""
 "User mailing list: https://lists.osgeo.org/mailman/listinfo/pgrouting-users"
 msgstr "用户邮件列表：https://lists.osgeo.org/mailman/listinfo/pgrouting-users"
 
-#, fuzzy
 msgid ""
 "Developer mailing list: https://discourse.osgeo.org/c/pgrouting/pgrouting-"
 "dev/"
-msgstr "开发者邮件列表：https://lists.osgeo.org/mailman/listinfo/pgrouting-dev"
+msgstr ""
+"开发人员邮件列表： https://discourse.osgeo.org/c/pgrouting/pgrouting-dev/"
 
-#, fuzzy
 msgid "Subscribe: https://discourse.osgeo.org/g/pgrouting-dev"
-msgstr "开发者邮件列表：https://lists.osgeo.org/mailman/listinfo/pgrouting-dev"
+msgstr "订阅：https://discourse.osgeo.org/g/pgrouting-dev"
 
 msgid ""
 "For general questions and topics about how to use pgRouting, please write to "
@@ -19857,9 +19918,10 @@ msgstr ""
 "与表关联的属性有助于指示图是有向的还是无向的，边是否是有向图上的单向，并且根"
 "据最终应用程序的需要，需要创建合适的拓扑。"
 
+#, fuzzy
 msgid ""
-"pgRouting suplies some functions to create a routing topology and to analyze "
-"the topology."
+"pgRouting supplies some functions to create a routing topology and to "
+"analyze the topology."
 msgstr "pgRouting 提供一些函数来创建路由拓扑并分析拓扑。"
 
 msgid "Additional functions to create a graph:"
@@ -19868,9 +19930,8 @@ msgstr "创建图表的附加函数："
 msgid "Additional functions to analyze a graph:"
 msgstr "用于分析图表的附加函数："
 
-#, fuzzy
 msgid "Transformation - Family of functions"
-msgstr "收缩 - 函数族"
+msgstr "转换 - 函数族"
 
 msgid ""
 "This family of functions is used for transforming a given input graph :math:"
@@ -19881,7 +19942,8 @@ msgstr ""
 msgid "Traversal - Family of functions"
 msgstr "Traversal - 函数族"
 
-msgid "Aditionaly there are 2 categories under this family"
+#, fuzzy
+msgid "Additionally there are 2 categories under this family"
 msgstr "此外，该家族下还有 2 个类别"
 
 msgid "Via - Category"
@@ -19897,8 +19959,9 @@ msgstr ""
 "给定一个图和一个顶点列表，找到所有相邻顶点对 :math:`vertex_i` 和 :math:"
 "`vertex_{i+1}` 之间的最短路径"
 
+#, fuzzy
 msgid ""
-"In other words, find a continuos route that visits all the vertices in the "
+"In other words, find a continuous route that visits all the vertices in the "
 "order given."
 msgstr "换句话说，找到一条按给定顺序访问所有顶点的连续路线。"
 
@@ -20277,6 +20340,1896 @@ msgstr "pgr_withPointsKSP 是 **带有点** 的 pgr_ksp"
 msgid "pgr_withPointsDD is pgr_drivingDistance **with points**"
 msgstr "pgr_withPointsDD 是 **带有点** 的 pgr_drivenDistance"
 
-#, fuzzy
 msgid "pgr_withPointsvia is pgr_dijkstraVia **with points**"
-msgstr "pgr_withPointsvia 是 **带有点** 的"
+msgstr "pgr_withPointsvia 是 pgr_dijkstraVia **with points** 的版本"
+
+#~ msgid "Proposed"
+#~ msgstr "建议"
+
+#~ msgid "Experimental"
+#~ msgstr "实验性的"
+
+#~ msgid "Contraction of the leaf nodes of the graph."
+#~ msgstr "图的叶节点的收缩。"
+
+#~ msgid "There are no outgoing edges and has at least one incoming edge."
+#~ msgstr "没有传出边缘，但至少有一个传入边缘。"
+
+#~ msgid "There are no incoming edges and has at least one outgoing edge."
+#~ msgstr "没有传入边缘，但至少有一个传出边缘。"
+
+#~ msgid ""
+#~ "When the conditions are true then the `Operation: Dead End Contraction`_ "
+#~ "can be done."
+#~ msgstr "当条件成立时，可以进行当条件成立时，可以进行 `操作: 死端收缩`_ 。"
+
+#~ msgid "The blue nodes have an unlimited number of edges."
+#~ msgstr "蓝色节点具有无限数量的边。"
+
+#~ msgid ":math:`b`"
+#~ msgstr ":math:`b`"
+
+#~ msgid ":math:`\\{v\\}`"
+#~ msgstr ":math:`\\{v\\}`"
+
+#~ msgid "Number of incoming edges"
+#~ msgstr "传入边数"
+
+#~ msgid "Number of outgoing edges"
+#~ msgstr "传出边数"
+
+#~ msgid ":math:`c`"
+#~ msgstr ":math:`c`"
+
+#~ msgid "2"
+#~ msgstr "2"
+
+#~ msgid ":math:`d`"
+#~ msgstr ":math:`d`"
+
+#~ msgid ":math:`\\{x\\}`"
+#~ msgstr ":math:`\\{x\\}`"
+
+#~ msgid ":math:`e`"
+#~ msgstr ":math:`e`"
+
+#~ msgid ":math:`\\{x, y\\}`"
+#~ msgstr ":math:`\\{x, y\\}`"
+
+#~ msgid ""
+#~ "On the following table, nodes :math:`\\{c, e\\}` because the even that "
+#~ "the number of adjacent vertices is not 1 for"
+#~ msgstr "下表中，节点 :math:`\\{c, e\\}` 因为相邻顶点数不为1的偶数为"
+
+#~ msgid "Operation: Dead End Contraction"
+#~ msgstr "操作：死端收缩"
+
+#~ msgid "In the algorithm, linear contraction is represented by 2."
+#~ msgstr "算法中，线性收缩用2表示。"
+
+#~ msgid "Linear"
+#~ msgstr "线性"
+
+#~ msgid ""
+#~ "In case of an undirected graph, a node is considered a `linear` node when"
+#~ msgstr "在无向图的情况下，当满足以下条件时，节点被视为`线性`节点"
+
+#~ msgid "Linear vertex on undirected graph"
+#~ msgstr "无向图上的线性顶点"
+
+#~ msgid "The green nodes are `linear`_ nodes"
+#~ msgstr "绿色节点是 `线性`_ 节点"
+
+#~ msgid ""
+#~ "The blue nodes have an unlimited number of incoming and outgoing edges."
+#~ msgstr "蓝色节点具有无限数量的传入和传出边缘。"
+
+#~ msgid "Undirected"
+#~ msgstr "无向"
+
+#~ msgid ":math:`v`"
+#~ msgstr ":math:`v`"
+
+#~ msgid ":math:`\\{u, w\\}`"
+#~ msgstr ":math:`\\{u, w\\}`"
+
+#~ msgid "Linear vertex on directed graph"
+#~ msgstr "有向图上的线性顶点"
+
+#~ msgid ""
+#~ "The white node is not linear because the linearity is not symetrical."
+#~ msgstr "白色节点不是线性的，因为线性不对称。"
+
+#~ msgid "It is possible to go :math:`y \\rightarrow c \\rightarrow z`"
+#~ msgstr "它是可能去走 :math:`y \\rightarrow c \\rightarrow z`"
+
+#~ msgid "It's not possible to go :math:`z \\rightarrow c \\rightarrow y`"
+#~ msgstr "不可能走 :math:`z \\rightarrow c \\rightarrow y`"
+
+#~ msgid "Is symmetrical?"
+#~ msgstr "是对称的吗？"
+
+#~ msgid ":math:`\\{u, v\\}`"
+#~ msgstr ":math:`\\{u, v\\}`"
+
+#~ msgid ":math:`\\{w, x\\}`"
+#~ msgstr ":math:`\\{w, x\\}`"
+
+#~ msgid ":math:`\\{y, z\\}`"
+#~ msgstr ":math:`\\{y, z\\}`"
+
+#~ msgid "no"
+#~ msgstr "否"
+
+#~ msgid "Operation: Linear Contraction"
+#~ msgstr "操作：线性收缩"
+
+#~ msgid "The vertex :math:`v` is removed from the graph"
+#~ msgstr "顶点 :math:`v` 已从图中移除"
+
+#~ msgid ""
+#~ "The edges :math:`u \\rightarrow v` and :math:`v \\rightarrow z` are "
+#~ "removed from the graph."
+#~ msgstr "从图中删除边 :math:`u \\rightarrow v` 和 :math:`v \\rightarrow z`。"
+
+#~ msgid ""
+#~ "A new edge :math:`u \\rightarrow z` is inserted represented with red "
+#~ "color."
+#~ msgstr "插入一条新边 :math:`u \\rightarrow z`，以红色表示。"
+
+#~ msgid "Original Data"
+#~ msgstr "原始数据"
+
+#~ msgid ""
+#~ "The following query shows the original data involved in the contraction "
+#~ "operation."
+#~ msgstr "以下查询显示了收缩操作所涉及的原始数据。"
+
+#~ msgid "Contraction results"
+#~ msgstr "收缩结果"
+
+#~ msgid ""
+#~ "Adding extra columns to the ``edge_table`` and "
+#~ "``edge_table_vertices_pgr`` tables, where:"
+#~ msgstr ""
+#~ "向 ``edge_table`` 和``edge_table_vertices_pgr`` 表添加额外的列，其中："
+
+#~ msgid "The vertex table update"
+#~ msgstr "顶点表更新"
+
+#~ msgid "The modified vertices table:"
+#~ msgstr "修改后的顶点表："
+
+#~ msgid "The edge table update"
+#~ msgstr "边缘表更新"
+
+#~ msgid "The modified ``edge_table``."
+#~ msgstr "修改后的 ``edge_table``。"
+
+#~ msgid "Contracted graph"
+#~ msgstr "收缩图"
+
+#~ msgid "Using the contracted graph with ``pgr_dijkstra``"
+#~ msgstr "将收缩图与 ``pgr_dijkstra`` 一起使用"
+
+#~ msgid ""
+#~ "Using the `Edges that belong to the contracted graph.`_ on lines 11 to 20."
+#~ msgstr "使用 `属于收缩图的边。`_ 第 11 至 20 行。"
+
+#~ msgid "Case 1"
+#~ msgstr "情况1"
+
+#~ msgid ""
+#~ "When both source and target belong to the contracted graph, a path is "
+#~ "found."
+#~ msgstr "当源和目标都属于收缩图时，就找到了一条路径。"
+
+#~ msgid "Case 2"
+#~ msgstr "情况2"
+
+#~ msgid ""
+#~ "When source and/or target belong to an edge subgraph then a path is not "
+#~ "found."
+#~ msgstr "当源和/或目标属于边缘子图时，则找不到路径。"
+
+#~ msgid ""
+#~ "In this case, the contracted graph do not have an edge connecting with "
+#~ "node :math:`4`."
+#~ msgstr "在这种情况下，收缩图没有与节点 :math:`4` 相连的边。"
+
+#~ msgid "Case 3"
+#~ msgstr "情况3"
+
+#~ msgid ""
+#~ "When source and/or target belong to a vertex then a path is not found."
+#~ msgstr "当源和/或目标属于顶点时，则找不到路径。"
+
+#~ msgid ""
+#~ "In this case, the contracted graph do not have an edge connecting with "
+#~ "node :math:`7` and of node :math:`4` of the second case."
+#~ msgstr ""
+#~ "在这种情况下，收缩图没有与第二种情况的节点 :math:`7` 和节点 :math:`4` 连接"
+#~ "的边。"
+
+#~ msgid "Refining the above function to include nodes that belong to an edge."
+#~ msgstr "改进上述函数以包含属于边的节点。"
+
+#~ msgid ""
+#~ "The vertices that need to be expanded are calculated on lines 11 to 17."
+#~ msgstr "需要扩展的顶点在第 11 至 17 行计算。"
+
+#~ msgid ""
+#~ "Adding to the contracted graph that additional section on lines 26 to 28."
+#~ msgstr "将第 26 至 28 行的附加部分添加到收缩图中。"
+
+#~ msgid ""
+#~ "When source and/or target belong to an edge subgraph, now, a path is "
+#~ "found."
+#~ msgstr "当源和目标都属于收缩图时，就找到了一条路径。"
+
+#~ msgid "The routing graph now has an edge connecting with node :math:`4`."
+#~ msgstr "路由图现在有一条与节点 :math:`4` 连接的边。"
+
+#~ msgid ""
+#~ "In this case, the contracted graph do not have an edge connecting with "
+#~ "node :math:`7`."
+#~ msgstr "在这种情况下，收缩图没有与节点 :math:`7` 相连的边。"
+
+#~ msgid ""
+#~ "The vertices that need to be expanded are calculated on lines 19 to 24."
+#~ msgstr "需要扩展的顶点在第19到24行计算。"
+
+#~ msgid ""
+#~ "Adding to the contracted graph that additional section on lines 38 to 40."
+#~ msgstr "将第 38 至 40 行的附加部分添加到收缩图中。"
+
+#~ msgid ""
+#~ "The code change do not affect this case so when source and/or target "
+#~ "belong to an edge subgraph, a path is still found."
+#~ msgstr ""
+#~ "代码更改不会影响这种情况，因此当源和/或目标属于边缘子图时，仍然会找到路"
+#~ "径。"
+
+#~ msgid "When source and/or target belong to a vertex, now, a path is found."
+#~ msgstr "当源和/或目标属于一个顶点时，现在就找到了一条路径。"
+
+#~ msgid "Now, the routing graph has an edge connecting with node :math:`7`."
+#~ msgstr "现在，路由图有一条与节点 :math:`7` 连接的边。"
+
+#~ msgid "proposed"
+#~ msgstr "建议的"
+
+#~ msgid "The weighted directed graph, :math:`G_d(V,E)`, is definied by:"
+#~ msgstr "加权有向图， :math:`G_d(V,E)` 的定义如下："
+
+#~ msgid ""
+#~ "That information is correct, for example, when the dead end is on the "
+#~ "limit of the imported graph."
+#~ msgstr "例如，当死端位于导入图的极限时，该信息是正确的。"
+
+#~ msgid ""
+#~ "Visually node :math:`4` looks to be as start/ending of 3 edges, but it is "
+#~ "not."
+#~ msgstr ""
+#~ "从视觉上看，节点 :math:`4` 看起来是 3 条边的开始/结束，但事实并非如此。"
+
+#~ msgid "Is that correct?"
+#~ msgstr "那是对的吗？"
+
+#~ msgid ""
+#~ "This information is correct, for example, when the application is taking "
+#~ "into account speed bumps, stop signals."
+#~ msgstr "例如，当应用程序考虑减速带、停止信号时，此信息是正确的。"
+
+#, fuzzy
+#~ msgid ""
+#~ "To upgrade pgRouting in the database to version 3.8.0 use the following "
+#~ "command:"
+#~ msgstr "要将数据库中的 pgRouting 升级到版本3.7.0，请使用以下命令："
+
+#, fuzzy
+#~ msgid "Boost Graph inside"
+#~ msgstr "Boost 图内部"
+
+#~ msgid "Dead End Contraction"
+#~ msgstr "死端收缩"
+
+#~ msgid "Linear Contraction"
+#~ msgstr "线性收缩"
+
+#~ msgid "the added edges by linear contraction."
+#~ msgstr "由线性收缩添加的边。"
+
+#~ msgid "The pgr_contraction function has the following signature:"
+#~ msgstr "pgr_contraction 函数具有以下签名："
+
+#~ msgid "``pgr_degree`` -- Proposed"
+#~ msgstr "``pgr_degree`` -- 拟议"
+
+#~ msgid "Degree from an existing table"
+#~ msgstr "来自现有表的度数"
+
+#, fuzzy
+#~ msgid "e Also"
+#~ msgstr "另请参阅"
+
+#~ msgid "``pgr_extractVertices`` -- Proposed"
+#~ msgstr "``pgr_extractVertices`` -- 拟议"
+
+#~ msgid "Classified as **proposed** function"
+#~ msgstr "列为 **拟议** 函数"
+
+#~ msgid "``pgr_findCloseEdges`` - Proposed"
+#~ msgstr "``pgr_findCloseEdges``- 拟议"
+
+#, fuzzy
+#~ msgid "**options:** [cap, partial, dryrun]``"
+#~ msgstr "**options:** ``[cap, partial, dryrun]``"
+
+#~ msgid "Default: ``cap => 1``"
+#~ msgstr "默认： ``cap => 1``"
+
+#~ msgid "Maximum one row answer."
+#~ msgstr "最多回答一行。"
+
+#~ msgid "Default: ``partial => true``"
+#~ msgstr "默认： ``partial => true``"
+
+#~ msgid "With less calculations as possible."
+#~ msgstr "尽可能减少计算。"
+
+#~ msgid "Default: ``dryrun => false``"
+#~ msgstr "默认： ``dryrun => false``"
+
+#~ msgid "Process query"
+#~ msgstr "过程查询"
+
+#~ msgid "Returns"
+#~ msgstr "返回"
+
+#~ msgid "values on ``edge_id``, ``fraction``, ``side`` columns."
+#~ msgstr "``edge_id``, ``fraction``, ``side`` 列的值。"
+
+#~ msgid "``NULL`` on ``distance``, ``geom``, ``edge`` columns."
+#~ msgstr "``distance``, ``geom``, ``edge``列上为``NULL``。"
+
+#~ msgid ""
+#~ "Find at most :math:`2` edges close to all vertices on the points of "
+#~ "interest table."
+#~ msgstr "最多找出 :math:`2` 接近兴趣点表上所有顶点的边。"
+
+#~ msgid "One answer per point, as small as possible."
+#~ msgstr "每点一个答案，越小越好。"
+
+#~ msgid ""
+#~ "Columns ``edge_id``, ``fraction``, ``side`` and ``geom`` are returned "
+#~ "with values."
+#~ msgstr "返回了带有值的列 ``edge_id``, ``fraction``, ``side`` 和 ``geom``。"
+
+#~ msgid ""
+#~ "``geom`` contains the original point geometry to assist on "
+#~ "deterpartialing to which point geometry the row belongs to."
+#~ msgstr "``geom`` 包含原始的点几何信息，以帮助确定该行属于哪个点几何。"
+
+#~ msgid "``partial``"
+#~ msgstr "``partial``"
+
+#~ msgid ""
+#~ "When ``true`` only columns needed for :doc:`withPoints-category` are "
+#~ "calculated."
+#~ msgstr "当为 ``true`` 时，只计算 :doc:`withPoints-category` 需要的列。"
+
+#~ msgid "When ``false`` all columns are calculated"
+#~ msgstr "当为 ``false`` 时，所有的列都计算"
+
+#~ msgid "In the right ``r``."
+#~ msgstr "在右边的 ``r``。"
+
+#~ msgid "In the left ``l``."
+#~ msgstr "在左边的 ``l``。"
+
+#~ msgid "``NULL`` when ``cap = 1`` on the `One point`_ signature"
+#~ msgstr "``NULL`` 当在 `一个点`_ 签名，``cap = 1`` 时"
+
+#~ msgid ""
+#~ "`One Point`_: Contains the point on the edge that is ``fraction`` away "
+#~ "from the starting point of the edge."
+#~ msgstr "`一个点`_：包含边缘上距边缘起点一小部分的点。"
+
+#~ msgid "`Many Points`_: Contains the corresponding **original point**"
+#~ msgstr "`多个点`_：包含对应的 **原始点**"
+
+#~ msgid "One point results"
+#~ msgstr "单一点的结果"
+
+#~ msgid ""
+#~ "The geometry ``geom`` is a point on the :math:`sp \\rightarrow ep` edge."
+#~ msgstr "几何 ``geom`` 是 :math:`sp \\rightarrow ep` 边上的一个点。"
+
+#~ msgid ""
+#~ "The geometry ``edge`` is a line that connects the **original point** with "
+#~ "``geom``"
+#~ msgstr "几何 ``edge`` 是连接 **original point** 和 ``geom`` 的线"
+
+#~ msgid "Many point results"
+#~ msgstr "多点成果"
+
+#~ msgid "One point examples"
+#~ msgstr "单点示例"
+
+#~ msgid "At most two answers"
+#~ msgstr "最多两个答案"
+
+#~ msgid "Maximum two row answer."
+#~ msgstr "最多回答两行。"
+
+#~ msgid "Understanding the result"
+#~ msgstr "了解结果"
+
+#~ msgid "``NULL`` on ``geom``, ``edge``"
+#~ msgstr "``NULL`` 在 ``geom``, ``edge`` 上"
+
+#~ msgid "``edge_id`` identifier of the edge close to the **original point**"
+#~ msgstr "``edge_id`` 靠近 **原始点** 的边的标识符"
+
+#~ msgid ""
+#~ "Two edges are withing :math:`0.5` distance units from the **original "
+#~ "point**: :math:`{5, 8}`"
+#~ msgstr ""
+#~ "有两条边与 **原始点** : :math:`{5, 8}` 的距离在 :math:`0.5` 单位范围内"
+
+#~ msgid "For edge :math:`5`:"
+#~ msgstr "对于边 :math:`5`:"
+
+#~ msgid ""
+#~ "``fraction``: The closest point from the **original point** is at the :"
+#~ "math:`0.8` fraction of the edge :math:`5`."
+#~ msgstr ""
+#~ "``fraction``：离 **原始点** 最近的点位于边 :math:`5` 处的 :math:`0.8` 分数"
+#~ "位置。"
+
+#~ msgid ""
+#~ "``distance``: The **original point** is located :math:`0.1` length units "
+#~ "from edge :math:`5`."
+#~ msgstr ""
+#~ "``distance``： **原始点** 位于边 :math:`5` 的 :math:`0.1` 长度单位处。"
+
+#~ msgid "For edge :math:`8`:"
+#~ msgstr "对于边 :math:`8`："
+
+#~ msgid ""
+#~ "``fraction``: The closest point from the **original point** is at the :"
+#~ "math:`0.89..` fraction of the edge :math:`8`."
+#~ msgstr ""
+#~ "``fraction``：离 **原始点** 最近的点位于边 :math:`8` 的 :math:`0.89..` 分"
+#~ "数位置。"
+
+#~ msgid ""
+#~ "``side``: The **original point** is located to the right side of edge :"
+#~ "math:`8`."
+#~ msgstr "``side``： **原始点** 位于边 :math:`8` 的右侧。"
+
+#~ msgid ""
+#~ "``distance``: The **original point** is located :math:`0.19..` length "
+#~ "units from edge :math:`8`."
+#~ msgstr ""
+#~ "``distance``： **原始点** 距离边 :math:`8` 有 :math:`0.19..` 长度单位。"
+
+#~ msgid "One answer, all columns"
+#~ msgstr "一个答案，所有列"
+
+#~ msgid "``partial => false``"
+#~ msgstr "``partial => false``"
+
+#~ msgid ""
+#~ "``edge_id`` identifier of the edge **closest** to the **original point**"
+#~ msgstr "``edge_id`` 与 **原始点** 最 **接近** 的边的标识符"
+
+#~ msgid ""
+#~ "From all edges within :math:`0.5` distance units from the **original "
+#~ "point**: :math:`{5}` is the closest one."
+#~ msgstr ""
+#~ "从距离 **原始点** 不超过 :math:`0.5` 距离单位的所有边中，边 :math:`{5}` 是"
+#~ "最近的一条。"
+
+#~ msgid ""
+#~ "``geom``: Contains the geometry of the closest point on edge :math:`5` "
+#~ "from the **original point**."
+#~ msgstr "``geom``:包含了从 **原始点** 到边 :math:`5` 上最近点的几何形状。"
+
+#~ msgid ""
+#~ "``edge``: Contains the ``LINESTRING`` geometry of the **original point** "
+#~ "to the closest point on on edge :math:`5` ``geom``"
+#~ msgstr ""
+#~ "``edge``：包含了从 **原始点** 到边 :math:`5` ``geom`` 上最近点的 "
+#~ "``LINESTRING`` 几何形状"
+
+#~ msgid "At most two answers with all columns"
+#~ msgstr "所有列最多有两个答案"
+
+#~ msgid "Understanding the result:"
+#~ msgstr "了解结果："
+
+#~ msgid ""
+#~ "``geom``: Contains the geometry of the closest point on edge :math:`8` "
+#~ "from the **original point**."
+#~ msgstr "``geom``：包含了从 **原始点** 到边 :math:`8` 上最近点的几何形状。"
+
+#~ msgid ""
+#~ "``edge``: Contains the ``LINESTRING`` geometry of the **original point** "
+#~ "to the closest point on on edge :math:`8` ``geom``"
+#~ msgstr ""
+#~ "``edge``：包含了从 **原始点** 到边 :math:`8` ``geom`` 上最近点的 "
+#~ "``LINESTRING`` 几何形状"
+
+#~ msgid "``partial => true``"
+#~ msgstr "``partial => true``"
+
+#~ msgid "Is ignored"
+#~ msgstr "被忽略"
+
+#~ msgid "``cap`` and **original point** are used in the code"
+#~ msgstr "代码中使用了 ``cap`` 和 **原始点**"
+
+#~ msgid "At most two answers per point"
+#~ msgstr "每个点最多两个答案"
+
+#~ msgid "``NULL`` on ``edge``"
+#~ msgstr "``edge``为``NULL``"
+
+#~ msgid ""
+#~ "``edge_id`` identifier of the edge close to a **original point** "
+#~ "(``geom``)"
+#~ msgstr "``edge_id``是与一个 **原始点** （``geom``）靠近的边的标识符"
+
+#~ msgid ""
+#~ "Two edges at most withing :math:`0.5` distance units from each of the "
+#~ "**original points**:"
+#~ msgstr ""
+#~ "每个 **原始点** 中，最多有两条边位于距离不超过 :math:`0.5` 距离单位的范围"
+#~ "内："
+
+#~ msgid ""
+#~ "For ``POINT(1.8 0.4)`` and ``POINT(0.3 1.8)`` only one edge was found."
+#~ msgstr "对于 ``POINT(1.8 0.4)`` 和 ``POINT(0.3 1.8)`` ，只找到一条边。"
+
+#~ msgid "For the rest of the points two edges were found."
+#~ msgstr "其余的点有两条边。"
+
+#~ msgid "For point ``POINT(2.9 1.8)``"
+#~ msgstr "对于点 ``POINT(2.9 1.8)``"
+
+#~ msgid ""
+#~ "Edge :math:`5` is before :math:`8` therefore edge :math:`5` has the "
+#~ "shortest distance to ``POINT(2.9 1.8)``."
+#~ msgstr ""
+#~ "边 :math:`5` 在 :math:`8` 之前，因此边 :math:`5` 到 ``POINT(2.9 1.8)`` 的"
+#~ "距离最短。"
+
+#~ msgid "One answer per point, all columns"
+#~ msgstr "每点一个答案，所有列"
+
+#~ msgid "For the **original point** ``POINT(2.9 1.8)``"
+#~ msgstr "对于 **原始点** ``POINT(2.9 1.8)``"
+
+#~ msgid ""
+#~ "``geom``: Contains the geometry of the **original point** ``POINT(2.9 "
+#~ "1.8)``"
+#~ msgstr "``geom``：包含了 **原始点** 的几何形状，即 ``POINT(2.9 1.8)``"
+
+#~ msgid ""
+#~ "``edge``: Contains the ``LINESTRING`` geometry of the **original point** "
+#~ "(``geom``) to the closest point on on edge."
+#~ msgstr ""
+#~ "``edge``：包含了 **原始点** （``geom``）到最接近的边上的 ``LINESTRING`` 几"
+#~ "何形状。"
+
+#~ msgid ""
+#~ "Identifier of the edge nearest edge that allows an arrival to the point."
+#~ msgstr "允许到达该点的最近边的标识符。"
+
+#~ msgid "The geometry of the points moved on top of the segment."
+#~ msgstr "在线段顶部移动的点的几何形状。"
+
+#, fuzzy
+#~ msgid "``pgr_trsp`` - Proposed"
+#~ msgstr "``pgr_trspVia`` - 拟议"
+
+#~ msgid "``pgr_trspVia_withPoints`` - Proposed"
+#~ msgstr "``pgr_trspVia_withPoints`` - 拟议"
+
+#, fuzzy
+#~ msgid "``pgr_trsp_withPoints`` - Proposed"
+#~ msgstr "``pgr_trspVia_withPoints`` - 拟议"
+
+#~ msgid "``pgr_withPoints`` - Proposed"
+#~ msgstr "``pgr_withPoints`` -拟议"
+
+#~ msgid "``pgr_withPointsCost`` - Proposed"
+#~ msgstr "``pgr_withPointsCost`` -拟议"
+
+#~ msgid "``pgr_withPointsCostMatrix`` - proposed"
+#~ msgstr "``pgr_withPointsCostMatrix`` - 拟议"
+
+#~ msgid "``pgr_withPointsDD`` - Proposed"
+#~ msgstr "``pgr_withPointsDD`` - 拟议"
+
+#, fuzzy
+#~ msgid ""
+#~ "pgr_withpointsdd(text,text,bigint,double precision,boolean,character,"
+#~ "boolean)``"
+#~ msgstr ""
+#~ "``pgr_withpointsdd(text,text,bigint,double precision,boolean,character,"
+#~ "boolean)``"
+
+#, fuzzy
+#~ msgid ""
+#~ "pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
+#~ "boolean,boolean)``"
+#~ msgstr ""
+#~ "``pgr_withpointsdd(text,text,anyarray,double precision,boolean,character,"
+#~ "boolean,boolean)``"
+
+#, fuzzy
+#~ msgid "``pgr_withPointsKSP`` - Proposed"
+#~ msgstr "``pgr_withPoints`` -拟议"
+
+#~ msgid "``pgr_withPointsVia`` - Proposed"
+#~ msgstr "``pgr_withPointsVia`` - 拟议"
+
+#~ msgid "These proposed functions do not modify the database."
+#~ msgstr "这些拟议的功能不会修改数据库。"
+
+#, fuzzy
+#~ msgid "Utilities Category"
+#~ msgstr "实用程序"
+
+#~ msgid ""
+#~ "`Boost's metric appro's metric approximation <https://www.boost.org/libs/"
+#~ "graph/doc/metric_tsp_approx.html>`__"
+#~ msgstr ""
+#~ "`Boost 的 metric appro 的 metric 近似 <https://www.boost.org/libs/graph/"
+#~ "doc/metric_tsp_approx.html>`__"
+
+#~ msgid "Vehicle Routing Functions - Category (Experimental)"
+#~ msgstr "车辆路由功能 - 类别（实验）"
+
+#~ msgid "The queries use the :doc:`sampledata` network."
+#~ msgstr "查询使用 :doc:`sampledata` 网络。"
+
+#~ msgid "https://www.boost.org/libs/graph/doc/astar_search.html"
+#~ msgstr "https://www.boost.org/libs/graph/doc/astar_search.html"
+
+#~ msgid "It is expected to terminate faster than pgr_astar"
+#~ msgstr "预计终止速度比 pgr_astar 更快"
+
+#~ msgid "Previous versions of this page"
+#~ msgstr "此页面的先前版本"
+
+#~ msgid ""
+#~ "`Boost: Sequential Vertex Coloring algorithm documentation <https://www."
+#~ "boost.org/libs/graph/doc/sequential_vertex_coloring.html>`__"
+#~ msgstr ""
+#~ "`Boost：顺序顶点着色算法文档 <https://www.boost.org/libs/graph/doc/"
+#~ "sequential_vertex_coloring.html>`__"
+
+#~ msgid ""
+#~ "`Boost: Edge Coloring Algorithm documentation <https://www.boost.org/libs/"
+#~ "graph/doc/edge_coloring.html>`__"
+#~ msgstr ""
+#~ "`Boost：边缘着色算法文档 <https://www.boost.org/libs/graph/doc/"
+#~ "edge_coloring.html>`__"
+
+#~ msgid "Adjecent nodes"
+#~ msgstr "相邻节点"
+
+#~ msgid ":doc:`pgr_topologicalSort`"
+#~ msgstr ":doc:`pgr_topologicalSort`"
+
+#~ msgid "Promoted to **proposed** signature."
+#~ msgstr "晋升为 **拟议** 签名。"
+
+#~ msgid "Migration of functions"
+#~ msgstr "函数迁移"
+
+#~ msgid "Migrating functions"
+#~ msgstr "迁移函数"
+
+#~ msgid "Migration of ``pgr_drivingdistance``"
+#~ msgstr "迁移 ``pgr_drivingdistance``"
+
+#~ msgid "``pgr_drivingdistance`` (Single vertex)"
+#~ msgstr "``pgr_drivingdistance`` (单个顶点)"
+
+#~ msgid "``pgr_drivingdistance`` (Multiple vertices)"
+#~ msgstr "``pgr_drivingdistance`` (多个顶点)"
+
+#~ msgid "Migration of turn restrictions"
+#~ msgstr "转弯限制的迁移"
+
+#~ msgid ""
+#~ ":doc:`pgr_trsp` signatures have changed and many issues have been fixed "
+#~ "in the new signatures. This section will show how to migrate from the old "
+#~ "signatures to the new replacement functions. This also affects the "
+#~ "restrictions."
+#~ msgstr ""
+#~ ":doc:`pgr_trsp` 的签名已更改，并且新签名中已修复许多问题。 本节将展示如何"
+#~ "从旧签名迁移到新的替换函数。 这也会影响限制。"
+
+#~ msgid "The integral type of the ``Edges SQL`` can only be ``INTEGER``."
+#~ msgstr "``Edges SQL`` 的整数类型只能是 ``INTEGER``。"
+
+#~ msgid "The floating point type of the ``Edges SQL`` can only be ``FLOAT``."
+#~ msgstr "``Edges SQL`` 的浮点类型只能是 ``FLOAT``。"
+
+#~ msgid "``directed`` flag is compulsory."
+#~ msgstr "``directed`` 标志是强制性的。"
+
+#~ msgid "Does not autodetect if ``reverse_cost`` column exist."
+#~ msgstr "不自动检测 ``reverse_cost`` 列是否存在。"
+
+#~ msgid ""
+#~ "User must be careful to match the existence of the column with the value "
+#~ "of ``has_rcost`` parameter."
+#~ msgstr "用户必须小心地将列的存在与 ``has_rcost`` 参数的值相匹配。"
+
+#~ msgid "The restrictions inner query is optional."
+#~ msgstr "内部查询的限制是可选的。"
+
+#~ msgid "The output column names are meaningless"
+#~ msgstr "输出列名没有意义"
+
+#~ msgid "Migrate by using:"
+#~ msgstr "使用以下方式迁移："
+
+#~ msgid ":doc:`pgr_dijkstra` when there are no restrictions,"
+#~ msgstr ":doc:`pgr_dijkstra` 当没有限制时，"
+
+#~ msgid ":doc:`pgr_trsp` (One to One) when there are restrictions."
+#~ msgstr ":doc:`pgr_trsp` (一对一)当有限制时。"
+
+#~ msgid "Migrating ``pgr_trsp`` (Vertices) using ``pgr_dijkstra``"
+#~ msgstr "使用 ``pgr_dijkstra`` 迁移 ``pgr_trsp`` （顶点）"
+
+#~ msgid "The following query does not have restrictions."
+#~ msgstr "以下查询没有限制。"
+
+#~ msgid "A message about deprecation is shown"
+#~ msgstr "显示有关弃用的消息"
+
+#~ msgid "Deprecated functions will be removed on the next mayor version 4.0.0"
+#~ msgstr "已弃用的功能将在下一个正式版本 4.0.0 中删除"
+
+#~ msgid "The types casting has been removed."
+#~ msgstr "类型强制转换已被删除。"
+
+#~ msgid ":doc:`pgr_dijkstra`:"
+#~ msgstr ":doc:`pgr_dijkstra`:"
+
+#~ msgid "Autodetects if ``reverse_cost`` column is in the edges SQL."
+#~ msgstr "自动检测 ``reverse_cost`` 列是否在边SQL中。"
+
+#~ msgid "Accepts ``ANY-INTEGER`` on integral types"
+#~ msgstr "接受整数类型 ``ANY-INTEGER``"
+
+#~ msgid "Accepts ``ANY-NUMERICAL`` on floating point types"
+#~ msgstr "接受浮点类型 ``ANY-NUMERICAL``"
+
+#~ msgid "``directed`` flag has a default value of ``true``."
+#~ msgstr "``directed`` 标志的默认值为``true``。"
+
+#~ msgid "Use the same value that on the original query."
+#~ msgstr "使用与原始查询相同的值。"
+
+#~ msgid "In this example it is ``true`` which is the default value."
+#~ msgstr "在此示例中，默认值为 ``true``。"
+
+#~ msgid "The flag has been omitted and the default is been used."
+#~ msgstr "该标志已被省略，并使用默认值。"
+
+#~ msgid ""
+#~ "When the need of using strictly the same (meaningless) names and types of "
+#~ "the function been migrated then:"
+#~ msgstr "当需要使用严格相同（无意义）的函数名称和类型进行迁移时："
+
+#~ msgid "Migrating ``pgr_trsp`` (Vertices) using ``pgr_trsp``"
+#~ msgstr "使用 ``pgr_trsp``迁移 ``pgr_trsp`` （顶点）"
+
+#~ msgid "The following query has restrictions."
+#~ msgstr "以下查询有限制。"
+
+#~ msgid "The restrictions are the last parameter of the function"
+#~ msgstr "限制是函数的最后一个参数"
+
+#~ msgid "Using the old structure of restrictions"
+#~ msgstr "使用旧的限制结构"
+
+#~ msgid "The new structure of restrictions is been used."
+#~ msgstr "使用了新的限制结构。"
+
+#~ msgid "It is the second parameter."
+#~ msgstr "这是第二个参数。"
+
+#~ msgid ":doc:`pgr_trsp`:"
+#~ msgstr ":doc:`pgr_trsp`:"
+
+#~ msgid "The integral types of the ``sql`` can only be ``INTEGER``."
+#~ msgstr "``sql`` 的整型类型只能是 ``INTEGER``。"
+
+#~ msgid "The floating point type of the ``sql`` can only be ``FLOAT``."
+#~ msgstr "``sql`` 的浮点类型只能是 ``FLOAT``。"
+
+#~ msgid "For these migration guide the following points will be used:"
+#~ msgstr "对于这些迁移指南，将使用以下几点："
+
+#~ msgid ":doc:`pgr_withPoints` when there are no restrictions,"
+#~ msgstr ":doc:`pgr_withPoints` 当没有任何限制的时候，"
+
+#~ msgid ":doc:`pgr_trsp_withPoints` (One to One) when there are restrictions."
+#~ msgstr ":doc:`pgr_trsp_withPoints` (一对一) 当有限制时。"
+
+#~ msgid "Migrating ``pgr_trsp`` (Edges) using ``pgr_withPoints``"
+#~ msgstr "使用 ``pgr_withPoints``迁移 ``pgr_trsp`` （边）"
+
+#~ msgid "Use :doc:`pgr_withPoints` instead."
+#~ msgstr "请使用 :doc:`pgr_withPoints`。"
+
+#~ msgid ""
+#~ "Do not show details, as the deprecated function does not show details."
+#~ msgstr "不显示详细信息，因为已弃用的函数不显示详细信息。"
+
+#~ msgid ":doc:`pgr_withPoints`:"
+#~ msgstr ":doc:`pgr_withPoints`:"
+
+#~ msgid "On the points query do not include the ``side`` column."
+#~ msgstr "在点查询中不包括 ``side`` 列。"
+
+#~ msgid ""
+#~ "When the need of using strictly the same (meaningless) names and types, "
+#~ "and node values of the function been migrated then:"
+#~ msgstr ""
+#~ "当需要使用严格相同（无意义）的名称和类型，并且函数的节点值被迁移时："
+
+#~ msgid "Migrating ``pgr_trsp`` (Edges) using ``pgr_trsp_withPoints``"
+#~ msgstr "使用 ``pgr_trsp_withPoints`` 迁移 ``pgr_trsp`` （边）"
+
+#~ msgid ":doc:`pgr_trsp_withPoints`:"
+#~ msgstr ":doc:`pgr_trsp_withPoints`:"
+
+#~ msgid "The integral types of the ``Edges SQL`` can only be ``INTEGER``."
+#~ msgstr "``Edges SQL`` 的整数类型只能是 ``INTEGER``。"
+
+#~ msgid ":doc:`pgr_dijkstraVia` when there are no restrictions,"
+#~ msgstr ":doc:`pgr_dijkstraVia` 当无限制时，"
+
+#~ msgid ":doc:`pgr_trspVia` when there are restrictions."
+#~ msgstr ":doc:`pgr_trspVia` 当有限制时。"
+
+#~ msgid "Migrating ``pgr_trspViaVertices`` using ``pgr_dijkstraVia``"
+#~ msgstr "使用 ``pgr_dijkstraVia``迁移 ``pgr_trspViaVertices``"
+
+#~ msgid ":doc:`pgr_dijkstraVia`:"
+#~ msgstr ":doc:`pgr_dijkstraVia`:"
+
+#~ msgid "Migrating ``pgr_trspViaVertices`` using ``pgr_trspVia``"
+#~ msgstr "使用 ``pgr_trspVia``迁移 ``pgr_trspViaVertices``"
+
+#~ msgid ":doc:`pgr_trspVia`:"
+#~ msgstr ":doc:`pgr_trspVia`:"
+
+#~ msgid ""
+#~ "And will travel thru the following Via points :math:"
+#~ "`4\\rightarrow3\\rightarrow6`"
+#~ msgstr "并将途经以下途经点： :math:`4\\rightarrow3\\rightarrow6`"
+
+#~ msgid ":doc:`pgr_withPointsVia` when there are no restrictions,"
+#~ msgstr ":doc:`pgr_withPointsVia` 当没有限制时，"
+
+#~ msgid ":doc:`pgr_trspVia_withPoints` when there are restrictions."
+#~ msgstr ":doc:`pgr_trspVia_withPoints` 当有限制时。"
+
+#~ msgid "Migrating ``pgr_trspViaEdges`` using ``pgr_withPointsVia``"
+#~ msgstr "使用 ``pgr_withPointsVia`` 迁移 ``pgr_trspViaEdges``"
+
+#~ msgid ":doc:`pgr_withPointsVia`:"
+#~ msgstr ":doc:`pgr_withPointsVia`:"
+
+#~ msgid "Migrating ``pgr_trspViaEdges`` using ``pgr_trspVia_withPoints``"
+#~ msgstr "使用 ``pgr_trspVia_withPoints``迁移``pgr_trspViaEdges``"
+
+#~ msgid ":doc:`pgr_trspVia_withPoints`:"
+#~ msgstr ":doc:`pgr_trspVia_withPoints`:"
+
+#~ msgid "``pgr_ksp`` (One to One)"
+#~ msgstr "``pgr_ksp`` (一对一)"
+
+#~ msgid "New overload functions:"
+#~ msgstr "新的重载函数："
+
+#~ msgid "``pgr_ksp`` (One to Many)"
+#~ msgstr "``pgr_ksp`` (一对多)"
+
+#~ msgid "``pgr_ksp`` (Many to One)"
+#~ msgstr "``pgr_ksp`` (多对一)"
+
+#~ msgid "``pgr_ksp`` (Many to Many)"
+#~ msgstr "``pgr_ksp`` (多对多)"
+
+#~ msgid "``pgr_ksp`` (Combinations)"
+#~ msgstr "``pgr_ksp`` (组合)"
+
+#~ msgid "**Official** function"
+#~ msgstr "**官方** 函数"
+
+#~ msgid "New **Official** function"
+#~ msgstr "**官方** 新函数"
+
+#~ msgid ":doc:`sampledata` network."
+#~ msgstr ":doc:`sampledata` 网络。"
+
+#~ msgid ""
+#~ "``pgr_aStar`` (`One to One`_) added ``start_vid`` and ``end_vid`` columns."
+#~ msgstr "``pgr_aStar`` (`一对一`_) 增加 ``start_vid`` 和 ``end_vid`` 列."
+
+#~ msgid "``pgr_aStar`` (`One to Many`_) added ``end_vid`` column."
+#~ msgstr "``pgr_aStar`` (`一对多`_) 增加 ``end_vid`` 列."
+
+#~ msgid "``pgr_aStar`` (`Many to One`_) added ``start_vid`` column."
+#~ msgstr "``pgr_aStar`` (`多对一`_) 增加 ``start_vid`` 列."
+
+#~ msgid "New **proposed** signature:"
+#~ msgstr "新 **拟议** 的签名："
+
+#~ msgid "``pgr_aStar`` (`Combinations`_)"
+#~ msgstr "``pgr_aStar`` (`组合`_)"
+
+#~ msgid "New **Proposed** signatures:"
+#~ msgstr "新 **拟议** 签名："
+
+#~ msgid "``pgr_aStar`` (`One to Many`_)"
+#~ msgstr "``pgr_aStar`` (`一对多`_)"
+
+#~ msgid "``pgr_aStar`` (`Many to One`_)"
+#~ msgstr "``pgr_aStar`` (`多对一`_)"
+
+#~ msgid "``pgr_aStar`` (`Many to Many`_)"
+#~ msgstr "``pgr_aStar`` (`多对多`_)"
+
+#~ msgid "Signature change on ``pgr_astar`` (`One to One`_)"
+#~ msgstr "签名更改 ``pgr_astar`` (`一对一`_)"
+
+#~ msgid "**Official** ``pgr_aStar`` (`One to One`_)"
+#~ msgstr "**官方** ``pgr_aStar`` (`一对一`_)"
+
+#~ msgid "pgr_aStarCost"
+#~ msgstr "pgr_aStarCost"
+
+#~ msgid "``pgr_aStarCost`` (`Combinations`_)"
+#~ msgstr "``pgr_aStarCost`` (`组合`_)"
+
+#~ msgid "New **proposed** function"
+#~ msgstr "新 **拟议** 函数"
+
+#~ msgid "pgr_analyzeGraph"
+#~ msgstr "pgr_analyzeGraph"
+
+#~ msgid "The examples use the :doc:`sampledata` network."
+#~ msgstr "这些示例使用 :doc:`sampledata` 网络。"
+
+#~ msgid "pgr_analyzeOneWay"
+#~ msgstr "pgr_analyzeOneWay"
+
+#~ msgid "New **experimental** function"
+#~ msgstr "新 **实验** 函数"
+
+#~ msgid ""
+#~ "Boost: `Biconnected components & articulation points <https://www.boost."
+#~ "org/libs/graph/doc/biconnected_components.html>`__"
+#~ msgstr ""
+#~ "Boost: `双连通分量和关节点 <https://www.boost.org/libs/graph/doc/"
+#~ "biconnected_components.html>`__"
+
+#~ msgid ""
+#~ "``pgr_bdAstar`` (`One to One`_) added ``start_vid`` and ``end_vid`` "
+#~ "columns."
+#~ msgstr "``pgr_bdAstar`` (`一对一`_) 增加 ``start_vid`` 和 ``end_vid`` 列。"
+
+#~ msgid "``pgr_bdAstar`` (`One to Many`_) added ``end_vid`` column."
+#~ msgstr "``pgr_bdAstar`` (`一对多`_) 增加 ``end_vid`` 列。"
+
+#~ msgid "``pgr_bdAstar`` (`Many to One`_) added ``start_vid`` column."
+#~ msgstr "``pgr_bdAstar`` (`多对一`_) 增加 ``start_vid`` 列。"
+
+#~ msgid "``pgr_bdAstar`` (`Combinations`_)"
+#~ msgstr "``pgr_bdAstar`` (`组合`_)"
+
+#~ msgid "``pgr_bdAstar`` (`One to Many`_)"
+#~ msgstr "``pgr_bdAstar`` (`一对多`_)"
+
+#~ msgid "``pgr_bdAstar`` (`Many to One`_)"
+#~ msgstr "``pgr_bdAstar`` (`多对一`_)"
+
+#~ msgid "``pgr_bdAstar`` (`Many to Many`_)"
+#~ msgstr "``pgr_bdAstar`` (`多对多`_)"
+
+#~ msgid "Signature change on ``pgr_bdAstar`` (`One to One`_)"
+#~ msgstr "在 ``pgr_bdAstar`` (`一对一`_)上的签名更改"
+
+#~ msgid "**Official** ``pgr_bdAstar`` (`One to One`_)"
+#~ msgstr "**官方** ``pgr_bdAstar`` (`一对一`_)"
+
+#~ msgid ""
+#~ "The results are equivalent to the union of the results of the "
+#~ "`pgr_bdAStar(` `One to One`_ `)` on the:"
+#~ msgstr "结果相当于`pgr_bdAStar(` `一对一`_ `)` 结果的并集："
+
+#~ msgid "pgr_bdAstarCost"
+#~ msgstr "pgr_bdAstarCost"
+
+#~ msgid "``pgr_bdAstarCost`` (`Combinations`_)"
+#~ msgstr "``pgr_bdAstarCost`` (`组合`_)"
+
+#~ msgid "pgr_bdDijkstra(`Combinations`_)"
+#~ msgstr "pgr_bdDijkstra(`组合`_)"
+
+#~ msgid "New **Proposed** functions:"
+#~ msgstr "新 **拟议** 函数："
+
+#~ msgid "``pgr_bdDijkstra`` (`One to Many`_)"
+#~ msgstr "``pgr_bdDijkstra`` (`一对多`_)"
+
+#~ msgid "``pgr_bdDijkstra`` (`Many to One`_)"
+#~ msgstr "``pgr_bdDijkstra`` (`多对一`_)"
+
+#~ msgid "``pgr_bdDijkstra`` (`Many to Many`_)"
+#~ msgstr "``pgr_bdDijkstra`` (`多对多`_)"
+
+#~ msgid "Signature change on ``pgr_bdDijsktra`` (`One to One`_)"
+#~ msgstr "``pgr_bdDijsktra`` (`一对一`_)上的签名更改"
+
+#~ msgid "**Official** ``pgr_bdDijkstra`` (`One to One`_)"
+#~ msgstr "**官方** ``pgr_bdDijkstra`` (`一对一`_)"
+
+#~ msgid ""
+#~ "https://www.cs.princeton.edu/courses/archive/spr06/cos423/Handouts/"
+#~ "EPP%20shortest%20path%20algorithms.pdf"
+#~ msgstr ""
+#~ "https://www.cs.princeton.edu/courses/archive/spr06/cos423/Handouts/"
+#~ "EPP%20shortest%20path%20algorithms.pdf"
+
+#~ msgid "``pgr_bdDijkstraCost`` (`Combinations`_)"
+#~ msgstr "``pgr_bdDijkstraCost`` (`组合`_)"
+
+#~ msgid "New **experimental** signature:"
+#~ msgstr "新 **实验性** 签名："
+
+#~ msgid "``pgr_bellmanFord`` (`Combinations`_)"
+#~ msgstr "``pgr_bellmanFord`` (`组合`_)"
+
+#~ msgid "New **experimental** signatures:"
+#~ msgstr "新 **实验** 签名："
+
+#~ msgid "``pgr_bellmanFord`` (`One to One`_)"
+#~ msgstr "``pgr_bellmanFord`` (`一对一`_)"
+
+#~ msgid "``pgr_bellmanFord`` (`One to Many`_)"
+#~ msgstr "``pgr_bellmanFord`` (`一对多`_)"
+
+#~ msgid "``pgr_bellmanFord`` (`Many to One`_)"
+#~ msgstr "``pgr_bellmanFord`` (`多对一`_)"
+
+#~ msgid "``pgr_bellmanFord`` (`Many to Many`_)"
+#~ msgstr "``pgr_bellmanFord`` (`多对多`_)"
+
+#~ msgid "New **experimental** function:"
+#~ msgstr "新的 **实验** 函数："
+
+#, fuzzy
+#~ msgid ""
+#~ "Boost's `betweenness_centrality <https://www.boost.org/doc/libs/1_84_0/"
+#~ "libs/graph/doc/betweenness_centrality.html>`_"
+#~ msgstr ""
+#~ "`Boost：Hawick 电路算法 <https://www.boost.org/doc/libs/1_78_0/libs/graph/"
+#~ "doc/hawick_circuits.html>`__"
+
+#~ msgid "Queries use the :doc:`sampledata` network."
+#~ msgstr "查询使用 :doc:`sampledata` 网络。"
+
+#~ msgid ""
+#~ "Boost: `Biconnected components <https://www.boost.org/libs/graph/doc/"
+#~ "biconnected_components.html>`__"
+#~ msgstr ""
+#~ "Boost: `双连通分量 <https://www.boost.org/libs/graph/doc/"
+#~ "biconnected_components.html>`__"
+
+#~ msgid "pgr_binaryBreadthFirstSearch(`Combinations`_)"
+#~ msgstr "pgr_binaryBreadthFirstSearch(`组合`_)"
+
+#~ msgid "pgr_binaryBreadthFirstSearch(`One to One`_)"
+#~ msgstr "pgr_binaryBreadthFirstSearch(`一对一`_)"
+
+#~ msgid "pgr_binaryBreadthFirstSearch(`One to Many`_)"
+#~ msgstr "pgr_binaryBreadthFirstSearch(`一对多`_)"
+
+#~ msgid "pgr_binaryBreadthFirstSearch(`Many to One`_)"
+#~ msgstr "pgr_binaryBreadthFirstSearch(`多对一`_)"
+
+#~ msgid "pgr_binaryBreadthFirstSearch(`Many to Many`_)"
+#~ msgstr "pgr_binaryBreadthFirstSearch(`多对多`_)"
+
+#~ msgid "pgr_bipartite -Experimental"
+#~ msgstr "pgr_bipartite -实验"
+
+#~ msgid "New **experimental** signature"
+#~ msgstr "新的 **实验** 签名"
+
+#~ msgid "New **proposed** signature"
+#~ msgstr "新的 **拟议** 签名"
+
+#~ msgid "``pgr_boykovKolmogorov`` (`Combinations`_)"
+#~ msgstr "``pgr_boykovKolmogorov`` (`组合`_)"
+
+#~ msgid "**Proposed** function"
+#~ msgstr "**拟议** 函数"
+
+#~ msgid "New **Experimental** function"
+#~ msgstr "新的 **实验** 函数"
+
+#~ msgid "https://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html"
+#~ msgstr ""
+#~ "https://www.boost.org/libs/graph/doc/boykov_kolmogorov_max_flow.html"
+
+#~ msgid "``pgr_breadthFirstSearch`` (`Single Vertex`_)"
+#~ msgstr "``pgr_breadthFirstSearch`` (`单顶点搜索`_)"
+
+#~ msgid "``pgr_breadthFirstSearch`` (`Multiple Vertices`_)"
+#~ msgstr "``pgr_breadthFirstSearch`` (`多顶点搜索`_)"
+
+#~ msgid ""
+#~ "`Boost: Breadth First Search algorithm documentation <https://www.boost."
+#~ "org/libs/graph/doc/breadth_first_search.html>`__"
+#~ msgstr ""
+#~ "`Boost：广度优先搜索算法文档 <https://www.boost.org/libs/graph/doc/"
+#~ "breadth_first_search.html>`__"
+
+#~ msgid "**Supported versions**"
+#~ msgstr "**支持版本**"
+
+#~ msgid ""
+#~ "Boost: `Connected components <https://www.boost.org/libs/graph/doc/"
+#~ "connected_components.html>`__"
+#~ msgstr ""
+#~ "Boost: ` 已连接组件 <https://www.boost.org/libs/graph/doc/"
+#~ "connected_components.html>`__"
+
+#~ msgid "pgr_createTopology"
+#~ msgstr "pgr_createTopology"
+
+#~ msgid "The example uses the :doc:`sampledata` network."
+#~ msgstr "本例使用 :doc:`sampledata` 网络。"
+
+#~ msgid "pgr_createVerticesTable"
+#~ msgstr "pgr_createVerticesTable"
+
+#~ msgid "pgr_dagShortestPath - Experimental"
+#~ msgstr "pgr_dagShortestPath - 实验"
+
+#~ msgid "Promoted to **proposed** function"
+#~ msgstr "升级至 **拟议** 函数"
+
+#~ msgid "``pgr_depthFirstSearch`` (`Single Vertex`_)"
+#~ msgstr "``pgr_depthFirstSearch`` (`单个顶点`_)"
+
+#~ msgid "``pgr_depthFirstSearch`` (`Multiple Vertices`_)"
+#~ msgstr "``pgr_depthFirstSearch`` (`多个顶点`_)"
+
+#~ msgid ""
+#~ "`Boost: Depth First Search algorithm documentation <https://www.boost.org/"
+#~ "libs/graph/doc/depth_first_search.html>`__"
+#~ msgstr ""
+#~ "`Boost：深度优先搜索算法文档 <https://www.boost.org/libs/graph/doc/"
+#~ "depth_first_search.html>`__"
+
+#~ msgid ""
+#~ "`Boost: Undirected DFS algorithm documentation <https://www.boost.org/"
+#~ "libs/graph/doc/undirected_dfs.html>`__"
+#~ msgstr ""
+#~ "`Boost：非定向 DFS 算法文档 <https://www.boost.org/libs/graph/doc/"
+#~ "undirected_dfs.html>`__"
+
+#~ msgid ""
+#~ "``pgr_dijkstra`` (`One to One`_) added ``start_vid`` and ``end_vid`` "
+#~ "columns."
+#~ msgstr "``pgr_dijkstra`` (`一对一`_)增加``start_vid`` 和``end_vid`` 列。"
+
+#~ msgid "``pgr_dijkstra`` (`One to Many`_) added ``end_vid`` column."
+#~ msgstr "``pgr_dijkstra`` (`一对多`_) 增加``end_vid`` 列。"
+
+#~ msgid "``pgr_dijkstra`` (`Many to One`_) added ``start_vid`` column."
+#~ msgstr "``pgr_dijkstra`` (`多对一`_) 增加 ``start_vid`` 列。"
+
+#~ msgid "``pgr_dijkstra`` (`Combinations`_)"
+#~ msgstr "``pgr_dijkstra`` (`组合`_)"
+
+#~ msgid "**Official** functions"
+#~ msgstr "**官方** 函数"
+
+#~ msgid "New **proposed** functions:"
+#~ msgstr "新的 **拟议** 函数："
+
+#~ msgid "``pgr_dijkstra`` (`One to Many`_)"
+#~ msgstr "``pgr_dijkstra`` (`一对多`_)"
+
+#~ msgid "``pgr_dijkstra`` (`Many to One`_)"
+#~ msgstr "``pgr_dijkstra`` (`多对一`_)"
+
+#~ msgid "``pgr_dijkstra`` (`Many to Many`_)"
+#~ msgstr "``pgr_dijkstra`` (`多对多`_)"
+
+#~ msgid "Signature change on ``pgr_dijkstra`` (`One to One`_)"
+#~ msgstr "``pgr_dijkstra`` (`一对一`_)的签名更改"
+
+#~ msgid "**Official** ``pgr_dijkstra`` (`One to One`_)"
+#~ msgstr "**官方** ``pgr_dijkstra`` (`一对一`_)"
+
+#~ msgid "``pgr_dijkstraCost`` (`Combinations`_)"
+#~ msgstr "``pgr_dijkstraCost`` (`组合`_)"
+
+#~ msgid "boost: https://www.boost.org/libs/graph/doc/table_of_contents.html"
+#~ msgstr "boost: https://www.boost.org/libs/graph/doc/table_of_contents.html"
+
+#~ msgid "Signature change pgr_drivingDistance(single vertex)"
+#~ msgstr "签名更改 pgr_drivingDistance（单顶点）"
+
+#~ msgid "New **Official** pgr_drivingDistance(multiple vertices)"
+#~ msgstr "新 **官方** pgr_drivingDistance(多顶点)"
+
+#~ msgid "Official:: pgr_drivingDistance(single vertex)"
+#~ msgstr "官方:: pgr_drivingDistance(单顶点)"
+
+#~ msgid "pgr_edgeColoring - Experimental"
+#~ msgstr "pgr_edgeColoring - 实验"
+
+#~ msgid "New **proposed** function:"
+#~ msgstr "新的 **拟议** 函数："
+
+#~ msgid "``pgr_edmondsKarp`` (`Combinations`_)"
+#~ msgstr "``pgr_edmondsKarp`` (`组合`_)"
+
+#~ msgid "https://www.boost.org/libs/graph/doc/edmonds_karp_max_flow.html"
+#~ msgstr "https://www.boost.org/libs/graph/doc/edmonds_karp_max_flow.html"
+
+#~ msgid "``pgr_edwardMoore - Experimental``"
+#~ msgstr "``pgr_edwardMoore - 实验``"
+
+#~ msgid "``pgr_edwardMoore`` (`Combinations`_)"
+#~ msgstr "``pgr_edwardMoore`` (`组合`_)"
+
+#~ msgid "``pgr_edwardMoore`` (`One to One`_)"
+#~ msgstr "``pgr_edwardMoore`` (`一对一`_)"
+
+#~ msgid "``pgr_edwardMoore`` (`One to Many`_)"
+#~ msgstr "``pgr_edwardMoore`` (`一对多`_)"
+
+#~ msgid "``pgr_edwardMoore`` (`Many to One`_)"
+#~ msgstr "``pgr_edwardMoore`` (`多对一`_)"
+
+#~ msgid "``pgr_edwardMoore`` (`Many to Many`_)"
+#~ msgstr "``pgr_edwardMoore`` (`多对多`_)"
+
+#~ msgid "pgr_extractVertices -- Proposed"
+#~ msgstr "pgr_extractVertices -- 拟议"
+
+#~ msgid "New **proposed** signatures:"
+#~ msgstr "新的 **拟议** 签名："
+
+#~ msgid "``pgr_findCloseEdges`` (`One point`_)"
+#~ msgstr "``pgr_findCloseEdges`` (`一个点`_)"
+
+#~ msgid "``pgr_findCloseEdges`` (`Many points`_)"
+#~ msgstr "``pgr_findCloseEdges`` (`多个点`_)"
+
+#~ msgid "Queries uses the :doc:`sampledata` network."
+#~ msgstr "查询使用 :doc:`sampledata` 网络。"
+
+#~ msgid "New **official** function"
+#~ msgstr "**官方** 新功能"
+
+#~ msgid "``pgr_hawickCircuits - Experimental``"
+#~ msgstr "``pgr_hawickCircuits - 实验``"
+
+#~ msgid "``pgr_hawickCircuits``"
+#~ msgstr "``pgr_hawickCircuits``"
+
+#~ msgid "https://www.boost.org/libs/graph/doc/boyer_myrvold.html"
+#~ msgstr "https://www.boost.org/libs/graph/doc/boyer_myrvold.html"
+
+#~ msgid "pgr_lengauerTarjanDominatorTree -Experimental"
+#~ msgstr "pgr_lengauerTarjanDominatorTree -实验"
+
+#~ msgid ""
+#~ "`Boost: Lengauer-Tarjan dominator tree algorithm <https://www.boost.org/"
+#~ "libs/graph/doc/lengauer_tarjan_dominator.htm>`__"
+#~ msgstr ""
+#~ "`BOOST：Languer-Tarzan 支配树算法 <https://www.boost.org/libs/graph/doc/"
+#~ "lengauer_tarjan_dominator.htm>`__"
+
+#, fuzzy
+#~ msgid "pgr_lineGraph - Proposed"
+#~ msgstr "pgr_trsp - 拟议"
+
+#~ msgid ""
+#~ "The examples of this section are based on the :doc:`sampledata` network. "
+#~ "The examples include the subgraph including edges 4, 7, 8, and 10 with "
+#~ "``reverse_cost``."
+#~ msgstr ""
+#~ "本节的示例基于 :doc:`sampledata` 网络。 这些示例包括包含具有 "
+#~ "``reverse_cost`` 的边 4、7、8 和 10 的子图。"
+
+#~ msgid ""
+#~ "Query done on :doc:`sampledata` network gives the list of edges that are "
+#~ "needed to connect the graph."
+#~ msgstr "在 :doc:`sampledata` 网络上完成的查询给出了连接图所需的边列表。"
+
+#~ msgid "https://www.boost.org/libs/graph/doc/make_connected.html"
+#~ msgstr "https://www.boost.org/libs/graph/doc/make_connected.html"
+
+#~ msgid "pgr_maxCardinalityMatch"
+#~ msgstr "pgr_maxCardinalityMatch"
+
+#~ msgid "``pgr_maxCardinalityMatch(text,boolean)``"
+#~ msgstr "``pgr_maxCardinalityMatch(text,boolean)``"
+
+#~ msgid "``directed => false`` when used."
+#~ msgstr "使用时 ``directed => false``。"
+
+#~ msgid "https://www.boost.org/libs/graph/doc/maximum_matching.html"
+#~ msgstr "https://www.boost.org/libs/graph/doc/maximum_matching.html"
+
+#~ msgid "``pgr_maxFlow`` (`Combinations`_)"
+#~ msgstr "``pgr_maxFlow`` (`组合`_)"
+
+#~ msgid "New **Proposed** function"
+#~ msgstr "新 **拟议** 的函数"
+
+#~ msgid "https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html"
+#~ msgstr "https://www.boost.org/libs/graph/doc/push_relabel_max_flow.html"
+
+#~ msgid "``pgr_maxFlowMinCost`` (`Combinations`_)"
+#~ msgstr "``pgr_maxFlowMinCost`` (`组合`_)"
+
+#~ msgid ""
+#~ "https://www.boost.org/libs/graph/doc/"
+#~ "successive_shortest_path_nonnegative_weights.html"
+#~ msgstr ""
+#~ "https://www.boost.org/libs/graph/doc/"
+#~ "successive_shortest_path_nonnegative_weights.html"
+
+#~ msgid "``pgr_maxFlowMinCost_Cost`` (`Combinations`_)"
+#~ msgstr "``pgr_maxFlowMinCost_Cost`` (`组合`_)"
+
+#~ msgid "``pgr_pushRelabel`` (`Combinations`_)"
+#~ msgstr "``pgr_pushRelabel`` (`组合`_)"
+
+#~ msgid "pgr_sequentialVertexColoring - Proposed"
+#~ msgstr "pgr_sequentialVertexColoring - 拟议"
+
+#~ msgid "Promoted to **proposed** signature"
+#~ msgstr "晋升为 **拟议** 签名"
+
+#~ msgid "pgr_stoerWagner - Experimental"
+#~ msgstr "pgr_stoerWagner - 实验"
+
+#~ msgid ""
+#~ "Boost: `Strong components <https://www.boost.org/libs/graph/doc/"
+#~ "strong_components.html>`__"
+#~ msgstr ""
+#~ "Boost: `强大组件 <https://www.boost.org/libs/graph/doc/strong_components."
+#~ "html>`__"
+
+#~ msgid "pgr_trsp - Proposed"
+#~ msgstr "pgr_trsp - 拟议"
+
+#~ msgid "New proposed signatures"
+#~ msgstr "新拟议的签名"
+
+#~ msgid "``pgr_trsp`` (`One to One`_)"
+#~ msgstr "``pgr_trsp`` (`一对一`_)"
+
+#~ msgid "``pgr_trsp`` (`One to Many`_)"
+#~ msgstr "``pgr_trsp`` (`一对多`_)"
+
+#~ msgid "``pgr_trsp`` (`Many to One`_)"
+#~ msgstr "``pgr_trsp`` (`多对一`_)"
+
+#~ msgid "``pgr_trsp`` (`Many to Many`_)"
+#~ msgstr "``pgr_trsp`` (`多对多`_)"
+
+#~ msgid "``pgr_trsp`` (`Combinations`_)"
+#~ msgstr "``pgr_trsp`` (`组合`_)"
+
+#~ msgid "``pgr_trsp(text,integer,integer,boolean,boolean,text)``"
+#~ msgstr "``pgr_trsp(text,integer,integer,boolean,boolean,text)``"
+
+#~ msgid "``pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)``"
+#~ msgstr "``pgr_trsp(text,integer,float,integer,float,boolean,boolean,text)``"
+
+#~ msgid "``pgr_trspViaVertices(text,anyarray,boolean,boolean,text)``"
+#~ msgstr "``pgr_trspViaVertices(text,anyarray,boolean,boolean,text)``"
+
+#~ msgid ""
+#~ "``pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,"
+#~ "text)``"
+#~ msgstr ""
+#~ "``pgr_trspviaedges(text,integer[],double precision[],boolean,boolean,"
+#~ "text)``"
+
+#~ msgid "``pgr_trspViaVertices``"
+#~ msgstr "``pgr_trspViaVertices``"
+
+#~ msgid "``pgr_trspViaEdges``"
+#~ msgstr "``pgr_trspViaEdges``"
+
+#~ msgid "New proposed function:"
+#~ msgstr "新提议的函数："
+
+#~ msgid "``pgr_trspVia`` (`One Via`_)"
+#~ msgstr "``pgr_trspVia`` (`One Via`_)"
+
+#~ msgid "``pgr_trspVia_withPoints`` (`One Via`_)"
+#~ msgstr "``pgr_trspVia_withPoints`` (`One Via`_)"
+
+#~ msgid "pgr_trsp_withPoints - Proposed"
+#~ msgstr "pgr_trsp_withPoints - 拟议"
+
+#~ msgid "``pgr_trsp_withPoints`` (`One to One`_)"
+#~ msgstr "``pgr_trsp_withPoints`` (`一对一`_)"
+
+#~ msgid "``pgr_trsp_withPoints`` (`One to Many`_)"
+#~ msgstr "``pgr_trsp_withPoints`` (`一对多`_)"
+
+#~ msgid "``pgr_trsp_withPoints`` (`Many to One`_)"
+#~ msgstr "``pgr_trsp_withPoints`` (`多对一`_)"
+
+#~ msgid "``pgr_trsp_withPoints`` (`Many to Many`_)"
+#~ msgstr "``pgr_trsp_withPoints`` (`多对多`_)"
+
+#~ msgid "``pgr_trsp_withPoints`` (`Combinations`_)"
+#~ msgstr "``pgr_trsp_withPoints`` (`组合`_)"
+
+#~ msgid "pgr_turnRestrictedPath - Experimental"
+#~ msgstr "pgr_turnRestrictedPath - 实验性"
+
+#~ msgid ""
+#~ "``pgr_turnRestrictedPath`` Using Yen's algorithm Vertex -Vertex routing "
+#~ "with restrictions"
+#~ msgstr "``pgr_turnRestrictedPath`` 使用 Yen 算法顶点- 带限制的顶点路由"
+
+#~ msgid "New experimental function"
+#~ msgstr "新实验功能"
+
+#~ msgid "pgr_vrpOneDepot - Experimental"
+#~ msgstr "pgr_vrpOneDepot -实验"
+
+#~ msgid "``pgr_withPointsDD`` (`Single vertex`)"
+#~ msgstr "``pgr_withPointsDD`` （`单顶点`）"
+
+#~ msgid "pgr_withPointsKSP - Proposed"
+#~ msgstr "pgr_withPointsKSP -拟议"
+
+#~ msgid "``pgr_withPointsKSP`` (One to One)"
+#~ msgstr "``pgr_withPointsKSP`` (一对一)"
+
+#~ msgid "New overload functions"
+#~ msgstr "新的重载函数"
+
+#~ msgid "``pgr_withPointsKSP`` (One to Many)"
+#~ msgstr "``pgr_withPointsKSP`` (一对多)"
+
+#~ msgid "``pgr_withPointsKSP`` (Many to One)"
+#~ msgstr "``pgr_withPointsKSP`` (多对一)"
+
+#~ msgid "``pgr_withPointsKSP`` (Many to Many)"
+#~ msgstr "``pgr_withPointsKSP`` (多对多)"
+
+#~ msgid "``pgr_withPointsKSP`` (Combinations)"
+#~ msgstr "``pgr_withPointsKSP`` (组合)"
+
+#~ msgid ""
+#~ "``pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
+#~ "boolean)``"
+#~ msgstr ""
+#~ "``pgr_withpointsksp(text,text,bigint,bigint,integer,boolean,boolean,char,"
+#~ "boolean)``"
+
+#~ msgid "New **proposed** function ``pgr_withPointsVia`` (`One Via`_)"
+#~ msgstr "新 **拟议** 的函数 ``pgr_withPointsVia`` (`One Via`_)"
+
+#~ msgid ""
+#~ "``pgr_aStar`` (`One to One`) added ``start_vid`` and ``end_vid`` columns."
+#~ msgstr "``pgr_aStar`` （`一对一`）增加了 ``start_vid`` 和 ``end_vid`` 列。"
+
+#~ msgid "``pgr_aStar`` (`One to Many`) added ``end_vid`` column."
+#~ msgstr "``pgr_aStar``（`一对多`）添加了 ``end_vid`` 列。"
+
+#~ msgid "``pgr_aStar`` (`Many to One`) added ``start_vid`` column."
+#~ msgstr "``pgr_aStar``（`多对一`）添加了 ``start_vid`` 列。"
+
+#~ msgid ""
+#~ "``pgr_bdAstar`` (`One to One`) added ``start_vid`` and ``end_vid`` "
+#~ "columns."
+#~ msgstr "``pgr_bdAstar``（`一对一`）增加了 ``start_vid`` 和``end_vid`` 列。"
+
+#~ msgid "``pgr_bdAstar`` (`One to Many`) added ``end_vid`` column."
+#~ msgstr "``pgr_bdAstar``（`一对多）添加了``end_vid`` 列。"
+
+#~ msgid "``pgr_bdAstar`` (`Many to One`) added ``start_vid`` column."
+#~ msgstr "``pgr_bdAstar``（`多对一`）添加了``start_vid`` 列。"
+
+#~ msgid ""
+#~ "`#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ Standarize "
+#~ "output pgr_drivingdistance"
+#~ msgstr ""
+#~ "`#2548 <https://github.com/pgRouting/pgrouting/pull/2548>`__ 标准化输出 "
+#~ "pgr_drivingdistance"
+
+#~ msgid ""
+#~ "`#2565 <https://github.com/pgRouting/pgrouting/issues/2565>`__ "
+#~ "pgr_pgr_lengauerTarjanDominatorTree triggers an assertion"
+#~ msgstr ""
+#~ "`#2565 <https://github.com/pgRouting/pgrouting/issues/2565>`__ "
+#~ "pgr_pgr_lengauerTarjanDominatorTree 触发了一个断言"
+
+#~ msgid ""
+#~ "``pgr_dijkstra`` (`One to One`) added ``start_vid`` and ``end_vid`` "
+#~ "columns."
+#~ msgstr "``pgr_dijkstra``（`一对一`）增加了``start_vid`` 和``end_vid`` 列。"
+
+#~ msgid "``pgr_dijkstra`` (`One to Many`) added ``end_vid`` column."
+#~ msgstr "``pgr_dijkstra``（`一对多`）添加了 ``end_vid`` 列。"
+
+#~ msgid "``pgr_dijkstra`` (`Many to One`) added ``start_vid`` column."
+#~ msgstr "``pgr_dijkstra`` （`多对一`）添加了 ``start_vid`` 列。"
+
+#~ msgid "``pgr_withPointsVia`` (One Via)"
+#~ msgstr "``pgr_withPointsVia`` (One Via)"
+
+#~ msgid "``pgr_trspVia`` (One Via)"
+#~ msgstr "``pgr_trspVia`` (One Via)"
+
+#~ msgid "``pgr_trspVia_withPoints`` (One Via)"
+#~ msgstr "pgr_trspVia_withPoints``（一次通过）"
+
+#~ msgid "``pgr_trsp`` (One to One)"
+#~ msgstr "``pgr_trsp`` （一对一）"
+
+#~ msgid "``pgr_trsp`` (One to Many)"
+#~ msgstr "``pgr_trsp`` （一对多）"
+
+#~ msgid "``pgr_trsp`` (Many to One)"
+#~ msgstr "``pgr_trsp`` （多对一）"
+
+#~ msgid "``pgr_trsp`` (Many to Many)"
+#~ msgstr "``pgr_trsp`` （多对多）"
+
+#~ msgid "``pgr_trsp`` (Combinations)"
+#~ msgstr "``pgr_trsp`` （组合）"
+
+#~ msgid "``pgr_trsp_withPoints`` (One to One)"
+#~ msgstr "``pgr_trsp_withPoints`` （一对一）"
+
+#~ msgid "``pgr_trsp_withPoints`` (One to Many)"
+#~ msgstr "``pgr_trsp_withPoints`` （一对多）"
+
+#~ msgid "``pgr_trsp_withPoints`` (Many to One)"
+#~ msgstr "pgr_trsp_withPoints``（多对一）"
+
+#~ msgid "``pgr_trsp_withPoints`` (Many to Many)"
+#~ msgstr "``pgr_trsp_withPoints`` （多对多）"
+
+#~ msgid "``pgr_trsp_withPoints`` (Combinations)"
+#~ msgstr "``pgr_trsp_withPoints`` （组合）"
+
+#~ msgid "``pgr_findCloseEdges`` (One point)"
+#~ msgstr "``pgr_findCloseEdges`` （单点）"
+
+#~ msgid "``pgr_findCloseEdges`` (Many points)"
+#~ msgstr "``pgr_findCloseEdges`` （多点）"
+
+#~ msgid "``pgr_cuthillMckeeOrdering``"
+#~ msgstr "``pgr_cuthillMckeeOrdering``"
+
+#~ msgid "``pgr_maxCardinalityMatch(text)``"
+#~ msgstr "``pgr_maxCardinalityMatch(text)``"
+
+#~ msgid "Deprecating ``pgr_maxCardinalityMatch(text,boolean)``"
+#~ msgstr "弃用 ``pgr_maxCardinalityMatch(text,boolean)``"
+
+#~ msgid ""
+#~ "``pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)``"
+#~ msgstr ""
+#~ "``pgr_trsp(text,integer,float8,integer,float8,boolean,boolean,text)``"
+
+#~ msgid "``pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)``"
+#~ msgstr "``pgr_trspViaEdges(text,integer[],float[],boolean,boolean,text)``"
+
+#~ msgid "New functions"
+#~ msgstr "新函数"
+
+#~ msgid "pgr_aStar(one to many)"
+#~ msgstr "pgr_aStar（一对多）"
+
+#~ msgid "pgr_aStar(many to one)"
+#~ msgstr "pgr_aStar（多对一）"
+
+#~ msgid "pgr_aStar(many to many)"
+#~ msgstr "pgr_aStar（多对多）"
+
+#~ msgid "pgr_aStarCost(one to one)"
+#~ msgstr "pgr_aStarCost(一对一)"
+
+#~ msgid "pgr_aStarCost(one to many)"
+#~ msgstr "pgr_aStarCost(一对多)"
+
+#~ msgid "pgr_aStarCost(many to one)"
+#~ msgstr "pgr_aStarCost(多对一)"
+
+#~ msgid "pgr_aStarCost(many to many)"
+#~ msgstr "pgr_aStarCost（多对多）"
+
+#~ msgid "pgr_aStarCostMatrix(one to one)"
+#~ msgstr "pgr_aStarCostMatrix(一对一)"
+
+#~ msgid "pgr_aStarCostMatrix(one to many)"
+#~ msgstr "pgr_aStarCostMatrix (一对多)"
+
+#~ msgid "pgr_aStarCostMatrix(many to one)"
+#~ msgstr "pgr_aStarCostMatrix (多对一)"
+
+#~ msgid "pgr_aStarCostMatrix(many to many)"
+#~ msgstr "pgr_aStarCostMatrix（多对多）"
+
+#~ msgid "pgr_bdAstar(one to many)"
+#~ msgstr "pgr_bdAstar（一对多）"
+
+#~ msgid "pgr_bdAstar(many to one)"
+#~ msgstr "pgr_bdAstar（多对一）"
+
+#~ msgid "pgr_bdAstar(many to many)"
+#~ msgstr "pgr_bdAstar（多对多）"
+
+#~ msgid "pgr_bdAstarCost(one to one)"
+#~ msgstr "pgr_bdAstarCost(一对一)"
+
+#~ msgid "pgr_bdAstarCost(one to many)"
+#~ msgstr "pgr_bdAstarCost(一对多)"
+
+#~ msgid "pgr_bdAstarCost(many to one)"
+#~ msgstr "pgr_bdAstarCost （多对一）"
+
+#~ msgid "pgr_bdAstarCost(many to many)"
+#~ msgstr "pgr_bdAstarCost (多对多)"
+
+#~ msgid "pgr_bdAstarCostMatrix(one to one)"
+#~ msgstr "pgr_bdAstarCostMatrix(一对一)"
+
+#~ msgid "pgr_bdAstarCostMatrix(one to many)"
+#~ msgstr "pgr_bdAstarCostMatrix(一对多)"
+
+#~ msgid "pgr_bdAstarCostMatrix(many to one)"
+#~ msgstr "pgr_bdAstarCostMatrix （多对一）"
+
+#~ msgid "pgr_bdAstarCostMatrix(many to many)"
+#~ msgstr "pgr_bdAstarCostMatrix （多对多）"
+
+#~ msgid "pgr_bdDijkstra(one to many)"
+#~ msgstr "pgr_bdDijkstra（一对多）"
+
+#~ msgid "pgr_bdDijkstra(many to one)"
+#~ msgstr "pgr_bdDijkstra（多对一）"
+
+#~ msgid "pgr_bdDijkstra(many to many)"
+#~ msgstr "pgr_bdDijkstra（多对多）"
+
+#~ msgid "pgr_bdDijkstraCost(one to one)"
+#~ msgstr "pgr_bdDijkstraCost (一对一)"
+
+#~ msgid "pgr_bdDijkstraCost(one to many)"
+#~ msgstr "pgr_bdDijkstraCost(一对多)"
+
+#~ msgid "pgr_bdDijkstraCost(many to one)"
+#~ msgstr "pgr_bdDijkstraCost (多对一)"
+
+#~ msgid "pgr_bdDijkstraCost(many to many)"
+#~ msgstr "pgr_bdDijkstraCost（多对多）"
+
+#~ msgid "pgr_bdDijkstraCostMatrix(one to one)"
+#~ msgstr "pgr_bdDijkstraCostMatrix(一对一)"
+
+#~ msgid "pgr_bdDijkstraCostMatrix(one to many)"
+#~ msgstr "pgr_bdDijkstraCostMatrix(一对多)"
+
+#~ msgid "pgr_bdDijkstraCostMatrix(many to one)"
+#~ msgstr "pgr_bdDijkstraCostMatrix (多对一)"
+
+#~ msgid "pgr_bdDijkstraCostMatrix(many to many)"
+#~ msgstr "pgr_bdDijkstraCostMatrix（多对多）"
+
+#~ msgid "pgr_pushRelabel(one to one)"
+#~ msgstr "pgr_pushRelabel(一对一)"
+
+#~ msgid "pgr_pushRelabel(one to many)"
+#~ msgstr "pgr_pushRelabel(一对多)"
+
+#~ msgid "pgr_pushRelabel(many to one)"
+#~ msgstr "pgr_pushRelabel(多对一)"
+
+#~ msgid "pgr_pushRelabel(many to many)"
+#~ msgstr "pgr_pushRelabel(多对多)"
+
+#~ msgid "pgr_edmondsKarp(one to one)"
+#~ msgstr "pgr_edmondsKarp（一对一）"
+
+#~ msgid "pgr_edmondsKarp(one to many)"
+#~ msgstr "pgr_edmondsKarp（一对多）"
+
+#~ msgid "pgr_edmondsKarp(many to one)"
+#~ msgstr "pgr_edmondsKarp（多对一）"
+
+#~ msgid "pgr_edmondsKarp(many to many)"
+#~ msgstr "pgr_edmondsKarp（多对多）"
+
+#~ msgid "pgr_boykovKolmogorov (one to one)"
+#~ msgstr "pgr_boykovKolmogorov (一对一)"
+
+#~ msgid "pgr_boykovKolmogorov (one to many)"
+#~ msgstr "pgr_boykovKolmogorov (一对多)"
+
+#~ msgid "pgr_boykovKolmogorov (many to one)"
+#~ msgstr "pgr_boykovKolmogorov (多对一)"
+
+#~ msgid "pgr_boykovKolmogorov (many to many)"
+#~ msgstr "pgr_boykovKolmogorov (多对多)"
+
+#~ msgid "pgr_edgeDisjointPaths(one to one)"
+#~ msgstr "pgr_edgeDisjointPaths (一对一)"
+
+#~ msgid "pgr_edgeDisjointPaths(one to many)"
+#~ msgstr "pgr_edgeDisjointPaths （一对多）"
+
+#~ msgid "pgr_edgeDisjointPaths(many to one)"
+#~ msgstr "pgr_edgeDisjointPaths (多对一)"
+
+#~ msgid "pgr_edgeDisjointPaths(many to many)"
+#~ msgstr "pgr_edgeDisjointPaths （多对多）"
+
+#~ msgid "pgr_astar"
+#~ msgstr "pgr_astar"
+
+#~ msgid "The many version results are the union of the one to one version"
+#~ msgstr "多版本结果是一对一版本的并集"
+
+#~ msgid "pgr_bdAstar(one to one)"
+#~ msgstr "pgr_bdAstar（一对一）"
+
+#~ msgid "New Proposed functions"
+#~ msgstr "新的拟议函数"
+
+#~ msgid "New Proposed Signatures"
+#~ msgstr "新的拟议签名"
+
+#~ msgid "pgr_astar(one to many)"
+#~ msgstr "pgr_astar（一对多）"
+
+#~ msgid "pgr_astar(many to one)"
+#~ msgstr "pgr_astar（多对一）"
+
+#~ msgid "pgr_astar(many to many)"
+#~ msgstr "pgr_astar（多对多）"
+
+#~ msgid "pgr_astarCost(one to one)"
+#~ msgstr "pgr_astarCost(一对一)"
+
+#~ msgid "pgr_astarCost(one to many)"
+#~ msgstr "pgr_astarCost(一对多)"
+
+#~ msgid "pgr_astarCost(many to one)"
+#~ msgstr "pgr_astarCost(多对一)"
+
+#~ msgid "pgr_astarCost(many to many)"
+#~ msgstr "pgr_astarCost（多对多）"
+
+#~ msgid "pgr_astarCostMatrix"
+#~ msgstr "pgr_astarCostMatrix"
+
+#~ msgid "pgr_maxFlowPushRelabel(one to one)"
+#~ msgstr "pgr_maxFlowPushRelabel(一对一)"
+
+#~ msgid "pgr_maxFlowPushRelabel(one to many)"
+#~ msgstr "pgr_maxFlowPushRelabel(一对多)"
+
+#~ msgid "pgr_maxFlowPushRelabel(many to one)"
+#~ msgstr "pgr_maxFlowPushRelabel(多对一)"
+
+#~ msgid "pgr_maxFlowPushRelabel(many to many)"
+#~ msgstr "pgr_maxFlowPushRelabel(多对多)"
+
+#~ msgid "pgr_maxFlowEdmondsKarp(one to one)"
+#~ msgstr "pgr_maxFlowEdmondsKarp（一对一）"
+
+#~ msgid "pgr_maxFlowEdmondsKarp(one to many)"
+#~ msgstr "pgr_maxFlowEdmondsKarp（一对多）"
+
+#~ msgid "pgr_maxFlowEdmondsKarp(many to one)"
+#~ msgstr "pgr_maxFlowEdmondsKarp（多对一）"
+
+#~ msgid "pgr_maxFlowEdmondsKarp(many to many)"
+#~ msgstr "pgr_maxFlowEdmondsKarp（多对多）"
+
+#~ msgid "pgr_maxFlowBoykovKolmogorov (one to one)"
+#~ msgstr "pgr_maxFlowBoykovKolmogorov （一对一）"
+
+#~ msgid "pgr_maxFlowBoykovKolmogorov (one to many)"
+#~ msgstr "pgr_maxFlowBoykovKolmogorov （一对多）"
+
+#~ msgid "pgr_maxFlowBoykovKolmogorov (many to one)"
+#~ msgstr "pgr_maxFlowBoykovKolmogorov （多对一）"
+
+#~ msgid "pgr_maxFlowBoykovKolmogorov (many to many)"
+#~ msgstr "pgr_maxFlowBoykovKolmogorov （多对多）"
+
+#~ msgid "pgr_astar - use pgr_aStar instead"
+#~ msgstr "pgr_astar - 使用 pgr_aStar 代替"
+
+#~ msgid "pgr_dijkstraCost(one to one)"
+#~ msgstr "pgr_dijkstraCost(一对一)"
+
+#~ msgid "pgr_dijkstraCost(one to many)"
+#~ msgstr "pgr_dijkstraCost(一对多)"
+
+#~ msgid "pgr_dijkstraCost(many to one)"
+#~ msgstr "pgr_dijkstraCost（多对一）"
+
+#~ msgid "pgr_dijkstraCost(many to many)"
+#~ msgstr "pgr_dijkstraCost（多对多）"
+
+#~ msgid "pgr_withPoints(one to one)"
+#~ msgstr "pgr_withPoints(一对一)"
+
+#~ msgid "pgr_withPoints(one to many)"
+#~ msgstr "pgr_withPoints（一对多）"
+
+#~ msgid "pgr_withPoints(many to one)"
+#~ msgstr "pgr_withPoints(多对一)"
+
+#~ msgid "pgr_withPoints(many to many)"
+#~ msgstr "pgr_withPoints(多对多)"
+
+#~ msgid "pgr_withPointsCost(one to one)"
+#~ msgstr "pgr_withPointsCost(一对一)"
+
+#~ msgid "pgr_withPointsCost(one to many)"
+#~ msgstr "pgr_withPointsCost(一对多)"
+
+#~ msgid "pgr_withPointsCost(many to one)"
+#~ msgstr "pgr_withPointsCost(多对一)"
+
+#~ msgid "pgr_withPointsCost(many to many)"
+#~ msgstr "pgr_withPointsCost(多对多)"
+
+#~ msgid "pgr_dijkstra(one to many)"
+#~ msgstr "pgr_dijkstra（一对多）"
+
+#~ msgid "pgr_dijkstra(many to one)"
+#~ msgstr "pgr_dijkstra（多对一）"
+
+#~ msgid "pgr_dijkstra(many to many)"
+#~ msgstr "pgr_dijkstra（多对多）"
+
+#~ msgid "pgr_dijkstra(one to one)"
+#~ msgstr "pgr_dijkstra（一对一）"
+
+#~ msgid ""
+#~ "pgRouting suplies some functions to create a routing topology and to "
+#~ "analyze the topology."
+#~ msgstr "pgRouting 提供一些函数来创建路由拓扑并分析拓扑。"


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [pgRouting/pgRouting](https://weblate.osgeo.org/projects/pgrouting/pgrouting-develop/).


It also includes following components:

* [pgRouting/index](https://weblate.osgeo.org/projects/pgrouting/index/)



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widget/pgrouting/pgrouting-develop/horizontal-auto.svg)

**Reminder**: Do not squash, do a rebase