### PR TITLE
clang-tidy: check and fix cppcoreguidelines-special-member-functions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,7 +25,6 @@ Checks: >
     -cppcoreguidelines-pro-type-union-access,
     -cppcoreguidelines-pro-type-vararg,
     -cppcoreguidelines-slicing,
-    -cppcoreguidelines-special-member-functions,
     -cppcoreguidelines-use-default-member-init
 
 CheckOptions:

--- a/include/chinese/chinesePostman.hpp
+++ b/include/chinese/chinesePostman.hpp
@@ -62,6 +62,10 @@ class PgrDirectedChPPGraph {
 
       ~PgrDirectedChPPGraph();
 
+      PgrDirectedChPPGraph(const PgrDirectedChPPGraph&) = delete;
+      PgrDirectedChPPGraph& operator=(const PgrDirectedChPPGraph&) = delete;
+      PgrDirectedChPPGraph(PgrDirectedChPPGraph&&) = delete;
+      PgrDirectedChPPGraph& operator=(PgrDirectedChPPGraph&&) = delete;
 
  private:
      bool EulerCircuitDFS(int64_t p);

--- a/include/cpp_common/line_vertex.hpp
+++ b/include/cpp_common/line_vertex.hpp
@@ -62,6 +62,11 @@ class Line_vertex {
          target(v.target),
          cost(v.cost) {}
 
+     Line_vertex& operator=(const Line_vertex&) = default;
+     Line_vertex(Line_vertex&&) = default;
+     Line_vertex& operator=(Line_vertex&&) = default;
+     ~Line_vertex() = default;
+
      void cp_members(const Line_vertex &other) {
          this->id = other.id;
          this->vertex_id = other.vertex_id;

--- a/include/vrp/solution.hpp
+++ b/include/vrp/solution.hpp
@@ -73,11 +73,14 @@ class Solution {
 
      /* @brief copy assignment */
      Solution& operator = (const Solution& sol) {
-         EPSILON = 0.0001,
+         EPSILON = 0.0001;
          fleet = sol.fleet;
          trucks = sol.trucks;
          return *this;
-     };
+     }
+
+     /* @brief destructor */
+     ~Solution() = default;
 
 
      Initials_code get_kind() const;

--- a/include/withPoints/withPoints.hpp
+++ b/include/withPoints/withPoints.hpp
@@ -50,6 +50,11 @@ class Pg_points_graph : public Pgr_messages {
  public:
      Pg_points_graph() = delete;
      Pg_points_graph(const Pg_points_graph &) = delete;
+     Pg_points_graph& operator=(const Pg_points_graph&) = delete;
+     Pg_points_graph(Pg_points_graph&&) = delete;
+     Pg_points_graph& operator=(Pg_points_graph&&) = delete;
+     ~Pg_points_graph() = default;
+
      Pg_points_graph(
              std::vector<Point_on_edge_t> p_points,
              std::vector<Edge_t>      p_edges_to_modify,

--- a/include/yen/ksp.hpp
+++ b/include/yen/ksp.hpp
@@ -35,6 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #pragma once
 
 #include <map>
+#include <memory>
 #include <sstream>
 #include <deque>
 #include <vector>
@@ -63,11 +64,15 @@ class Pgr_ksp :  public Pgr_messages {
          m_end(0),
          m_K(0),
          m_heap_paths(false),
-         m_vis(new Visitor) {
+         m_vis(std::make_unique<Visitor>()) {
          }
-     ~Pgr_ksp() {
-         delete m_vis;
-     }
+
+     ~Pgr_ksp() = default;
+
+     Pgr_ksp(const Pgr_ksp&) = delete;
+     Pgr_ksp& operator=(const Pgr_ksp&) = delete;
+     Pgr_ksp(Pgr_ksp&&) = delete;
+     Pgr_ksp& operator=(Pgr_ksp&&) = delete;
 
      std::deque<Path> Yen(
              G &graph,
@@ -121,7 +126,13 @@ class Pgr_ksp :  public Pgr_messages {
 
      class Visitor {
       public:
-          virtual ~Visitor() {}
+          virtual ~Visitor() = default;
+
+          Visitor() = default;
+          Visitor(const Visitor&) = delete;
+          Visitor& operator=(const Visitor&) = delete;
+          Visitor(Visitor&&) = delete;
+          Visitor& operator=(Visitor&&) = delete;
 
          virtual void on_insert_first_solution(const Path) const {
              /* noop */
@@ -239,7 +250,7 @@ class Pgr_ksp :  public Pgr_messages {
      pSet m_ResultSet;  //!< ordered set of shortest paths
      pSet m_Heap;  //!< the heap
 
-     Visitor *m_vis;
+     std::unique_ptr<Visitor> m_vis;
 };
 
 

--- a/include/yen/turnRestrictedPath.hpp
+++ b/include/yen/turnRestrictedPath.hpp
@@ -36,6 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <set>
 #include <limits>
 #include <cstdint>
+#include <memory>
 
 #include "yen/ksp.hpp"
 #include "cpp_common/assert.hpp"
@@ -161,8 +162,7 @@ class Pgr_turnRestrictedPath : public Pgr_ksp< G > {
          this->m_end = end_vertex;
          this->m_K = K;
          Pgr_ksp<G>::m_heap_paths = true;
-         delete this->m_vis;
-         this->m_vis = new Myvisitor(
+         this->m_vis = std::make_unique<Myvisitor>(
                  m_solutions,
                  m_restrictions,
                  m_stop_on_first);


### PR DESCRIPTION
Fixes # 3042

#summary
This PR enables and fixes the `cppcoreguidelines-special-member-functions` clang-tidy check.

Changes proposed in this pull request:
- Removed the check from the disabled list in [.clang-tidy](cci:7://file://wsl.localhost/Ubuntu-24.04/home/mohit31/GSoC-pgRouting/.clang-tidy:0:0-0:0)
- Fixed 6 classes across 5 header files by adding missing special member functions (destructor, copy constructor, copy assignment operator) following the Rule of Five


@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved memory ownership and lifecycle handling across graph and routing components for greater stability and safety.
  * Made several algorithmic classes non-copyable to prevent inadvertent resource errors.

* **Chores**
  * Adjusted static analysis configuration to relax a special-member-function check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->