### PR TITLE
Remove developer name from script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ notUsed
 *.swp
 
 .vscode
+taptest.sh

--- a/tools/developer/run.sh
+++ b/tools/developer/run.sh
@@ -58,6 +58,9 @@ function set_cmake {
     # with developers documentation
     #cmake  -DWITH_DOC=ON -DBUILD_DOXY=ON ..
 
+    # using a particular PostgreSQL configuration
+    #cmake -DPOSTGRESQL_PG_CONFIG="/usr/lib/postgresql/${PGVERSION}/bin/pg_config" ..
+
     # Building using clang
     #CXX=clang++ CC=clang cmake -DPOSTGRESQL_BIN=${PGBIN} -DCMAKE_BUILD_TYPE=Debug  -DDOC_USE_BOOTSTRAP=ON -DWITH_DOC=ON -DBUILD_DOXY=OFF ..
 
@@ -82,7 +85,7 @@ function tap_test {
     dropdb --if-exists -p $PGPORT ___pgr___test___
     createdb  -p $PGPORT ___pgr___test___
     echo $PGPORT
-    tools/testers/pg_prove_tests.sh vicky $PGPORT
+    tools/testers/pg_prove_tests.sh "$PGUSER" $PGPORT
     dropdb  -p $PGPORT ___pgr___test___
 }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- modify `.gitignore` to ignore taptest.sh located at the root of the repo;
- remove reference to the `vicky` user in the `run.sh` script;
- add an example to connect to a different version of PG than the last one.

@pgRouting/admins
