### PR TITLE
Fix ubuntu ci and start testing PG18

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -29,28 +29,28 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          psql: [13,14,15,16,17]
+          psql: [13,14,15,16,17,18]
           postgis: [3]
-          os: [ubuntu-latest, ubuntu-22.04, ubuntu-20.04]
+          os: [ubuntu-latest, ubuntu-22.04]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: get postgres version
+      - name: 'Raise Priority for apt.postgresql.org'
         run: |
-          sudo service postgresql start
-          pgver=$(psql --version | grep -Po '(?<=psql \(PostgreSQL\) )[^;]+(?=\.\d+ \()')
-          echo "PGVER=${pgver}" >> $GITHUB_ENV
-          PGP=5433
-          if [ "${{ matrix.psql }}" == "${pgver}" ]; then PGP=5432; fi
-          echo "PGPORT=${PGP}" >> $GITHUB_ENV
-
+          cat << EOF >> ./pgdg.pref
+          Package: *
+          Pin: release o=apt.postgresql.org
+          Pin-Priority: 600
+          EOF
+          sudo mv ./pgdg.pref /etc/apt/preferences.d/
+          sudo apt update
+        
       - name: Add PostgreSQL APT repository
         run: |
-          sudo apt-get install curl ca-certificates gnupg
-          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ \
-            $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo apt-get purge postgresql-*
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg-testing main ${{ matrix.psql }}" > /etc/apt/sources.list.d/pgdg.list'
+          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
 
       - name: Install dependencies
         run: |
@@ -81,6 +81,7 @@ jobs:
         run: |
           sudo service postgresql start
           export PG_RUNNER_USER=`whoami`
+          export PGPORT=5432
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS ___pgr___test___;"
           sudo -u postgres psql -p ${PGPORT} -c "DROP DATABASE IF EXISTS \"${PG_RUNNER_USER}\";"
           sudo -u postgres psql -p ${PGPORT} -c "DROP ROLE IF EXISTS \"${PG_RUNNER_USER}\";"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          psql: [13,14,15,16,17,18]
+          psql: [13, 14, 15, 16, 17, 18]
           postgis: [3]
           os: [ubuntu-latest, ubuntu-22.04]
 


### PR DESCRIPTION
 - Add PG 18 to testing
 - Purge old PostgreSQL install so new one is already 5432
 - remove 20.04, that is no longer available
 - Use apt.postgresql.org -testing repo, so can test PG18
 - Use trustpg instead of deprecated apt key for repo cert



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated test workflows to include PostgreSQL 18 and remove Ubuntu 20.04.
  - Improved PostgreSQL installation steps for reliability and consistency in testing environments.
  - Standardized PostgreSQL port usage during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->