### PR TITLE
pgr_extractVertices promoted to official

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,11 +8,14 @@
 
 ### pgRouting 3.8.0 Release Notes
 
-**Changes on proposed functions**
+**Promotion to official function of pgRouting.**
 
 * pgr_extractVertices
 
   * Error messages adjustment.
+  * Function promoted to official.
+
+**Changes on proposed functions**
 
 * pgr_findCloseEdges
 

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -39,13 +39,15 @@ pgRouting 3.8
 pgRouting 3.8.0 Release Notes
 -------------------------------------------------------------------------------
 
-.. rubric:: Changes on proposed functions
+.. rubric:: Promotion to official function of pgRouting.
 
 * pgr_extractVertices
 
   .. include:: pgr_extractVertices.rst
      :start-after: Version 3.8.0
      :end-before: .. rubric
+
+.. rubric:: Changes on proposed functions
 
 * pgr_findCloseEdges
 

--- a/doc/topology/pgr_extractVertices.rst
+++ b/doc/topology/pgr_extractVertices.rst
@@ -9,25 +9,21 @@
 
 .. index::
    single: Topology Family ; pgr_extractVertices
-   single: extractVertices - Proposed on v3.3
+   single: extractVertices
 
 |
 
-``pgr_extractVertices`` -- Proposed
+``pgr_extractVertices``
 ===============================================================================
 
 ``pgr_extractVertices`` — Extracts the vertices information
-
-
-.. include:: proposed.rst
-   :start-after: warning-begin
-   :end-before: end-warning
 
 .. rubric:: Availability
 
 .. rubric:: Version 3.8.0
 
 * Error messages adjustment.
+* Function promoted to official.
 
 .. rubric:: Version 3.3.0
 

--- a/doc/topology/topology-functions.rst
+++ b/doc/topology/topology-functions.rst
@@ -34,6 +34,8 @@ have special permissions given by the administrators to use them.
   table.
 - :doc:`pgr_analyzeOneWay` - to analyze directionality of the edges.
 - :doc:`pgr_nodeNetwork` - to create nodes to a not noded edge table.
+- :doc:`pgr_extractVertices` - Extracts vertex information based on the edge
+  table information.
 
 .. official-end
 
@@ -60,8 +62,6 @@ Additional functions to analyze a graph:
 These proposed functions do not modify the database.
 
 - :doc:`pgr_degree` - Returns a set of vertices and corresponding count of incidet edges to the vertex.
-- :doc:`pgr_extractVertices` - Extracts vertex information based on the edge
-  table information.
 
 .. proposed-end
 

--- a/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-27 23:12+0000\n"
+"POT-Creation-Date: 2025-03-01 19:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4362,6 +4362,11 @@ msgstr ""
 msgid ":doc:`pgr_nodeNetwork` - to create nodes to a not noded edge table."
 msgstr ""
 
+msgid ""
+":doc:`pgr_extractVertices` - Extracts vertex information based on the "
+"edge table information."
+msgstr ""
+
 msgid ":doc:`pgr_trsp` - Turn Restriction Shortest Path (TRSP)"
 msgstr ""
 
@@ -4404,13 +4409,19 @@ msgstr ""
 msgid "pgRouting 3.8.0 Release Notes"
 msgstr ""
 
-msgid "Changes on proposed functions"
+msgid "Promotion to official function of pgRouting."
 msgstr ""
 
 msgid "pgr_extractVertices"
 msgstr ""
 
 msgid "Error messages adjustment."
+msgstr ""
+
+msgid "Function promoted to official."
+msgstr ""
+
+msgid "Changes on proposed functions"
 msgstr ""
 
 msgid "pgr_findCloseEdges"
@@ -7845,9 +7856,6 @@ msgid "New proposed signature:"
 msgstr ""
 
 msgid "pgr_aStar(Combinations)"
-msgstr ""
-
-msgid "Function promoted to official."
 msgstr ""
 
 msgid "Version 2.4.0"
