### PR TITLE
Contraction: Fix Code Organization

### DIFF
--- a/include/contraction/contractionGraph.hpp
+++ b/include/contraction/contractionGraph.hpp
@@ -375,8 +375,9 @@ class Pgr_contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_dire
         auto e2 = get_min_cost_edge(v, w);
 
         double cost = std::numeric_limits<double>::max();
-        if (std::get<1>(e1) && std::get<1>(e2))
+        if (std::get<1>(e1) && std::get<1>(e2)) {
             cost = std::get<0>(e1).cost + std::get<0>(e2).cost;
+        }
 
         // Create shortcut
         CH_edge shortcut(
@@ -410,8 +411,9 @@ class Pgr_contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_dire
             auto e2 = get_min_cost_edge(v, w);
 
             double cost = std::numeric_limits<double>::max();
-            if (std::get<1>(e1) && std::get<1>(e2))
+            if (std::get<1>(e1) && std::get<1>(e2)) {
                 cost = std::get<0>(e1).cost + std::get<0>(e2).cost;
+            }
             log << "cost = " << cost << std::endl;
 
             // Create shortcut
@@ -448,8 +450,9 @@ class Pgr_contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_dire
                 bool found_f;
                 boost::tie(f, found_f) = boost::edge(v, w, this->graph);
                 if ((found_f) && (u != w)) {
-                    if ((this->graph[e].cost + this->graph[f].cost) > p_max)
+                    if ((this->graph[e].cost + this->graph[f].cost) > p_max) {
                         p_max = this->graph[e].cost + this->graph[f].cost;
+                    }
                 }
             }
         }
@@ -528,9 +531,9 @@ class Pgr_contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_dire
     Identifiers<V> find_adjacent_out_vertices(V v) const {
         Identifiers<V> adjacent_vertices;
 
-        for (const auto &out :
-                boost::make_iterator_range(out_edges(v, this->graph)))
+        for (const auto &out : boost::make_iterator_range(out_edges(v, this->graph))) {
             adjacent_vertices += this->adjacent(v, out);
+        }
 
         return adjacent_vertices;
     }
@@ -543,9 +546,9 @@ class Pgr_contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_dire
     Identifiers<V> find_adjacent_in_vertices(V v) const {
         Identifiers<V> adjacent_vertices;
 
-        for (const auto &in :
-                boost::make_iterator_range(in_edges(v, this->graph)))
+        for (const auto &in : boost::make_iterator_range(in_edges(v, this->graph))) {
             adjacent_vertices += this->adjacent(v, in);
+        }
 
         return adjacent_vertices;
     }

