### PR TITLE
clang-tidy: check and fix cppcoreguidelines-avoid-c-arrays

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,6 @@ Checks: >
     -clang-analyzer-core.uninitialized.Assign,
     clang-diagnostic-*,
     cppcoreguidelines-*,
-    -cppcoreguidelines-avoid-c-arrays,
     -cppcoreguidelines-avoid-const-or-ref-data-members,
     -cppcoreguidelines-avoid-do-while,
     -cppcoreguidelines-avoid-magic-numbers,

--- a/src/common/assert.cpp
+++ b/src/common/assert.cpp
@@ -35,18 +35,19 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <execinfo.h>
 #endif
 
+#include <array>
 #include <string>
 #include <exception>
 
 
 std::string get_backtrace() {
 #ifdef __GLIBC__
-        void *trace[16];
+        const int max_trace_size = 16;
+        std::array<void *, max_trace_size> trace{};
         int i = 0, trace_size = 0;
 
-        trace_size = backtrace(trace, 16);
-        char** funcNames = backtrace_symbols(trace, trace_size);
-
+        trace_size = backtrace(trace.data(), max_trace_size);
+        char** funcNames = backtrace_symbols(trace.data(), trace_size);
 
         std::string message = "\n*** Execution path***\n";
         for (i = 0; i < trace_size; ++i) {


### PR DESCRIPTION
This PR adds `cppcoreguidelines-avoid-c-arrays` in `.clang-tidy`.

Enabling this check resulted in a single warning where the c array was replaced with `std::array`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized internal error/diagnostic handling to improve robustness and maintainability.

* **Chores**
  * Updated static analysis configuration to streamline development tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->