### PR TITLE
Get rid of path hardcoding for GCC_TYPE for winnie build

### DIFF
--- a/ci/winnie/build_pgrouting.sh
+++ b/ci/winnie/build_pgrouting.sh
@@ -41,10 +41,6 @@ if  [[ "${POSTGIS_VER}" == '' ]] ; then
     POSTGIS_VER=3.3.2
 fi;
 
-if  [[ "${GCC_TYPE}" == '' ]] ; then
-    GCC_TYPE=gcc81
-fi;
-
 if  [[ "${BOOST_VER}" == '' ]] ; then
     BOOST_VER=1.78.0
 fi;


### PR DESCRIPTION
Need to get rid of hard-coding when blank, cause new gcc won't have a gcc path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated build configuration to avoid applying a default compiler when none is specified.
  - Builds now respect an unset compiler variable, requiring explicit selection in CI or local environments.
  - Enhances predictability by preventing unintended compiler version usage.
  - May require updating environment or pipeline settings to define the desired compiler explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->