### PR TITLE
Ignore run.sh in root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ notUsed
 
 .vscode
 taptest.sh
+run.sh


### PR DESCRIPTION
Related with https://github.com/pgRouting/GSoC-pgRouting/pull/449

Changes proposed in this pull request:
- Ignore `run.sh` in root.

@pgRouting/admins
