### PR TITLE
Cleanup the build update script

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,7 @@ milestone for 4.0.0
 **code enhancements:**
 
 * Removal of unused C/C++ code
+* Refactor the Script to build the update PostgreSQL file.
 
 **Removal of SQL deprecated signatures**
 

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -75,6 +75,7 @@ milestone for 4.0.0
 .. rubric:: code enhancements:
 
 * Removal of unused C/C++ code
+* Refactor the Script to build the update PostgreSQL file.
 
 .. rubric:: Removal of SQL deprecated signatures
 

--- a/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-27 15:13+0000\n"
+"POT-Creation-Date: 2025-05-29 20:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3985,6 +3985,9 @@ msgid "code enhancements:"
 msgstr ""
 
 msgid "Removal of unused C/C++ code"
+msgstr ""
+
+msgid "Refactor the Script to build the update PostgreSQL file."
 msgstr ""
 
 msgid "Removal of SQL deprecated signatures"

--- a/locale/pot/pgrouting_doc_strings.pot
+++ b/locale/pot/pgrouting_doc_strings.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-27 15:13+0000\n"
+"POT-Creation-Date: 2025-05-29 20:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3584,6 +3584,9 @@ msgid "code enhancements:"
 msgstr ""
 
 msgid "Removal of unused C/C++ code"
+msgstr ""
+
+msgid "Refactor the Script to build the update PostgreSQL file."
 msgstr ""
 
 msgid "Removal of SQL deprecated signatures"

