### PR TITLE
clang-tidy: add -cppcoreguidelines-use-enum-class

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,6 +24,7 @@ Checks: >
     -cppcoreguidelines-pro-type-union-access,
     -cppcoreguidelines-pro-type-vararg,
     -cppcoreguidelines-slicing
+    -cppcoreguidelines-use-enum-class
 
 CheckOptions:
     - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
* Updated code quality analysis configuration to include an additional static analysis check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->