### PR TITLE
clang-tidy: check and fix cppcoreguidelines-use-default-member-init

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,8 +24,7 @@ Checks: >
     -cppcoreguidelines-pro-type-reinterpret-cast,
     -cppcoreguidelines-pro-type-union-access,
     -cppcoreguidelines-pro-type-vararg,
-    -cppcoreguidelines-slicing,
-    -cppcoreguidelines-use-default-member-init
+    -cppcoreguidelines-slicing
 
 CheckOptions:
     - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor

--- a/include/bdAstar/bdAstar.hpp
+++ b/include/bdAstar/bdAstar.hpp
@@ -72,9 +72,7 @@ class Pgr_bdAstar : public Pgr_bidirectional<G> {
 
  public:
     explicit Pgr_bdAstar(G &pgraph) :
-        Pgr_bidirectional<G>(pgraph),
-        m_heuristic(5),
-        m_factor(1.0) {
+        Pgr_bidirectional<G>(pgraph) {
         m_log << "pgr_bdAstar constructor\n";
     }
 
@@ -184,8 +182,8 @@ class Pgr_bdAstar : public Pgr_bidirectional<G> {
     }
 
  private:
-    int m_heuristic;
-    double m_factor;
+    int m_heuristic{5};
+    double m_factor{1.0};
 };
 
 }  // namespace bidirectional

