### PR TITLE
Fix 2924 standardize pgr edge coloring

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,14 +16,29 @@ milestone for 4.0.0
 
 Summary of changes by function
 
-* pgr_contraction
+* pgr_aStar
 
-  * Breaking change, signatures no longer available:
-    * pgr_contraction(text,bigint[],integer,bigint[],boolean)
+  * Combinations signature promoted to official.
+
+* pgr_aStarCost
+
+  * Combinations signature promoted to official.
+
+* pgr_bdAstar
+
+  * Combinations signature promoted to official.
+
+* pgr_bdAstarCost
+
+  * Combinations signature promoted to official.
 
 * pgr_bdDijkstra
 
   * Output columns standardized to ``(seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)``
+  * Combinations signature promoted to official.
+
+* pgr_bdDijkstraCost
+
   * Combinations signature promoted to official.
 
 * pgr_bellmanFord
@@ -34,17 +49,43 @@ Summary of changes by function
 
   * Output columns standardized to ``(seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)``
 
+* pgr_contraction
+
+  .. Breaking change
+  * Breaking change, signatures no longer available:
+    * pgr_contraction(text,bigint[],integer,bigint[],boolean)
+
+* pgr_dagShortestPath
+
+  * Output columns standardized to ``(seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)``
+
+* pgr_dijkstra
+
+  * Combinations signature promoted to official.
+
+* pgr_dijkstraCost
+
+  * Combinations signature promoted to official.
+
 * pgr_edgeColoring
 
-  * Output columns standardized to ``(edge, color)``
+  * Output columns standardized to ``(edge)``-color
 
 * pgr_edwardMoore
 
   * Output columns standardized to ``(seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)``
 
-* pgr_DAGshortestPath
+* pgr_KSP
 
-  * Output columns standardized to ``(seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)``
+  * All signatures promoted to official.
+
+* pgr_maxFlow
+
+  * Combinations signature promoted to official.
+
+* pgr_pushRelabel
+
+  * Combinations signature promoted to official.
 
 * pgr_trsp
 
@@ -57,6 +98,7 @@ Summary of changes by function
 * pgr_trspVia
 
   * Function promoted to official.
+  .. Breaking change
   * Breaking change, signatures no longer available:
     * pgr_trspviavertices(text,anyarray,boolean,boolean,text)
 
