### PR TITLE
Collapse warnings of proposed and experimental

### DIFF
--- a/doc/categories/DFS-category.rst
+++ b/doc/categories/DFS-category.rst
@@ -24,8 +24,6 @@ Traversal using Depth First Search.
 .. official-end
 
 
-.. rubric:: Proposed
-
 .. include:: proposed.rst
    :start-after: warning-begin
    :end-before: end-warning

--- a/doc/categories/KSP-category.rst
+++ b/doc/categories/KSP-category.rst
@@ -20,8 +20,6 @@ K shortest paths - Category
 
 .. official-end
 
-.. rubric:: Proposed
-
 .. include:: proposed.rst
    :start-after: warning-begin
    :end-before: end-warning

--- a/doc/categories/cost-category.rst
+++ b/doc/categories/cost-category.rst
@@ -26,8 +26,6 @@ Cost - Category
 
 .. official-end
 
-.. rubric:: Proposed
-
 .. include:: proposed.rst
     :start-after: warning-begin
     :end-before: end-warning

--- a/doc/categories/costMatrix-category.rst
+++ b/doc/categories/costMatrix-category.rst
@@ -24,8 +24,6 @@ Cost Matrix - Category
 .. official-end
 
 
-.. rubric:: proposed
-
 .. include:: proposed.rst
     :start-after: warning-begin
     :end-before: end-warning

--- a/doc/categories/drivingDistance-category.rst
+++ b/doc/categories/drivingDistance-category.rst
@@ -19,13 +19,11 @@ Driving Distance - Category
 * :doc:`pgr_drivingDistance` - Driving Distance based on Dijkstra's algorithm
 * :doc:`pgr_primDD` - Driving Distance based on Prim's algorithm
 * :doc:`pgr_kruskalDD` - Driving Distance based on Kruskal's algorithm
-* Post pocessing
+* Post processing
 
   * :doc:`pgr_alphaShape` - Alpha shape computation
 
 .. official-end
-
-.. rubric:: Proposed
 
 .. include:: proposed.rst
    :start-after: warning-begin

--- a/doc/categories/via-category.rst
+++ b/doc/categories/via-category.rst
@@ -14,8 +14,6 @@
 Via - Category
 ===============================================================================
 
-.. rubric:: proposed
-
 .. include:: proposed.rst
     :start-after: warning-begin
     :end-before: end-warning
@@ -37,7 +35,7 @@ This category intends to solve the general problem:
    Given a graph and a list of vertices, find the shortest path between
    :math:`vertex_i` and :math:`vertex_{i+1}` for all vertices
 
-In other words, find a continuos route that visits all the vertices in the order
+In other words, find a continuous route that visits all the vertices in the order
 given.
 
 :path: represents a section of a **route**.

--- a/doc/coloring/coloring-family.rst
+++ b/doc/coloring/coloring-family.rst
@@ -14,8 +14,6 @@
 Coloring - Family of functions
 ===============================================================================
 
-.. rubric:: Proposed
-
 .. include:: proposed.rst
    :start-after: warning-begin
    :end-before: end-warning
@@ -26,8 +24,6 @@ Coloring - Family of functions
   approach.
 
 .. proposed-end
-
-.. rubric:: Experimental
 
 .. include:: experimental.rst
    :start-after: warning-begin

--- a/doc/components/components-family.rst
+++ b/doc/components/components-family.rst
@@ -27,8 +27,6 @@ Components - Family of functions
 
 .. official-end
 
-.. rubric:: Experimental
-
 .. include:: experimental.rst
    :start-after: warning-begin
    :end-before: end-warning

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -54,6 +54,7 @@ extensions = [
         'sphinx.ext.mathjax',
         'sphinx.ext.graphviz',
         'sphinx.ext.autosectionlabel',
+        'sphinx_collapse',
         ]
 autosectionlabel_prefix_document = True
 

--- a/doc/dijkstra/dijkstra-family.rst
+++ b/doc/dijkstra/dijkstra-family.rst
@@ -26,8 +26,6 @@ Dijkstra - Family of functions
 
 .. official-end
 