--- a/include/chinese/chinesePostman.hpp
+++ b/include/chinese/chinesePostman.hpp
@@ -74,8 +74,8 @@ class PgrDirectedChPPGraph {
      void setPathEdges(graph::PgrCostFlowGraph &flowGraph);
 
  private:
-     int64_t totalDeg;
-     double totalCost;
+     int64_t totalDeg{0};
+     double totalCost{0};
      int64_t superSource, superTarget;
      int64_t startPoint;
      double m_cost;
@@ -110,7 +110,7 @@ PgrDirectedChPPGraph::~PgrDirectedChPPGraph() {
     edgeToIdx.clear();
 }
 PgrDirectedChPPGraph::PgrDirectedChPPGraph(const std::vector<Edge_t> &dataEdges) :
-    totalDeg(0), totalCost(0), vertices(),
+    vertices(),
     edgeToIdx(), originalEdges(),
     resultGraph(), VToVecid(), edgeVisited(),
     pathStack(), resultPath(),

--- a/include/contraction/contractionGraph.hpp
+++ b/include/contraction/contractionGraph.hpp
@@ -66,8 +66,7 @@ class Pgr_contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_dire
        Prepares the _graph_ to be of type *directed*
        */
      explicit Pgr_contractionGraph()
-         : Pgr_base_graph<G, CH_vertex, CH_edge, t_directed>(),
-        min_edge_id(0) {
+         : Pgr_base_graph<G, CH_vertex, CH_edge, t_directed>() {
          }
 
      /*! @brief get the vertex descriptors of adjacent vertices of *v*
@@ -548,7 +547,7 @@ class Pgr_contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_dire
     }
 
  private:
-    int64_t min_edge_id;
+     int64_t min_edge_id{0};
     Identifiers<V> forbiddenVertices;
 };
 

--- a/include/cpp_common/bidirectional.hpp
+++ b/include/cpp_common/bidirectional.hpp
@@ -73,8 +73,7 @@ class Pgr_bidirectional {
  public:
     explicit Pgr_bidirectional(G &pgraph):
         graph(pgraph),
-        INF((std::numeric_limits<double>::max)()),
-        best_cost(0) {
+        INF((std::numeric_limits<double>::max)()) {
         m_log << "constructor\n";
     }
 
@@ -222,7 +221,7 @@ class Pgr_bidirectional {
 
     double INF;  //!< infinity
 
-    double best_cost;
+    double best_cost{0};
 
     mutable std::ostringstream m_log;
     Priority_queue forward_queue;

--- a/include/visitors/dijkstra_visitors.hpp
+++ b/include/visitors/dijkstra_visitors.hpp
@@ -147,7 +147,6 @@ class dijkstra_distance_visitor_no_init : public boost::default_dijkstra_visitor
              std::vector<boost::default_color_type> &color_map) :
          m_root(root),
          m_distance_goal(distance_goal),
-         m_num_examined(0),
          m_predecessors(predecessors),
          m_dist(distances),
          m_color(color_map) {
@@ -190,7 +189,7 @@ class dijkstra_distance_visitor_no_init : public boost::default_dijkstra_visitor
  private:
      V m_root;
      double m_distance_goal;
-     size_t m_num_examined;
+     size_t m_num_examined{0};
      std::vector<V > &m_predecessors;
      std::vector<double> &m_dist;
      std::vector<boost::default_color_type> &m_color;

--- a/include/vrp/solution.hpp
+++ b/include/vrp/solution.hpp
@@ -46,7 +46,7 @@ class Solution {
     friend class Optimize;
     friend class PD_problem;
  protected:
-     double EPSILON;
+     double EPSILON{0.0001};
      std::deque<Vehicle_pickDeliver> fleet;
 
      /* this solution belongs to this problem*/
@@ -66,14 +66,12 @@ class Solution {
 
      /* @brief copy constructor */
      Solution(const Solution &sol) :
-         EPSILON(0.0001),
          fleet(sol.fleet),
          trucks(sol.trucks)
     {};
 
      /* @brief copy assignment */
      Solution& operator = (const Solution& sol) {
-         EPSILON = 0.0001;
          fleet = sol.fleet;
          trucks = sol.trucks;
          return *this;

--- a/include/yen/ksp.hpp
+++ b/include/yen/ksp.hpp
@@ -60,10 +60,6 @@ class Pgr_ksp :  public Pgr_messages {
 
  public:
      Pgr_ksp() :
-         m_start(0),
-         m_end(0),
-         m_K(0),
-         m_heap_paths(false),
          m_vis(std::make_unique<Visitor>()) {
          }
 
@@ -240,10 +236,10 @@ class Pgr_ksp :  public Pgr_messages {
      ///@{
      V v_source;  //!< source descriptor
      V v_target;  //!< target descriptor
-     int64_t m_start;  //!< source id
-     int64_t m_end;   //!< target id
-     size_t m_K;
-     bool m_heap_paths;
+     int64_t m_start{0};  //!< source id
+     int64_t m_end{0};   //!< target id
+     size_t m_K{0};
+     bool m_heap_paths{false};
 
      Path curr_result_path;  //!< storage for the current result
 

--- a/src/pickDeliver/solution.cpp
+++ b/src/pickDeliver/solution.cpp
@@ -230,7 +230,6 @@ Solution::get_kind() const {
 }
 
 Solution::Solution() :
-    EPSILON(0.0001),
     trucks(problem->trucks()) {
     ENTERING(msg());
     for (const auto &t : trucks) {


### PR DESCRIPTION
Fixes #3041

 Summary
- Enable `cppcoreguidelines-use-default-member-init` in `.clang-tidy`.
- Refactor initialization in these classes to use default member initializers:
  - `Pgr_bdAstar`
  - `PgrDirectedChPPGraph`
  - `Pgr_contractionGraph`
  - `Pgr_bidirectional`
  - `dijkstra_distance_visitor_no_init`
  - `Solution`
  - `Pgr_ksp`
  
 Changes proposed in this pull request
- Update `.clang-tidy` to enable `cppcoreguidelines-use-default-member-init`.
- Refactor constructor initializations as per the guideline for the classes above.
- Run clang-tidy and ensure no violations remain for this check.
- All tests and builds pass locally with the new code style.


@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized default value handling by moving many initializations into member declarations and simplifying constructors.
  * Internal cleanup only — no changes to public interfaces or user-facing behavior.

* **Chore**
  * Adjusted lint/config checks (internal) with one rule removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->