### PR TITLE
Check cppcoreguidelines-prefer-member-initializer and fix code

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,8 @@ Checks: >
     cppcoreguidelines-avoid-goto,
     cppcoreguidelines-avoid-non-const-global-variables,
     cppcoreguidelines-avoid-reference-coroutine-parameters,
-    cppcoreguidelines-init-variables
+    cppcoreguidelines-init-variables,
+    cppcoreguidelines-prefer-member-initializer
 
 WarningsAsErrors: ''
 HeaderFilterRegex: './include'

--- a/include/trsp/trspHandler.hpp
+++ b/include/trsp/trspHandler.hpp
@@ -91,8 +91,9 @@ class TrspHandler : public pgrouting::Pgr_messages {
 
     class CostHolder {
      public:
-         CostHolder() {
-             endCost =  startCost = (std::numeric_limits<double>::max)();
+         CostHolder() :
+             startCost((std::numeric_limits<double>::max)()),
+             endCost((std::numeric_limits<double>::max)()) {
          }
 
      public:

--- a/include/yen/ksp.hpp
+++ b/include/yen/ksp.hpp
@@ -62,8 +62,8 @@ class Pgr_ksp :  public Pgr_messages {
          m_start(0),
          m_end(0),
          m_K(0),
-         m_heap_paths(false) {
-             m_vis = new Visitor;
+         m_heap_paths(false),
+         m_vis(new Visitor) {
          }
      ~Pgr_ksp() {
          delete m_vis;


### PR DESCRIPTION
`Title: clang-tidy: Enable and fix cppcoreguidelines-prefer-member-initializer`

Hello,

This pull request improves code quality and consistency by enforcing a modern C++ best practice for constructor initialization. It adheres to the C++ Core Guideline C.49: "Prefer initialization to assignment in constructors".

Using member initializer lists is more efficient than assigning values inside the constructor body, as it avoids a potential two-step process (default construction followed by assignment).

The changes in this PR are:

- The cppcoreguidelines-prefer-member-initializer check is enabled in the .clang-tidy configuration file.
- The constructors in CostHolder (trspHandler.hpp) and Pgr_ksp (ksp.hpp) have been refactored to use member initializer lists, fixing the warnings introduced by the new rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code initialization patterns to follow C++ best practices for enhanced code quality and maintainability.

* **Chores**
  * Updated code analysis configuration to enforce additional code quality standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->