@@ -151,17 +193,17 @@ Functions promoted to official
   pgr_trspVia_withPoints
 * [#2701](https://github.com/pgRouting/pgrouting/issues/2701)
   pgr_trsp_withPoints
-* [#2905](https://github.com/pgRouting/pgrouting/issues/2905)
+* [#2700](https://github.com/pgRouting/pgrouting/issues/2700)
   pgr_withPoints
-* [#2905](https://github.com/pgRouting/pgrouting/issues/2905)
+* [#2700](https://github.com/pgRouting/pgrouting/issues/2700)
   pgr_withPointsCost
-* [#2905](https://github.com/pgRouting/pgrouting/issues/2905)
+* [#2700](https://github.com/pgRouting/pgrouting/issues/2700)
   pgr_withPointsCostMatrix
-* [#2905](https://github.com/pgRouting/pgrouting/issues/2905)
+* [#2700](https://github.com/pgRouting/pgrouting/issues/2700)
   pgr_withPointsDD
-* [#2905](https://github.com/pgRouting/pgrouting/issues/2905)
+* [#2700](https://github.com/pgRouting/pgrouting/issues/2700)
   pgr_withPointsKSP
-* [#2905](https://github.com/pgRouting/pgrouting/issues/2905)
+* [#2700](https://github.com/pgRouting/pgrouting/issues/2700)
   pgr_withPointsVia
 
 Signatures promoted to official
@@ -218,8 +260,9 @@ Standardize output columns of functions with different output columns within ove
 * [#2905](https://github.com/pgRouting/pgrouting/issues/2905)
   pgr_withPointsCost
 * [#2905](https://github.com/pgRouting/pgrouting/issues/2905)
+  pgr_withPointsCostMatrix
 
-**Standardized to ``(edge, color)``**
+**Standardized to ``(edge)``-color**
 
 * [#2924](https://github.com/pgRouting/pgrouting/issues/2924)
   pgr_edgeColoring
@@ -235,6 +278,10 @@ Removal of SQL deprecated signatures
 
     * pgr_trsp(text,integer,integer,boolean,boolean,text)
     * pgr_trsp(text,integer,double precision,integer,double precision,boolean,boolean,text)
+
+* [#2683](https://github.com/pgRouting/pgrouting/issues/2683): pgr_trspVia
+
+    * pgr_trspviavertices(text,anyarray,boolean,boolean,text)
 
 * [#2700](https://github.com/pgRouting/pgrouting/issues/2700):
   pgr_withPointsVia
@@ -392,9 +439,6 @@ Summary of functions and signatures no longer on pgrouting
 * #2919 pgr_withpoints(text,text,bigint,bigint,boolean,character,boolean)
 * #2919 pgr_withpoints(text,text,text,boolean,character,boolean)
 * #2919 pgr_withpointsvia(text,text,anyarray,boolean,boolean,boolean,character,boolean)
-
-**Internal functions**
-
 
 Code enhancements
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -69,7 +69,7 @@ Summary of changes by function
 
 * pgr_edgeColoring
 
-  * Output columns standardized to ``(edge)``-color
+  * Output columns standardized to ``(edge, color)``
 
 * pgr_edwardMoore
 
@@ -262,7 +262,7 @@ Standardize output columns of functions with different output columns within ove
 * [#2905](https://github.com/pgRouting/pgrouting/issues/2905)
   pgr_withPointsCostMatrix
 
-**Standardized to ``(edge)``-color**
+**Standardized to ``(edge, color)``**
 
 * [#2924](https://github.com/pgRouting/pgrouting/issues/2924)
   pgr_edgeColoring

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,10 @@ Summary of changes by function
 
   * Output columns standardized to ``(seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)``
 
+* pgr_edgeColoring
+
+  * Output columns standardized to ``(edge, color)``
+
 * pgr_edwardMoore
 
   * Output columns standardized to ``(seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost)``
@@ -214,7 +218,11 @@ Standardize output columns of functions with different output columns within ove
 * [#2905](https://github.com/pgRouting/pgrouting/issues/2905)
   pgr_withPointsCost
 * [#2905](https://github.com/pgRouting/pgrouting/issues/2905)
-  pgr_withPointsCostMatrix
+
+**Standardized to ``(edge, color)``**
+
+* [#2924](https://github.com/pgRouting/pgrouting/issues/2924)
+  pgr_edgeColoring
 
 Removal of SQL deprecated signatures
 

--- a/doc/coloring/coloring-family.rst
+++ b/doc/coloring/coloring-family.rst
@@ -51,7 +51,7 @@ Result columns
 
 .. result-edge-color-start
 
-Returns set of ``(node, color)``
+Returns set of |result_edge_color|
 
 ===============  =========== ======================================
 Column           Type        Description
@@ -64,7 +64,6 @@ Column           Type        Description
 ===============  =========== ======================================
 
 .. result-edge-color-end
-
 
 .. result columns start
 
@@ -81,22 +80,6 @@ Column           Type        Description
 ===============  =========== ======================================
 
 .. result columns end
-
-.. result columns start edgeColoring
-
-Returns set of ``(edge_id, color_id)``
-
-===============  =========== =====================================
-Column           Type        Description
-===============  =========== =====================================
-``edge_id``      ``BIGINT``  Identifier of the edge.
-``color_id``     ``BIGINT``  Identifier of the color of the edge.
-
-                             - The minimum value of color is 1.
-
-===============  =========== =====================================
-
-.. result columns end edgeColoring
 
 See Also
 -------------------------------------------------------------------------------

--- a/doc/coloring/coloring-family.rst
+++ b/doc/coloring/coloring-family.rst
@@ -49,6 +49,23 @@ Coloring - Family of functions
 Result columns
 -------------------------------------------------------------------------------
 
+.. result-edge-color-start
+
+Returns set of ``(node, color)``
+
+===============  =========== ======================================
+Column           Type        Description
+===============  =========== ======================================
+``edge``         ``BIGINT``  Identifier of the edge.
+``color``        ``BIGINT``  Color of the edge.
+
+                             - The minimum value of color is 1.
+
+===============  =========== ======================================
+
+.. result-edge-color-end
+
+
 .. result columns start
 
 Returns set of ``(vertex_id, color_id)``

--- a/doc/coloring/pgr_edgeColoring.rst
+++ b/doc/coloring/pgr_edgeColoring.rst
@@ -25,9 +25,13 @@ graphs
 
 .. rubric:: Availability
 
-* Version 3.3.0
+.. rubric:: Version 4.0.0
 
-  * New experimental function.
+* Output columns standardized to |result-edge-color|
+
+.. rubric:: Version 3.3.0
+
+* New experimental function.
 
 Description
 -------------------------------------------------------------------------------

--- a/doc/coloring/pgr_edgeColoring.rst
+++ b/doc/coloring/pgr_edgeColoring.rst
@@ -113,8 +113,8 @@ Result columns
 -------------------------------------------------------------------------------
 
 .. include:: coloring-family.rst
-    :start-after: result columns start edgeColoring
-    :end-before: result columns end edgeColoring
+    :start-after: result-edge-color-start
+    :end-before: result-edge-color-end
 
 
 See Also

--- a/doc/coloring/pgr_edgeColoring.rst
+++ b/doc/coloring/pgr_edgeColoring.rst
@@ -27,7 +27,7 @@ graphs
 
 .. rubric:: Version 4.0.0
 
-* Output columns standardized to |result-edge-color|
+* Output columns standardized to |result_edge_color|
 
 .. rubric:: Version 3.3.0
 
@@ -81,7 +81,7 @@ Signatures
 
    | pgr_edgeColoring(`Edges SQL`_)
 
-   | Returns set of |result-edge-color|
+   | Returns set of |result_edge_color|
    | OR EMPTY SET
 
 :Example: Graph coloring of pgRouting :doc:`sampledata`

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -365,7 +365,7 @@ rst_epilog="""
 .. |result-1-1-no-seq| replace:: ``(seq, node, edge, cost, agg_cost)``
 .. |result-m-1-no-seq| replace:: ``(seq, start_vid, node, edge, cost, agg_cost)``
 .. |result-node-color| replace:: ``(vertex_id, color_id)``
-.. |result-edge-color| replace:: ``(edge, color)``
+.. |result_edge_color| replace:: ``(edge, color)``
 .. |result-node| replace:: ``(node)``
 .. |result-edge| replace:: ``(edge)``
 .. |result-separate| replace:: ``(seq,id,sub_id,geom)``

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -365,7 +365,7 @@ rst_epilog="""
 .. |result-1-1-no-seq| replace:: ``(seq, node, edge, cost, agg_cost)``
 .. |result-m-1-no-seq| replace:: ``(seq, start_vid, node, edge, cost, agg_cost)``
 .. |result-node-color| replace:: ``(vertex_id, color_id)``
-.. |result-edge-color| replace:: ``(edge_id, color_id)``
+.. |result-edge-color| replace:: ``(edge, color)``
 .. |result-node| replace:: ``(node)``
 .. |result-edge| replace:: ``(edge)``
 .. |result-separate| replace:: ``(seq,id,sub_id,geom)``

--- a/doc/contraction/pgr_contraction.rst
+++ b/doc/contraction/pgr_contraction.rst
@@ -24,6 +24,8 @@ vertices and edges.
 
 .. rubric:: Version 4.0.0
 
+.. Breaking change
+
 * Breaking change, signatures no longer available:
 
   * pgr_contraction(text,bigint[],integer,bigint[],boolean)

--- a/doc/dijkstra/pgr_dijkstra.rst
+++ b/doc/dijkstra/pgr_dijkstra.rst
@@ -21,43 +21,43 @@
 
 .. rubric:: Availability
 
-* Version 4.0.0
+.. rubric:: Version 4.0.0
 
-  * Combinations signature promoted to official.
+* Combinations signature promoted to official.
 
-* Version 3.5.0
+.. rubric:: Version 3.5.0
 
-  * Standardizing output columns to |short-generic-result|
+* Standardizing output columns to |short-generic-result|
 
-    * pgr_dijkstra(One to One) added ``start_vid`` and ``end_vid`` columns.
-    * pgr_dijkstra(One to Many) added ``end_vid`` column.
-    * pgr_dijkstra(Many to One) added ``start_vid`` column.
+  * pgr_dijkstra(One to One) added ``start_vid`` and ``end_vid`` columns.
+  * pgr_dijkstra(One to Many) added ``end_vid`` column.
+  * pgr_dijkstra(Many to One) added ``start_vid`` column.
 
-* Version 3.1.0
+.. rubric:: Version 3.1.0
 
-  * New proposed signature:
+* New proposed signature:
 
-    * pgr_dijkstra(Combinations)
+  * pgr_dijkstra(Combinations)
 
-* Version 3.0.0
+.. rubric:: Version 3.0.0
 
-  * Function promoted to official.
+* Function promoted to official.
 
-* Version 2.2.0
+.. rubric:: Version 2.2.0
 
-  * New proposed signatures:
+* New proposed signatures:
 
-    * pgr_dijkstra(One to Many)
-    * pgr_dijkstra(Many to One)
-    * pgr_dijkstra(Many to Many)
+  * pgr_dijkstra(One to Many)
+  * pgr_dijkstra(Many to One)
+  * pgr_dijkstra(Many to Many)
 
-* Version 2.1.0
+.. rubric:: Version 2.1.0
 
-  * Signature change on pgr_dijkstra(One to One)
+* Signature change on pgr_dijkstra(One to One)
 
-* Version 2.0.0
+.. rubric:: Version 2.0.0
 
-  * Official function.
+* Official function.
 
 
 Description

--- a/doc/dijkstra/pgr_dijkstraCost.rst
+++ b/doc/dijkstra/pgr_dijkstraCost.rst
@@ -23,19 +23,19 @@ algorithm.
 
 .. rubric:: Availability
 
-* Version 4.0.0
+.. rubric:: Version 4.0.0
 
-  * Combinations signature promoted to official.
+* Combinations signature promoted to official.
 
-* Version 3.1.0
+.. rubric:: Version 3.1.0
 
-  * New proposed signature:
+* New proposed signature:
 
-    * pgr_dijkstraCost(Combinations)
+  * pgr_dijkstraCost(Combinations)
 
-* Version 2.2.0
+.. rubric:: Version 2.2.0
 
-  * Official function.
+* Official function.
 
 
 Description

--- a/doc/ksp/pgr_KSP.rst
+++ b/doc/ksp/pgr_KSP.rst
@@ -20,9 +20,9 @@
 
 .. rubric:: Availability
 
-* Version 4.0.0
+.. rubric:: Version 4.0.0
 
-  * All signatures promoted to official.
+* All signatures promoted to official.
 
 .. rubric:: Version 3.6.0
 

--- a/doc/max_flow/pgr_maxFlow.rst
+++ b/doc/max_flow/pgr_maxFlow.rst
@@ -21,23 +21,23 @@ source(s) to the targets(s) using the Push Relabel algorithm.
 
 .. Rubric:: Availability
 
-* Version 4.0.0
+.. rubric:: Version 4.0.0
 
-  * Combinations signature promoted to official.
+* Combinations signature promoted to official.
 
-* Version 3.2.0
+.. rubric:: Version 3.2.0
 
-  * New proposed signature:
+* New proposed signature:
 
-    * pgr_maxFlow(Combinations)
+  * pgr_maxFlow(Combinations)
 
-* Version 3.0.0
+.. rubric:: Version 3.0.0
 
-  *  Function promoted to official.
+*  Function promoted to official.
 
-* Version 2.4.0
+.. rubric:: Version 2.4.0
 
-  * New proposed function.
+* New proposed function.
 
 
 Description

--- a/doc/max_flow/pgr_pushRelabel.rst
+++ b/doc/max_flow/pgr_pushRelabel.rst
@@ -21,28 +21,28 @@ flow from the sources to the targets using Push Relabel Algorithm.
 
 .. Rubric:: Availability
 
-* Version 4.0.0
+.. rubric:: Version 4.0.0
 
-  * Combinations signature promoted to official.
+* Combinations signature promoted to official.
 
-* Version 3.2.0
+.. rubric:: Version 3.2.0
 
-  * New proposed signature:
+* New proposed signature:
 
-    * pgr_pushRelabel(Combinations)
+  * pgr_pushRelabel(Combinations)
 
-* Version 3.0.0
+.. rubric:: Version 3.0.0
 
-  * Function promoted to official.
+* Function promoted to official.
 
-* Version 2.5.0
+.. rubric:: Version 2.5.0
 
-  * Renamed from ``pgr_maxFlowPushRelabel``
-  * Function promoted to proposed.
+* Renamed from ``pgr_maxFlowPushRelabel``
+* Function promoted to proposed.
 
-* Version 2.3.0
+.. rubric:: Version 2.3.0
 
-  * New experimental function.
+* New experimental function.
 
 
 Description

--- a/doc/src/migration.rst
+++ b/doc/src/migration.rst
@@ -33,6 +33,7 @@ Migration to standardized columns
 .. |pid-m-1| replace:: ``(seq, path_seq, start_pid, node, edge, cost, agg_cost)``
 .. |pid-m-m| replace:: ``(seq, path_seq, start_pid, end_pid, node, edge, cost, agg_cost)``
 .. |matrix-pid| replace:: ``(start_pid, end_pid, agg_cost)``
+.. |old-edge-color| replace:: ``(edge_id, color_id)``
 
 There has been an effort to standardize function output columns names and
 types.
@@ -85,6 +86,8 @@ types.
      - `Migration of single path functions`_
    * - .. versionchanged:: 4.0.0 :doc:`pgr_dagShortestPath` [3]_
      - `Migration of single path functions`_
+   * - .. versionchanged:: 4.0.0 :doc:`pgr_edgeColoring` [3]_
+     - `Migration of output column name change`_
    * - .. versionchanged:: 4.0.0 :doc:`pgr_edwardMoore` [3]_
      - `Migration of single path functions`_
    * - .. versionchanged:: 4.0.0 :doc:`pgr_withPoints` [2]_
@@ -836,6 +839,20 @@ To get the old version column names |result-dij-dd-m|: filter out the column
 .. literalinclude:: migration.queries
    :start-after: --drivingdistance4
    :end-before: --drivingdistance5
+
+Migration of output column name change
+-------------------------------------------------------------------------------
+
+.. rubric:: :doc:`pgr_edgeColoring`
+
+From: |old-edge-color|
+To: |result-edge-color|
+
+Before update:
+
+* Rename ``edge_id`` to ``edge`` and ``color_id`` to ``color``.
+* To get the old version column names: in the ``SELECT`` clause use ``edge AS
+  edge_id`` and ``color AS color_id``
 
 Migration of deleted functions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/doc/src/migration.rst
+++ b/doc/src/migration.rst
@@ -846,7 +846,7 @@ Migration of output column name change
 .. rubric:: :doc:`pgr_edgeColoring`
 
 From: |old-edge-color|
-To: |result-edge-color|
+To: |result_edge_color|
 
 Before update:
 

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -50,15 +50,39 @@ milestone for 4.0.0
 Summary of changes by function
 ...............................................................................
 
-* pgr_contraction
+* pgr_aStar
 
-  .. include:: pgr_contraction.rst
+  .. include:: pgr_aStar.rst
+     :start-after: Version 4.0.0
+     :end-before: .. rubric
+
+* pgr_aStarCost
+
+  .. include:: pgr_aStarCost.rst
+     :start-after: Version 4.0.0
+     :end-before: .. rubric
+
+* pgr_bdAstar
+
+  .. include:: pgr_bdAstar.rst
+     :start-after: Version 4.0.0
+     :end-before: .. rubric
+
+* pgr_bdAstarCost
+
+  .. include:: pgr_bdAstarCost.rst
      :start-after: Version 4.0.0
      :end-before: .. rubric
 
 * pgr_bdDijkstra
 
   .. include:: pgr_bdDijkstra.rst
+     :start-after: Version 4.0.0
+     :end-before: .. rubric
+
+* pgr_bdDijkstraCost
+
+  .. include:: pgr_bdDijkstraCost.rst
      :start-after: Version 4.0.0
      :end-before: .. rubric
 
@@ -74,6 +98,30 @@ Summary of changes by function
      :start-after: Version 4.0.0
      :end-before: .. rubric
 
+* pgr_contraction
+
+  .. include:: pgr_contraction.rst
+     :start-after: Version 4.0.0
+     :end-before: .. rubric
+
+* pgr_dagShortestPath
+
+  .. include:: pgr_dagShortestPath.rst
+     :start-after: Version 4.0.0
+     :end-before: .. rubric
+
+* pgr_dijkstra
+
+  .. include:: pgr_dijkstra.rst
+     :start-after: Version 4.0.0
+     :end-before: .. rubric
+
+* pgr_dijkstraCost
+
+  .. include:: pgr_dijkstraCost.rst
+     :start-after: Version 4.0.0
+     :end-before: .. rubric
+
 * pgr_edgeColoring
 
   .. include:: pgr_edgeColoring.rst
@@ -86,9 +134,21 @@ Summary of changes by function
      :start-after: Version 4.0.0
      :end-before: .. rubric
 
-* pgr_DAGshortestPath
+* pgr_KSP
 
-  .. include:: pgr_dagShortestPath.rst
+  .. include:: pgr_KSP.rst
+     :start-after: Version 4.0.0
+     :end-before: .. rubric
+
+* pgr_maxFlow
+
+  .. include:: pgr_maxFlow.rst
+     :start-after: Version 4.0.0
+     :end-before: .. rubric
+
+* pgr_pushRelabel
+
+  .. include:: pgr_pushRelabel.rst
      :start-after: Version 4.0.0
      :end-before: .. rubric
 
@@ -163,17 +223,17 @@ Functions promoted to official
   pgr_trspVia_withPoints
 * `#2701 <https://github.com/pgRouting/pgrouting/issues/2701>`__
   pgr_trsp_withPoints
-* `#2905 <https://github.com/pgRouting/pgrouting/issues/2905>`__
+* `#2700 <https://github.com/pgRouting/pgrouting/issues/2700>`__
   pgr_withPoints
-* `#2905 <https://github.com/pgRouting/pgrouting/issues/2905>`__
+* `#2700 <https://github.com/pgRouting/pgrouting/issues/2700>`__
   pgr_withPointsCost
-* `#2905 <https://github.com/pgRouting/pgrouting/issues/2905>`__
+* `#2700 <https://github.com/pgRouting/pgrouting/issues/2700>`__
   pgr_withPointsCostMatrix
-* `#2905 <https://github.com/pgRouting/pgrouting/issues/2905>`__
+* `#2700 <https://github.com/pgRouting/pgrouting/issues/2700>`__
   pgr_withPointsDD
-* `#2905 <https://github.com/pgRouting/pgrouting/issues/2905>`__
+* `#2700 <https://github.com/pgRouting/pgrouting/issues/2700>`__
   pgr_withPointsKSP
-* `#2905 <https://github.com/pgRouting/pgrouting/issues/2905>`__
+* `#2700 <https://github.com/pgRouting/pgrouting/issues/2700>`__
   pgr_withPointsVia
 
 Signatures promoted to official
@@ -232,6 +292,7 @@ Standardize output columns of functions with different output columns within ove
 * `#2905 <https://github.com/pgRouting/pgrouting/issues/2905>`__
   pgr_withPointsCost
 * `#2905 <https://github.com/pgRouting/pgrouting/issues/2905>`__
+  pgr_withPointsCostMatrix
 
 .. rubric:: Standardized to |result-edge-color|
 
@@ -251,6 +312,12 @@ Removal of SQL deprecated signatures
 * `#2683 <https://github.com/pgRouting/pgrouting/issues/2683>`__: pgr_trsp
 
   .. include:: pgr_trsp.rst
+     :start-after: Breaking change
+     :end-before: .. rubric
+
+* `#2683 <https://github.com/pgRouting/pgrouting/issues/2683>`__: pgr_trspVia
+
+  .. include:: pgr_trspVia.rst
      :start-after: Breaking change
      :end-before: .. rubric
 
@@ -422,9 +489,6 @@ Summary of functions and signatures no longer on pgrouting
 * #2919 pgr_withpoints(text,text,bigint,bigint,boolean,character,boolean)
 * #2919 pgr_withpoints(text,text,text,boolean,character,boolean)
 * #2919 pgr_withpointsvia(text,text,anyarray,boolean,boolean,boolean,character,boolean)
-
-.. rubric:: Internal functions
-
 
 Code enhancements
 ...............................................................................

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -294,7 +294,7 @@ Standardize output columns of functions with different output columns within ove
 * `#2905 <https://github.com/pgRouting/pgrouting/issues/2905>`__
   pgr_withPointsCostMatrix
 
-.. rubric:: Standardized to |result-edge-color|
+.. rubric:: Standardized to |result_edge_color|
 
 * `#2924 <https://github.com/pgRouting/pgrouting/issues/2924>`__
   pgr_edgeColoring

--- a/doc/src/release_notes.rst
+++ b/doc/src/release_notes.rst
@@ -74,6 +74,12 @@ Summary of changes by function
      :start-after: Version 4.0.0
      :end-before: .. rubric
 
+* pgr_edgeColoring
+
+  .. include:: pgr_edgeColoring.rst
+     :start-after: Version 4.0.0
+     :end-before: .. rubric
+
 * pgr_edwardMoore
 
   .. include:: pgr_edwardMoore.rst
@@ -226,7 +232,11 @@ Standardize output columns of functions with different output columns within ove
 * `#2905 <https://github.com/pgRouting/pgrouting/issues/2905>`__
   pgr_withPointsCost
 * `#2905 <https://github.com/pgRouting/pgrouting/issues/2905>`__
-  pgr_withPointsCostMatrix
+
+.. rubric:: Standardized to |result-edge-color|
+
+* `#2924 <https://github.com/pgRouting/pgrouting/issues/2924>`__
+  pgr_edgeColoring
 
 Removal of SQL deprecated signatures
 ...............................................................................

--- a/doc/trsp/pgr_trspVia.rst
+++ b/doc/trsp/pgr_trspVia.rst
@@ -25,6 +25,9 @@
 .. rubric:: Version 4.0.0
 
 * Function promoted to official.
+
+.. Breaking change
+
 * Breaking change, signatures no longer available:
 
   * pgr_trspviavertices(text,anyarray,boolean,boolean,text)

--- a/docqueries/coloring/edgeColoring.pg
+++ b/docqueries/coloring/edgeColoring.pg
@@ -1,7 +1,7 @@
 -- CopyRight(c) pgRouting developers
 -- Creative Commons Attribution-Share Alike 3.0 License : https://creativecommons.org/licenses/by-sa/3.0/
 /* -- q1 */
-SELECT * FROM pgr_edgeColoring(
+SELECT edge, color FROM pgr_edgeColoring(
     'SELECT id, source, target, cost, reverse_cost FROM edges
     ORDER BY id'
 );

--- a/docqueries/coloring/edgeColoring.result
+++ b/docqueries/coloring/edgeColoring.result
@@ -3,30 +3,30 @@ BEGIN
 SET client_min_messages TO NOTICE;
 SET
 /* -- q1 */
-SELECT * FROM pgr_edgeColoring(
+SELECT edge, color FROM pgr_edgeColoring(
     'SELECT id, source, target, cost, reverse_cost FROM edges
     ORDER BY id'
 );
- edge_id | color_id
----------+----------
-       1 |        3
-       2 |        2
-       3 |        3
-       4 |        4
-       5 |        4
-       6 |        1
-       7 |        2
-       8 |        1
-       9 |        2
-      10 |        5
-      11 |        5
-      12 |        3
-      13 |        2
-      14 |        1
-      15 |        3
-      16 |        1
-      17 |        1
-      18 |        1
+ edge | color
+------+-------
+    1 |     3
+    2 |     2
+    3 |     3
+    4 |     4
+    5 |     4
+    6 |     1
+    7 |     2
+    8 |     1
+    9 |     2
+   10 |     5
+   11 |     5
+   12 |     3
+   13 |     2
+   14 |     1
+   15 |     3
+   16 |     1
+   17 |     1
+   18 |     1
 (18 rows)
 
 /* -- q2 */

--- a/pgtap/coloring/edgeColoring/edge_cases.pg
+++ b/pgtap/coloring/edgeColoring/edge_cases.pg
@@ -20,16 +20,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 BEGIN;
 
 UPDATE edges SET cost = sign(cost), reverse_cost = sign(reverse_cost);
-SELECT CASE WHEN NOT min_version('3.3.0') THEN plan(1) ELSE plan(29) END;
+SELECT CASE WHEN min_version('4.0.0') THEN plan(29) ELSE plan(1) END;
 
 CREATE OR REPLACE FUNCTION edge_cases()
 RETURNS SETOF TEXT AS
 $BODY$
 BEGIN
 
-IF NOT min_version('3.3.0') THEN
+IF NOT min_version('4.0.0') THEN
   RETURN QUERY
-  SELECT skip(1, 'Function is new on 3.3.0');
+  SELECT skip(1, 'pgr_edgecoloring: testing only signatures standardaized in v4.0.0.');
   RETURN;
 END IF;
 
@@ -118,7 +118,7 @@ SELECT set_eq('q5',
 );
 
 RETURN QUERY
-SELECT ok((SELECT count(DISTINCT color_id) <= 3 FROM pgr_edgeColoring('q5')), 'At most three colors are expected');
+SELECT ok((SELECT count(DISTINCT color) <= 3 FROM pgr_edgeColoring('q5')), 'At most three colors are expected');
 
 
 -- even length cycle test
@@ -142,7 +142,7 @@ SELECT set_eq('q6',
 );
 
 RETURN QUERY
-SELECT ok((SELECT count(DISTINCT color_id) <= 3 FROM pgr_edgeColoring('q6')), 'At most three colors are expected');
+SELECT ok((SELECT count(DISTINCT color) <= 3 FROM pgr_edgeColoring('q6')), 'At most three colors are expected');
 
 -- changing the order of the edges will change the number of colors expected
 
@@ -165,7 +165,7 @@ SELECT set_eq('q7',
 );
 
 RETURN QUERY
-SELECT is((SELECT count(DISTINCT color_id)::INTEGER FROM pgr_edgeColoring('q7')), 2, 'Two colors are expected');
+SELECT is((SELECT count(DISTINCT color)::INTEGER FROM pgr_edgeColoring('q7')), 2, 'Two colors are expected');
 
 
 -- odd length cycle test
@@ -200,7 +200,7 @@ SELECT set_eq('q8',
 );
 
 RETURN QUERY
-SELECT is((SELECT count(DISTINCT color_id)::INTEGER FROM pgr_edgeColoring('q8')), 3, 'Three colors are expected');
+SELECT is((SELECT count(DISTINCT color)::INTEGER FROM pgr_edgeColoring('q8')), 3, 'Three colors are expected');
 
 
 -- 5 vertices cyclic
@@ -237,7 +237,7 @@ SELECT set_eq('q9',
 );
 
 RETURN QUERY
-SELECT is((SELECT count(DISTINCT color_id)::INTEGER FROM pgr_edgeColoring('q9')), 3, 'Three colors are expected');
+SELECT is((SELECT count(DISTINCT color)::INTEGER FROM pgr_edgeColoring('q9')), 3, 'Three colors are expected');
 
 
 -- self loop test
@@ -344,7 +344,7 @@ SELECT set_eq('q12',
 );
 
 RETURN QUERY
-SELECT is((SELECT count(DISTINCT color_id)::INTEGER FROM pgr_edgeColoring('q12')), 3, 'Three colors are expected');
+SELECT is((SELECT count(DISTINCT color)::INTEGER FROM pgr_edgeColoring('q12')), 3, 'Three colors are expected');
 
 
 -- 3 vertices multiple edge
@@ -377,7 +377,7 @@ SELECT set_eq('q13',
 );
 
 RETURN QUERY
-SELECT is((SELECT count(DISTINCT color_id)::INTEGER FROM pgr_edgeColoring('q13')), 2, 'Two colors are expected');
+SELECT is((SELECT count(DISTINCT color)::INTEGER FROM pgr_edgeColoring('q13')), 2, 'Two colors are expected');
 
 
 -- 2 vertices multiple edge
@@ -442,7 +442,7 @@ SELECT set_eq('q15',
 );
 
 RETURN QUERY
-SELECT is((SELECT count(DISTINCT color_id)::INTEGER FROM pgr_edgeColoring('q15')), 1, 'One color is required');
+SELECT is((SELECT count(DISTINCT color)::INTEGER FROM pgr_edgeColoring('q15')), 1, 'One color is required');
 
 
 END;

--- a/pgtap/coloring/edgeColoring/types_check.pg
+++ b/pgtap/coloring/edgeColoring/types_check.pg
@@ -19,16 +19,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  ********************************************************************PGR-GNU*/
 BEGIN;
 
-SELECT CASE WHEN NOT min_version('3.3.0') THEN plan(1) ELSE plan(5) END;
+SELECT CASE WHEN NOT min_version('4.0.0') THEN plan(1) ELSE plan(5) END;
 
 CREATE OR REPLACE FUNCTION types_check()
 RETURNS SETOF TEXT AS
 $BODY$
 BEGIN
 
-  IF NOT min_version('3.3.0') THEN
+  IF NOT min_version('4.0.0') THEN
     RETURN QUERY
-    SELECT skip(1, 'Function is new on 3.3.0');
+    SELECT skip(1, 'pgr_edgecoloring: testing only signatures standardaized in v4.0.0.');
     RETURN;
   END IF;
 
@@ -38,7 +38,7 @@ BEGIN
 
   RETURN QUERY
   SELECT function_args_eq('pgr_edgecoloring',
-    $$SELECT  '{"","edge_id","color_id"}'::TEXT[] $$
+    $$SELECT  '{"","edge","color"}'::TEXT[] $$
   );
 
   RETURN QUERY

--- a/sql/coloring/edgeColoring.sql
+++ b/sql/coloring/edgeColoring.sql
@@ -34,17 +34,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 CREATE FUNCTION pgr_edgeColoring(
     TEXT, -- edges_sql (required)
 
-    OUT edge_id BIGINT,
-    OUT color_id BIGINT)
+    OUT edge BIGINT,
+    OUT color BIGINT)
 RETURNS SETOF RECORD AS
 $BODY$
-BEGIN
-    RETURN QUERY
-    SELECT a.edge_id, a.color_id
-    FROM _pgr_edgeColoring(_pgr_get_statement($1)) AS a;
-END;
+    SELECT edge_id, color_id
+    FROM _pgr_edgeColoring(_pgr_get_statement($1));
 $BODY$
-LANGUAGE plpgsql VOLATILE STRICT;
+LANGUAGE SQL VOLATILE STRICT;
 
 -- COMMENTS
 

--- a/sql/scripts/build-extension-update-files.pl
+++ b/sql/scripts/build-extension-update-files.pl
@@ -279,6 +279,10 @@ sub generate_upgrade_script {
                 push @commands, drop_special_case_function("pgr_dagshortestpath(text,text)");
             }
 
+            if ($old_minor >= "3.3") {
+                push @commands, drop_special_case_function("pgr_edgecoloring(text)");
+            }
+
             # Row type defined by OUT parameters is different.
             # Out parameters changed names on v4.0.0
             # Experimental functions


### PR DESCRIPTION
Fixes #2924 

Changes proposed in this pull request:
- Standardizing output columns pgr_edgeColoring to (edge,color)
- Adding migration guide of pgr_edgeColoring
- News and release notes about pgr_edgeColoring
- NEWS and release notes : Adding missing information
- 
@pgRouting/admins
