### PR TITLE
clang-tidy: check and fix cppcoreguidelines-pro-type-member-init

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,7 +18,6 @@ Checks: >
     -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
     -cppcoreguidelines-pro-bounds-pointer-arithmetic,
     -cppcoreguidelines-pro-type-const-cast,
-    -cppcoreguidelines-pro-type-member-init,
     -cppcoreguidelines-pro-type-reinterpret-cast,
     -cppcoreguidelines-pro-type-union-access,
     -cppcoreguidelines-pro-type-vararg,

--- a/include/chinese/chinesePostman.hpp
+++ b/include/chinese/chinesePostman.hpp
@@ -160,7 +160,7 @@ PgrDirectedChPPGraph::PgrDirectedChPPGraph(const std::vector<Edge_t> &dataEdges)
             }
         }
 
-        CostFlow_t edge;
+        CostFlow_t edge{};
         edge.edge_id = e.id;
         edge.reverse_capacity = -1;
         edge.reverse_cost = -1.0;
@@ -185,7 +185,7 @@ PgrDirectedChPPGraph::PgrDirectedChPPGraph(const std::vector<Edge_t> &dataEdges)
         int d = iter->second;
         if (d == 0) continue;
         if (d > 0) totalDeg += d;
-        CostFlow_t edge = {};
+        CostFlow_t edge{};
         edge.reverse_capacity = -1;
         edge.reverse_cost = -1.0;
         edge.cost = 0.0;

