### PR TITLE
Fix pgr_bellmanFord neg-edges empty check

### DIFF
--- a/src/bellman_ford/bellman_ford_neg_driver.cpp
+++ b/src/bellman_ford/bellman_ford_neg_driver.cpp
@@ -116,7 +116,7 @@ pgr_do_bellman_ford_neg(
         hint = neg_edges_sql;
         auto neg_edges = get_edges(std::string(neg_edges_sql), true, false);
 
-        if (edges.size() + neg_edges.empty()) {
+        if (edges.empty() && neg_edges.empty()) {
             *notice_msg = to_pg_msg("No edges found");
             *log_msg = hint? to_pg_msg(hint) : to_pg_msg(log);
             return;


### PR DESCRIPTION
## Fix wrong empty-check in Bellman-Ford neg-edges driver

The neg-edges driver was returning "No edges found" whenever the main `edges_sql` had any rows. The bug is in the condition that decides when to treat the graph as empty.

## What was wrong

In `bellman_ford_neg_driver.cpp` we had:

```cpp
if (edges.size() + neg_edges.empty()) {
    *notice_msg = to_pg_msg("No edges found");
    return;
}
```

`edges.size()` is a `size_t` and `neg_edges.empty()` is a `bool` (0 or 1). So we're doing integer + bool. For example with 3 positive edges and 2 negative edges we get `3 + 0 = 3` (truthy), so we always hit this early return when there are any positive edges. The only time we didn't was when `edges` was empty and `neg_edges.empty()` was true (`0 + 1 = 1`), i.e. both empty.

## Fix

We only want to return "No edges found" when both edge sets are empty:

```cpp
if (edges.empty() && neg_edges.empty()) {
    *notice_msg = to_pg_msg("No edges found");
    return;
}
```

## Example (before vs after)

Before the fix, a call with both positive and negative edges returns no rows:

```sql
-- Positive edges: 1→2 (cost 1), 2→3 (cost 2)
-- Negative edge: 3→4 (cost -0.5)
-- Path 1→4 should have cost 2.5

SELECT * FROM pgr_bellmanFord(
  'SELECT 1 AS id, 1 AS source, 2 AS target, 1.0::float AS cost
   UNION ALL SELECT 2, 2, 3, 2.0',
  'SELECT 3 AS id, 3 AS source, 4 AS target, -0.5::float AS cost',
  1, 4, true
);
-- Before: 0 rows (wrong)
-- After:  path with agg_cost 2.5
```

## What's in this PR

- Fix the condition in `src/bellman_ford/bellman_ford_neg_driver.cpp` (line 119).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected edge detection logic in the Bellman-Ford algorithm to properly identify and handle graphs with no edges, ensuring accurate processing and appropriate status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->