### PR TITLE
clang-tidy: check and fix cppcoreguidelines-avoid-c-arrays

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,7 @@ Checks: >
     -clang-analyzer-core.uninitialized.Assign,
     clang-diagnostic-*,
     cppcoreguidelines-*,
-    -cppcoreguidelines-avoid-c-arrays,
+    cppcoreguidelines-avoid-c-arrays,
     -cppcoreguidelines-avoid-const-or-ref-data-members,
     -cppcoreguidelines-avoid-do-while,
     -cppcoreguidelines-avoid-magic-numbers,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,6 @@ Checks: >
     -clang-analyzer-core.uninitialized.Assign,
     clang-diagnostic-*,
     cppcoreguidelines-*,
-    cppcoreguidelines-avoid-c-arrays,
     -cppcoreguidelines-avoid-const-or-ref-data-members,
     -cppcoreguidelines-avoid-do-while,
     -cppcoreguidelines-avoid-magic-numbers,

--- a/src/common/assert.cpp
+++ b/src/common/assert.cpp
@@ -36,27 +36,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #endif
 
 #include <string>
+#include <array>
 #include <exception>
-
 
 std::string get_backtrace() {
 #ifdef __GLIBC__
-        void *trace[16];
-        int i = 0, trace_size = 0;
+    std::array<void *, 16> trace;
+    int trace_size = 0;
 
-        trace_size = backtrace(trace, 16);
-        char** funcNames = backtrace_symbols(trace, trace_size);
+    trace_size = backtrace(trace.data(), trace.size());
+    char **funcNames = backtrace_symbols(trace.data(), trace_size);
 
-
-        std::string message = "\n*** Execution path***\n";
-        for (i = 0; i < trace_size; ++i) {
+    std::string message = "\n*** Execution path***\n";
+    if (funcNames != nullptr) {
+        for (int i = 0; i < trace_size; ++i) {
             message += "[bt]" + static_cast<std::string>(funcNames[i]) + "\n";
         }
-
         free(funcNames);
-        return message;
+    } else {
+        message += "[bt] Failed to get backtrace symbols\n";
+    }
+
+    return message;
 #else
-        return "";
+    return "";
 #endif
 }
 
@@ -64,12 +67,8 @@ std::string get_backtrace(const std::string &msg) {
     return std::string("\n") + msg + "\n" + get_backtrace();
 }
 
-
-
-const char* AssertFailedException::what() const throw() {
+const char *AssertFailedException::what() const throw() {
     return str.c_str();
 }
 
-AssertFailedException::AssertFailedException(std::string msg) :
-    str(msg) {}
-
+AssertFailedException::AssertFailedException(std::string msg) : str(msg) {}


### PR DESCRIPTION
This PR adds `cppcoreguidelines-avoid-c-arrays` check in clang-tidy (by removing it from the disabled list).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled an additional static analysis check to enforce safer C++ practices.
* **Bug Fixes**
  * Improved memory-safety and backtrace/debugging reliability to reduce crash risk and provide clearer diagnostics.
* **Style**
  * Internal formatting adjustments for code consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->