### PR TITLE
Fix comment typo in pgr_primDD

### DIFF
--- a/sql/spanningTree/primDD.sql
+++ b/sql/spanningTree/primDD.sql
@@ -154,7 +154,7 @@ IS 'pgr_primDD(Single Vertex)
     - Edges SQL with columns: id, source, target, cost [,reverse_cost]
     - From root vertex identifier
     - Distance
-- DocumentatiEdgeson:
+- Documentation:
     - ${PROJECT_DOC_LINK}/pgr_primDD.html
 ';
 


### PR DESCRIPTION
#### changes:
Only the text of one COMMENT ON FUNCTION in sql/spanningTree/primDD.sql (line 157). No code or function behavior is changed.
#### Why:
That COMMENT block had a typo. The other three overloads in the same file and all COMMENT blocks in the sibling kruskalDD.sql use "Documentation" correctly. This keeps the stored description consistent and correct for that overload.
#### Impact:
Runtime / behavior: None.
Database: Only the comment text for this overload is updated (e.g. what shows in \df+ pgr_primDD or in doc tools that use these comments)

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a typo in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->