### PR TITLE
Add missing include for int64_t

### DIFF
--- a/include/drivers/ordering_driver.hpp
+++ b/include/drivers/ordering_driver.hpp
@@ -37,7 +37,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <cstddef>
 #include <string>
-
+#include <cstdint>
 
 void
 do_ordering(


### PR DESCRIPTION
Closes #2979 for 4.0.0 (main)

Fixes #2979 