### PR TITLE
clang-tidy: check and fix cppcoreguidelines-virtual-class-destructor

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,8 +26,7 @@ Checks: >
     -cppcoreguidelines-pro-type-vararg,
     -cppcoreguidelines-slicing,
     -cppcoreguidelines-special-member-functions,
-    -cppcoreguidelines-use-default-member-init,
-    -cppcoreguidelines-virtual-class-destructor
+    -cppcoreguidelines-use-default-member-init
 
 CheckOptions:
     - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor

--- a/include/bdAstar/bdAstar.hpp
+++ b/include/bdAstar/bdAstar.hpp
@@ -78,7 +78,7 @@ class Pgr_bdAstar : public Pgr_bidirectional<G> {
         m_log << "pgr_bdAstar constructor\n";
     }
 
-    ~Pgr_bdAstar() = default;
+    virtual ~Pgr_bdAstar() = default;
 
     Path pgr_bdAstar(V start_vertex, V end_vertex,
             int heuristic,

--- a/include/bdDijkstra/bdDijkstra.hpp
+++ b/include/bdDijkstra/bdDijkstra.hpp
@@ -77,7 +77,7 @@ class Pgr_bdDijkstra : public Pgr_bidirectional<G> {
              m_log << "pgr_bdDijkstra constructor\n";
          }
 
-     ~Pgr_bdDijkstra() = default;
+     virtual ~Pgr_bdDijkstra() = default;
 
      Path pgr_bdDijkstra(V start_vertex, V end_vertex, bool only_cost) {
          m_log << "pgr_bdDijkstra\n";

--- a/include/cpp_common/bidirectional.hpp
+++ b/include/cpp_common/bidirectional.hpp
@@ -78,7 +78,7 @@ class Pgr_bidirectional {
         m_log << "constructor\n";
     }
 
-    ~Pgr_bidirectional() = default;
+    virtual ~Pgr_bidirectional() = default;
 
     std::string log() const {return m_log.str();}
     void clean_log() {m_log.clear();}

--- a/include/spanningTree/kruskal.hpp
+++ b/include/spanningTree/kruskal.hpp
@@ -42,6 +42,7 @@ namespace functions {
 template <class G>
 class Pgr_kruskal : public Pgr_mst<G> {
  public:
+     virtual ~Pgr_kruskal() = default;
      std::vector<MST_rt> kruskal(G &graph);
 
      std::vector<MST_rt> kruskalBFS(

--- a/include/spanningTree/mst.hpp
+++ b/include/spanningTree/mst.hpp
@@ -50,6 +50,9 @@ namespace functions {
 
 template <class G>
 class Pgr_mst {
+ public:
+     virtual ~Pgr_mst() = default;
+
  protected:
      typedef typename G::B_G B_G;
      typedef typename G::V V;

--- a/include/spanningTree/prim.hpp
+++ b/include/spanningTree/prim.hpp
@@ -51,6 +51,7 @@ class Pgr_prim : public Pgr_mst<G> {
      typedef typename G::B_G B_G;
 
  public:
+     virtual ~Pgr_prim() = default;
      std::vector<MST_rt> prim(G &graph);
 
      std::vector<MST_rt> primBFS(


### PR DESCRIPTION
**Description**
This PR enables the `cppcoreguidelines-virtual-class-destructor` check in `.clang-tidy` and fixes the warnings currently present in the codebase.

**Changes**
* Modified `.clang-tidy` to enable the check.
* Added `virtual ~ClassName() = default;` to the following classes:
    * `Pgr_bdAstar` in `include/bdAstar/bdAstar.hpp`
    * `Pgr_bdDijkstra` in `include/bdDijkstra/bdDijkstra.hpp`
    * `Pgr_bidirectional` in `include/cpp_common/bidirectional.hpp`
    * `Pgr_kruskal` in `include/spanningTree/kruskal.hpp`
    * `Pgr_mst` in `include/spanningTree/mst.hpp`
    * `Pgr_prim` in `include/spanningTree/prim.hpp`

**Verification**
Built locally with `clang-tidy` enabled using:
`CXX=clang++ CC=clang cmake -DUSE_CLANG_TIDY=ON ..`
Result: Build completed successfully with no warnings generated for this check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code quality configurations and standards compliance across the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->