### PR TITLE
Don't assume no GCC_TYPE means 81, as new will be unmarked

### DIFF
--- a/ci/winnie/build_pgrouting.sh
+++ b/ci/winnie/build_pgrouting.sh
@@ -41,10 +41,6 @@ if  [[ "${POSTGIS_VER}" == '' ]] ; then
     POSTGIS_VER=3.3.2
 fi;
 
-if  [[ "${GCC_TYPE}" == '' ]] ; then
-    GCC_TYPE=gcc81
-fi;
-
 if  [[ "${BOOST_VER}" == '' ]] ; then
     BOOST_VER=1.78.0
 fi;


### PR DESCRIPTION
This is to allow my new GCC to be used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline to remove implicit compiler defaults, requiring explicit toolchain selection during builds.
  * Improves consistency and transparency across environments by avoiding unintended default configurations.
  * No impact on application features or behavior; end-users will not see any changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->