-.. rubric:: Proposed
-
 .. include:: proposed.rst
    :start-after: warning-begin
    :end-before: end-warning
@@ -35,7 +33,7 @@ Dijkstra - Family of functions
 
 .. proposed-start
 
-* :doc:`pgr_dijkstraVia` - Get a route of a seuence of vertices.
+* :doc:`pgr_dijkstraVia` - Get a route of a sequence of vertices.
 * :doc:`pgr_dijkstraNear` - Get the route to the nearest vertex.
 * :doc:`pgr_dijkstraNearCost` - Get the cost to the nearest vertex.
 
@@ -192,7 +190,7 @@ The graphs are defined as follows:
 
 .. rubric:: Directed graph
 
-The weighted directed graph, :math:`G_d(V,E)`, is definied by:
+The weighted directed graph, :math:`G_d(V,E)`, is defined by:
 
 * the set of vertices :math:`V`
 
@@ -211,7 +209,7 @@ The weighted directed graph, :math:`G_d(V,E)`, is definied by:
 
 .. rubric:: Undirected graph
 
-The weighted undirected graph, :math:`G_u(V,E)`, is definied by:
+The weighted undirected graph, :math:`G_u(V,E)`, is defined by:
 
 * the set of vertices :math:`V`
 

--- a/doc/max_flow/flow-family.rst
+++ b/doc/max_flow/flow-family.rst
@@ -33,8 +33,6 @@ Flow - Family of functions
 
 .. official-end
 
-.. rubric:: Experimental
-
 .. include:: experimental.rst
    :start-after: warning-begin
    :end-before: end-warning
@@ -71,7 +69,7 @@ Flow Functions General Information
 - When the maximum flow is 0 then there is no flow and **EMPTY SET** is
   returned.
 
-  - There is no flow when source has the same vaule as target.
+  - There is no flow when source has the same value as target.
 
 - Any duplicated values in source or target are ignored.
 - Calculates the flow/residual capacity for each edge. In the output

--- a/doc/metrics/metrics-family.rst
+++ b/doc/metrics/metrics-family.rst
@@ -15,8 +15,6 @@
 Metrics - Family of functions
 ===============================================================================
 
-.. rubric:: Experimental
-
 .. include:: experimental.rst
    :start-after: warning-begin
    :end-before: end-warning

--- a/doc/ordering/ordering-family.rst
+++ b/doc/ordering/ordering-family.rst
@@ -14,8 +14,6 @@
 Ordering - Family of functions
 ===============================================================================
 
-.. rubric:: Experimental
-
 .. include:: experimental.rst
    :start-after: warning-begin
    :end-before: end-warning

--- a/doc/src/experimental.rst
+++ b/doc/src/experimental.rst
@@ -14,27 +14,29 @@ Experimental Functions
 
 .. warning-begin
 
-.. warning:: Possible server crash
+.. collapse:: Experimental
 
-  - These functions might create a server crash
+   .. warning:: Possible server crash
 
-.. warning:: Experimental functions
+     - These functions might create a server crash
 
-  - They are not officially of the current release.
-  - They likely will not be officially be part of the next release:
+   .. warning:: Experimental functions
 
-    - The functions might not make use of ANY-INTEGER and ANY-NUMERICAL
-    - Name might change.
-    - Signature might change.
-    - Functionality might change.
-    - pgTap tests might be missing.
-    - Might need c/c++ coding.
-    - May lack documentation.
-    - Documentation if any might need to be rewritten.
-    - Documentation examples might need to be automatically generated.
-    - Might need a lot of feedback from the comunity.
-    - Might depend on a proposed function of pgRouting
-    - Might depend on a deprecated function of pgRouting
+     - They are not officially of the current release.
+     - They likely will not be officially be part of the next release:
+
+       - The functions might not make use of ANY-INTEGER and ANY-NUMERICAL
+       - Name might change.
+       - Signature might change.
+       - Functionality might change.
+       - pgTap tests might be missing.
+       - Might need c/c++ coding.
+       - May lack documentation.
+       - Documentation if any might need to be rewritten.
+       - Documentation examples might need to be automatically generated.
+       - Might need a lot of feedback from the community.
+       - Might depend on a proposed function of pgRouting
+       - Might depend on a deprecated function of pgRouting
 
 .. end-warning
 
