### PR TITLE
(winnie) Fix struct stat redefinition - reorder includes

### DIFF
--- a/src/cpp_common/report_messages.cpp
+++ b/src/cpp_common/report_messages.cpp
@@ -23,14 +23,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  ********************************************************************PGR-GNU*/
 
-#include "cpp_common/report_messages.hpp"
-
 extern "C" {
 #include "c_common/postgres_connection.h"
 #include "c_common/e_report.h"
 }
 
 #include <sstream>
+
+#include "cpp_common/report_messages.hpp"
 
 #include "cpp_common/alloc.hpp"
 


### PR DESCRIPTION
Fixes #3067  (for main branch)
This PR applies the same struct stat redefinition fix to the **main** branch, matching the fix already merged into develop via PR #3068.
 Changes
Reordered includes in `src/cpp_common/report_messages.cpp` so that PostgreSQL headers are included before C++ headers, following the pattern used in previous fixes (#2648).

@pgRouting/admins
