### PR TITLE
Fix macOS CI error

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Release -DWITH_DOC=OFF ..
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_SHARED_MODULE_SUFFIX_CXX=.dylib -DWITH_DOC=OFF ..
 
       - name: Build
         run: |


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix macOS CI error (https://github.com/pgRouting/pgrouting/actions/runs/18355661012) by updating postgresql version from 14 to 17 for postgis package.
  - https://github.com/Homebrew/homebrew-core/commit/7897963459566ad30f1e3b75d411d2310cd6397d
- Use `dylib` extension from homebrew `pgrouting.rb` formula.
  - https://github.com/Homebrew/homebrew-core/blob/main/Formula/p/pgrouting.rb#L42-L44
    ```rb
    # CMake MODULE libraries use .so on macOS but PostgreSQL 16+ looks for .dylib
    # Ref: https://github.com/postgres/postgres/commit/b55f62abb2c2e07dfae99e19a2b3d7ca9e58dc1a
    args << "-DCMAKE_SHARED_MODULE_SUFFIX_CXX=.dylib" if OS.mac? && postgresql.version >= 16
    ```

@pgRouting/admins