@@ -11460,7 +11468,7 @@ msgstr ""
 msgid "https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm"
 msgstr ""
 
-msgid "``pgr_extractVertices`` -- Proposed"
+msgid "``pgr_extractVertices``"
 msgstr ""
 
 msgid "``pgr_extractVertices`` — Extracts the vertices information"
@@ -15355,11 +15363,6 @@ msgstr ""
 msgid ""
 ":doc:`pgr_degree` - Returns a set of vertices and corresponding count of "
 "incidet edges to the vertex."
-msgstr ""
-
-msgid ""
-":doc:`pgr_extractVertices` - Extracts vertex information based on the "
-"edge table information."
 msgstr ""
 
 msgid ""

--- a/locale/pot/pgrouting_doc_strings.pot
+++ b/locale/pot/pgrouting_doc_strings.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-27 23:12+0000\n"
+"POT-Creation-Date: 2025-03-01 19:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3886,6 +3886,9 @@ msgstr ""
 msgid ":doc:`pgr_nodeNetwork` - to create nodes to a not noded edge table."
 msgstr ""
 
+msgid ":doc:`pgr_extractVertices` - Extracts vertex information based on the edge table information."
+msgstr ""
+
 msgid ":doc:`pgr_trsp` - Turn Restriction Shortest Path (TRSP)"
 msgstr ""
 
@@ -3928,13 +3931,19 @@ msgstr ""
 msgid "pgRouting 3.8.0 Release Notes"
 msgstr ""
 
-msgid "Changes on proposed functions"
+msgid "Promotion to official function of pgRouting."
 msgstr ""
 
 msgid "pgr_extractVertices"
 msgstr ""
 
 msgid "Error messages adjustment."
+msgstr ""
+
+msgid "Function promoted to official."
+msgstr ""
+
+msgid "Changes on proposed functions"
 msgstr ""
 
 msgid "pgr_findCloseEdges"
@@ -6821,9 +6830,6 @@ msgid "New proposed signature:"
 msgstr ""
 
 msgid "pgr_aStar(Combinations)"
-msgstr ""
-
-msgid "Function promoted to official."
 msgstr ""
 
 msgid "Version 2.4.0"
@@ -9754,7 +9760,7 @@ msgstr ""
 msgid "https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm"
 msgstr ""
 
-msgid "``pgr_extractVertices`` -- Proposed"
+msgid "``pgr_extractVertices``"
 msgstr ""
 
 msgid "``pgr_extractVertices`` — Extracts the vertices information"
@@ -12896,9 +12902,6 @@ msgid "These proposed functions do not modify the database."
 msgstr ""
 
 msgid ":doc:`pgr_degree` - Returns a set of vertices and corresponding count of incidet edges to the vertex."
-msgstr ""
-
-msgid ":doc:`pgr_extractVertices` - Extracts vertex information based on the edge table information."
 msgstr ""
 
 msgid ":doc:`pgr_lineGraph` - Transformation algorithm for generating a Line Graph."

--- a/sql/topology/extractVertices.sql
+++ b/sql/topology/extractVertices.sql
@@ -298,7 +298,6 @@ LANGUAGE plpgsql VOLATILE STRICT;
 
 COMMENT ON FUNCTION pgr_extractVertices(TEXT, BOOLEAN)
 IS 'pgr_extractVertices
-- PROPOSED
 - Parameters
   - Edges SQL with columns: [id,] startpoint, endpoint
         OR


### PR DESCRIPTION
Fixes #2772 .

Changes proposed in this pull request:
- Documentation about the promotion
  - In the SQL function comment
  - In the documentation file


@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Reorganized and clarified release notes to distinctly mark the `pgr_extractVertices` function as officially recognized while retaining a separate section for proposed functions.
  - Updated section headings and error messaging to enhance clarity and user comprehension.
  - Simplified detailed commentary in parameter descriptions for improved readability.
  - Added new function `pgr_extractVertices` to the documentation, describing its role in extracting vertex information based on edge table information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->