### PR TITLE
Deprecating pgr AlphaShape

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,8 @@ milestone for 3.8.0
 
 **Deprecation of functions.**
 
+* [#2749](https://github.com/pgRouting/pgrouting/issues/2749):
+  pgr_alphaShape
 * [#2754](https://github.com/pgRouting/pgrouting/issues/2754):
   pgr_analyzeOneWay
 * [#2753](https://github.com/pgRouting/pgrouting/issues/2753):

--- a/doc/_static/page_history.js
+++ b/doc/_static/page_history.js
@@ -261,7 +261,7 @@ var filesArr = [
     ]),
     new createInfo('pgr_alphaShape', '2.0', [
         { v: '2.1', n: 'src/driving_distance/doc/dd_alphashape'},
-        { v: '2.3', n: 'src/alpha_shape/doc/pgr_alphaShape'}
+        { v: '2.3', n: 'src/alpha_shape/doc/pgr_alphaShape'}, 3.8
     ]),
 
 ];

--- a/doc/alpha_shape/pgr_alphaShape.rst
+++ b/doc/alpha_shape/pgr_alphaShape.rst
@@ -20,6 +20,10 @@
 
 .. rubric:: Availability
 
+* Version 3.8.0
+
+  * Deprecated function.
+
 * Version 3.0.0
 
   * Breaking change on signature
@@ -39,7 +43,10 @@
   * New official function.
   * Renamed from version 1.x
 
-.. rubric:: Support
+
+.. include:: migration.rst
+   :start-after: migrate_pgr_alphaShape_start
+   :end-before: migrate_pgr_alphaShape_end
 
 Description
 -------------------------------------------------------------------------------

--- a/doc/driving_distance/pgr_drivingDistance.rst
+++ b/doc/driving_distance/pgr_drivingDistance.rst
@@ -177,7 +177,6 @@ Additional Examples
 See Also
 -------------------------------------------------------------------------------
 
-* :doc:`pgr_alphaShape` - Alpha shape computation
 * :doc:`sampledata`
 
 .. rubric:: Indices and tables

--- a/doc/src/migration.rst
+++ b/doc/src/migration.rst
@@ -24,6 +24,36 @@ Results can be different because of the changes.
 .. contents:: Contents
    :depth: 2
 
+.. migrate_pgr_alphaShape_start
+
+Migration of ``pgr_alphaShape``
+-------------------------------------------------------------------------------
+
+Starting from `v3.8.0 <https://docs.pgrouting.org/3.8/en/migration.html>`__
+
+**Before Deprecation:** The following was calculated:
+
+* An alphaShape was calculated
+
+**After Deprecation:**
+
+PostGIS has two ways of generating alphaShape.
+
+If you have SFCGAL, which you can install using
+
+::
+
+  CREATE EXTENSION postgis_sfcgal
+
+* Since PostGIS 3.5+ use `CG_AlphaShape <https://postgis.net/docs/CG_AlphaShape.html>`__
+* For PostGIS 3.5+ use the old name ``ST_AlphaShape``
+
+Other PostGIS options are
+* `ST_ConvexHull <https://postgis.net/docs/ST_ConvexHull.html>`__
+* `ST_ConcaveHull <https://postgis.net/docs/ST_ConcaveHull.html>`__
+
+.. migrate_pgr_alphaShape_end
+
 .. migrate_pgr_createTopology_start
 
 Migration of ``pgr_createTopology``

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -68,6 +68,8 @@ milestone for 3.8.0
 
 .. rubric:: Deprecation of functions.
 
+* `#2749 <https://github.com/pgRouting/pgrouting/issues/2749>`__:
+  pgr_alphaShape
 * `#2754 <https://github.com/pgRouting/pgrouting/issues/2754>`__:
   pgr_analyzeOneWay
 * `#2753 <https://github.com/pgRouting/pgrouting/issues/2753>`__:

--- a/doc/withPoints/pgr_withPointsDD.rst
+++ b/doc/withPoints/pgr_withPointsDD.rst
@@ -267,7 +267,6 @@ See Also
 -------------------------------------------------------------------------------
 
 * :doc:`pgr_drivingDistance`
-* :doc:`pgr_alphaShape`
 * :doc:`sampledata`
 
 .. rubric:: Indices and tables

--- a/docqueries/alpha_shape/alphashape.result
+++ b/docqueries/alpha_shape/alphashape.result
@@ -5,6 +5,7 @@ SET
 /* -- q1 */
 SELECT ST_Area(pgr_alphaShape((SELECT ST_Collect(geom)
       FROM vertices), 1.5));
+WARNING:  pgr_alphashape(geometry,double precision) deprecated function on v3.8.0
  st_area
 ---------
     9.75

--- a/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-08 17:43+0000\n"
+"POT-Creation-Date: 2025-04-08 19:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3960,6 +3960,11 @@ msgid "Deprecation of functions."
 msgstr ""
 
 msgid ""
+"`#2749 <https://github.com/pgRouting/pgrouting/issues/2749>`__: "
+"pgr_alphaShape"
+msgstr ""
+
+msgid ""
 "`#2754 <https://github.com/pgRouting/pgrouting/issues/2754>`__: "
 "pgr_analyzeOneWay"
 msgstr ""
@@ -4057,7 +4062,7 @@ msgstr ""
 msgid "All deprecated functions will be removed on next major version 4.0.0"
 msgstr ""
 
-msgid "Migration of ``pgr_createTopology``"
+msgid "Migration of ``pgr_alphaShape``"
 msgstr ""
 
 msgid ""
@@ -4066,6 +4071,35 @@ msgid ""
 msgstr ""
 
 msgid "**Before Deprecation:** The following was calculated:"
+msgstr ""
+
+msgid "An alphaShape was calculated"
+msgstr ""
+
+msgid "**After Deprecation:**"
+msgstr ""
+
+msgid "PostGIS has two ways of generating alphaShape."
+msgstr ""
+
+msgid "If you have SFCGAL, which you can install using"
+msgstr ""
+
+msgid ""
+"Since PostGIS 3.5+ use `CG_AlphaShape "
+"<https://postgis.net/docs/CG_AlphaShape.html>`__"
+msgstr ""
+
+msgid "For PostGIS 3.5+ use the old name ``ST_AlphaShape``"
+msgstr ""
+
+msgid ""
+"Other PostGIS options are * `ST_ConvexHull "
+"<https://postgis.net/docs/ST_ConvexHull.html>`__ * `ST_ConcaveHull "
+"<https://postgis.net/docs/ST_ConcaveHull.html>`__"
+msgstr ""
+
+msgid "Migration of ``pgr_createTopology``"
 msgstr ""
 
 msgid "A table with `<edges>_vertices_pgr` was created."
@@ -7828,6 +7862,12 @@ msgstr ""
 msgid "``pgr_alphaShape`` — Polygon part of an alpha shape."
 msgstr ""
 
+msgid "Version 3.8.0"
+msgstr ""
+
+msgid "Deprecated function."
+msgstr ""
+
 msgid "Breaking change on signature"
 msgstr ""
 
@@ -7847,9 +7887,6 @@ msgid "Support to return multiple outer/inner ring"
 msgstr ""
 
 msgid "Renamed from version 1.x"
-msgstr ""
-
-msgid "Support"
 msgstr ""
 
 msgid "Returns the polygon part of an alpha shape."
@@ -7926,12 +7963,6 @@ msgid "``pgr_analyzeGraph`` -- Deprecated since 3.8.0"
 msgstr ""
 
 msgid "``pgr_analyzeGraph`` — Analyzes the network topology."
-msgstr ""
-
-msgid "Version 3.8.0"
-msgstr ""
-
-msgid "Deprecated function."
 msgstr ""
 
 msgid "The function returns:"
@@ -15123,9 +15154,6 @@ msgid ""
 "driving side, with details."
 msgstr ""
 
-msgid ":doc:`pgr_alphaShape`"
-msgstr ""
-
 msgid "``pgr_withPointsKSP`` - Proposed"
 msgstr ""
 
@@ -15483,6 +15511,9 @@ msgid ""
 "To see all issues & pull requests closed by this release see the `Git "
 "closed milestone for 3.7.0 "
 "<https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.0%22>`__"
+msgstr ""
+
+msgid "Support"
 msgstr ""
 
 msgid ""

--- a/locale/pot/pgrouting_doc_strings.pot
+++ b/locale/pot/pgrouting_doc_strings.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-08 17:43+0000\n"
+"POT-Creation-Date: 2025-04-08 19:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3550,6 +3550,9 @@ msgstr ""
 msgid "Deprecation of functions."
 msgstr ""
 
+msgid "`#2749 <https://github.com/pgRouting/pgrouting/issues/2749>`__: pgr_alphaShape"
+msgstr ""
+
 msgid "`#2754 <https://github.com/pgRouting/pgrouting/issues/2754>`__: pgr_analyzeOneWay"
 msgstr ""
 
@@ -3625,13 +3628,37 @@ msgstr ""
 msgid "All deprecated functions will be removed on next major version 4.0.0"
 msgstr ""
 
-msgid "Migration of ``pgr_createTopology``"
+msgid "Migration of ``pgr_alphaShape``"
 msgstr ""
 
 msgid "Starting from `v3.8.0 <https://docs.pgrouting.org/3.8/en/migration.html>`__"
 msgstr ""
 
 msgid "**Before Deprecation:** The following was calculated:"
+msgstr ""
+
+msgid "An alphaShape was calculated"
+msgstr ""
+
+msgid "**After Deprecation:**"
+msgstr ""
+
+msgid "PostGIS has two ways of generating alphaShape."
+msgstr ""
+
+msgid "If you have SFCGAL, which you can install using"
+msgstr ""
+
+msgid "Since PostGIS 3.5+ use `CG_AlphaShape <https://postgis.net/docs/CG_AlphaShape.html>`__"
+msgstr ""
+
+msgid "For PostGIS 3.5+ use the old name ``ST_AlphaShape``"
+msgstr ""
+
+msgid "Other PostGIS options are * `ST_ConvexHull <https://postgis.net/docs/ST_ConvexHull.html>`__ * `ST_ConcaveHull <https://postgis.net/docs/ST_ConcaveHull.html>`__"
+msgstr ""
+
+msgid "Migration of ``pgr_createTopology``"
 msgstr ""
 
 msgid "A table with `<edges>_vertices_pgr` was created."
@@ -6799,6 +6826,12 @@ msgstr ""
 msgid "``pgr_alphaShape`` — Polygon part of an alpha shape."
 msgstr ""
 
+msgid "Version 3.8.0"
+msgstr ""
+
+msgid "Deprecated function."
+msgstr ""
+
 msgid "Breaking change on signature"
 msgstr ""
 
@@ -6818,9 +6851,6 @@ msgid "Support to return multiple outer/inner ring"
 msgstr ""
 
 msgid "Renamed from version 1.x"
-msgstr ""
-
-msgid "Support"
 msgstr ""
 
 msgid "Returns the polygon part of an alpha shape."
@@ -6893,12 +6923,6 @@ msgid "``pgr_analyzeGraph`` -- Deprecated since 3.8.0"
 msgstr ""
 
 msgid "``pgr_analyzeGraph`` — Analyzes the network topology."
-msgstr ""
-
-msgid "Version 3.8.0"
-msgstr ""
-
-msgid "Deprecated function."
 msgstr ""
 
 msgid "The function returns:"
@@ -12769,9 +12793,6 @@ msgstr ""
 msgid "From point :math:`1` within a distance of :math:`3.3`, does not matter driving side, with details."
 msgstr ""
 
-msgid ":doc:`pgr_alphaShape`"
-msgstr ""
-
 msgid "``pgr_withPointsKSP`` - Proposed"
 msgstr ""
 
@@ -13031,6 +13052,9 @@ msgid "pgRouting 3.7.0 Release Notes"
 msgstr ""
 
 msgid "To see all issues & pull requests closed by this release see the `Git closed milestone for 3.7.0 <https://github.com/pgRouting/pgrouting/issues?utf8=%E2%9C%93&q=milestone%3A%22Release%203.7.0%22>`__"
+msgstr ""
+
+msgid "Support"
 msgstr ""
 
 msgid "`#2656 <https://github.com/pgRouting/pgrouting/pull/2656>`__ Stop support of PostgreSQL12 on pgrouting v3.7"

--- a/sql/alpha_shape/alphaShape.sql
+++ b/sql/alpha_shape/alphaShape.sql
@@ -40,6 +40,7 @@ geom      geometry;
 delauny_query   TEXT;
 
 BEGIN
+    RAISE WARNING 'pgr_alphashape(geometry,double precision) deprecated function on v3.8.0';
     delauny_query = format($$
         WITH
         original AS (
@@ -83,11 +84,4 @@ LANGUAGE plpgsql VOLATILE STRICT
 COST 100;
 
 COMMENT ON FUNCTION pgr_alphashape(geometry, FLOAT)
-IS 'pgr_alphaShape
-- Parameters
-	- An SQL with columns: geom
-- Optional Parameters
-	- alpha := 0
-- Documentation:
-    - ${PROJECT_DOC_LINK}/pgr_alphaShape.html
-';
+IS 'pgr_alphaShape deprecated function on v3.8.0';


### PR DESCRIPTION
Fixes #2749  .

Changes proposed in this pull request:
- Deprecation message
- Remove use on doc, docqueries, pgtap
- (doc) documenting changes on NEWS and release notes

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated user-facing deprecation notices in release notes and guides to highlight that the alpha shape functionality is deprecated as of version 3.8.
  - Added migration guidance with alternatives for generating alpha shapes.
  - Removed obsolete references linking to the deprecated feature.

- **Chores**
  - Introduced warning messages in query results and SQL outputs to clearly indicate the deprecation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->