### PR TITLE
Deprecate pgr create vertices table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,8 @@ milestone for 3.8.0
   pgr_analyzeOneWay
 * [#2753](https://github.com/pgRouting/pgrouting/issues/2753):
   pgr_analyzeGraph
+* [#2826](https://github.com/pgRouting/pgrouting/issues/2826):
+  pgr_createVerticesTable
 
 **Official functions changes**
 

--- a/doc/_static/page_history.js
+++ b/doc/_static/page_history.js
@@ -216,7 +216,7 @@ var filesArr = [
     ]),
     new createInfo('pgr_createVerticesTable', '2.0', [
         { v: '2.1', n: 'src/common/doc/functions/create_vert_table'},
-        { v: '2.3', n: 'src/topology/doc/pgr_createVerticesTable'},
+        { v: '2.3', n: 'src/topology/doc/pgr_createVerticesTable'}, 3.8
     ]),
     new createInfo('pgr_createTopology', '2.0', [
         { v: '2.1', n: 'src/common/doc/functions/create_topology'},

--- a/doc/src/migration.rst
+++ b/doc/src/migration.rst
@@ -24,6 +24,26 @@ Results can be different because of the changes.
 .. contents:: Contents
    :depth: 2
 
+.. migrate_pgr_createVerticesTable_start
+
+Migration of ``pgr_createVerticesTable``
+-------------------------------------------------------------------------------
+
+Starting from `v3.8.0 <https://docs.pgrouting.org/3.8/en/migration.html>`__
+
+**Before Deprecation:** The following was calculated:
+
+* A table with `<edges>_vertices_pgr` was created.
+
+**After Deprecation:** The user is responsible to create the vertices table,
+indexes, etc. They may use :doc:`pgr_extractVertices` for that purpose.
+
+.. literalinclude:: sampledata.queries
+   :start-after: -- q1
+   :end-before: -- q1-1
+
+.. migrate_pgr_createVerticesTable_end
+
 .. migrate_pgr_analyzeOneWay_start
 
 Migration of ``pgr_analyzeOneWay``

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -72,6 +72,8 @@ milestone for 3.8.0
   pgr_analyzeOneWay
 * `#2753 <https://github.com/pgRouting/pgrouting/issues/2753>`__:
   pgr_analyzeGraph
+* `#2826 <https://github.com/pgRouting/pgrouting/issues/2826>`__:
+  pgr_createVerticesTable
 
 .. rubric:: Official functions changes
 

--- a/doc/topology/pgr_analyzeGraph.rst
+++ b/doc/topology/pgr_analyzeGraph.rst
@@ -55,7 +55,6 @@ The edge table to be analyzed must contain a source column and a target column
 filled with id's of the vertices of the segments and the corresponding vertices
 table <edge_table>_vertices_pgr that stores the vertices information.
 
-- Use :doc:`pgr_createVerticesTable` to create the vertices table.
 - Use :doc:`pgr_createTopology` to create the topology and the vertices table.
 
 Parameters
@@ -96,8 +95,8 @@ The function returns:
 
 .. rubric:: The Vertices Table
 
-The vertices table can be created with :doc:`pgr_createVerticesTable
-<pgr_createVerticesTable>` or :doc:`pgr_createTopology <pgr_createTopology>`
+The vertices table can be created with
+:doc:`pgr_createTopology <pgr_createTopology>`
 
 The structure of the vertices table is:
 
@@ -291,7 +290,6 @@ See Also
 * :doc:`sampledata`
 * :doc:`topology-functions`
 * :doc:`pgr_analyzeOneWay`
-* :doc:`pgr_createVerticesTable`
 * :doc:`pgr_nodeNetwork` to create nodes to a not noded edge table.
 
 .. rubric:: Indices and tables

--- a/doc/topology/pgr_analyzeOneWay.rst
+++ b/doc/topology/pgr_analyzeOneWay.rst
@@ -64,7 +64,6 @@ The edge table to be analyzed must contain a source column and a target column
 filled with id's of the vertices of the segments and the corresponding vertices
 table <edge_table>_vertices_pgr that stores the vertices information.
 
-- Use :doc:`pgr_createVerticesTable` to create the vertices table.
 - Use :doc:`pgr_createTopology` to create the topology and the vertices table.
 
 |Boost| Boost Graph Inside
@@ -99,7 +98,7 @@ Parameters
 
 .. note::
    It is strongly recommended to use the named notation. See
-   :doc:`pgr_createVerticesTable` or :doc:`pgr_createTopology` for examples.
+   :doc:`pgr_createTopology` for examples.
 
 The function returns:
 
@@ -121,7 +120,7 @@ condition.
 
 .. rubric:: The Vertices Table
 
-The vertices table can be created with :doc:`pgr_createVerticesTable` or
+The vertices table can be created with
 :doc:`pgr_createTopology`
 
 The structure of the vertices table is:
@@ -148,7 +147,6 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`topology-functions`
-* :doc:`pgr_createVerticesTable`
 * :doc:`sampledata`
 
 .. rubric:: Indices and tables

--- a/doc/topology/pgr_createTopology.rst
+++ b/doc/topology/pgr_createTopology.rst
@@ -274,7 +274,6 @@ See Also
 
 * :doc:`sampledata`
 * :doc:`topology-functions`
-* :doc:`pgr_createVerticesTable`
 
 .. rubric:: Indices and tables
 

--- a/doc/topology/pgr_createVerticesTable.rst
+++ b/doc/topology/pgr_createVerticesTable.rst
@@ -30,6 +30,10 @@ source and target information.
   * Official function.
   * Renamed from version 1.x
 
+.. include:: migration.rst
+   :start-after: migrate_pgr_createVerticesTable_start
+   :end-before: migrate_pgr_createVerticesTable_end
+
 Description
 -------------------------------------------------------------------------------
 

--- a/doc/topology/pgr_createVerticesTable.rst
+++ b/doc/topology/pgr_createVerticesTable.rst
@@ -8,18 +8,22 @@
    ****************************************************************************
 
 .. index::
-   single: Topology Family ; pgr_createVerticesTable
-   single: createVerticesTable
+   single: Topology Family ; pgr_createVerticesTable - Deprecated since 3.8.0
+   single: createVerticesTable - Deprecated since 3.8.0
 
 |
 
-``pgr_createVerticesTable``
+``pgr_createVerticesTable`` - Deprecated since 3.8.0
 ===============================================================================
 
 ``pgr_createVerticesTable`` — Reconstructs the vertices table based on the
 source and target information.
 
 .. rubric:: Availability
+
+* Version 3.8.0
+
+  * Deprecated function.
 
 * Version 2.0.0
 

--- a/doc/topology/pgr_extractVertices.rst
+++ b/doc/topology/pgr_extractVertices.rst
@@ -302,7 +302,6 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`topology-functions`
-* :doc:`pgr_createVerticesTable`
 
 .. rubric:: Indices and tables
 

--- a/docqueries/topology/createVertTab-any.result
+++ b/docqueries/topology/createVertTab-any.result
@@ -11,6 +11,7 @@ SELECT AddGeometryColumn ('public','edges','the_geom',0,'LINESTRING',2);
 UPDATE edges SET the_geom = geom;
 UPDATE 18
 SELECT  pgr_createVerticesTable('edges');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','the_geom','source','target','true')
 NOTICE:  Performing checks, please wait .....
@@ -27,6 +28,7 @@ NOTICE:  ----------------------------------------------
 (1 row)
 
 SELECT  pgr_createVerticesTable('edges','the_geom','source','target');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','the_geom','source','target','true')
 NOTICE:  Performing checks, please wait .....
@@ -43,6 +45,7 @@ NOTICE:  ----------------------------------------------
 (1 row)
 
 SELECT  pgr_createVerticesTable('edges',the_geom:='the_geom',source:='source',target:='target');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','the_geom','source','target','true')
 NOTICE:  Performing checks, please wait .....
@@ -59,6 +62,7 @@ NOTICE:  ----------------------------------------------
 (1 row)
 
 SELECT  pgr_createVerticesTable('edges',source:='source',target:='target',the_geom:='the_geom');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','the_geom','source','target','true')
 NOTICE:  Performing checks, please wait .....
@@ -75,6 +79,7 @@ NOTICE:  ----------------------------------------------
 (1 row)
 
 SELECT  pgr_createVerticesTable('edges',source:='source');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','the_geom','source','target','true')
 NOTICE:  Performing checks, please wait .....
@@ -91,6 +96,7 @@ NOTICE:  ----------------------------------------------
 (1 row)
 
 SELECT  pgr_createVerticesTable('edges',rows_where:='id < 10');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','the_geom','source','target','id < 10')
 NOTICE:  Performing checks, please wait .....
@@ -107,6 +113,7 @@ NOTICE:  ----------------------------------------------
 (1 row)
 
 SELECT  pgr_createVerticesTable('edges',rows_where:='the_geom && (select st_buffer(the_geom,0.5) FROM edge_table WHERE id=5)');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','the_geom','source','target','the_geom && (select st_buffer(the_geom,0.5) FROM edge_table WHERE id=5)')
 NOTICE:  Performing checks, please wait .....
@@ -121,6 +128,7 @@ NOTICE:  select * from public.edges WHERE true AND (the_geom && (select st_buffe
 CREATE TABLE otherTable AS  (SELECT 100 AS gid, st_point(2.5,2.5) AS other_geom) ;
 SELECT 1
 SELECT  pgr_createVerticesTable('edges',rows_where:='the_geom && (select st_buffer(other_geom,0.5) FROM otherTable WHERE gid=100)');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','the_geom','source','target','the_geom && (select st_buffer(other_geom,0.5) FROM otherTable WHERE gid=100)')
 NOTICE:  Performing checks, please wait .....
@@ -139,6 +147,7 @@ NOTICE:  ----------------------------------------------
 CREATE TABLE mytable AS (SELECT id AS gid, the_geom AS mygeom,source AS src ,target AS tgt FROM edges) ;
 SELECT 18
 SELECT  pgr_createVerticesTable('mytable','mygeom','src','tgt');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','true')
 NOTICE:  Performing checks, please wait .....
@@ -155,6 +164,7 @@ NOTICE:  ----------------------------------------------
 (1 row)
 
 SELECT  pgr_createVerticesTable('mytable',the_geom:='mygeom',source:='src',target:='tgt');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','true')
 NOTICE:  Performing checks, please wait .....
@@ -171,6 +181,7 @@ NOTICE:  ----------------------------------------------
 (1 row)
 
 SELECT  pgr_createVerticesTable('mytable',source:='src',target:='tgt',the_geom:='mygeom');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','true')
 NOTICE:  Performing checks, please wait .....
@@ -187,6 +198,7 @@ NOTICE:  ----------------------------------------------
 (1 row)
 
 SELECT  pgr_createVerticesTable('mytable','mygeom','src','tgt',rows_where:='gid < 10');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','gid < 10')
 NOTICE:  Performing checks, please wait .....
@@ -203,6 +215,7 @@ NOTICE:  ----------------------------------------------
 (1 row)
 
 SELECT  pgr_createVerticesTable('mytable',source:='src',target:='tgt',the_geom:='mygeom',rows_where:='gid < 10');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','gid < 10')
 NOTICE:  Performing checks, please wait .....
@@ -220,6 +233,7 @@ NOTICE:  ----------------------------------------------
 
 SELECT  pgr_createVerticesTable('mytable','mygeom','src','tgt',
 	                            rows_where:='mygeom && (SELECT st_buffer(mygeom,0.5) FROM mytable WHERE gid=5)');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','mygeom && (SELECT st_buffer(mygeom,0.5) FROM mytable WHERE gid=5)')
 NOTICE:  Performing checks, please wait .....
@@ -237,6 +251,7 @@ NOTICE:  ----------------------------------------------
 
 SELECT  pgr_createVerticesTable('mytable',source:='src',target:='tgt',the_geom:='mygeom',
 	                            rows_where:='mygeom && (SELECT st_buffer(mygeom,0.5) FROM mytable WHERE gid=5)');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','mygeom && (SELECT st_buffer(mygeom,0.5) FROM mytable WHERE gid=5)')
 NOTICE:  Performing checks, please wait .....
@@ -258,6 +273,7 @@ CREATE TABLE otherTable AS  (SELECT 100 AS gid, st_point(2.5,2.5) AS other_geom)
 SELECT 1
 SELECT  pgr_createVerticesTable('mytable','mygeom','src','tgt',
 	                            rows_where:='mygeom && (SELECT st_buffer(other_geom,0.5) FROM otherTable WHERE gid=100)');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','mygeom && (SELECT st_buffer(other_geom,0.5) FROM otherTable WHERE gid=100)')
 NOTICE:  Performing checks, please wait .....
@@ -275,6 +291,7 @@ NOTICE:  ----------------------------------------------
 
 SELECT  pgr_createVerticesTable('mytable',source:='src',target:='tgt',the_geom:='mygeom',
 	                            rows_where:='mygeom && (SELECT st_buffer(other_geom,0.5) FROM otherTable WHERE gid=100)');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','mygeom && (SELECT st_buffer(other_geom,0.5) FROM otherTable WHERE gid=100)')
 NOTICE:  Performing checks, please wait .....
@@ -291,6 +308,7 @@ NOTICE:  ----------------------------------------------
 (1 row)
 
 SELECT pgr_createVerticesTable('edges');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','the_geom','source','target','true')
 NOTICE:  Performing checks, please wait .....

--- a/docqueries/topology/createVerticesTable.result
+++ b/docqueries/topology/createVerticesTable.result
@@ -4,6 +4,7 @@ SET client_min_messages TO NOTICE;
 SET
 /* --q1 */
 SELECT  pgr_createVerticesTable('edges', 'geom');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','geom','source','target','true')
 NOTICE:  Performing checks, please wait .....
@@ -22,6 +23,7 @@ NOTICE:  ----------------------------------------------
 /* --q1.1 */
 /* --q2 */
 SELECT  pgr_createVerticesTable('edges', 'geom', 'source', 'target');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','geom','source','target','true')
 NOTICE:  Performing checks, please wait .....
@@ -39,6 +41,7 @@ NOTICE:  ----------------------------------------------
 
 /* --q2.1 */
 SELECT  pgr_createVerticesTable('edges', 'source', 'geom', 'target');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','source','geom','target','true')
 NOTICE:  Performing checks, please wait .....
@@ -53,6 +56,7 @@ NOTICE:  Unexpected error raise_exception
 /* --q2.2 */
 /* --q3.1 */
 SELECT  pgr_createVerticesTable('edges', the_geom:='geom', source:='source', target:='target');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','geom','source','target','true')
 NOTICE:  Performing checks, please wait .....
@@ -71,6 +75,7 @@ NOTICE:  ----------------------------------------------
 /* --q3.2 */
 /* --q4 */
 SELECT  pgr_createVerticesTable('edges', source:='source', target:='target', the_geom:='geom');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','geom','source','target','true')
 NOTICE:  Performing checks, please wait .....
@@ -89,6 +94,7 @@ NOTICE:  ----------------------------------------------
 /* --q4.1 */
 /* --q5 */
 SELECT  pgr_createVerticesTable('edges', 'geom', source:='source');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','geom','source','target','true')
 NOTICE:  Performing checks, please wait .....
@@ -107,6 +113,7 @@ NOTICE:  ----------------------------------------------
 /* --q5.1 */
 /* --q6 */
 SELECT  pgr_createVerticesTable('edges', 'geom', rows_where:='id < 10');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','geom','source','target','id < 10')
 NOTICE:  Performing checks, please wait .....
@@ -126,6 +133,7 @@ NOTICE:  ----------------------------------------------
 /* --q7 */
 SELECT  pgr_createVerticesTable('edges', 'geom',
     rows_where:='geom && (select st_buffer(geom,0.5) FROM edges WHERE id=5)');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','geom','source','target','geom && (select st_buffer(geom,0.5) FROM edges WHERE id=5)')
 NOTICE:  Performing checks, please wait .....
@@ -150,6 +158,7 @@ CREATE TABLE otherTable AS  (SELECT 100 AS gid, st_point(2.5,2.5) AS other_geom)
 SELECT 1
 SELECT  pgr_createVerticesTable('edges', 'geom',
     rows_where:='geom && (select st_buffer(other_geom,0.5) FROM otherTable WHERE gid=100)');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('edges','geom','source','target','geom && (select st_buffer(other_geom,0.5) FROM otherTable WHERE gid=100)')
 NOTICE:  Performing checks, please wait .....
@@ -175,6 +184,7 @@ SELECT 18
 /* --tab2 */
 /* --q9 */
 SELECT  pgr_createVerticesTable('mytable', 'mygeom', 'src', 'tgt');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','true')
 NOTICE:  Performing checks, please wait .....
@@ -192,6 +202,7 @@ NOTICE:  ----------------------------------------------
 
 /* --q9.1 */
 SELECT  pgr_createVerticesTable('mytable', 'src', 'mygeom', 'tgt');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','src','mygeom','tgt','true')
 NOTICE:  Performing checks, please wait .....
@@ -206,6 +217,7 @@ NOTICE:  Unexpected error raise_exception
 /* --q9.2 */
 /* --q10 */
 SELECT  pgr_createVerticesTable('mytable',the_geom:='mygeom',source:='src',target:='tgt');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','true')
 NOTICE:  Performing checks, please wait .....
@@ -226,6 +238,7 @@ NOTICE:  ----------------------------------------------
 SELECT  pgr_createVerticesTable(
     'mytable', source:='src', target:='tgt',
     the_geom:='mygeom');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','true')
 NOTICE:  Performing checks, please wait .....
@@ -246,6 +259,7 @@ NOTICE:  ----------------------------------------------
 SELECT  pgr_createVerticesTable(
     'mytable', 'mygeom', 'src', 'tgt',
     rows_where:='gid < 10');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','gid < 10')
 NOTICE:  Performing checks, please wait .....
@@ -266,6 +280,7 @@ NOTICE:  ----------------------------------------------
 SELECT  pgr_createVerticesTable(
     'mytable', source:='src', target:='tgt', the_geom:='mygeom',
     rows_where:='gid < 10');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','gid < 10')
 NOTICE:  Performing checks, please wait .....
@@ -286,6 +301,7 @@ NOTICE:  ----------------------------------------------
 SELECT  pgr_createVerticesTable(
     'mytable', 'mygeom', 'src', 'tgt',
     rows_where := 'the_geom && (SELECT st_buffer(mygeom,0.5) FROM mytable WHERE gid=5)');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','the_geom && (SELECT st_buffer(mygeom,0.5) FROM mytable WHERE gid=5)')
 NOTICE:  Performing checks, please wait .....
@@ -302,6 +318,7 @@ NOTICE:  select * from public.mytable WHERE true AND (the_geom && (SELECT st_buf
 SELECT  pgr_createVerticesTable(
     'mytable', source:='src', target:='tgt', the_geom:='mygeom',
     rows_where:='mygeom && (SELECT st_buffer(mygeom,0.5) FROM mytable WHERE id=5)');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','mygeom && (SELECT st_buffer(mygeom,0.5) FROM mytable WHERE id=5)')
 NOTICE:  Performing checks, please wait .....
@@ -323,6 +340,7 @@ SELECT 1
 SELECT pgr_createVerticesTable(
     'mytable', 'mygeom', 'src', 'tgt',
     rows_where:='the_geom && (SELECT st_buffer(othergeom,0.5) FROM otherTable WHERE gid=100)');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','the_geom && (SELECT st_buffer(othergeom,0.5) FROM otherTable WHERE gid=100)')
 NOTICE:  Performing checks, please wait .....
@@ -339,6 +357,7 @@ NOTICE:  select * from public.mytable WHERE true AND (the_geom && (SELECT st_buf
 SELECT  pgr_createVerticesTable(
     'mytable',source:='src',target:='tgt',the_geom:='mygeom',
     rows_where:='the_geom && (SELECT st_buffer(othergeom,0.5) FROM otherTable WHERE gid=100)');
+WARNING:  pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0
 NOTICE:  PROCESSING:
 NOTICE:  pgr_createVerticesTable('mytable','mygeom','src','tgt','the_geom && (SELECT st_buffer(othergeom,0.5) FROM otherTable WHERE gid=100)')
 NOTICE:  Performing checks, please wait .....

--- a/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-05 20:44+0000\n"
+"POT-Creation-Date: 2025-04-08 12:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3969,6 +3969,11 @@ msgid ""
 "pgr_analyzeGraph"
 msgstr ""
 
+msgid ""
+"`#2826 <https://github.com/pgRouting/pgrouting/issues/2826>`__: "
+"pgr_createVerticesTable"
+msgstr ""
+
 msgid "Official functions changes"
 msgstr ""
 
@@ -4047,7 +4052,7 @@ msgstr ""
 msgid "All deprecated functions will be removed on next major version 4.0.0"
 msgstr ""
 
-msgid "Migration of ``pgr_analyzeOneWay``"
+msgid "Migration of ``pgr_createVerticesTable``"
 msgstr ""
 
 msgid ""
@@ -4056,6 +4061,18 @@ msgid ""
 msgstr ""
 
 msgid "**Before Deprecation:** The following was calculated:"
+msgstr ""
+
+msgid "A table with `<edges>_vertices_pgr` was created."
+msgstr ""
+
+msgid ""
+"**After Deprecation:** The user is responsible to create the vertices "
+"table, indexes, etc. They may use :doc:`pgr_extractVertices` for that "
+"purpose."
+msgstr ""
+
+msgid "Migration of ``pgr_analyzeOneWay``"
 msgstr ""
 
 msgid "Number of potential problems in directionality"
@@ -7935,9 +7952,6 @@ msgid ""
 "vertices information."
 msgstr ""
 
-msgid "Use :doc:`pgr_createVerticesTable` to create the vertices table."
-msgstr ""
-
 msgid ""
 "Use :doc:`pgr_createTopology` to create the topology and the vertices "
 "table."
@@ -8030,8 +8044,7 @@ msgid "The Vertices Table"
 msgstr ""
 
 msgid ""
-"The vertices table can be created with :doc:`pgr_createVerticesTable "
-"<pgr_createVerticesTable>` or :doc:`pgr_createTopology "
+"The vertices table can be created with :doc:`pgr_createTopology "
 "<pgr_createTopology>`"
 msgstr ""
 
@@ -8168,9 +8181,6 @@ msgstr ""
 msgid ":doc:`pgr_analyzeOneWay`"
 msgstr ""
 
-msgid ":doc:`pgr_createVerticesTable`"
-msgstr ""
-
 msgid ":doc:`pgr_nodeNetwork` to create nodes to a not noded edge table."
 msgstr ""
 
@@ -8268,7 +8278,7 @@ msgstr ""
 
 msgid ""
 "It is strongly recommended to use the named notation. See "
-":doc:`pgr_createVerticesTable` or :doc:`pgr_createTopology` for examples."
+":doc:`pgr_createTopology` for examples."
 msgstr ""
 
 msgid "Fills completely the ``ein`` and ``eout`` columns of the vertices table."
@@ -8283,9 +8293,7 @@ msgid ""
 "**in** or **out** condition."
 msgstr ""
 
-msgid ""
-"The vertices table can be created with :doc:`pgr_createVerticesTable` or "
-":doc:`pgr_createTopology`"
+msgid "The vertices table can be created with :doc:`pgr_createTopology`"
 msgstr ""
 
 msgid "``pgr_articulationPoints``"
@@ -10141,7 +10149,7 @@ msgid ""
 "incremented to the rest of the edges."
 msgstr ""
 
-msgid "``pgr_createVerticesTable``"
+msgid "``pgr_createVerticesTable`` - Deprecated since 3.8.0"
 msgstr ""
 
 msgid ""

--- a/locale/pot/pgrouting_doc_strings.pot
+++ b/locale/pot/pgrouting_doc_strings.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-05 20:44+0000\n"
+"POT-Creation-Date: 2025-04-08 12:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3556,6 +3556,9 @@ msgstr ""
 msgid "`#2753 <https://github.com/pgRouting/pgrouting/issues/2753>`__: pgr_analyzeGraph"
 msgstr ""
 
+msgid "`#2826 <https://github.com/pgRouting/pgrouting/issues/2826>`__: pgr_createVerticesTable"
+msgstr ""
+
 msgid "Official functions changes"
 msgstr ""
 
@@ -3619,13 +3622,22 @@ msgstr ""
 msgid "All deprecated functions will be removed on next major version 4.0.0"
 msgstr ""
 
-msgid "Migration of ``pgr_analyzeOneWay``"
+msgid "Migration of ``pgr_createVerticesTable``"
 msgstr ""
 
 msgid "Starting from `v3.8.0 <https://docs.pgrouting.org/3.8/en/migration.html>`__"
 msgstr ""
 
 msgid "**Before Deprecation:** The following was calculated:"
+msgstr ""
+
+msgid "A table with `<edges>_vertices_pgr` was created."
+msgstr ""
+
+msgid "**After Deprecation:** The user is responsible to create the vertices table, indexes, etc. They may use :doc:`pgr_extractVertices` for that purpose."
+msgstr ""
+
+msgid "Migration of ``pgr_analyzeOneWay``"
 msgstr ""
 
 msgid "Number of potential problems in directionality"
@@ -6907,9 +6919,6 @@ msgstr ""
 msgid "The edge table to be analyzed must contain a source column and a target column filled with id's of the vertices of the segments and the corresponding vertices table <edge_table>_vertices_pgr that stores the vertices information."
 msgstr ""
 
-msgid "Use :doc:`pgr_createVerticesTable` to create the vertices table."
-msgstr ""
-
 msgid "Use :doc:`pgr_createTopology` to create the topology and the vertices table."
 msgstr ""
 
@@ -6985,7 +6994,7 @@ msgstr ""
 msgid "The Vertices Table"
 msgstr ""
 
-msgid "The vertices table can be created with :doc:`pgr_createVerticesTable <pgr_createVerticesTable>` or :doc:`pgr_createTopology <pgr_createTopology>`"
+msgid "The vertices table can be created with :doc:`pgr_createTopology <pgr_createTopology>`"
 msgstr ""
 
 msgid "The structure of the vertices table is:"
@@ -7093,9 +7102,6 @@ msgstr ""
 msgid ":doc:`pgr_analyzeOneWay`"
 msgstr ""
 
-msgid ":doc:`pgr_createVerticesTable`"
-msgstr ""
-
 msgid ":doc:`pgr_nodeNetwork` to create nodes to a not noded edge table."
 msgstr ""
 
@@ -7162,7 +7168,7 @@ msgstr ""
 msgid "``boolean`` flag to treat oneway NULL values as bi-directional. Default value is ``true``."
 msgstr ""
 
-msgid "It is strongly recommended to use the named notation. See :doc:`pgr_createVerticesTable` or :doc:`pgr_createTopology` for examples."
+msgid "It is strongly recommended to use the named notation. See :doc:`pgr_createTopology` for examples."
 msgstr ""
 
 msgid "Fills completely the ``ein`` and ``eout`` columns of the vertices table."
@@ -7174,7 +7180,7 @@ msgstr ""
 msgid "The rules are defined as an array of text strings that if match the ``oneway`` value would be counted as ``true`` for the source or target **in** or **out** condition."
 msgstr ""
 
-msgid "The vertices table can be created with :doc:`pgr_createVerticesTable` or :doc:`pgr_createTopology`"
+msgid "The vertices table can be created with :doc:`pgr_createTopology`"
 msgstr ""
 
 msgid "``pgr_articulationPoints``"
@@ -8695,7 +8701,7 @@ msgstr ""
 msgid "This example start a clean topology, with 5 edges, and then its incremented to the rest of the edges."
 msgstr ""
 
-msgid "``pgr_createVerticesTable``"
+msgid "``pgr_createVerticesTable`` - Deprecated since 3.8.0"
 msgstr ""
 
 msgid "``pgr_createVerticesTable`` — Reconstructs the vertices table based on the source and target information."

--- a/pgtap/topology/analyzeGraph/issue_1311.pg
+++ b/pgtap/topology/analyzeGraph/issue_1311.pg
@@ -29,7 +29,10 @@ SET client_min_messages = WARNING;
 -- The following should be OK
 -- id INTEGER
 SELECT * INTO edges2 FROM edges;
-SELECT pgr_createVerticesTable('edges2','geom');
+SELECT *, 0 AS cnt, 0 AS chk, 0 AS ein, 0 AS eout, geom AS the_geom
+INTO edges2_vertices_pgr
+FROM pgr_extractVertices('SELECT id, geom FROM edges2');
+
 ALTER TABLE edges2 ALTER COLUMN id SET DATA TYPE INTEGER;
 
 SELECT is(pgr_analyzegraph('edges2', 0.000001, 'geom'), 'OK', '1');

--- a/pgtap/topology/analyzeOneWay/edge_cases.pg
+++ b/pgtap/topology/analyzeOneWay/edge_cases.pg
@@ -27,7 +27,10 @@ SELECT plan(2);
 
 DROP TABLE IF EXISTS edge_table;
 SELECT *, NULL::TEXT AS dir INTO edge_table FROM edges;
-SELECT pgr_createVerticesTable('edge_table', 'geom');
+
+SELECT *, 0 AS ein, 0 AS eout
+INTO edge_table_vertices_pgr
+FROM pgr_extractVertices('SELECT id, geom FROM edge_table');
 
 UPDATE edge_table SET
 dir = CASE WHEN (cost>0 AND reverse_cost>0) THEN 'B'   -- both ways

--- a/pgtap/topology/createVerticesTable/checkVertTab.pg
+++ b/pgtap/topology/createVerticesTable/checkVertTab.pg
@@ -1,0 +1,51 @@
+
+/*PGR-GNU*****************************************************************
+
+Copyright (c) 2018  pgRouting developers
+Mail: project@pgrouting.org
+
+------
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ ********************************************************************PGR-GNU*/
+
+BEGIN;
+
+UPDATE edges SET cost = sign(cost), reverse_cost = sign(reverse_cost);
+SELECT plan(12);
+
+
+SET client_min_messages  to WARNING;
+SELECT pgr_createVerticesTable('edges', 'geom');
+
+SELECT has_column( 'edges_vertices_pgr', 'cnt', '1' );
+SELECT has_column( 'edges_vertices_pgr', 'chk', '2' );
+SELECT results_eq( 'SELECT  3, * FROM  _pgr_checkVertTab(''edges_vertices_pgr'', ''{"id","cnt","chk"}''::text[]) ',
+    'SELECT 3, ''public''::TEXT,''edges_vertices_pgr''::TEXT');
+SELECT has_column( 'edges_vertices_pgr', 'cnt', '4' );
+SELECT has_column( 'edges_vertices_pgr', 'chk', '5' );
+
+SELECT hasnt_column( 'edges', 'cnt', '6' );
+SELECT hasnt_column( 'edges', 'chk', '7' );
+SELECT has_column( 'edges', 'id', '8' );
+SELECT results_eq( 'SELECT  9, * FROM  _pgr_checkVertTab(''edges'', ''{"id","cnt","chk"}''::text[]) ',
+    'SELECT 9, ''public''::TEXT,''edges''::TEXT');
+SELECT has_column( 'edges', 'cnt', '10' );
+SELECT has_column( 'edges', 'chk', '11' );
+
+SELECT throws_ok('SELECT  * FROM  _pgr_checkVertTab(''no_table'', ''{"id","cnt","chk"}''::text[])',
+    'P0001', 'raise_exception', '12');
+
+-- Finish the tests and clean up.
+SELECT * FROM finish();
+ROLLBACK;
+

--- a/sql/common/utilities_pgr.sql
+++ b/sql/common/utilities_pgr.sql
@@ -282,7 +282,7 @@ BEGIN
        err = sname is NULL or vname is NULL;
     perform _pgr_onError( err, 2, fnName,
           'Vertex Table: ' || vertname || ' not found',
-          'Please create ' || vertname || ' using  _pgr_createTopology() or pgr_createVerticesTable()',
+          'Please create ' || vertname || ' using  _pgr_createTopology()',
           'Vertex Table: ' || vertname || ' found');
 
 

--- a/sql/topology/createverticestable.sql
+++ b/sql/topology/createverticestable.sql
@@ -95,6 +95,8 @@ DECLARE
 
 BEGIN
   fnName = 'pgr_createVerticesTable';
+
+  RAISE WARNING 'pgr_createverticestable(text,text,text,text,text) deprecated function on v3.8.0';
   RAISE NOTICE 'PROCESSING:';
   RAISE NOTICE 'pgr_createVerticesTable(''%'',''%'',''%'',''%'',''%'')',edge_table,the_geom,source,target,rows_where;
   EXECUTE 'show client_min_messages' INTO debuglevel;
@@ -263,14 +265,4 @@ $BODY$
 
 
 COMMENT ON FUNCTION pgr_createverticestable(TEXT, TEXT, TEXT, TEXT, TEXT)
-IS 'pgr_createVerticesTable
-- Parameters
-  - Edge table name
-- Optional parameters
-  - the_geom := ''the_geom''
-  - source := ''source''
-  - target := ''target''
-  - rows_where := ''true''
-- Documentation:
-  - ${PROJECT_DOC_LINK}/pgr_createVerticesTable.html
-';
+IS 'pgr_createVerticesTable deprecated function on v3.8.0';


### PR DESCRIPTION
Fixes #2826 .

Changes proposed in this pull request:
- Deprecation message into the function
- Migration instructions 
- Removes use of function on pgtap and docqueries

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated release notes and migration guides for version 3.8.0.
  - Removed outdated references and streamlined instructions regarding vertices table creation.
  - Added deprecation notices and updated error messaging.

- **New Features**
  - Introduced enhanced guidance and SQL warnings to support the transition from the legacy automatic vertices creation to a manual process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->