### PR TITLE
(contraction-family) Fix spelling: tha -> that

### DIFF
--- a/doc/contraction/contraction-family.rst
+++ b/doc/contraction/contraction-family.rst
@@ -531,7 +531,7 @@ Use ``is_contracted`` column to indicate the vertices that are contracted.
    :start-after: -- q4
    :end-before: -- q5
 
-Fill ``contracted_vertices`` with the information from the results tha belong to
+Fill ``contracted_vertices`` with the information from the results that belong to
 the vertices.
 
 .. literalinclude:: contraction-family.queries


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a typo to enhance clarity in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->