--- a/sql/allpairs/floydWarshall.sql
+++ b/sql/allpairs/floydWarshall.sql
@@ -28,7 +28,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 
---v2.6
+--v3.0
 CREATE FUNCTION pgr_floydWarshall(
     TEXT,    -- edges_sql (required)
     directed BOOLEAN DEFAULT true,

--- a/sql/allpairs/johnson.sql
+++ b/sql/allpairs/johnson.sql
@@ -28,7 +28,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 
---v2.6
+--v3.0
 CREATE FUNCTION pgr_johnson(
     TEXT,    -- edges_sql (required)
     directed BOOLEAN DEFAULT true,

--- a/sql/astar/_astar.sql
+++ b/sql/astar/_astar.sql
@@ -39,7 +39,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 -----------------
 
 
---v2.6
+--v3.0
 CREATE FUNCTION _pgr_astar(
     edges_sql TEXT, -- XY edges sql
     start_vids ANYARRAY,

--- a/sql/astar/astar.sql
+++ b/sql/astar/astar.sql
@@ -123,7 +123,7 @@ COST 100
 ROWS 1000;
 
 
---v2.6
+--v3.0
 CREATE FUNCTION pgr_aStar(
     TEXT,       -- edges sql (required)
     ANYARRAY,   -- from_vids (required)

--- a/sql/astar/astarCost.sql
+++ b/sql/astar/astarCost.sql
@@ -33,7 +33,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 -----------------
 
 
---v2.6
+--v3.0
 CREATE FUNCTION pgr_aStarCost(
     TEXT,     -- edges sql (required)
     BIGINT,   -- from_vid (required)
@@ -60,7 +60,7 @@ ROWS 1000;
 
 
 
---v2.6
+--v3.0
 CREATE FUNCTION pgr_aStarCost(
     TEXT,       -- edges sql (required)
     BIGINT,     -- from_vid (required)
@@ -86,7 +86,7 @@ ROWS 1000;
 
 
 
---v2.6
+--v3.0
 CREATE FUNCTION pgr_aStarCost(
     TEXT,       -- edges sql (required)
     ANYARRAY,   -- from_vids (required)
@@ -111,7 +111,7 @@ COST 100
 ROWS 1000;
 
 
---v2.6
+--v3.0
 CREATE FUNCTION pgr_aStarCost(
     TEXT,       -- edges sql (required)
     ANYARRAY,   -- from_vids (required)

--- a/sql/astar/astarCostMatrix.sql
+++ b/sql/astar/astarCostMatrix.sql
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 -----------------------------
 
 
---v2.6
+--v3.0
 CREATE FUNCTION pgr_aStarCostMatrix(
     TEXT,     -- edges sql (required)
     ANYARRAY, -- vids (required)

--- a/sql/bdAstar/_bdAstar.sql
+++ b/sql/bdAstar/_bdAstar.sql
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 
---v2.6
+--v3.0
 CREATE FUNCTION _pgr_bdAstar(
     TEXT,
     ANYARRAY,

--- a/sql/bdAstar/bdAstar.sql
+++ b/sql/bdAstar/bdAstar.sql
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 -- one to one
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdAstar(
     TEXT,   -- edges_sql (required)
     BIGINT, -- from_vid (required)
@@ -58,7 +58,7 @@ COST 100
 ROWS 1000;
 
 -- one to many
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdAstar(
     TEXT,     -- edges_sql (required)
     BIGINT,   -- from_vid (required)
@@ -87,7 +87,7 @@ COST 100
 ROWS 1000;
 
 -- many to one
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdAstar(
     TEXT,     -- edges_sql (required)
     ANYARRAY, -- from_vids (required)
@@ -116,7 +116,7 @@ COST 100
 ROWS 1000;
 
 -- many to many
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdAstar(
     TEXT,     -- edges_sql (required)
     ANYARRAY, -- from_vids (required)

--- a/sql/bdAstar/bdAstarCost.sql
+++ b/sql/bdAstar/bdAstarCost.sql
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 --------------------
 
 -- one to one
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdAstarCost(
     TEXT,   -- edges_sql (required)
     BIGINT, -- from_vid (required)
@@ -54,7 +54,7 @@ ROWS 1000;
 
 
 -- one to many
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdAstarCost(
     TEXT,     -- edges_sql (required)
     BIGINT,   -- from_vid (required)
@@ -79,7 +79,7 @@ ROWS 1000;
 
 
 -- many to one
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdAstarCost(
     TEXT,     -- edges_sql (required)
     ANYARRAY, -- from_vids (required)
@@ -105,7 +105,7 @@ ROWS 1000;
 
 
 -- many to many
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdAstarCost(
     TEXT,     -- edges_sql (required)
     ANYARRAY, -- from_vids (required)

--- a/sql/bdAstar/bdAstarCostMatrix.sql
+++ b/sql/bdAstar/bdAstarCostMatrix.sql
@@ -30,7 +30,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 -----------------------------
 
 
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdAstarCostMatrix(
     TEXT,     -- edges sql (required)
     ANYARRAY, -- vids (required)

--- a/sql/bdDijkstra/bdDijkstra.sql
+++ b/sql/bdDijkstra/bdDijkstra.sql
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 -- ONE TO ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdDijkstra(
     TEXT,   -- edges_sql (required)
     BIGINT, -- from_vid
@@ -56,7 +56,7 @@ ROWS 1000;
 
 
 -- ONE TO MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdDijkstra(
     TEXT,    -- edges_sql (required)
     BIGINT,   -- from_vid (required)
@@ -82,7 +82,7 @@ ROWS 1000;
 
 
 -- MANY TO ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdDijkstra(
     TEXT,    -- edges_sql (required)
     ANYARRAY, -- from_vids (required)
@@ -109,7 +109,7 @@ ROWS 1000;
 
 
 -- MANY TO MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdDijkstra(
     TEXT,     -- edges_sql (required)
     ANYARRAY, -- from_vids (required)

--- a/sql/bdDijkstra/bdDijkstraCost.sql
+++ b/sql/bdDijkstra/bdDijkstraCost.sql
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 -- ONE TO ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdDijkstraCost(
     TEXT,   -- edges_sql (required)
     BIGINT, -- from_vid (required)
@@ -53,7 +53,7 @@ ROWS 1000;
 
 
 -- ONE TO MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdDijkstraCost(
     TEXT,     -- edges_sql (required)
     BIGINT,   -- from_vid (required)
@@ -75,7 +75,7 @@ ROWS 1000;
 
 
 -- MANY TO ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdDijkstraCost(
     TEXT,     -- edges_sql (required)
     ANYARRAY, -- from_vids (required)
@@ -97,7 +97,7 @@ ROWS 1000;
 
 
 -- MANY TO MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdDijkstraCost(
     TEXT,     -- edges_sql (required)
     ANYARRAY, -- from_vids (required)

--- a/sql/bdDijkstra/bdDijkstraCostMatrix.sql
+++ b/sql/bdDijkstra/bdDijkstraCostMatrix.sql
@@ -28,7 +28,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 -- pgr_bdDijkstraCostMatrix
 -----------------------------
 
---v2.6
+--v3.0
 CREATE FUNCTION pgr_bdDijkstraCostMatrix(
     TEXT,     -- edges_sql (required)
     ANYARRAY, -- vids (required)

--- a/sql/common/_get_statement.sql
+++ b/sql/common/_get_statement.sql
@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 
---v2.6
+--v3.0
 CREATE FUNCTION _pgr_get_statement(o_sql text)
 RETURNS text AS
 $BODY$

--- a/sql/common/parameter_check.sql
+++ b/sql/common/parameter_check.sql
@@ -37,7 +37,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 -- johnson (source, target, cost, [reverse_cost])
 */
 
---v2.6
+--v3.0
 CREATE FUNCTION _pgr_parameter_check(fn text, sql text, big boolean default false)
   RETURNS bool AS
   $BODY$

--- a/sql/dijkstra/dijkstra.sql
+++ b/sql/dijkstra/dijkstra.sql
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ---------------
 
 -- ONE to ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_dijkstra(
     TEXT,   -- edges_sql (required)
     BIGINT, -- from_vid (required)
@@ -60,7 +60,7 @@ COST 100
 ROWS 1000;
 
 -- ONE to MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_dijkstra(
     TEXT,     -- edges_sql (required)
     BIGINT,   -- from_vid (required)
@@ -86,7 +86,7 @@ COST 100
 ROWS 1000;
 
 -- MANY to ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_dijkstra(
     TEXT,     -- edges_sql (required)
     ANYARRAY, -- from_vids (required)
@@ -112,7 +112,7 @@ COST 100
 ROWS 1000;
 
 -- MANY to MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_dijkstra(
     TEXT,     -- edges_sql (required)
     ANYARRAY, -- from_vids (required)

--- a/sql/dijkstra/dijkstraCost.sql
+++ b/sql/dijkstra/dijkstraCost.sql
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 -------------------
 
 -- ONE to ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_dijkstraCost(
     TEXT,   -- edges_sql (required)
     BIGINT, -- from_vids (required)
@@ -52,7 +52,7 @@ ROWS 1000;
 
 
 -- ONE to MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_dijkstraCost(
     TEXT,     -- edges_sql (required)
     BIGINT,   -- from_vid (required)
@@ -76,7 +76,7 @@ ROWS 1000;
 
 
 -- MANY to ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_dijkstraCost(
     TEXT,     -- edges_sql (required)
     ANYARRAY, -- from_vids (required)
@@ -100,7 +100,7 @@ ROWS 1000;
 
 
 -- MANY to MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_dijkstraCost(
     TEXT,     -- edges_sql (required)
     ANYARRAY, -- from_vids (required)

--- a/sql/dijkstra/dijkstraCostMatrix.sql
+++ b/sql/dijkstra/dijkstraCostMatrix.sql
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 -----------------------------
 
 
---v2.6
+--v3.0
 CREATE FUNCTION pgr_dijkstraCostMatrix(
     TEXT,     -- edges_sql (required)
     ANYARRAY, -- vids (required)

--- a/sql/dijkstra/dijkstraVia.sql
+++ b/sql/dijkstra/dijkstraVia.sql
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 
---v2.6
+--v3.0
 CREATE FUNCTION pgr_dijkstraVia(
     TEXT,     -- edges_sql (required)
     ANYARRAY, -- via_vids (required)

--- a/sql/lineGraph/lineGraph.sql
+++ b/sql/lineGraph/lineGraph.sql
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 
---v2.6
+--v3.0
 CREATE FUNCTION pgr_lineGraph(
     TEXT, -- edges_sql (required)
 

--- a/sql/lineGraph/lineGraphFull.sql
+++ b/sql/lineGraph/lineGraphFull.sql
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 
---v2.6
+--v3.0
 CREATE FUNCTION pgr_lineGraphFull(
     TEXT, -- edges_sql (required)
 

--- a/sql/max_flow/_maxflow.sql
+++ b/sql/max_flow/_maxflow.sql
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 --------------
 
 
---v2.6
+--v3.0
 CREATE FUNCTION _pgr_maxflow(
     edges_sql TEXT,
     sources ANYARRAY,

--- a/sql/max_flow/boykovKolmogorov.sql
+++ b/sql/max_flow/boykovKolmogorov.sql
@@ -30,7 +30,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 -- ONE to ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_boykovKolmogorov(
     TEXT, -- edges_sql (required)
     BIGINT, -- from_vid (required)
@@ -51,7 +51,7 @@ CREATE FUNCTION pgr_boykovKolmogorov(
 
 
 -- ONE to MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_boykovKolmogorov(
     TEXT, -- edges_sql (required)
     BIGINT, -- from_vid (required)
@@ -72,7 +72,7 @@ CREATE FUNCTION pgr_boykovKolmogorov(
 
 
 -- MANY to ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_boykovKolmogorov(
     TEXT, -- edges_sql (required)
     ANYARRAY, -- from_vids (required)
@@ -93,7 +93,7 @@ CREATE FUNCTION pgr_boykovKolmogorov(
 
 
 -- MANY to MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_boykovKolmogorov(
     TEXT, -- edges_sql (required)
     ANYARRAY, -- from_vids (required)

--- a/sql/max_flow/edgeDisjointPaths.sql
+++ b/sql/max_flow/edgeDisjointPaths.sql
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  ********************************************************************PGR-GNU*/
 
 -- ONE to ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_edgeDisjointPaths(
     TEXT,   --edges_sql (required)
     BIGINT, -- From_vid (required)
@@ -50,7 +50,7 @@ LANGUAGE SQL VOLATILE STRICT;
 
 
 -- ONE to MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_edgeDisjointPaths(
     TEXT,     --edges_sql (required)
     BIGINT,   -- From_vid (required)
@@ -76,7 +76,7 @@ LANGUAGE SQL VOLATILE STRICT;
 
 
 -- MANY to ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_edgeDisjointPaths(
     TEXT,     --edges_sql (required)
     ANYARRAY, -- From_vids (required)
@@ -102,7 +102,7 @@ LANGUAGE SQL VOLATILE STRICT;
 
 
 -- MANY to MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_edgeDisjointPaths(
     TEXT,     --edges_sql (required)
     ANYARRAY, -- From_vids (required)

--- a/sql/max_flow/edmondsKarp.sql
+++ b/sql/max_flow/edmondsKarp.sql
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 -------------------
 
 -- ONE to ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_edmondsKarp(
     TEXT, -- edges_sql (required)
     BIGINT, -- from_vid (required)
@@ -50,7 +50,7 @@ CREATE FUNCTION pgr_edmondsKarp(
 
 
 -- ONE to MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_edmondsKarp(
     TEXT, -- edges_sql (required)
     BIGINT, -- from_vid (required)
@@ -71,7 +71,7 @@ CREATE FUNCTION pgr_edmondsKarp(
 
 
 -- MANY to ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_edmondsKarp(
     TEXT, -- edges_sql (required)
     ANYARRAY, -- from_vids (required)
@@ -92,7 +92,7 @@ CREATE FUNCTION pgr_edmondsKarp(
 
 
 -- MANY to MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_edmondsKarp(
     TEXT, -- edges_sql (required)
     ANYARRAY, -- from_vids (required)

--- a/sql/max_flow/maxFlow.sql
+++ b/sql/max_flow/maxFlow.sql
@@ -30,7 +30,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 -- ONE to ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_maxFlow(
     TEXT, -- edges_sql (required)
     BIGINT, -- from_vid (required)
@@ -44,7 +44,7 @@ CREATE FUNCTION pgr_maxFlow(
 
 
 -- ONE to MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_maxFlow(
     TEXT, -- edges_sql (required)
     BIGINT, -- from_vid (required)
@@ -58,7 +58,7 @@ CREATE FUNCTION pgr_maxFlow(
 
 
 -- MANY to ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_maxFlow(
     TEXT, -- edges_sql (required)
     ANYARRAY, -- from_vids (required)
@@ -72,7 +72,7 @@ CREATE FUNCTION pgr_maxFlow(
 
 
 -- MANY to MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_maxFlow(
     TEXT, -- edges_sql (required)
     ANYARRAY, -- from_vids (required)

--- a/sql/max_flow/pushRelabel.sql
+++ b/sql/max_flow/pushRelabel.sql
@@ -30,7 +30,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 -- ONE to ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_pushRelabel(
     TEXT, -- edges_sql (required)
     BIGINT, -- from_vid (required)
@@ -51,7 +51,7 @@ CREATE FUNCTION pgr_pushRelabel(
 
 
 -- ONE to MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_pushRelabel(
     TEXT, -- edges_sql (required)
     BIGINT, -- from_vid (required)
@@ -72,7 +72,7 @@ CREATE FUNCTION pgr_pushRelabel(
 
 
 -- MANY to ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_pushRelabel(
     TEXT, -- edges_sql (required)
     ANYARRAY, -- from_vids (required)
@@ -93,7 +93,7 @@ CREATE FUNCTION pgr_pushRelabel(
 
 
 -- MANY to MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_pushRelabel(
     TEXT, -- edges_sql (required)
     ANYARRAY, -- from_vids (required)

--- a/sql/pickDeliver/_pickDeliver.sql
+++ b/sql/pickDeliver/_pickDeliver.sql
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 
---v2.6
+--v3.0
 CREATE FUNCTION _pgr_pickDeliver(
     TEXT, -- orders_sql
     TEXT, -- vehicles_sql

--- a/sql/pickDeliver/_pickDeliverEuclidean.sql
+++ b/sql/pickDeliver/_pickDeliverEuclidean.sql
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 
---v2.6
+--v3.0
 CREATE FUNCTION _pgr_pickDeliverEuclidean (
     TEXT, -- orders_sql
     TEXT, -- vehicles_sql

--- a/sql/trsp/_array_reverse.sql
+++ b/sql/trsp/_array_reverse.sql
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 
---v2.6
+--v3.0
 CREATE FUNCTION _pgr_array_reverse(anyarray) RETURNS anyarray AS $$
 SELECT ARRAY(
     SELECT $1[i]

--- a/sql/vrp_basic/_pgr_vrpOneDepot.sql
+++ b/sql/vrp_basic/_pgr_vrpOneDepot.sql
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 --------------------
 
 
---v2.6
+--v3.0
 CREATE FUNCTION _pgr_vrpOneDepot(
     TEXT, -- customers_sql
     TEXT, -- vehicles_sql

--- a/sql/vrp_basic/vrpOneDepot.sql
+++ b/sql/vrp_basic/vrpOneDepot.sql
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 --------------------
 
 
---v2.6
+--v3.0
 CREATE FUNCTION pgr_vrpOneDepot(
 	text,  -- order_sql
 	text, -- vehicle_sql

--- a/sql/withPoints/_withPoints.sql
+++ b/sql/withPoints/_withPoints.sql
@@ -40,7 +40,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ------------------
 
 
---v2.6
+--v3.0
 CREATE FUNCTION _pgr_withPoints(
     edges_sql TEXT,
     points_sql TEXT,

--- a/sql/withPoints/withPoints.sql
+++ b/sql/withPoints/withPoints.sql
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 -- ONE TO ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_withPoints(
     TEXT, -- edges_sql (required)
     TEXT, -- points_sql (required)
@@ -63,7 +63,7 @@ ROWS 1000;
 
 
 -- ONE TO MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_withPoints(
     TEXT, -- edges_sql (required)
     TEXT, -- points_sql (required)
@@ -92,7 +92,7 @@ ROWS 1000;
 
 
 -- MANY TO ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_withPoints(
     TEXT, -- edges_sql (required)
     TEXT, -- points_sql (required)
@@ -121,7 +121,7 @@ ROWS 1000;
 
 
 -- MANY TO MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_withPoints(
     TEXT, -- edges_sql (required)
     TEXT, -- points_sql (required)

--- a/sql/withPoints/withPointsCost.sql
+++ b/sql/withPoints/withPointsCost.sql
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 -- ONE TO ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_withPointsCost(
     TEXT, -- edges_sql (required)
     TEXT, -- points_sql (required)
@@ -58,7 +58,7 @@ ROWS 1000;
 
 
 -- ONE TO MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_withPointsCost(
     TEXT, -- edges_sql (required)
     TEXT, -- points_sql (required)
@@ -82,7 +82,7 @@ ROWS 1000;
 
 
 -- MANY TO ONE
---v2.6
+--v3.0
 CREATE FUNCTION pgr_withPointsCost(
     TEXT, -- edges_sql (required)
     TEXT, -- points_sql (required)
@@ -106,7 +106,7 @@ ROWS 1000;
 
 
 -- MANY TO MANY
---v2.6
+--v3.0
 CREATE FUNCTION pgr_withPointsCost(
     TEXT, -- edges_sql (required)
     TEXT, -- points_sql (required)

--- a/sql/withPoints/withPointsCostMatrix.sql
+++ b/sql/withPoints/withPointsCostMatrix.sql
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 -- pgr_withPointsCostMatrix
 ---------------------------
 
---v2.6
+--v3.0
 CREATE FUNCTION pgr_withPointsCostMatrix(
     TEXT,     -- edges_sql (required)
     TEXT,     -- points_sql (required)


### PR DESCRIPTION
Changes proposed in this pull request:
- Refactoring the build update script
  - everything in v2 gets dropped as we do not test the update from v2.6
  - All functions marked as created on v2.6 now are marked as 3.0
 

@pgRouting/admins
