### PR TITLE
Issue 2802: code reorganization on `pgr_contraction`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -124,6 +124,10 @@ milestone for 4.0.0
     * New name and order of optional parameters.
   * Deprecated signature pgr_contraction(text,bigint[],integer,bigint[],boolean)
 
+**C/C++ code enhancement**
+
+* Code factorization on pgr_contraction family
+
 **New proposed functions**
 
 * Contraction

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -163,6 +163,10 @@ pgRouting 3.8.0 Release Notes
      :start-after: Version 3.8.0
      :end-before: .. rubric
 
+.. rubric:: C/C++ code enhancement
+
+* Code factorization on pgr_contraction family
+
 .. rubric:: New proposed functions
 
 * Contraction

--- a/include/contraction/contract.hpp
+++ b/include/contraction/contract.hpp
@@ -106,7 +106,7 @@ class Pgr_contract {
     void perform_deadEnd(G &graph,
             Identifiers<V> forbidden_vertices) {
         Pgr_deadend<G> deadendContractor;
-        deadendContractor.setForbiddenVertices(forbidden_vertices);
+        graph.set_forbidden_vertices(forbidden_vertices);
 
         deadendContractor.calculateVertices(graph);
         try {

--- a/include/contraction/contractionGraph.hpp
+++ b/include/contraction/contractionGraph.hpp
@@ -36,7 +36,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <vector>
 #include <iostream>
 #include <tuple>
-#include <cstdint>
 
 #include <boost/graph/iteration_macros.hpp>
 
@@ -44,113 +43,123 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "cpp_common/ch_vertex.hpp"
 #include "cpp_common/ch_edge.hpp"
 
-
 namespace pgrouting {
 namespace graph {
 
 template <class G, bool t_directed>
-class Pgr_contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed> {
+class Pgr_contractionGraph :
+    public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed> {
  public:
-     typedef typename boost::graph_traits < G >::vertex_descriptor V;
-     typedef typename boost::graph_traits < G >::edge_descriptor E;
-     typedef typename boost::graph_traits < G >::out_edge_iterator EO_i;
-     typedef typename boost::graph_traits < G >::in_edge_iterator EI_i;
+    using V = typename boost::graph_traits<G>::vertex_descriptor;
+    using E = typename boost::graph_traits<G>::edge_descriptor;
+    using EO_i = typename boost::graph_traits<G>::out_edge_iterator;
+    using EI_i = typename boost::graph_traits<G>::in_edge_iterator;
 
      /*!
        Prepares the _graph_ to be of type *directed*
        */
-     explicit Pgr_contractionGraph()
-         : Pgr_base_graph<G, CH_vertex, CH_edge, t_directed>() {
-         }
+     explicit Pgr_contractionGraph<G, t_directed>()
+            : Pgr_base_graph<G, CH_vertex, CH_edge, t_directed>() {
+        min_edge_id = 0;
+    }
 
-     /*! @brief get the vertex descriptors of adjacent vertices of *v*
-       @param [in] v vertex_descriptor
-       @return Identifiers<V>: The set of vertex descriptors adjacent to the given vertex *v*
-       */
-     Identifiers<V> find_adjacent_vertices(V v) const {
-         EO_i out, out_end;
-         EI_i in, in_end;
-         Identifiers<V> adjacent_vertices;
+    /*!
+        @brief get the vertex descriptors of adjacent vertices of *v*
+        @param [in] v vertex_descriptor
+        @return Identifiers<V>: The set of vertex descriptors adjacent to the given vertex *v*
+    */
+    Identifiers<V> find_adjacent_vertices(V v) const {
+        Identifiers<V> adjacent_vertices;
 
-         for (boost::tie(out, out_end) = out_edges(v, this->graph);
-                 out != out_end; ++out) {
-             adjacent_vertices += this->adjacent(v, *out);
-         }
-         for (boost::tie(in, in_end) = in_edges(v, this->graph);
-                 in != in_end; ++in) {
-             adjacent_vertices += this->adjacent(v, *in);
-         }
-         return adjacent_vertices;
-     }
+        for (const auto &e : boost::make_iterator_range(
+                out_edges(v, this->graph)))
+            adjacent_vertices += this->adjacent(v, e);
+
+        for (const auto &e : boost::make_iterator_range(
+                in_edges(v, this->graph)))
+            adjacent_vertices += this->adjacent(v, e);
+
+        return adjacent_vertices;
+    }
 
 
-     /*! @brief get the edge with minimum cost between two vertices
-       @param [in] u vertex_descriptor of source vertex
-       @param [in] v vertex_descriptor of target vertex
-       @return E: The edge descriptor of the edge with minimum cost
-       */
-     std::tuple<double, Identifiers<int64_t>, bool>
-     get_min_cost_edge(V u, V v) {
-         E min_edge;
-         Identifiers<int64_t> contracted_vertices;
-         double min_cost = (std::numeric_limits<double>::max)();
-         bool found = false;
+    /*! @brief get the edge with minimum cost between two vertices
+        @param [in] u vertex_descriptor of source vertex
+        @param [in] v vertex_descriptor of target vertex
+        @return E: The edge descriptor of the edge with minimum cost
+    */
+    std::tuple<CH_edge, bool> get_min_cost_edge(V u, V v) {
+        Identifiers<int64_t> contracted_vertices;
+        double min_cost = (std::numeric_limits<double>::max)();
+        bool found = false;
+        CH_edge edge;
 
-         if (this->is_directed()) {
-             BGL_FORALL_OUTEDGES_T(u, e, this->graph, G) {
-                 if (this->target(e) == v) {
-                     contracted_vertices += this->graph[e].contracted_vertices();
-                     if (this->graph[e].cost < min_cost) {
-                         min_cost = this->graph[e].cost;
-                         min_edge = e;
-                         found = true;
-                     }
-                 }
-             }
-             return std::make_tuple(min_cost, contracted_vertices, found);
-         }
+        if (this->is_directed()) {
+            for (const auto &e : boost::make_iterator_range(
+                    out_edges(u, this->graph))) {
+                if (target(e, this->graph) == v) {
+                    contracted_vertices +=
+                        (this->graph[e]).contracted_vertices();
+                    if ((this->graph[e]).cost < min_cost) {
+                        min_cost = (this->graph[e]).cost;
+                        found = true;
+                        edge = this->graph[e];
+                    }
+                }
+            }
+            // To follow the principles presented
+            // for linear contraction in "issue_1002.pg" test 3
+            edge.set_contracted_vertices(contracted_vertices);
 
-         pgassert(this->is_undirected());
-         BGL_FORALL_OUTEDGES_T(u, e, this->graph, G) {
-             if (this->adjacent(u, e) == v) {
-                 contracted_vertices += this->graph[e].contracted_vertices();
-                 if (this->graph[e].cost < min_cost) {
-                     min_cost = this->graph[e].cost;
-                     min_edge = e;
-                     found = true;
-                 }
-             }
-         }
-         return std::make_tuple(min_cost, contracted_vertices, found);
-     }
+            return std::make_tuple(edge, found);
+        }
 
+        pgassert(this->is_undirected());
+        for (const auto &e : boost::make_iterator_range(
+                out_edges(u, this->graph))) {
+            if (this->adjacent(u, e) == v) {
+                contracted_vertices +=
+                    (this->graph[e]).contracted_vertices();
+                if ((this->graph[e]).cost < min_cost) {
+                    min_cost = (this->graph[e]).cost;
+                    found = true;
+                    edge = this->graph[e];
+                }
+            }
+        }
+        // To follow the principles presented
+        // for linear contraction in "issue_1002.pg" test 3
+        edge.set_contracted_vertices(contracted_vertices);
+
+        return std::make_tuple(edge, found);
+    }
 
      /*! @brief print the graph with contracted vertices of
        all vertices and edges
        */
-     friend
-     std::ostream& operator <<(
-             std::ostream &os,
-             const Pgr_contractionGraph &g) {
-         EO_i out, out_end;
-         for (auto vi = vertices(g.graph).first;
-                 vi != vertices(g.graph).second;
-                 ++vi) {
-             if ((*vi) >= g.num_vertices()) break;
-             os << g.graph[*vi].id << "(" << (*vi) << ")"
-                 << g.graph[*vi].contracted_vertices() << std::endl;
-             os << " out_edges_of(" << g.graph[*vi].id << "):";
-             for (boost::tie(out, out_end) = out_edges(*vi, g.graph);
-                     out != out_end; ++out) {
-                 os << ' ' << g.graph[*out].id
-                     << "=(" << g.graph[g.source(*out)].id
-                     << ", " << g.graph[g.target(*out)].id << ") = "
-                     <<  g.graph[*out].cost <<"\t";
-             }
-             os << std::endl;
-         }
-         return os;
-     }
+      friend
+      std::ostream& operator <<(
+              std::ostream &os,
+              const Pgr_contractionGraph &g) {
+          EO_i out, out_end;
+          for (auto vi = vertices(g.graph).first;
+                  vi != vertices(g.graph).second;
+                  ++vi) {
+              if ((*vi) >= g.num_vertices()) break;
+              os << g.graph[*vi].id << "(" << (*vi) << ")"
+                  << g.graph[*vi].contracted_vertices() << std::endl;
+              os << " out_edges_of(" << g.graph[*vi].id << "):";
+              for (boost::tie(out, out_end) = out_edges(*vi, g.graph);
+                      out != out_end; ++out) {
+                  os << ' ' << g.graph[*out].id
+                      << "=(" << g.graph[g.source(*out)].id
+                      << ", " << g.graph[g.target(*out)].id << ") = "
+                      <<  g.graph[*out].cost <<"\t";
+              }
+              os << std::endl;
+          }
+          return os;
+      }
 
 
      /*! @brief add_shortuct to the graph during contraction
@@ -166,20 +175,18 @@ class Pgr_contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_dire
        edge (u, v) is a new edge e
        contracted_vertices = w + contracted vertices
        */
+      bool add_shortcut(const CH_edge &edge, V u, V v) {
+        bool inserted;
+        E e;
+        if (edge.cost < 0) return false;
 
-     void add_shortcut(const CH_edge &edge, V u, V v) {
-         bool inserted;
-         E e;
-         if (edge.cost < 0) return;
-
-         boost::tie(e, inserted) = boost::add_edge(u, v, this->graph);
-
-         this->graph[e]= edge;
-     }
-
+        boost::tie(e, inserted) = boost::add_edge(u, v, this->graph);
+        this->graph[e]= edge;
+        return inserted;
+    }
 
      bool has_u_v_w(V u, V v, V w) const {
-         return boost::edge(u, v, this->graph).second &&  boost::edge(v, w, this->graph).second;
+         return boost::edge(u, v, this->graph).second && boost::edge(v, w, this->graph).second;
      }
 
      /**
@@ -205,56 +212,186 @@ class Pgr_contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_dire
       }
       @enddot
       */
-     bool is_shortcut_possible(
-             V u,
-             V v,
-             V w) {
-         if (u == v || v == w || u == w) return false;
-         pgassert(u != v);
-         pgassert(v != w);
-         pgassert(u != w);
-         if (this->is_undirected()) {
-             /*
-              * u - v - w
-              */
-             return has_u_v_w(u, v, w);
-         }
+    bool is_shortcut_possible(
+        V u,
+        V v,
+        V w) {
+        if (u == v || v == w || u == w) return false;
+        pgassert(u != v);
+        pgassert(v != w);
+        pgassert(u != w);
+        if (this->is_undirected()) {
+            /*
+            * u - v - w
+            */
+            return has_u_v_w(u, v, w);
+        }
 
-         pgassert(this->is_directed());
-         return
-             /*
-              * u <-> v <-> w
-              */
-             (has_u_v_w(u, v, w) && has_u_v_w(w, v, u))
-             /*
-              * u -> v -> w
-              */
-             ||
-             (has_u_v_w(u, v, w) && !(boost::edge(v, u, this->graph).second || boost::edge(w, v, this->graph).second))
-             /*
-              * u <- v <- w
-              */
-             ||
-             (has_u_v_w(w, v, u) && !(boost::edge(v, w, this->graph).second || boost::edge(u, v, this->graph).second));
-     }
+        pgassert(this->is_directed());
+        return
+            /*
+            * u <-> v <-> w
+            */
+            (has_u_v_w(u, v, w) && has_u_v_w(w, v, u))
+            /*
+            * u -> v -> w
+            */
+            ||
+            (has_u_v_w(u, v, w) && !(boost::edge(v, u, this->graph).second
+            || boost::edge(w, v, this->graph).second))
+            /*
+            * u <- v <- w
+            */
+            ||
+            (has_u_v_w(w, v, u) && !(boost::edge(v, w, this->graph).second
+            || boost::edge(u, v, this->graph).second));
+    }
 
-     bool is_linear(V v) {
-         // Checking adjacent vertices constraint
-         auto adjacent_vertices = find_adjacent_vertices(v);
+    bool is_linear(V v) {
+        // Checking adjacent vertices constraint
+        auto adjacent_vertices = find_adjacent_vertices(v);
 
-         if (adjacent_vertices.size() == 2) {
-             // Checking u - v - w
-             V u = adjacent_vertices.front();
-             adjacent_vertices.pop_front();
-             V w = adjacent_vertices.front();
-             adjacent_vertices.pop_front();
-             if (is_shortcut_possible(u, v, w)) {
-                 return true;
-             }
-             return false;
-         }
-         return false;
-     }
+        if (adjacent_vertices.size() == 2) {
+            // Checking u - v - w
+            V u = adjacent_vertices.front();
+            adjacent_vertices.pop_front();
+            V w = adjacent_vertices.front();
+            adjacent_vertices.pop_front();
+            if (is_shortcut_possible(u, v, w)) {
+                return true;
+            }
+            return false;
+        }
+        return false;
+    }
+
+    /*!
+        @brief Accessor to the next negative vertex id (to be created)
+        @return int64_t: id of the next vertex to be created
+    */
+    int64_t get_next_id() {
+        return --min_edge_id;
+    }
+
+    /*!
+        @brief Accessor to the vertices on which contraction is forbidden
+        @param [in] Identifiers<V>: The set of forbidden vertex descriptors
+    */
+    void set_forbidden_vertices(
+            Identifiers<V> m_forbidden_vertices) {
+        forbiddenVertices = m_forbidden_vertices;
+    }
+
+    /*!
+        @brief Checks if a vertex is forbidden to the contraction process
+        @param [in] v vertex to test
+        @return true if the vertex is forbiddent to the contraction process, false else
+    */
+    bool is_forbidden(V v) {
+        if (forbiddenVertices.has(v)) {
+            return true;
+        }
+        return false;
+    }
+
+    /*!
+        @brief Accessor of the vertices on which contraction is forbidden
+        @return Identifiers<V>: The set of forbidden vertex descriptors
+    */
+    bool is_dead_end(V v) {
+        if (this->is_undirected()) {
+            return this->find_adjacent_vertices(v).size() == 1;
+        }
+
+        pgassert(this->is_directed());
+
+        return this->find_adjacent_vertices(v).size() == 1
+            || (this->in_degree(v) > 0 && this->out_degree(v) == 0);
+    }
+
+    /*! @brief vertices with at least one contracted vertex
+        @result The vids Identifiers with at least one contracted vertex
+    */
+    std::vector<E> get_shortcuts() {
+        std::vector<E> eids;
+        for (const auto &e : boost::make_iterator_range(edges(this->graph))) {
+            if (this->graph[e].id < 0) {
+                eids.push_back(e);
+                pgassert(!(this->graph[e]).contracted_vertices().empty());
+            } else {
+                pgassert((this->graph[e]).contracted_vertices().empty());
+            }
+        }
+        std::sort(
+            eids.begin(),
+            eids.end(),
+            [&](E lhs, E rhs) {
+                return
+                    -1*((this->graph)[lhs]).id < -1*((this->graph)[rhs]).id;
+                });
+        return eids;
+    }
+
+    /*! @brief vertices with at least one contracted vertex
+        @result The vids Identifiers with at least one contracted vertex
+    */
+    Identifiers<int64_t> get_modified_vertices() {
+        Identifiers<int64_t> vids;
+        for (const auto &v :
+                boost::make_iterator_range(boost::vertices(this->graph))) {
+            if ((this->graph[v].vertex_order > 0)
+            || ((this->graph[v]).has_contracted_vertices())) {
+                vids += (this->graph[v]).id;
+            }
+        }
+        return vids;
+    }
+
+    /**
+     @brief builds the shortcut information and adds it during contraction
+     or afterwards to copy them to the source graph
+     @param [in] u origin node of the shortcut
+     @param [in] v shortcuted node
+     @param [in] w destination node of the shortcut
+     @return CH_edge: object containing the shortcut edge
+     *
+     * u ----e1{v1}----> v ----e2{v2}----> w
+     *
+     * e1: min cost edge from u to v
+     * e2: min cost edge from v to w
+     *
+     *
+     * result:
+     * u ---{v+v1+v2}---> w
+     *
+     */
+    CH_edge process_shortcut(V u, V v, V w) {
+        auto e1 = get_min_cost_edge(u, v);
+        auto e2 = get_min_cost_edge(v, w);
+
+        double cost = std::numeric_limits<double>::max();
+        if (std::get<1>(e1) && std::get<1>(e2))
+            cost = std::get<0>(e1).cost + std::get<0>(e2).cost;
+
+        // Create shortcut
+        CH_edge shortcut(
+            get_next_id(),
+            (this->graph[u]).id,
+            (this->graph[w]).id,
+            cost);
+        shortcut.add_contracted_vertex(this->graph[v]);
+        shortcut.add_contracted_edge_vertices(std::get<0>(e1));
+        shortcut.add_contracted_edge_vertices(std::get<0>(e2));
+
+        // Add shortcut in the current graph (to go on the process)
+        add_shortcut(shortcut, u, w);
+
+        return shortcut;
+    }
+
+ private:
+    int64_t min_edge_id;
+    Identifiers<V> forbiddenVertices;
 };
 
 }  // namespace graph

--- a/include/contraction/deadEndContraction.hpp
+++ b/include/contraction/deadEndContraction.hpp
@@ -31,7 +31,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #define INCLUDE_CONTRACTION_DEADENDCONTRACTION_HPP_
 #pragma once
 
-
 #include <queue>
 #include <functional>
 #include <vector>
@@ -53,29 +52,12 @@ class Pgr_deadend {
  public:
     Pgr_deadend() = default;
 
-    void setForbiddenVertices(
-            Identifiers<V> forbidden_vertices) {
-        forbiddenVertices = forbidden_vertices;
-    }
-
-
     void calculateVertices(G &graph) {
         for (const auto v : boost::make_iterator_range(vertices(graph.graph))) {
-            if (is_dead_end(graph, v) && !forbiddenVertices.has(v)) {
+            if (graph.is_dead_end(v) && !graph.is_forbidden(v)) {
                 deadendVertices += v;
             }
         }
-    }
-
-    bool is_dead_end(G &graph, V v) {
-        if (graph.is_undirected()) {
-            return graph.find_adjacent_vertices(v).size() == 1;
-        }
-
-        pgassert(graph.is_directed());
-
-        return graph.find_adjacent_vertices(v).size() == 1
-            || (graph.in_degree(v) > 0 && graph.out_degree(v) == 0);
     }
 
     void doContraction(G &graph) {
@@ -84,7 +66,7 @@ class Pgr_deadend {
         while (!deadendVertices.empty()) {
             V v = deadendVertices.front();
             deadendVertices -= v;
-            pgassert(is_dead_end(graph, v));
+            pgassert(graph.is_dead_end(v));
 
             Identifiers<V> local;
             for (auto u : graph.find_adjacent_vertices(v)) {
@@ -93,10 +75,10 @@ class Pgr_deadend {
                  *
                  * u{v1 + v + v2 + v3}     v{}
                  */
-                auto v2(graph.get_min_cost_edge(u, v));
-                graph[u].contracted_vertices() += std::get<1>(v2);
-                graph[u].contracted_vertices() += graph[v].id;
-                graph[u].contracted_vertices() += graph[v].contracted_vertices();
+                const auto& e = graph.get_min_cost_edge(u, v);
+                graph[u].contracted_vertices() +=
+                    std::get<0>(e).contracted_vertices();
+                graph[u].add_contracted_vertex(graph[v]);
 
                 deadendVertices -= v;
                 local += u;
@@ -105,11 +87,13 @@ class Pgr_deadend {
             graph[v].contracted_vertices().clear();
             boost::clear_vertex(v, graph.graph);
 
-            /* abort in case of an interruption occurs (e.g. the query is being cancelled) */
+            /* abort in case of an interruption occurs
+            (e.g. the query is being cancelled) */
             CHECK_FOR_INTERRUPTS();
 
             for (const auto u : local) {
-                if (is_dead_end(graph, u) && !forbiddenVertices.has(u)) {
+                if (graph.is_dead_end(u)
+                    && !graph.is_forbidden(u)) {
                     deadendVertices += u;
                 } else {
                     deadendVertices -= u;
@@ -120,7 +104,6 @@ class Pgr_deadend {
 
  private:
     Identifiers<V> deadendVertices;
-    Identifiers<V> forbiddenVertices;
 };
 
 }  // namespace contraction

--- a/include/cpp_common/ch_edge.hpp
+++ b/include/cpp_common/ch_edge.hpp
@@ -47,10 +47,13 @@ class CH_edge {
          id(eid), source(source),
          target(target), cost(cost) {}
 
+     void set_contracted_vertices(Identifiers<int64_t>&);
+
      void cp_members(const CH_edge &other);
 
      void add_contracted_vertex(CH_vertex& v);
      void add_contracted_edge_vertices(CH_edge& e);
+     void add_contracted_vertices(Identifiers<int64_t>&);
 
      bool has_contracted_vertices() const;
 

--- a/include/cpp_common/ch_vertex.hpp
+++ b/include/cpp_common/ch_vertex.hpp
@@ -42,21 +42,26 @@ namespace pgrouting {
 class CH_vertex {
  public:
     int64_t id;
-    CH_vertex() = default;
-    CH_vertex(const CH_vertex &) = default;
+    int64_t vertex_order;
+    int64_t metric;
+    CH_vertex();
     CH_vertex(const Edge_t &other, bool is_source) :
       id(is_source? other.source : other.target)
       {}
+    void set_contracted_vertices(Identifiers<int64_t>&);
     void cp_members(const CH_vertex &other) {
         this->id = other.id;
     }
     void add_contracted_vertex(CH_vertex& v);
+    void add_contracted_vertex_id(int64_t vid);
+    void add_contracted_vertices_id(const Identifiers<int64_t>&);
     void add_vertex_id(int64_t vid) {m_contracted_vertices += vid;}
     const Identifiers<int64_t>& contracted_vertices() const;
     Identifiers<int64_t>& contracted_vertices();
     bool has_contracted_vertices() const;
     void clear_contracted_vertices() {m_contracted_vertices.clear();}
-    friend std::ostream& operator <<(std::ostream& os, const CH_vertex& v);
+    friend std::ostream& operator << (std::ostream& os, const CH_vertex& v);
+
  private:
     Identifiers<int64_t> m_contracted_vertices;
 };

--- a/src/common/ch_edge.cpp
+++ b/src/common/ch_edge.cpp
@@ -31,6 +31,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 namespace pgrouting {
 
+void CH_edge::set_contracted_vertices(
+    Identifiers<int64_t>& contracted_vertices_ids) {
+    m_contracted_vertices = contracted_vertices_ids;
+}
+
 void
 CH_edge::cp_members(const CH_edge &other) {
     this->cost = other.cost;
@@ -39,7 +44,6 @@ CH_edge::cp_members(const CH_edge &other) {
     this->target = other.target;
     this->m_contracted_vertices += other.contracted_vertices();
 }
-
 
 bool
 CH_edge::has_contracted_vertices() const {
@@ -56,7 +60,6 @@ CH_edge::contracted_vertices() {
     return m_contracted_vertices;
 }
 
-
 void
 CH_edge::add_contracted_vertex(CH_vertex& v) {
     m_contracted_vertices += v.id;
@@ -67,6 +70,10 @@ void
 CH_edge::add_contracted_edge_vertices(CH_edge &e) {
     if (e.has_contracted_vertices())
         m_contracted_vertices += e.contracted_vertices();
+}
+
+void CH_edge::add_contracted_vertices(Identifiers<int64_t>& ids) {
+    m_contracted_vertices += ids;
 }
 
 std::ostream& operator <<(std::ostream& os, const CH_edge& e) {

--- a/src/common/ch_vertex.cpp
+++ b/src/common/ch_vertex.cpp
@@ -34,6 +34,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 namespace pgrouting {
 
+CH_vertex::CH_vertex() {
+    vertex_order = -1;
+    metric = -1;
+}
+
+void CH_vertex::set_contracted_vertices(
+    Identifiers<int64_t>& contracted_vertices_ids) {
+    m_contracted_vertices = contracted_vertices_ids;
+}
 
 const Identifiers<int64_t>&
     CH_vertex::contracted_vertices() const {
@@ -45,7 +54,6 @@ Identifiers<int64_t>&
     return m_contracted_vertices;
 }
 
-
 bool CH_vertex::has_contracted_vertices() const {
     if (m_contracted_vertices.size() == 0)
         return false;
@@ -55,6 +63,15 @@ bool CH_vertex::has_contracted_vertices() const {
 void CH_vertex::add_contracted_vertex(CH_vertex& v) {
     m_contracted_vertices += v.id;
     m_contracted_vertices += v.contracted_vertices();
+}
+
+void CH_vertex::add_contracted_vertex_id(int64_t vid) {
+    m_contracted_vertices += vid;
+}
+
+void CH_vertex::add_contracted_vertices_id(
+    const Identifiers<int64_t>& vertices_ids) {
+    m_contracted_vertices += vertices_ids;
 }
 
 std::ostream& operator <<(std::ostream& os, const CH_vertex& v) {

--- a/src/contraction/contractGraph_driver.cpp
+++ b/src/contraction/contractGraph_driver.cpp
@@ -45,43 +45,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 namespace {
 
-/*! @brief vertices with at least one contracted vertex
-
-  @result The vids Identifiers with at least one contracted vertex
-*/
-template <typename G>
-pgrouting::Identifiers<int64_t> get_modified_vertices(const G& graph) {
-    pgrouting::Identifiers<int64_t> vids;
-    for (auto v : boost::make_iterator_range(boost::vertices(graph.graph))) {
-        if (graph[v].has_contracted_vertices()) {
-            vids += graph[v].id;
-        }
-    }
-    return vids;
-}
-
-/*! @brief vertices with at least one contracted vertex
-
-  @result The vids Identifiers with at least one contracted vertex
-*/
-template <typename G>
-std::vector<typename G::E> get_shortcuts(const G& graph) {
-    using E = typename G::E;
-    pgrouting::Identifiers<E> eids;
-    for (auto e : boost::make_iterator_range(boost::edges(graph.graph))) {
-        if (graph[e].id < 0) {
-            eids += e;
-            pgassert(!graph[e].contracted_vertices().empty());
-        } else {
-            pgassert(graph[e].contracted_vertices().empty());
-        }
-    }
-    std::vector<E> o_eids(eids.begin(), eids.end());
-    std::sort(o_eids.begin(), o_eids.end(),
-            [&](E lhs, E rhs) {return -graph[lhs].id < -graph[rhs].id;});
-    return o_eids;
-}
-
 
 template <typename G>
 void process_contraction(
@@ -115,8 +78,8 @@ void get_postgres_result(
         contracted_rt **return_tuples,
         size_t *count) {
     using pgrouting::pgr_alloc;
-    auto modified_vertices(get_modified_vertices(graph));
-    auto shortcut_edges(get_shortcuts(graph));
+    auto modified_vertices(graph.get_modified_vertices());
+    auto shortcut_edges(graph.get_shortcuts());
 
     (*count) = modified_vertices.size() + shortcut_edges.size();
     (*return_tuples) = pgr_alloc((*count), (*return_tuples));


### PR DESCRIPTION
Changes proposed in this pull request:
- This PR prepares the contraction hierarchies algorithm insertion, by reorganizing the code of the dead-end and of the linear contraction functions. Some parts of the code are factorized.

See #2802 

@pgRouting/admins
