### PR TITLE
Fix ubuntu ci and start testing PG18

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -36,21 +36,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: get postgres version
+      - name: 'Raise Priority for apt.postgresql.org'
         run: |
-          sudo service postgresql start
-          pgver=$(psql --version | grep -Po '(?<=psql \(PostgreSQL\) )[^;]+(?=\.\d+ \()')
-          echo "PGVER=${pgver}" >> $GITHUB_ENV
-          PGP=5433
-          if [ "${{ matrix.psql }}" == "${pgver}" ]; then PGP=5432; fi
-          echo "PGPORT=${PGP}" >> $GITHUB_ENV
-
+          cat << EOF >> ./pgdg.pref
+          Package: *
+          Pin: release o=apt.postgresql.org
+          Pin-Priority: 600
+          EOF
+          sudo mv ./pgdg.pref /etc/apt/preferences.d/
+          sudo apt update
+        
       - name: Add PostgreSQL APT repository
         run: |
-          sudo apt-get install curl ca-certificates gnupg
-          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ \
-            $(lsb_release -cs)-pgdg-snapshot main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo apt-get purge postgresql-*
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg-snapshot main " > /etc/apt/sources.list.d/pgdg.list'
+          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
 
       - name: Install dependencies
         run: |
@@ -81,6 +81,7 @@ jobs:
         run: |
           sudo service postgresql start
           export PG_RUNNER_USER=`whoami`
+          export PGPORT=5432
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS \"${PG_RUNNER_USER}\";"
           sudo -u postgres psql -p ${PGPORT} -c "DROP ROLE IF EXISTS \"${PG_RUNNER_USER}\";"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -31,7 +31,7 @@ jobs:
         matrix:
           psql: [13,14,15,16,17,18]
           postgis: [3]
-          os: [ubuntu-latest, ubuntu-22.04, ubuntu-20.04]
+          os: [ubuntu-latest, ubuntu-22.04]
 
     steps:
       - uses: actions/checkout@v4
@@ -49,7 +49,7 @@ jobs:
       - name: Add PostgreSQL APT repository
         run: |
           sudo apt-get purge postgresql-*
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg-snapshot main ${{ matrix.psql }}" > /etc/apt/sources.list.d/pgdg.list'
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg-testing main ${{ matrix.psql }}" > /etc/apt/sources.list.d/pgdg.list'
           curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
 
       - name: Install dependencies

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          psql: [13,14,15,16,17]
+          psql: [13,14,15,16,17,18]
           postgis: [3]
           os: [ubuntu-latest, ubuntu-22.04, ubuntu-20.04]
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -50,7 +50,7 @@ jobs:
           sudo apt-get install curl ca-certificates gnupg
           curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ \
-            $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+            $(lsb_release -cs)-pgdg-snapshot main" > /etc/apt/sources.list.d/pgdg.list'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Add PostgreSQL APT repository
         run: |
           sudo apt-get purge postgresql-*
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg-snapshot main " > /etc/apt/sources.list.d/pgdg.list'
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg-snapshot main ${{ matrix.psql }}" > /etc/apt/sources.list.d/pgdg.list'
           curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
 
       - name: Install dependencies


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Remove ubuntu 20.04 - no longer available on github
- Purge existing versions of PostgreSQL before install, so no issue with dependencies or having to check if port is not 5432
- Use trust gpg instead of deprecated apt key for adding repo
- Using apt.postgresql.org  --testing branch so can test pre-released versions like PG18
- Add PG18 to testing

@pgRouting/admins