--- a/include/contraction/contractionHierarchies.hpp
+++ b/include/contraction/contractionHierarchies.hpp
@@ -55,85 +55,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 namespace pgrouting {
+namespace detail {
 
-/*!
-    @brief contracts vertex *v*
-    @param [in] G graph
-    @param [in] v vertex_descriptor
-    @param [in] log log output
-    @param [in] err err output
-    @return contraction metric: the node-contraction associated metrics
-*/
-template < class G >
-int64_t vertex_contraction(
-    G &graph,
-    bool directed,
-    typename G::V v,
-    bool simulation,
-    std::vector<CH_edge> &shortcuts,
-    std::ostringstream &log,
-    std::ostringstream &err
-) {
-    Identifiers<typename G::V> adjacent_in_vertices;
-    Identifiers<typename G::V> adjacent_out_vertices;
-    int64_t n_old_edges;
-    std::vector<typename G::E> shortcut_edges;
-
-    if (directed) {
-        adjacent_in_vertices = graph.find_adjacent_in_vertices(v);
-        adjacent_out_vertices = graph.find_adjacent_out_vertices(v);
-        n_old_edges =
-            static_cast<int64_t>(adjacent_in_vertices.size()
-            + adjacent_out_vertices.size());
-    } else {
-        adjacent_in_vertices = graph.find_adjacent_vertices(v);
-        adjacent_out_vertices = adjacent_in_vertices;
-        n_old_edges = static_cast<int64_t>(adjacent_in_vertices.size());
-    }
-
-    log << ">> Contraction of node " << graph[v].id << std::endl
-        << num_vertices(graph.graph) << " vertices and "
-        << num_edges(graph.graph) << " edges " << std::endl;
-
-    for (auto &u : adjacent_in_vertices) {
-        log << "  >> from " << graph[u].id << std::endl;
-        compute_shortcuts(
-            graph,
-            u,
-            v,
-            adjacent_out_vertices,
-            shortcut_edges,
-            log,
-            err);
-    }
-    if (!simulation) {
-        for (auto &w : adjacent_out_vertices)
-            boost::remove_edge(v, w, graph.graph);
-        for (auto &u : graph.find_adjacent_in_vertices(v))
-            boost::remove_edge(u, v, graph.graph);
-        graph[v].clear_contracted_vertices();
-        for (auto &e : shortcut_edges)
-            shortcuts.push_back(graph.graph[e]);
-    } else {
-        for (auto &e : shortcut_edges)
-            boost::remove_edge(e, graph.graph);
-    }
-
-    log << "  Size of the graph after contraction: "
-        << num_vertices(graph.graph)
-        << " vertices and " << num_edges(graph.graph)
-        << " edges" << std::endl
-        << "  " << shortcut_edges.size()
-        << " shortcuts created, " << n_old_edges
-        << " old edges" << std::endl;
-
-    int64_t m;
-    m = static_cast<int64_t>(shortcut_edges.size())
-      - static_cast<int64_t>(n_old_edges);
-    log << "  Metric: edge difference = " << shortcut_edges.size()
-        << " - " << n_old_edges << " = " << m << std::endl;
-    return m;
-}
 
 /*!
     @brief builds shortcuts inside the graph to contract it
@@ -227,7 +150,88 @@ void compute_shortcuts(
     }
 }
 
-namespace functions {
+/*!
+    @brief contracts vertex *v*
+    @param [in] G graph
+    @param [in] v vertex_descriptor
+    @param [in] log log output
+    @param [in] err err output
+    @return contraction metric: the node-contraction associated metrics
+*/
+template <class G>
+int64_t vertex_contraction(
+    G &graph,
+    bool directed,
+    typename G::V v,
+    bool simulation,
+    std::vector<CH_edge> &shortcuts,
+    std::ostringstream &log,
+    std::ostringstream &err
+) {
+    Identifiers<typename G::V> adjacent_in_vertices;
+    Identifiers<typename G::V> adjacent_out_vertices;
+    int64_t n_old_edges;
+    std::vector<typename G::E> shortcut_edges;
+
+    if (directed) {
+        adjacent_in_vertices = graph.find_adjacent_in_vertices(v);
+        adjacent_out_vertices = graph.find_adjacent_out_vertices(v);
+        n_old_edges =
+            static_cast<int64_t>(adjacent_in_vertices.size()
+            + adjacent_out_vertices.size());
+    } else {
+        adjacent_in_vertices = graph.find_adjacent_vertices(v);
+        adjacent_out_vertices = adjacent_in_vertices;
+        n_old_edges = static_cast<int64_t>(adjacent_in_vertices.size());
+    }
+
+    log << ">> Contraction of node " << graph[v].id << std::endl
+        << num_vertices(graph.graph) << " vertices and "
+        << num_edges(graph.graph) << " edges " << std::endl;
+
+    for (auto &u : adjacent_in_vertices) {
+        log << "  >> from " << graph[u].id << std::endl;
+        compute_shortcuts(
+            graph,
+            u,
+            v,
+            adjacent_out_vertices,
+            shortcut_edges,
+            log,
+            err);
+    }
+    if (!simulation) {
+        for (auto &w : adjacent_out_vertices) {
+            boost::remove_edge(v, w, graph.graph);
+        }
+        for (auto &u : graph.find_adjacent_in_vertices(v)) {
+            boost::remove_edge(u, v, graph.graph);
+        }
+        graph[v].clear_contracted_vertices();
+        for (auto &e : shortcut_edges) {
+            shortcuts.push_back(graph.graph[e]);
+        }
+    } else {
+        for (auto &e : shortcut_edges) {
+            boost::remove_edge(e, graph.graph);
+        }
+    }
+
+    log << "  Size of the graph after contraction: "
+        << num_vertices(graph.graph)
+        << " vertices and " << num_edges(graph.graph)
+        << " edges" << std::endl
+        << "  " << shortcut_edges.size()
+        << " shortcuts created, " << n_old_edges
+        << " old edges" << std::endl;
+
+    int64_t m;
+    m = static_cast<int64_t>(shortcut_edges.size())
+      - static_cast<int64_t>(n_old_edges);
+    log << "  Metric: edge difference = " << shortcut_edges.size()
+        << " - " << n_old_edges << " = " << m << std::endl;
+    return m;
+}
 
 template < class G >
 void contractionHierarchies(
@@ -256,7 +260,7 @@ void contractionHierarchies(
         std::pair< int64_t, typename G::V > ordered_vertex = minPQ.top();
         minPQ.pop();
         int64_t corrected_metric =
-            vertex_contraction(
+            detail::vertex_contraction(
                 graph_copy,
                 directed,
                 ordered_vertex.second,
@@ -279,7 +283,7 @@ void contractionHierarchies(
             std::pair< int64_t, typename G::V > contracted_vertex;
             typename G::V u =
                 graph.vertices_map[graph[ordered_vertex.second].id];
-            contracted_vertex.first = vertex_contraction(
+            contracted_vertex.first = detail::vertex_contraction(
                 graph_copy,
                 directed,
                 u,
@@ -296,6 +300,42 @@ void contractionHierarchies(
     graph.copy_shortcuts(shortcuts, log);
     log << std::endl << "Priority queue: " << std::endl;
     graph.set_vertices_metric_and_hierarchy(priority_queue, log);
+}
+
+}  // namespace detail
+
+namespace functions {
+
+/*! @brief execute the contraction hierarchies, after having forbidden the needed vertices
+    @param [in/out] graph in: original graph out: contracted graph
+    @param [in] forbidden_vertices vector of forbidden vertices
+    @param [in/out] log string stream containing log information
+    @param [in/out] err string stream containing err information
+ */
+template <class G>
+void contractionHierarchies(
+        G &graph,
+        bool directed,
+        const std::vector<int64_t> &forbidden_vertices,
+        std::ostringstream &log,
+        std::ostringstream &err) {
+    // Transform the forbidden vertices IDs vector to a collection of vertices
+    pgrouting::Identifiers<typename G::V> forbid_vertices;
+    for (const auto &vertex : forbidden_vertices) {
+        if (graph.has_vertex(vertex)) {
+            forbid_vertices += graph.get_V(vertex);
+        }
+    }
+    graph.set_forbidden_vertices(forbid_vertices);
+
+    // Execute the contraction
+    try {
+        detail::contractionHierarchies(graph, directed, log, err);
+    }
+    catch ( ... ) {
+        err << "Contractions hierarchy failed" << std::endl;
+        throw;
+    }
 }
 
 }  // namespace functions

--- a/include/cpp_common/to_postgres.hpp
+++ b/include/cpp_common/to_postgres.hpp
@@ -36,7 +36,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "cpp_common/alloc.hpp"
 #include "cpp_common/identifiers.hpp"
 
-#include "contraction/contractionHierarchies.hpp"
 
 namespace pgrouting {
 namespace to_postgres {
@@ -73,54 +72,16 @@ void vector_to_tuple(
     }
 }
 
-}  // namespace to_postgres
-}  // namespace pgrouting
 
-namespace detail {
-
-/*! @brief execute the contraction hierarchies, after having forbidden the needed vertices
-    @param [in] graph created graph with base Graph
-    @param [in] forbidden_vertices vector of forbidden vertices
-    @param [in/out] log string stream containing log information
-    @param [in/out] err string stream containing err information
- */
-template <class G>
-void perform_contractionHierarchies(
-        G &graph,
-        bool directed,
-        const std::vector< Edge_t > &edges,
-        const std::vector< int64_t > &forbidden_vertices,
-        std::ostringstream &log,
-        std::ostringstream &err) {
-    // Create the graph
-    graph.insert_edges(edges);
-
-    // Transform the forbidden vertices IDs vector to a collection of vertices
-    pgrouting::Identifiers<typename G::V> forbid_vertices;
-    for (const auto &vertex : forbidden_vertices) {
-        if (graph.has_vertex(vertex)) {
-            forbid_vertices += graph.get_V(vertex);
-        }
-    }
-    graph.set_forbidden_vertices(forbid_vertices);
-
-    // Execute the contraction
-    try {
-        pgrouting::functions::contractionHierarchies(graph, directed, log, err);
-    }
-    catch ( ... ) {
-        err << "Contractions hierarchy failed" << std::endl;
-        throw;
-    }
-}
-
-/*! @brief returns results to the SQL function
+/** @brief returns results to the SQL function
     @param [in] graph created graph
     @param [out] return_tuples tuples containing the results to pass to the SQL function
     @param [out] count string stream containing log information
+
+  Currently works for pgr_contractionHierarchies
 */
 template <class G>
-void get_postgres_result_contractionHierarchies(
+void graph_to_tuple(
         G &graph,
         contractionHierarchies_rt **return_tuples,
         size_t *count) {
@@ -177,6 +138,7 @@ void get_postgres_result_contractionHierarchies(
     }
 }
 
-}  // namespace detail
+}  // namespace to_postgres
+}  // namespace pgrouting
 
 #endif  // INCLUDE_CPP_COMMON_TO_POSTGRES_HPP_

--- a/pgtap/contraction/contraction/types_check.pg
+++ b/pgtap/contraction/contraction/types_check.pg
@@ -18,16 +18,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  ********************************************************************PGR-GNU*/
 
 BEGIN;
-SELECT CASE WHEN min_version('3.8.0') THEN plan(5) ELSE plan(2) END;
+SELECT CASE WHEN min_version('4.0.0') THEN plan(5) ELSE plan(2) END;
 
 CREATE OR REPLACE FUNCTION types_check()
 RETURNS SETOF TEXT AS
 $BODY$
 BEGIN
 
-  IF NOT min_version('3.8.0') THEN
+  IF NOT min_version('4.0.0') THEN
     RETURN QUERY
-    SELECT skip(1, 'pgr_contraction new signature added on 3.8.0');
+    SELECT skip(1, 'pgr_contraction old signature removed on 4.0.0');
     RETURN;
   END IF;
 

--- a/pgtap/utilities/findCloseEdges/edge_cases.pg
+++ b/pgtap/utilities/findCloseEdges/edge_cases.pg
@@ -20,7 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 BEGIN;
 
 UPDATE edges SET cost = sign(cost), reverse_cost = sign(reverse_cost);
-SELECT CASE  WHEN min_version('3.8.0') THEN plan(17) WHEN min_version('3.8.0') THEN plan(33) WHEN min_version('3.4.0') THEN plan(34) ELSE plan(1) END;
+SELECT CASE WHEN min_version('4.0.0') THEN plan(17) WHEN min_version('3.8.0') THEN plan(33) WHEN min_version('3.4.0') THEN plan(34) ELSE plan(1) END;
 SET client_min_messages TO 'WARNING';
 
 

--- a/src/contraction/contractionHierarchies_driver.cpp
+++ b/src/contraction/contractionHierarchies_driver.cpp
@@ -44,6 +44,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "cpp_common/identifiers.hpp"
 #include "cpp_common/alloc.hpp"
 
+
 void
 pgr_contractionHierarchies(
         const char *edges_sql,
@@ -59,6 +60,8 @@ pgr_contractionHierarchies(
     using pgrouting::pgr_free;
     using pgrouting::pgget::get_intArray;
     using pgrouting::pgget::get_edges;
+    using pgrouting::functions::contractionHierarchies;
+    using pgrouting::to_postgres::graph_to_tuple;
 
     std::ostringstream log;
     std::ostringstream notice;
@@ -86,21 +89,17 @@ pgr_contractionHierarchies(
         if (directed) {
             using DirectedGraph = pgrouting::graph::CHDirectedGraph;
             DirectedGraph digraph;
+            digraph.insert_edges(edges);
 
-            detail::perform_contractionHierarchies(digraph, directed, edges, forbid, log, err);
-            detail::get_postgres_result_contractionHierarchies(
-                    digraph,
-                    return_tuples,
-                    return_count);
+            contractionHierarchies(digraph, directed, forbid, log, err);
+            graph_to_tuple(digraph, return_tuples, return_count);
         } else {
             using UndirectedGraph = pgrouting::graph::CHUniqueUndirectedGraph;
             UndirectedGraph undigraph;
+            undigraph.insert_edges(edges);
 
-            detail::perform_contractionHierarchies(undigraph, directed, edges, forbid, log, err);
-            detail::get_postgres_result_contractionHierarchies(
-                    undigraph,
-                    return_tuples,
-                    return_count);
+            contractionHierarchies(undigraph, directed, forbid, log, err);
+            graph_to_tuple(undigraph, return_tuples, return_count);
         }
 
         pgassert(err.str().empty());


### PR DESCRIPTION
Work on #2870: Code Organization Issues.

Changes proposed in this pull request:
- (pgtap/contraction) Fix pgr_contraction types check test
- (pgtap/findCloseEdges) fixing edge cases
- Reorganizing to_postgres.hpp & contractionHierarchies.hpp
  - Using namespace detail for helper functions
  - Moving perform_contractionHierarchies from to_postgres
  - Using suitable names on functions
  - Graph creation is done before calling contracion
  - Fix clang tidy warnings & errors

@pgRouting/admins
