### PR TITLE
(winnie) Fix struct stat redefinition - reorder includes

### DIFF
--- a/src/cpp_common/report_messages.cpp
+++ b/src/cpp_common/report_messages.cpp
@@ -23,14 +23,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 
-#include "cpp_common/report_messages.hpp"
-
 extern "C" {
 #include "c_common/postgres_connection.h"
 #include "c_common/e_report.h"
 }
 
 #include <sstream>
+
+#include "cpp_common/report_messages.hpp"
 
 #include "cpp_common/alloc.hpp"
 


### PR DESCRIPTION
Fixes #3067 .

On Windows (MinGW), C++ headers like `<sstream>` must be included **AFTER** PostgreSQL headers to avoid `struct stat` redefinition errors.

 The Problem
The include order in `report_messages.cpp` was:
#include "cpp_common/report_messages.hpp"  // includes <sstream>
extern "C" {
#include "c_common/postgres_connection.h"  // PostgreSQL AFTER = broken
}
This causes MinGW's <sys/stat.h> to define struct stat first, then PostgreSQL's win32_port.h tries to redefine it → compilation error.
The Fix
Reorder includes so PostgreSQL headers come first:
extern "C" {
#include "c_common/postgres_connection.h"  // PostgreSQL FIRST
#include "c_common/e_report.h"
}
#include `<sstream> `                       // C++ headers AFTER
#include "cpp_common/report_messages.hpp"   // Project headers AFTER

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements with no functional changes to end-user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->