--- a/include/cpp_common/base_graph.hpp
+++ b/include/cpp_common/base_graph.hpp
@@ -720,7 +720,7 @@ class Pgr_base_graph {
       * @return edge data
       */
      T_E get_edge_info(const E &e) const {
-         T_E d_edge;
+         T_E d_edge{};
          d_edge.id = graph[e].id;
          d_edge.source = graph[source(e)].id;
          d_edge.target = graph[target(e)].id;

--- a/include/cpp_common/ch_edge.hpp
+++ b/include/cpp_common/ch_edge.hpp
@@ -63,10 +63,10 @@ class CH_edge {
      friend std::ostream& operator <<(std::ostream& os, const CH_edge& e);
 
  public:
-     int64_t id;
-     int64_t source;
-     int64_t target;
-     double cost;
+     int64_t id{};
+     int64_t source{};
+     int64_t target{};
+     double cost{};
 
  private:
      Identifiers<int64_t> m_contracted_vertices;

--- a/include/cpp_common/ch_vertex.hpp
+++ b/include/cpp_common/ch_vertex.hpp
@@ -41,7 +41,7 @@ namespace pgrouting {
 
 class CH_vertex {
  public:
-    int64_t id;
+    int64_t id{};
 
     CH_vertex();
     CH_vertex(const Edge_t &other, bool is_source) :

--- a/include/cpp_common/line_vertex.hpp
+++ b/include/cpp_common/line_vertex.hpp
@@ -93,11 +93,11 @@ class Line_vertex {
      }
 
  public:
-     int64_t id;
-     int64_t vertex_id;
-     int64_t source;
-     int64_t target;
-     double cost;
+     int64_t id{};
+     int64_t vertex_id{};
+     int64_t source{};
+     int64_t target{};
+     double cost{};
 };
 
 }  // namespace pgrouting

--- a/include/cpp_common/path.hpp
+++ b/include/cpp_common/path.hpp
@@ -57,9 +57,9 @@ class Path {
 
  private:
     std::deque< Path_t > path;
-    int64_t m_start_id;
-    int64_t m_end_id;
-    double m_tot_cost;
+    int64_t m_start_id{};
+    int64_t m_end_id{};
+    double m_tot_cost{};
 
  public:
     Path(): m_start_id(0), m_end_id(0), m_tot_cost(0)

--- a/include/lineGraph/lineGraphFull.hpp
+++ b/include/lineGraph/lineGraphFull.hpp
@@ -292,7 +292,7 @@ class Pgr_lineGraphFull : public Pgr_base_graph<G, T_V, T_E, t_directed> {
     }
 
  private:
-    int64_t m_num_edges;
+    int64_t m_num_edges{};
     std::map < int64_t, double > m_edge_costs;
     std::map < int64_t, std::pair< int64_t, int64_t > > m_transformation_map;
     std::map < std::pair< int64_t, int64_t >, int64_t > m_vertex_map;

--- a/include/max_flow/maxflow.hpp
+++ b/include/max_flow/maxflow.hpp
@@ -193,8 +193,8 @@ class PgrFlowGraph {
      * The same applies for sinks.
      * To avoid code repetition, a supersource/sink is used even in the one to one signature.
      */
-     V supersource;
-     V supersink;
+     V supersource{};
+     V supersink{};
 };
 
 }  // namespace graph

--- a/include/max_flow/minCostMaxFlow.hpp
+++ b/include/max_flow/minCostMaxFlow.hpp
@@ -138,8 +138,8 @@ class PgrCostFlowGraph {
      * The same applies for sinks.
      * To avoid code repetition, a supersource/sink is used even in the one to one signature.
      */
-     V supersource;
-     V supersink;
+     V supersource{};
+     V supersink{};
 };
 
 }  // namespace graph

--- a/include/spanningTree/mst.hpp
+++ b/include/spanningTree/mst.hpp
@@ -144,9 +144,9 @@ class Pgr_mst {
 
  protected:
      std::set<int64_t> m_roots;
-     bool m_get_component;
-     int64_t  m_max_depth;
-     double  m_distance;
+     bool m_get_component{};
+     int64_t  m_max_depth{};
+     double  m_distance{};
 
      struct InSpanning {
          std::set<E> edges;

--- a/include/trsp/edgeInfo.hpp
+++ b/include/trsp/edgeInfo.hpp
@@ -85,8 +85,8 @@ class EdgeInfo {
 
 
  private:
-     Edge_t m_edge;
-     size_t m_edgeIndex;
+     Edge_t m_edge{};
+     size_t m_edgeIndex{};
      std::vector<size_t> m_startConnectedEdge;
      std::vector<size_t> m_endConnectedEdge;
 };

--- a/include/trsp/trspHandler.hpp
+++ b/include/trsp/trspHandler.hpp
@@ -172,13 +172,13 @@ class TrspHandler : public pgrouting::Pgr_messages {
     /* idx -> id */
     std::map<int64_t, int64_t> m_idx_to_id;
 
-    int64_t m_start_vertex{};
-    int64_t m_end_vertex{};
+    [[maybe_unused]] int64_t m_start_vertex{};
+    [[maybe_unused]] int64_t m_end_vertex{};
 
     /*
      * Used in dijkstra_exploration
      */
-    int64_t m_current_node{};
+    [[maybe_unused]] int64_t m_current_node{};
 
     Path m_path;
 

--- a/include/trsp/trspHandler.hpp
+++ b/include/trsp/trspHandler.hpp
@@ -172,13 +172,13 @@ class TrspHandler : public pgrouting::Pgr_messages {
     /* idx -> id */
     std::map<int64_t, int64_t> m_idx_to_id;
 
-    int64_t m_start_vertex{}; // NOSONAR
-    int64_t m_end_vertex{}; // NOSONAR
+    int64_t m_start_vertex{};  // NOSONAR
+    int64_t m_end_vertex{};  // NOSONAR
 
     /*
      * Used in dijkstra_exploration
      */
-    int64_t m_current_node{}; // NOSONAR
+    int64_t m_current_node{};  // NOSONAR
 
     Path m_path;
 

--- a/include/trsp/trspHandler.hpp
+++ b/include/trsp/trspHandler.hpp
@@ -172,13 +172,13 @@ class TrspHandler : public pgrouting::Pgr_messages {
     /* idx -> id */
     std::map<int64_t, int64_t> m_idx_to_id;
 
-    int64_t m_start_vertex;
-    int64_t m_end_vertex;
+    int64_t m_start_vertex{};
+    int64_t m_end_vertex{};
 
     /*
      * Used in dijkstra_exploration
      */
-    int64_t m_current_node;
+    int64_t m_current_node{};
 
     Path m_path;
 

--- a/include/trsp/trspHandler.hpp
+++ b/include/trsp/trspHandler.hpp
@@ -172,13 +172,13 @@ class TrspHandler : public pgrouting::Pgr_messages {
     /* idx -> id */
     std::map<int64_t, int64_t> m_idx_to_id;
 
-    [[maybe_unused]] int64_t m_start_vertex{};
-    [[maybe_unused]] int64_t m_end_vertex{};
+    int64_t m_start_vertex{}; // NOSONAR
+    int64_t m_end_vertex{}; // NOSONAR
 
     /*
      * Used in dijkstra_exploration
      */
-    [[maybe_unused]] int64_t m_current_node{};
+    int64_t m_current_node{}; // NOSONAR
 
     Path m_path;
 

--- a/include/vrp/tw_node.hpp
+++ b/include/vrp/tw_node.hpp
@@ -221,12 +221,12 @@ class Tw_node : public Dnode {
 
 
  private:
-     int64_t m_order;       ///< order to which it belongs
-     double m_opens;        ///< opening time of the node
-     double m_closes;       ///< closing time of the node
-     double m_service_time;  // /< time it takes to be served
-     double m_demand;       ///< The demand for the Node
-     NodeType m_type;       ///< The demand for the Node
+     int64_t m_order{};       ///< order to which it belongs
+     double m_opens{};        ///< opening time of the node
+     double m_closes{};       ///< closing time of the node
+     double m_service_time{};  ///< time it takes to be served
+     double m_demand{};       ///< The demand for the Node
+     NodeType m_type{};       ///< The type for the Node
 };
 
 }  //  namespace vrp

--- a/include/yen/turnRestrictedPath.hpp
+++ b/include/yen/turnRestrictedPath.hpp
@@ -254,10 +254,10 @@ class Pgr_turnRestrictedPath : public Pgr_ksp< G > {
 
  private:
      std::vector<pgrouting::trsp::Rule> m_restrictions;
-     bool m_strict;
+     bool m_strict{};
      pSet m_solutions;
-     bool m_stop_on_first;
-     bool m_heap_paths;
+     bool m_stop_on_first{};
+     bool m_heap_paths{};
 };
 
 }  // namespace yen

--- a/src/cpp_common/pgdata_fetchers.cpp
+++ b/src/cpp_common/pgdata_fetchers.cpp
@@ -68,7 +68,7 @@ II_t_rt fetch_combination(
         int64_t*,
         size_t*,
         bool) {
-    II_t_rt combination;
+    II_t_rt combination{};
     combination.d1.source = getBigInt(tuple, tupdesc, info[0]);
     combination.d2.target = getBigInt(tuple, tupdesc, info[1]);
     return combination;
@@ -81,7 +81,7 @@ Coordinate_t fetch_coordinate(
         int64_t *default_id,
         size_t*,
         bool) {
-    Coordinate_t coordinate;
+    Coordinate_t coordinate{};
     if (column_found(info[0].colNumber)) {
         coordinate.id = getBigInt(tuple, tupdesc, info[0]);
     } else {
@@ -100,7 +100,7 @@ Delauny_t fetch_delauny(
         int64_t*,
         size_t*,
         bool) {
-    Delauny_t delauny;
+    Delauny_t delauny{};
     delauny.tid = getBigInt(tuple, tupdesc, info[0]);
     delauny.pid = getBigInt(tuple, tupdesc, info[1]);
     delauny.x = getFloat8(tuple, tupdesc, info[2]);
@@ -117,7 +117,7 @@ Edge_bool_t fetch_basic_edge(
         int64_t *default_id,
         size_t *valid_edges,
         bool) {
-    Edge_bool_t edge;
+    Edge_bool_t edge{};
     if (column_found(info[0].colNumber)) {
         edge.id = getBigInt(tuple, tupdesc, info[0]);
     } else {
@@ -150,7 +150,7 @@ Edge_t fetch_edge(
         int64_t *default_id,
         size_t *valid_edges,
         bool normal) {
-    Edge_t edge;
+    Edge_t edge{};
     if (column_found(info[0].colNumber)) {
         edge.id = getBigInt(tuple, tupdesc, info[0]);
     } else {
@@ -194,7 +194,7 @@ CostFlow_t fetch_costFlow_edge(
         int64_t *default_id,
         size_t *valid_edges,
         bool normal) {
-    CostFlow_t edge;
+    CostFlow_t edge{};
     if (column_found(info[0].colNumber)) {
         edge.edge_id = getBigInt(tuple, tupdesc, info[0]);
     } else {
@@ -236,7 +236,7 @@ Edge_xy_t fetch_edge_xy(
         int64_t *default_id,
         size_t *valid_edges,
         bool normal) {
-    Edge_xy_t edge;
+    Edge_xy_t edge{};
     if (column_found(info[0].colNumber)) {
         edge.id = getBigInt(tuple, tupdesc, info[0]);
     } else {
@@ -276,7 +276,7 @@ IID_t_rt pgr_fetch_row(
         int64_t*,
         size_t*,
         bool) {
-    IID_t_rt distance;
+    IID_t_rt distance{};
     distance.from_vid = getBigInt(tuple, tupdesc,  info[0]);
     distance.to_vid = getBigInt(tuple, tupdesc,  info[1]);
     distance.cost = getFloat8(tuple, tupdesc, info[2]);
@@ -291,7 +291,7 @@ Orders_t fetch_orders(
         int64_t*,
         size_t*,
         bool with_id) {
-    Orders_t pd_order;
+    Orders_t pd_order{};
     pd_order.id = getBigInt(tuple, tupdesc, info[0]);
     pd_order.demand = getFloat8(tuple, tupdesc, info[1]);
 
@@ -334,7 +334,7 @@ Restriction_t fetch_restriction(
         int64_t*,
         size_t*,
         bool) {
-    Restriction_t restriction;
+    Restriction_t restriction{};
     restriction.cost = getFloat8(tuple, tupdesc, info[0]);
 
     restriction.via = NULL;
@@ -377,7 +377,7 @@ Vehicle_t fetch_vehicle(
         int64_t*,
         size_t*,
         bool with_id) {
-    Vehicle_t vehicle;
+    Vehicle_t vehicle{};
     vehicle.id = getBigInt(tuple, tupdesc, info[0]);
     vehicle.capacity = getFloat8(tuple, tupdesc, info[1]);
 

--- a/src/max_flow/minCostMaxFlow.cpp
+++ b/src/max_flow/minCostMaxFlow.cpp
@@ -145,7 +145,7 @@ PgrCostFlowGraph::GetFlowEdges() const {
         if (((capacity[*e] - residual_capacity[*e]) > 0) &&
                 ((*e).m_source != supersource) &&
                 ((*e).m_target != supersink)) {
-            Flow_t edge;
+            Flow_t edge{};
             edge.edge = GetEdgeId(*e);
             edge.source = GetVertexId((*e).m_source);
             edge.target = GetVertexId((*e).m_target);


### PR DESCRIPTION
Enable `cppcoreguidelines-pro-type-member-init` in `.clang-tidy` file and fix warning related to it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added default/value initializers across many modules to ensure members and local variables have defined defaults.
  * Reduced risk of uninitialized data, improving runtime stability and predictability.
  * Standardized initialization patterns project-wide to enhance robustness and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->