@@ -138,7 +140,7 @@ Experimental Functions
 
   pgr_isPlanar
 
-.. rubric:: Miscellaneous Algoritms
+.. rubric:: Miscellaneous Algorithms
 
 - :doc:`pgr_lengauerTarjanDominatorTree`
 - :doc:`pgr_stoerWagner`

--- a/doc/src/proposed.rst
+++ b/doc/src/proposed.rst
@@ -15,17 +15,19 @@ Proposed Functions
 
 .. warning-begin
 
-.. warning:: Proposed functions for next mayor release.
+.. collapse:: Proposed
 
-  - They are not officially in the current release.
-  - They will likely officially be part of the next mayor release:
+   .. warning:: Proposed functions for next mayor release.
 
-    - The functions make use of ANY-INTEGER and ANY-NUMERICAL
-    - Name might not change. (But still can)
-    - Signature might not change. (But still can)
-    - Functionality might not change. (But still can)
-    - pgTap tests have being done. But might need more.
-    - Documentation might need refinement.
+     - They are not officially in the current release.
+     - They will likely officially be part of the next mayor release:
+
+       - The functions make use of ANY-INTEGER and ANY-NUMERICAL
+       - Name might not change. (But still can)
+       - Signature might not change. (But still can)
+       - Functionality might not change. (But still can)
+       - pgTap tests have being done. But might need more.
+       - Documentation might need refinement.
 
 .. end-warning
 

--- a/doc/topology/topology-functions.rst
+++ b/doc/topology/topology-functions.rst
@@ -51,8 +51,6 @@ Additional functions to analyze a graph:
 * :doc:`components-family`
 
 
-.. rubric:: Proposed
-
 .. include:: proposed.rst
    :start-after: warning-begin
    :end-before: end-warning

--- a/doc/traversal/traversal-family.rst
+++ b/doc/traversal/traversal-family.rst
@@ -14,8 +14,6 @@
 Traversal - Family of functions
 ===============================================================================
 
-.. rubric:: Proposed
-
 .. include:: proposed.rst
    :start-after: warning-begin
    :end-before: end-warning
@@ -25,8 +23,6 @@ Traversal - Family of functions
 * :doc:`pgr_depthFirstSearch` - Depth first search traversal of the graph.
 
 .. official-end
-
-.. rubric:: Experimental
 
 .. include:: experimental.rst
    :start-after: warning-begin
@@ -40,7 +36,7 @@ Traversal - Family of functions
 
 .. experimental-end
 
-Aditionaly there are 2 categories under this family
+Additionally there are 2 categories under this family
 
 * :doc:`BFS-category`
 * :doc:`DFS-category`

--- a/doc/trsp/TRSP-family.rst
+++ b/doc/trsp/TRSP-family.rst
@@ -16,8 +16,6 @@ TRSP - Family of functions
 
 When points are also given as input:
 
-.. rubric:: Proposed
-
 .. include:: proposed.rst
    :start-after: warning-begin
    :end-before: end-warning
@@ -33,8 +31,6 @@ When points are also given as input:
 
 .. Warning:: Read the :doc:`migration` about how to migrate from the
    deprecated TRSP functionality to the new signatures or replacement functions.
-
-.. rubric:: Experimental
 
 .. include:: experimental.rst
    :start-after: warning-begin

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Sphinx>4.0.0,<7.0.0
 sphinx-bootstrap-theme>=0.8.0
+sphinx-collapse


### PR DESCRIPTION
Fixes #2779 

Changes proposed in this pull request:
- Collapse warnings of proposed and experimental
- fix some spelling mistakes

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Streamlined documentation by removing redundant headings that categorized sections as “Proposed” or “Experimental.”
	- Improved clarity with typographical corrections (e.g., updating misspelled phrases and ensuring consistent terminology).
	- Enhanced the presentation of warnings by restructuring them into a collapsible format.

- **Chores**
	- Integrated an extension that supports collapsible content, enriching the interactivity of the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->