### PR TITLE
clang-tidy : added cppcoreguidelines-avoid-do-while and fix interruption.hpp

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,45 @@
+Checks: >
+    -*,
+    google-*,
+    -google-readability-casting,
+    clang-analyzer-*,
+    -clang-analyzer-cplusplus.NewDelete,
+    -clang-analyzer-core.uninitialized.Assign,
+    clang-diagnostic-*,
+    cppcoreguidelines-*,
+    -cppcoreguidelines-avoid-c-arrays,
+    -cppcoreguidelines-avoid-const-or-ref-data-members,
+    -cppcoreguidelines-avoid-do-while,
+    -cppcoreguidelines-avoid-magic-numbers,
+    -cppcoreguidelines-explicit-virtual-functions,
+    -cppcoreguidelines-macro-usage,
+    -cppcoreguidelines-narrowing-conversions,
+    -cppcoreguidelines-no-malloc,
+    -cppcoreguidelines-non-private-member-variables-in-classes,
+    -cppcoreguidelines-owning-memory,
+    -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+    -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+    -cppcoreguidelines-pro-type-const-cast,
+    -cppcoreguidelines-pro-type-member-init,
+    -cppcoreguidelines-pro-type-reinterpret-cast,
+    -cppcoreguidelines-pro-type-union-access,
+    -cppcoreguidelines-pro-type-vararg,
+    -cppcoreguidelines-slicing,
+    -cppcoreguidelines-special-member-functions,
+    -cppcoreguidelines-use-default-member-init,
+    -cppcoreguidelines-virtual-class-destructor
+
+CheckOptions:
+    - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+      value: true
+    - key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions
+      value: true
+    - key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted
+      value: true
+    - key: cppcoreguidelines-special-member-functions.AllowImplicitlyDeletedCopyOrMove
+      value: true
+
+WarningsAsErrors: ''
+HeaderFilterRegex: './include'
+FormatStyle:     none
+InheritParentConfig: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated static analysis configuration (no change to behavior).

* **Refactor**
  * Internal refactor of interrupt-handling implementation for maintainability; no behavioral or public API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->