### PR TITLE
Deprecate pgr_analyzeGraph

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,24 +8,36 @@
 
 ### pgRouting 3.8.0 Release Notes
 
+To see all issues & pull requests closed by this release see the [Git closed
+milestone for 3.8.0
+](https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.8.0%22)
+
 **Promotion to official function of pgRouting.**
 
-* pgr_extractVertices
+* [#2772](https://github.com/pgRouting/pgrouting/issues/2772):
+  pgr_extractVertices
 
   * Error messages adjustment.
   * Function promoted to official.
 
-* pgr_degree
+* [#2760](https://github.com/pgRouting/pgrouting/issues/2760):
+  pgr_degree
 
   * Error messages adjustment.
   * New signature with only Edges SQL.
   * Function promoted to official.
 
-* pgr_findCloseEdges
+* [#2774](https://github.com/pgRouting/pgrouting/issues/2774):
+  pgr_findCloseEdges
 
   * Error messages adjustment.
   * ``partial`` option is removed.
   * Function promoted to official.
+
+**Deprecation of functions.**
+
+* [#2753](https://github.com/pgRouting/pgrouting/issues/2753):
+  pgr_analizeGraph
 
 **Official functions changes**
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,7 +37,7 @@ milestone for 3.8.0
 **Deprecation of functions.**
 
 * [#2753](https://github.com/pgRouting/pgrouting/issues/2753):
-  pgr_analizeGraph
+  pgr_analyzeGraph
 
 **Official functions changes**
 

--- a/doc/metrics/pgr_degree.rst
+++ b/doc/metrics/pgr_degree.rst
@@ -348,6 +348,8 @@ development needs.
 Finding dead ends
 ...............................................................................
 
+.. finding_dead_ends_start
+
 If there is a vertices table already built using ``pgr_extractVertices``
 and want the degree of the whole graph rather than a subset, it can be forgo using
 ``pgr_degree`` and work with the ``in_edges`` and ``out_edges`` columns
@@ -358,6 +360,8 @@ The degree of a dead end is 1.
 .. include:: pgRouting-concepts.rst
    :start-after: degree_from_table_start
    :end-before: degree_from_table_end
+
+.. finding_dead_ends_end
 
 Finding linear vertices
 ...............................................................................

--- a/doc/src/migration.rst
+++ b/doc/src/migration.rst
@@ -24,6 +24,79 @@ Results can be different because of the changes.
 .. contents:: Contents
    :depth: 2
 
+.. migrate_pgr_analyzeGraph_start
+
+Migration of ``pgr_analyzeGraph``
+-------------------------------------------------------------------------------
+
+Starting from `v3.8.0 <https://docs.pgrouting.org/3.8/en/migration.html>`__
+
+**Before Deprecation:** The following was calculated:
+
+* Number of isolated segments.
+* Number of dead ends.
+* Number of potential gaps found near dead ends.
+* Number of intersections. (between 2 edges)
+
+WHERE
+
+:Graph component: A connected subgraph that is not part of any larger connected
+                  subgraph.
+:Isolated segment: A graph component with only one segment.
+:Dead ends: A vertex that participates in only one edge.
+:gaps: Space between two geometries.
+:Intersection: Is a topological relationship between two geometries.
+
+.. rubric:: Migration.
+
+.. rubric:: Components.
+
+Instead of counting only isolated segments, determine all the components of the
+graph.
+
+Depending of the final application requirements use:
+
+* :doc:`pgr_connectedComponents`
+* :doc:`pgr_strongComponents`
+* :doc:`pgr_biconnectedComponents`
+
+For example:
+
+.. literalinclude:: migration.queries
+   :start-after: --analysis1
+   :end-before: --analysis2
+
+.. rubric:: Dead ends.
+
+Instead of counting the dead ends, determine all the dead ends of the graph.
+
+.. literalinclude:: migration.queries
+   :start-after: --analysis2
+   :end-before: --analysis3
+
+.. rubric:: Potential gaps near dead ends.
+
+Instead of counting potential gaps between geometries, determine geometric
+relationships between geometries.
+
+Several PostGIS functions can be used, for example:
+
+* `ST_ClosestPoint <https://postgis.net/docs/ST_ClosestPoint.html>`__
+* `ST_Distance <https://postgis.net/docs/ST_Distance.html>`__
+
+.. rubric::  Topological relationships.
+
+Instead of counting intersections, determine topological relationships between
+geometries.
+
+Several PostGIS functions can be used, for example:
+
+* `ST_Intersects <https://postgis.net/docs/ST_Intersects.html>`__
+* `ST_Crosses <https://postgis.net/docs/ST_Crosses.html>`__
+* `ST_Overlaps <https://postgis.net/docs/ST_Overlaps.html>`__
+
+.. migrate_pgr_analyzeGraph_end
+
 Migration of ``pgr_aStar``
 -------------------------------------------------------------------------------
 
@@ -35,7 +108,7 @@ Signatures to be migrated:
 * ``pgr_aStar`` (`One to Many`)
 * ``pgr_aStar`` (`Many to One`)
 
-:Before Migration:
+.. rubric:: Before Migration
 
 * Output columns were |old-generic-result|
 

--- a/doc/src/migration.rst
+++ b/doc/src/migration.rst
@@ -68,7 +68,10 @@ For example:
 
 .. rubric:: Dead ends.
 
-Instead of counting the dead ends, determine all the dead ends of the graph.
+Instead of counting the dead ends, determine all the dead ends of the graph
+using :doc:`pgr_degree`.
+
+For example:
 
 .. literalinclude:: migration.queries
    :start-after: --analysis2
@@ -76,24 +79,30 @@ Instead of counting the dead ends, determine all the dead ends of the graph.
 
 .. rubric:: Potential gaps near dead ends.
 
-Instead of counting potential gaps between geometries, determine geometric
-relationships between geometries.
+Instead of counting potential gaps between geometries, determine the geometric
+gaps in the graph using :doc:`pgr_findCloseEdges`.
 
-Several PostGIS functions can be used, for example:
+For example:
 
-* `ST_ClosestPoint <https://postgis.net/docs/ST_ClosestPoint.html>`__
-* `ST_Distance <https://postgis.net/docs/ST_Distance.html>`__
+.. literalinclude:: migration.queries
+   :start-after: --analysis3
+   :end-before: --analysis4
 
 .. rubric::  Topological relationships.
 
 Instead of counting intersections, determine topological relationships between
 geometries.
 
-Several PostGIS functions can be used, for example:
+Several PostGIS functions can be used:
+`ST_Intersects <https://postgis.net/docs/ST_Intersects.html>`__,
+`ST_Crosses <https://postgis.net/docs/ST_Crosses.html>`__,
+`ST_Overlaps <https://postgis.net/docs/ST_Overlaps.html>`__, etc.
 
-* `ST_Intersects <https://postgis.net/docs/ST_Intersects.html>`__
-* `ST_Crosses <https://postgis.net/docs/ST_Crosses.html>`__
-* `ST_Overlaps <https://postgis.net/docs/ST_Overlaps.html>`__
+For example:
+
+.. literalinclude:: migration.queries
+   :start-after: --analysis4
+   :end-before: --analysis5
 
 .. migrate_pgr_analyzeGraph_end
 

--- a/doc/src/pgRouting-concepts.rst
+++ b/doc/src/pgRouting-concepts.rst
@@ -737,6 +737,8 @@ Disconnected graphs
 
 .. connecting_graph_start
 
+.. disconnected_graph_start
+
 To get the graph connectivity:
 
 .. literalinclude:: concepts.queries
@@ -745,6 +747,8 @@ To get the graph connectivity:
 
 In this example, the component :math:`2` consists of vertices :math:`\{2, 4\}`
 and both vertices are also part of the dead end result set.
+
+.. disconnected_graph_end
 
 This graph needs to be connected.
 

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -69,7 +69,7 @@ milestone for 3.8.0
 .. rubric:: Deprecation of functions.
 
 * `#2753 <https://github.com/pgRouting/pgrouting/issues/2753>`__:
-  pgr_analizeGraph
+  pgr_analyzeGraph
 
 .. rubric:: Official functions changes
 

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -39,25 +39,37 @@ pgRouting 3.8
 pgRouting 3.8.0 Release Notes
 -------------------------------------------------------------------------------
 
+To see all issues & pull requests closed by this release see the `Git closed
+milestone for 3.8.0
+<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.8.0%22>`__
+
 .. rubric:: Promotion to official function of pgRouting.
 
-* pgr_extractVertices
+* `#2772 <https://github.com/pgRouting/pgrouting/issues/2772>`__:
+  pgr_extractVertices
 
   .. include:: pgr_extractVertices.rst
      :start-after: Version 3.8.0
      :end-before: .. rubric
 
-* pgr_degree
+* `#2760 <https://github.com/pgRouting/pgrouting/issues/2760>`__:
+  pgr_degree
 
   .. include:: pgr_degree.rst
      :start-after: Version 3.8.0
      :end-before: .. rubric
 
-* pgr_findCloseEdges
+* `#2774 <https://github.com/pgRouting/pgrouting/issues/2774>`__:
+  pgr_findCloseEdges
 
   .. include:: pgr_findCloseEdges.rst
      :start-after: Version 3.8.0
      :end-before: .. rubric
+
+.. rubric:: Deprecation of functions.
+
+* `#2753 <https://github.com/pgRouting/pgrouting/issues/2753>`__:
+  pgr_analizeGraph
 
 .. rubric:: Official functions changes
 

--- a/doc/topology/pgr_analyzeGraph.rst
+++ b/doc/topology/pgr_analyzeGraph.rst
@@ -20,10 +20,17 @@
 
 .. rubric:: Availability
 
+* Version 3.8.0
+
+  * Deprecated function.
+
 * Version 2.0.0
 
   * Official function.
 
+.. include:: migration.rst
+   :start-after: migrate_pgr_analyzeGraph_start
+   :end-before: migrate_pgr_analyzeGraph_end
 
 Description
 -------------------------------------------------------------------------------

--- a/doc/topology/pgr_analyzeGraph.rst
+++ b/doc/topology/pgr_analyzeGraph.rst
@@ -13,7 +13,7 @@
 
 |
 
-``pgr_analyzeGraph``
+``pgr_analyzeGraph`` -- Deprecated since 3.8.0
 ===============================================================================
 
 ``pgr_analyzeGraph`` — Analyzes the network topology.

--- a/docqueries/src/migration.pg
+++ b/docqueries/src/migration.pg
@@ -377,3 +377,14 @@ FROM pgr_primDD(
   'SELECT id, source, target, cost, reverse_cost FROM edges ORDER BY id',
   ARRAY[9, 6], 3.5);
 /* --primDD5 */
+
+/* --analysis1 */
+SELECT *
+FROM pgr_connectedComponents(
+  'SELECT id, source, target, cost, reverse_cost FROM edges'
+);
+/* --analysis2 */
+SELECT *
+FROM pgr_degree($$SELECT id, source, target FROM edges$$)
+WHERE degree = 1;
+/* --analysis3*/

--- a/docqueries/src/migration.pg
+++ b/docqueries/src/migration.pg
@@ -388,3 +388,16 @@ SELECT *
 FROM pgr_degree($$SELECT id, source, target FROM edges$$)
 WHERE degree = 1;
 /* --analysis3*/
+WITH
+deadends AS (
+  SELECT id,geom, (in_edges || out_edges)[1] as inhere
+  FROM vertices where array_length(in_edges || out_edges, 1) = 1),
+results AS (
+  SELECT (pgr_findCloseEdges('SELECT id, geom FROM edges WHERE id != ' || inhere , geom, 0.001)).*
+  FROM deadends)
+SELECT d.id, edge_id, distance, st_AsText(geom) AS point, st_asText(edge) edge
+FROM results JOIN deadends d USING (geom);
+/* --analysis4*/
+SELECT e1.id AS id1, e2.id AS id2
+FROM edges e1, edges e2 WHERE e1 < e2 AND st_crosses(e1.geom, e2.geom);
+/* --analysis5*/

--- a/docqueries/src/migration.result
+++ b/docqueries/src/migration.result
@@ -1283,5 +1283,28 @@ WHERE degree = 1;
 (7 rows)
 
 /* --analysis3*/
+WITH
+deadends AS (
+  SELECT id,geom, (in_edges || out_edges)[1] as inhere
+  FROM vertices where array_length(in_edges || out_edges, 1) = 1),
+results AS (
+  SELECT (pgr_findCloseEdges('SELECT id, geom FROM edges WHERE id != ' || inhere , geom, 0.001)).*
+  FROM deadends)
+SELECT d.id, edge_id, distance, st_AsText(geom) AS point, st_asText(edge) edge
+FROM results JOIN deadends d USING (geom);
+ id | edge_id |     distance      |           point           |                 edge
+----+---------+-------------------+---------------------------+--------------------------------------
+  4 |      14 | 1.00008890058e-12 | POINT(1.999999999999 3.5) | LINESTRING(1.999999999999 3.5,2 3.5)
+(1 row)
+
+/* --analysis4*/
+SELECT e1.id AS id1, e2.id AS id2
+FROM edges e1, edges e2 WHERE e1 < e2 AND st_crosses(e1.geom, e2.geom);
+ id1 | id2
+-----+-----
+  13 |  18
+(1 row)
+
+/* --analysis5*/
 ROLLBACK;
 ROLLBACK

--- a/docqueries/src/migration.result
+++ b/docqueries/src/migration.result
@@ -1241,5 +1241,47 @@ FROM pgr_primDD(
 (17 rows)
 
 /* --primDD5 */
+/* --analysis1 */
+SELECT *
+FROM pgr_connectedComponents(
+  'SELECT id, source, target, cost, reverse_cost FROM edges'
+);
+ seq | component | node
+-----+-----------+------
+   1 |         1 |    1
+   2 |         1 |    3
+   3 |         1 |    5
+   4 |         1 |    6
+   5 |         1 |    7
+   6 |         1 |    8
+   7 |         1 |    9
+   8 |         1 |   10
+   9 |         1 |   11
+  10 |         1 |   12
+  11 |         1 |   15
+  12 |         1 |   16
+  13 |         1 |   17
+  14 |         2 |    2
+  15 |         2 |    4
+  16 |        13 |   13
+  17 |        13 |   14
+(17 rows)
+
+/* --analysis2 */
+SELECT *
+FROM pgr_degree($$SELECT id, source, target FROM edges$$)
+WHERE degree = 1;
+ node | degree
+------+--------
+    9 |      1
+    5 |      1
+    4 |      1
+   14 |      1
+   13 |      1
+    2 |      1
+    1 |      1
+(7 rows)
+
+/* --analysis3*/
 ROLLBACK;
 ROLLBACK

--- a/docqueries/topology/analyzeGraph.result
+++ b/docqueries/topology/analyzeGraph.result
@@ -18,6 +18,7 @@ NOTICE:  ----------------------------------------------
 (1 row)
 
 SELECT  pgr_analyzeGraph('edges',0.001,'geom');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','true')
 NOTICE:  Performing checks, please wait ...
@@ -40,6 +41,7 @@ NOTICE:                      Ring geometries: 0
 /* -- q1.1 */
 /* -- q3 */
 SELECT  pgr_analyzeGraph('edges',0.001,'geom','id','source','target');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','true')
 NOTICE:  Performing checks, please wait ...
@@ -62,6 +64,7 @@ NOTICE:                      Ring geometries: 0
 /* -- q3.1 */
 /* -- q5 */
 SELECT  pgr_analyzeGraph('edges',0.001,'id','geom','source','target');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'id','geom','source','target','true')
 NOTICE:  Performing checks, please wait ...
@@ -75,6 +78,7 @@ NOTICE:  ERROR: something went wrong when checking for SRID of id in table publi
 /* -- q5.1 */
 /* -- q6 */
 SELECT  pgr_analyzeGraph('edges',0.001,the_geom:='geom',id:='id',source:='source',target:='target');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','true')
 NOTICE:  Performing checks, please wait ...
@@ -97,6 +101,7 @@ NOTICE:                      Ring geometries: 0
 /* -- q6.1 */
 /* -- q7 */
 SELECT  pgr_analyzeGraph('edges',0.001,source:='source',id:='id',target:='target',the_geom:='geom');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','true')
 NOTICE:  Performing checks, please wait ...
@@ -119,6 +124,7 @@ NOTICE:                      Ring geometries: 0
 /* -- q7.1 */
 /* -- q8. */
 SELECT  pgr_analyzeGraph('edges',0.001, 'geom', source:='source');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','true')
 NOTICE:  Performing checks, please wait ...
@@ -141,6 +147,7 @@ NOTICE:                      Ring geometries: 0
 /* -- q8.1 */
 /* -- q9 */
 SELECT  pgr_analyzeGraph('edges',0.001, 'geom', rows_where:='id < 10');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','id < 10')
 NOTICE:  Performing checks, please wait ...
@@ -163,6 +170,7 @@ NOTICE:                      Ring geometries: 0
 /* -- q9.1 */
 /* -- q10 */
 SELECT  pgr_analyzeGraph('edges',0.001, 'geom', rows_where:='geom && (SELECT st_buffer(geom,0.05) FROM edge_table WHERE id=5)');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','geom && (SELECT st_buffer(geom,0.05) FROM edge_table WHERE id=5)')
 NOTICE:  Performing checks, please wait ...
@@ -179,6 +187,7 @@ NOTICE:  select count(*) from public.edges WHERE true   AND (geom && (SELECT st_
 CREATE TABLE otherTable AS  (SELECT 100 AS gid, st_point(2.5,2.5) AS other_geom) ;
 SELECT 1
 SELECT  pgr_analyzeGraph('edges',0.001, 'geom', rows_where:='geom && (SELECT st_buffer(geom,1) FROM otherTable WHERE gid=100)');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','geom && (SELECT st_buffer(geom,1) FROM otherTable WHERE gid=100)')
 NOTICE:  Performing checks, please wait ...
@@ -219,6 +228,7 @@ NOTICE:  ----------------------------------------------
 /* -- q12.1 */
 /* -- q13 */
 SELECT  pgr_analyzeGraph('mytable',0.001,'mygeom','gid','src','tgt');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('mytable',0.001,'mygeom','gid','src','tgt','true')
 NOTICE:  Performing checks, please wait ...
@@ -241,6 +251,7 @@ NOTICE:                      Ring geometries: 0
 /* -- q13.1 */
 /* -- q14 */
 SELECT  pgr_analyzeGraph('mytable',0.0001,'gid','mygeom','src','tgt');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('mytable',0.0001,'gid','mygeom','src','tgt','true')
 NOTICE:  Performing checks, please wait ...
@@ -254,6 +265,7 @@ NOTICE:  ERROR: something went wrong when checking for SRID of gid in table publ
 /* -- q14.1 */
 /* -- q15 */
 SELECT  pgr_analyzeGraph('mytable',0.001,the_geom:='mygeom',id:='gid',source:='src',target:='tgt');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('mytable',0.001,'mygeom','gid','src','tgt','true')
 NOTICE:  Performing checks, please wait ...
@@ -276,6 +288,7 @@ NOTICE:                      Ring geometries: 0
 /* -- q15.1 */
 /* -- q16 */
 SELECT  pgr_analyzeGraph('mytable',0.001,source:='src',id:='gid',target:='tgt',the_geom:='mygeom');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('mytable',0.001,'mygeom','gid','src','tgt','true')
 NOTICE:  Performing checks, please wait ...
@@ -298,6 +311,7 @@ NOTICE:                      Ring geometries: 0
 /* -- q16.1 */
 /* -- q17 */
 SELECT  pgr_analyzeGraph('mytable',0.001,'mygeom','gid','src','tgt',rows_where:='gid < 10');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('mytable',0.001,'mygeom','gid','src','tgt','gid < 10')
 NOTICE:  Performing checks, please wait ...
@@ -320,6 +334,7 @@ NOTICE:                      Ring geometries: 0
 /* -- q17.1 */
 /* -- q18 */
 SELECT  pgr_analyzeGraph('mytable',0.001,source:='src',id:='gid',target:='tgt',the_geom:='mygeom',rows_where:='gid < 10');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('mytable',0.001,'mygeom','gid','src','tgt','gid < 10')
 NOTICE:  Performing checks, please wait ...
@@ -343,6 +358,7 @@ NOTICE:                      Ring geometries: 0
 /* -- q19 */
 SELECT  pgr_analyzeGraph('mytable',0.001,'mygeom','gid','src','tgt',
     rows_where:='mygeom && (SELECT st_buffer(mygeom,1) FROM mytable WHERE gid=5)');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('mytable',0.001,'mygeom','gid','src','tgt','mygeom && (SELECT st_buffer(mygeom,1) FROM mytable WHERE gid=5)')
 NOTICE:  Performing checks, please wait ...
@@ -366,6 +382,7 @@ NOTICE:                      Ring geometries: 0
 /* -- q20 */
 SELECT  pgr_analyzeGraph('mytable',0.001,source:='src',id:='gid',target:='tgt',the_geom:='mygeom',
     rows_where:='mygeom && (SELECT st_buffer(mygeom,1) FROM mytable WHERE gid=5)');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('mytable',0.001,'mygeom','gid','src','tgt','mygeom && (SELECT st_buffer(mygeom,1) FROM mytable WHERE gid=5)')
 NOTICE:  Performing checks, please wait ...
@@ -393,6 +410,7 @@ CREATE TABLE otherTable AS  (SELECT 'myhouse'::text AS place, st_point(2.5,2.5) 
 SELECT 1
 SELECT  pgr_analyzeGraph('mytable',0.001,'mygeom','gid','src','tgt',
     rows_where:='mygeom && (SELECT st_buffer(other_geom,1) FROM otherTable WHERE place='||quote_literal('myhouse')||')');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('mytable',0.001,'mygeom','gid','src','tgt','mygeom && (SELECT st_buffer(other_geom,1) FROM otherTable WHERE place='myhouse')')
 NOTICE:  Performing checks, please wait ...
@@ -416,6 +434,7 @@ NOTICE:                      Ring geometries: 0
 /* -- q22 */
 SELECT  pgr_analyzeGraph('mytable',0.001,source:='src',id:='gid',target:='tgt',the_geom:='mygeom',
     rows_where:='mygeom && (SELECT st_buffer(other_geom,1) FROM otherTable WHERE place='||quote_literal('myhouse')||')');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('mytable',0.001,'mygeom','gid','src','tgt','mygeom && (SELECT st_buffer(other_geom,1) FROM otherTable WHERE place='myhouse')')
 NOTICE:  Performing checks, please wait ...
@@ -452,6 +471,7 @@ NOTICE:  ----------------------------------------------
 (1 row)
 
 SELECT pgr_analyzeGraph('edges', 0.001, 'geom');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','true')
 NOTICE:  Performing checks, please wait ...
@@ -474,6 +494,7 @@ NOTICE:                      Ring geometries: 0
 /* -- q23.1 */
 /* -- q24 */
 SELECT  pgr_analyzeGraph('edges',0.001,'geom', rows_where:='id < 10');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','id < 10')
 NOTICE:  Performing checks, please wait ...
@@ -496,6 +517,7 @@ NOTICE:                      Ring geometries: 0
 /* -- q24.1 */
 /* -- q25 */
 SELECT  pgr_analyzeGraph('edges',0.001,'geom', rows_where:='id >= 10');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','id >= 10')
 NOTICE:  Performing checks, please wait ...
@@ -518,6 +540,7 @@ NOTICE:                      Ring geometries: 0
 /* -- q25.1 */
 /* -- q26 */
 SELECT  pgr_analyzeGraph('edges',0.001,'geom', rows_where:='id < 17');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','id < 17')
 NOTICE:  Performing checks, please wait ...
@@ -556,6 +579,7 @@ NOTICE:  ----------------------------------------------
 /* -- q27.1 */
 /* -- q28 */
 SELECT pgr_analyzeGraph('edges', 0.001, 'geom');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','true')
 NOTICE:  Performing checks, please wait ...

--- a/docqueries/topology/nodeNetwork.result
+++ b/docqueries/topology/nodeNetwork.result
@@ -20,6 +20,7 @@ NOTICE:  ----------------------------------------------
 /* --q1.1 */
 /* --q2 */
 SELECT pgr_analyzegraph('edges', 0.001, 'geom');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','true')
 NOTICE:  Performing checks, please wait ...
@@ -111,6 +112,7 @@ NOTICE:  ----------------------------------------------
 /* --q5.1 */
 /* --q6 */
 SELECT pgr_analyzegraph('edges_noded', 0.001, 'geom');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges_noded',0.001,'geom','id','source','target','true')
 NOTICE:  Performing checks, please wait ...
@@ -163,6 +165,7 @@ NOTICE:  ----------------------------------------------
 /* --q8.1 */
 /* --q9 */
 SELECT pgr_analyzegraph('edges', 0.001, 'geom', rows_where:='id not in (select old_id from edges where old_id is not null)');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','id not in (select old_id from edges where old_id is not null)')
 NOTICE:  Performing checks, please wait ...
@@ -185,6 +188,7 @@ NOTICE:                      Ring geometries: 0
 /* --q9.1 */
 /* --q10 */
 SELECT pgr_analyzegraph('edges', 0.001, 'geom', rows_where:='old_id is null');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','old_id is null')
 NOTICE:  Performing checks, please wait ...
@@ -207,6 +211,7 @@ NOTICE:                      Ring geometries: 0
 /* --q10.1 */
 /* --q11 */
 SELECT pgr_analyzegraph('edges', 0.001, 'geom');
+WARNING:  pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_analyzeGraph('edges',0.001,'geom','id','source','target','true')
 NOTICE:  Performing checks, please wait ...

--- a/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-30 03:07+0000\n"
+"POT-Creation-Date: 2025-04-04 16:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3921,10 +3921,19 @@ msgstr ""
 msgid "pgRouting 3.8.0 Release Notes"
 msgstr ""
 
+#, python-format
+msgid ""
+"To see all issues & pull requests closed by this release see the `Git "
+"closed milestone for 3.8.0 "
+"<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.8.0%22>`__"
+msgstr ""
+
 msgid "Promotion to official function of pgRouting."
 msgstr ""
 
-msgid "pgr_extractVertices"
+msgid ""
+"`#2772 <https://github.com/pgRouting/pgrouting/issues/2772>`__: "
+"pgr_extractVertices"
 msgstr ""
 
 msgid "Error messages adjustment."
@@ -3933,16 +3942,26 @@ msgstr ""
 msgid "Function promoted to official."
 msgstr ""
 
-msgid "pgr_degree"
+msgid "`#2760 <https://github.com/pgRouting/pgrouting/issues/2760>`__: pgr_degree"
 msgstr ""
 
 msgid "New signature with only Edges SQL."
 msgstr ""
 
-msgid "pgr_findCloseEdges"
+msgid ""
+"`#2774 <https://github.com/pgRouting/pgrouting/issues/2774>`__: "
+"pgr_findCloseEdges"
 msgstr ""
 
 msgid "``partial`` option is removed."
+msgstr ""
+
+msgid "Deprecation of functions."
+msgstr ""
+
+msgid ""
+"`#2753 <https://github.com/pgRouting/pgrouting/issues/2753>`__: "
+"pgr_analyzeGraph"
 msgstr ""
 
 msgid "Official functions changes"
@@ -4021,6 +4040,119 @@ msgid "Results can be different because of the changes."
 msgstr ""
 
 msgid "All deprecated functions will be removed on next mayor version 4.0.0"
+msgstr ""
+
+msgid "Migration of ``pgr_analyzeGraph``"
+msgstr ""
+
+msgid ""
+"Starting from `v3.8.0 "
+"<https://docs.pgrouting.org/3.8/en/migration.html>`__"
+msgstr ""
+
+msgid "**Before Deprecation:** The following was calculated:"
+msgstr ""
+
+msgid "Number of isolated segments."
+msgstr ""
+
+msgid "Number of dead ends."
+msgstr ""
+
+msgid "Number of potential gaps found near dead ends."
+msgstr ""
+
+msgid "Number of intersections. (between 2 edges)"
+msgstr ""
+
+msgid "WHERE"
+msgstr ""
+
+msgid "Graph component"
+msgstr ""
+
+msgid "A connected subgraph that is not part of any larger connected subgraph."
+msgstr ""
+
+msgid "Isolated segment"
+msgstr ""
+
+msgid "A graph component with only one segment."
+msgstr ""
+
+msgid "Dead ends"
+msgstr ""
+
+msgid "A vertex that participates in only one edge."
+msgstr ""
+
+msgid "gaps"
+msgstr ""
+
+msgid "Space between two geometries."
+msgstr ""
+
+msgid "Intersection"
+msgstr ""
+
+msgid "Is a topological relationship between two geometries."
+msgstr ""
+
+msgid "Migration."
+msgstr ""
+
+msgid "Components."
+msgstr ""
+
+msgid ""
+"Instead of counting only isolated segments, determine all the components "
+"of the graph."
+msgstr ""
+
+msgid "Depending of the final application requirements use:"
+msgstr ""
+
+msgid ":doc:`pgr_connectedComponents`"
+msgstr ""
+
+msgid ":doc:`pgr_strongComponents`"
+msgstr ""
+
+msgid ":doc:`pgr_biconnectedComponents`"
+msgstr ""
+
+msgid "For example:"
+msgstr ""
+
+msgid "Dead ends."
+msgstr ""
+
+msgid ""
+"Instead of counting the dead ends, determine all the dead ends of the "
+"graph using :doc:`pgr_degree`."
+msgstr ""
+
+msgid "Potential gaps near dead ends."
+msgstr ""
+
+msgid ""
+"Instead of counting potential gaps between geometries, determine the "
+"geometric gaps in the graph using :doc:`pgr_findCloseEdges`."
+msgstr ""
+
+msgid "Topological relationships."
+msgstr ""
+
+msgid ""
+"Instead of counting intersections, determine topological relationships "
+"between geometries."
+msgstr ""
+
+msgid ""
+"Several PostGIS functions can be used: `ST_Intersects "
+"<https://postgis.net/docs/ST_Intersects.html>`__, `ST_Crosses "
+"<https://postgis.net/docs/ST_Crosses.html>`__, `ST_Overlaps "
+"<https://postgis.net/docs/ST_Overlaps.html>`__, etc."
 msgstr ""
 
 msgid "Migration of ``pgr_aStar``"
@@ -5726,9 +5858,6 @@ msgstr ""
 msgid ""
 "A complete method on how to contract and how to use the contracted graph "
 "is described on :doc:`contraction-family`"
-msgstr ""
-
-msgid "Dead ends"
 msgstr ""
 
 msgid "To get the dead ends:"
@@ -7727,10 +7856,16 @@ msgstr ""
 msgid "`ST_ConcaveHull <https://postgis.net/docs/ST_ConcaveHull.html>`__"
 msgstr ""
 
-msgid "``pgr_analyzeGraph``"
+msgid "``pgr_analyzeGraph`` -- Deprecated since 3.8.0"
 msgstr ""
 
 msgid "``pgr_analyzeGraph`` — Analyzes the network topology."
+msgstr ""
+
+msgid "Version 3.8.0"
+msgstr ""
+
+msgid "Deprecated function."
 msgstr ""
 
 msgid "The function returns:"
@@ -9110,9 +9245,6 @@ msgstr ""
 msgid ""
 "``pgr_contraction`` — Performs graph contraction and returns the "
 "contracted vertices and edges."
-msgstr ""
-
-msgid "Version 3.8.0"
 msgstr ""
 
 msgid "Name change from ``pgr_contractGraph``"
@@ -15771,6 +15903,9 @@ msgstr ""
 msgid "Changes on the documentation to the following:"
 msgstr ""
 
+msgid "pgr_degree"
+msgstr ""
+
 msgid "pgr_dijkstra"
 msgstr ""
 
@@ -16160,6 +16295,9 @@ msgid "pgr_dijkstraNearCost(One to Many)"
 msgstr ""
 
 msgid "pgr_sequentialVertexColoring"
+msgstr ""
+
+msgid "pgr_extractVertices"
 msgstr ""
 
 msgid "Traversal"

--- a/locale/pot/pgrouting_doc_strings.pot
+++ b/locale/pot/pgrouting_doc_strings.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-30 03:07+0000\n"
+"POT-Creation-Date: 2025-04-04 16:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3520,10 +3520,13 @@ msgstr ""
 msgid "pgRouting 3.8.0 Release Notes"
 msgstr ""
 
+msgid "To see all issues & pull requests closed by this release see the `Git closed milestone for 3.8.0 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.8.0%22>`__"
+msgstr ""
+
 msgid "Promotion to official function of pgRouting."
 msgstr ""
 
-msgid "pgr_extractVertices"
+msgid "`#2772 <https://github.com/pgRouting/pgrouting/issues/2772>`__: pgr_extractVertices"
 msgstr ""
 
 msgid "Error messages adjustment."
@@ -3532,16 +3535,22 @@ msgstr ""
 msgid "Function promoted to official."
 msgstr ""
 
-msgid "pgr_degree"
+msgid "`#2760 <https://github.com/pgRouting/pgrouting/issues/2760>`__: pgr_degree"
 msgstr ""
 
 msgid "New signature with only Edges SQL."
 msgstr ""
 
-msgid "pgr_findCloseEdges"
+msgid "`#2774 <https://github.com/pgRouting/pgrouting/issues/2774>`__: pgr_findCloseEdges"
 msgstr ""
 
 msgid "``partial`` option is removed."
+msgstr ""
+
+msgid "Deprecation of functions."
+msgstr ""
+
+msgid "`#2753 <https://github.com/pgRouting/pgrouting/issues/2753>`__: pgr_analyzeGraph"
 msgstr ""
 
 msgid "Official functions changes"
@@ -3605,6 +3614,105 @@ msgid "Results can be different because of the changes."
 msgstr ""
 
 msgid "All deprecated functions will be removed on next mayor version 4.0.0"
+msgstr ""
+
+msgid "Migration of ``pgr_analyzeGraph``"
+msgstr ""
+
+msgid "Starting from `v3.8.0 <https://docs.pgrouting.org/3.8/en/migration.html>`__"
+msgstr ""
+
+msgid "**Before Deprecation:** The following was calculated:"
+msgstr ""
+
+msgid "Number of isolated segments."
+msgstr ""
+
+msgid "Number of dead ends."
+msgstr ""
+
+msgid "Number of potential gaps found near dead ends."
+msgstr ""
+
+msgid "Number of intersections. (between 2 edges)"
+msgstr ""
+
+msgid "WHERE"
+msgstr ""
+
+msgid "Graph component"
+msgstr ""
+
+msgid "A connected subgraph that is not part of any larger connected subgraph."
+msgstr ""
+
+msgid "Isolated segment"
+msgstr ""
+
+msgid "A graph component with only one segment."
+msgstr ""
+
+msgid "Dead ends"
+msgstr ""
+
+msgid "A vertex that participates in only one edge."
+msgstr ""
+
+msgid "gaps"
+msgstr ""
+
+msgid "Space between two geometries."
+msgstr ""
+
+msgid "Intersection"
+msgstr ""
+
+msgid "Is a topological relationship between two geometries."
+msgstr ""
+
+msgid "Migration."
+msgstr ""
+
+msgid "Components."
+msgstr ""
+
+msgid "Instead of counting only isolated segments, determine all the components of the graph."
+msgstr ""
+
+msgid "Depending of the final application requirements use:"
+msgstr ""
+
+msgid ":doc:`pgr_connectedComponents`"
+msgstr ""
+
+msgid ":doc:`pgr_strongComponents`"
+msgstr ""
+
+msgid ":doc:`pgr_biconnectedComponents`"
+msgstr ""
+
+msgid "For example:"
+msgstr ""
+
+msgid "Dead ends."
+msgstr ""
+
+msgid "Instead of counting the dead ends, determine all the dead ends of the graph using :doc:`pgr_degree`."
+msgstr ""
+
+msgid "Potential gaps near dead ends."
+msgstr ""
+
+msgid "Instead of counting potential gaps between geometries, determine the geometric gaps in the graph using :doc:`pgr_findCloseEdges`."
+msgstr ""
+
+msgid "Topological relationships."
+msgstr ""
+
+msgid "Instead of counting intersections, determine topological relationships between geometries."
+msgstr ""
+
+msgid "Several PostGIS functions can be used: `ST_Intersects <https://postgis.net/docs/ST_Intersects.html>`__, `ST_Crosses <https://postgis.net/docs/ST_Crosses.html>`__, `ST_Overlaps <https://postgis.net/docs/ST_Overlaps.html>`__, etc."
 msgstr ""
 
 msgid "Migration of ``pgr_aStar``"
@@ -5021,9 +5129,6 @@ msgid "A fairly good method of finding out if contraction can be useful is becau
 msgstr ""
 
 msgid "A complete method on how to contract and how to use the contracted graph is described on :doc:`contraction-family`"
-msgstr ""
-
-msgid "Dead ends"
 msgstr ""
 
 msgid "To get the dead ends:"
@@ -6736,10 +6841,16 @@ msgstr ""
 msgid "`ST_ConcaveHull <https://postgis.net/docs/ST_ConcaveHull.html>`__"
 msgstr ""
 
-msgid "``pgr_analyzeGraph``"
+msgid "``pgr_analyzeGraph`` -- Deprecated since 3.8.0"
 msgstr ""
 
 msgid "``pgr_analyzeGraph`` — Analyzes the network topology."
+msgstr ""
+
+msgid "Version 3.8.0"
+msgstr ""
+
+msgid "Deprecated function."
 msgstr ""
 
 msgid "The function returns:"
@@ -7817,9 +7928,6 @@ msgid "``pgr_contraction``"
 msgstr ""
 
 msgid "``pgr_contraction`` — Performs graph contraction and returns the contracted vertices and edges."
-msgstr ""
-
-msgid "Version 3.8.0"
 msgstr ""
 
 msgid "Name change from ``pgr_contractGraph``"
@@ -13234,6 +13342,9 @@ msgstr ""
 msgid "Changes on the documentation to the following:"
 msgstr ""
 
+msgid "pgr_degree"
+msgstr ""
+
 msgid "pgr_dijkstra"
 msgstr ""
 
@@ -13544,6 +13655,9 @@ msgid "pgr_dijkstraNearCost(One to Many)"
 msgstr ""
 
 msgid "pgr_sequentialVertexColoring"
+msgstr ""
+
+msgid "pgr_extractVertices"
 msgstr ""
 
 msgid "Traversal"

--- a/sql/topology/analyzegraph.sql
+++ b/sql/topology/analyzegraph.sql
@@ -135,6 +135,8 @@ DECLARE
 
 
 BEGIN
+  RAISE WARNING 'pgr_analyzegraph(text,double precision,text,text,text,text,text) deprecated function on v3.8.0';
+
   RAISE NOTICE 'PROCESSING:';
   RAISE NOTICE 'pgr_analyzeGraph(''%'',%,''%'',''%'',''%'',''%'',''%'')',edge_table,tolerance,the_geom,id,source,target,rows_where;
   RAISE NOTICE 'Performing checks, please wait ...';
@@ -395,16 +397,4 @@ $BODY$
 
 
 COMMENT ON FUNCTION pgr_analyzeGraph(TEXT, FLOAT, TEXT, TEXT, TEXT, TEXT, TEXT)
-IS 'pgr_analyzeGraph
-- Parameters
-  - Edge table name
-  - tolerance
-- Optional parameters
-  - the_geom: default ''the_geom''
-  - id := ''id''
-  - source := ''source''
-  - target := ''target''
-  - rows_where := ''true''
-- Documentation:
-  - ${PROJECT_DOC_LINK}/pgr_analyzeGraph.html
-';
+IS 'pgr_analyzeGraph deprecated function on v3.8.0';


### PR DESCRIPTION
Fixes #2753

Changes proposed in this pull request:
- SQL: mark function as deprecated
- doc:
  - Migration: add migration suggestions
- docqueries:
  - Update results adding message that is shown

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced release notes now include links to closed issues and pull requests.
  - Expanded analytical capabilities improve graph analysis and troubleshooting.

- **Documentation**
  - Updated guides and structured sections provide clearer navigation and improved migration instructions.
  - New markers enhance the readability of topics like graph connectivity and dead-end analysis.

- **Deprecations**
  - The `pgr_analyzeGraph` function is now deprecated, with warning messages added to facilitate user transition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->