### PR TITLE
Enable cppcoreguidelines-avoid-c-arrays for safer alternatives

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,7 +22,8 @@ Checks: >
     -cppcoreguidelines-pro-type-reinterpret-cast,
     -cppcoreguidelines-pro-type-union-access,
     -cppcoreguidelines-pro-type-vararg,
-    -cppcoreguidelines-slicing
+    -cppcoreguidelines-slicing,
+    cppcoreguidelines-avoid-c-arrays
 
 CheckOptions:
     - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
@@ -34,7 +35,7 @@ CheckOptions:
     - key: cppcoreguidelines-special-member-functions.AllowImplicitlyDeletedCopyOrMove
       value: true
 
-WarningsAsErrors: ''
-HeaderFilterRegex: './include'
-FormatStyle:     none
+WarningsAsErrors: ""
+HeaderFilterRegex: "./include"
+FormatStyle: none
 InheritParentConfig: true


### PR DESCRIPTION
… arrays and encourage safer alternatives

Fixes # .

Changes proposed in this pull request:
- Enable clang-tidy rule `cppcoreguidelines-avoid-c-arrays`
- Detect usage of C-style arrays
- Encourage use of safer alternatives such as std::array or std::vector

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality checks for stricter adherence to C++ coding standards and memory safety practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->