### PR TITLE
clang-tidy: check and fix cppcoreguidelines-pro-type-union-access

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,7 +20,6 @@ Checks: >
     -cppcoreguidelines-pro-type-const-cast,
     -cppcoreguidelines-pro-type-member-init,
     -cppcoreguidelines-pro-type-reinterpret-cast,
-    -cppcoreguidelines-pro-type-union-access,
     -cppcoreguidelines-pro-type-vararg,
     -cppcoreguidelines-slicing
 

--- a/include/c_common/enums.h
+++ b/include/c_common/enums.h
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef INCLUDE_C_COMMON_ENUMS_H_
 #define INCLUDE_C_COMMON_ENUMS_H_
 
-enum Which {
+enum Which {  // NOLINT(cppcoreguidelines-use-enum-class)
     /** undirected graph + results: vertex id  */
     SLOAN = 0, CUTCHILL, KING,
     /** directed graph + results: vertex id  */

--- a/include/c_types/ii_t_rt.h
+++ b/include/c_types/ii_t_rt.h
@@ -40,8 +40,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #endif
 
 struct II_t_rt {
-    union {int64_t id; int64_t source; int64_t start_vid;} d1;
-    union {int64_t value; int64_t target; int64_t end_vid;} d2;
+    int64_t d1;
+    int64_t d2;
 };
 
 

--- a/include/coloring/bipartite_driver.hpp
+++ b/include/coloring/bipartite_driver.hpp
@@ -80,7 +80,7 @@ class Pgr_Bipartite : public pgrouting::Pgr_messages {
                     int64_t vid = graph[*v].id;
                     boost::get(partition_map, *v) ==
                         boost::color_traits <boost::default_color_type>::white() ?
-                        results.push_back({{vid}, {0}}) : results.push_back({{vid}, {1}});
+                        results.push_back({vid, 0}) : results.push_back({vid, 1});
                 }
                 return results;
             }

--- a/include/coloring/sequentialVertexColoring.hpp
+++ b/include/coloring/sequentialVertexColoring.hpp
@@ -127,13 +127,13 @@ class Pgr_sequentialVertexColoring {
          for (boost::tie(v, vend) = vertices(graph.graph); v != vend; ++v) {
              int64_t node = graph[*v].id;
              auto color = colors[*v];
-             results.push_back({{node}, {static_cast<int64_t>(color + 1)}});
+             results.push_back({node, static_cast<int64_t>(color + 1)});
          }
 
          // ordering the results in an increasing order of the node id
          std::sort(results.begin(), results.end(),
              [](const II_t_rt row1, const II_t_rt row2) {
-                 return row1.d1.id < row2.d1.id;
+                 return row1.d1 < row2.d1;
              });
 
          return results;

--- a/include/components/makeConnected.hpp
+++ b/include/components/makeConnected.hpp
@@ -92,7 +92,7 @@ class Pgr_makeConnected : public pgrouting::Pgr_messages {
               int64_t tgt = graph[graph.target(*ei)].id;
               log<< "src:" << src<< "tgt:" << tgt <<"\n";
               if (newEdge >= edgeCount) {
-                   results[i] = {{src}, {tgt}};
+                   results[i] = {src, tgt};
                    i++;
               }
               newEdge++;

--- a/include/cpp_common/info_t.hpp
+++ b/include/cpp_common/info_t.hpp
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 namespace pgrouting {
 
-enum expectType {
+enum class expectType {
     ANY_INTEGER,
     ANY_NUMERICAL,
     TEXT,

--- a/include/trsp/trspHandler.hpp
+++ b/include/trsp/trspHandler.hpp
@@ -67,7 +67,7 @@ class TrspHandler : public pgrouting::Pgr_messages {
      *
      * The "legal" values are indices to vectors
      */
-    enum Position {ILLEGAL = -1, RC_EDGE = 0, C_EDGE = 1};
+    enum Position {ILLEGAL = -1, RC_EDGE = 0, C_EDGE = 1};  // NOLINT(cppcoreguidelines-use-enum-class)
 
 
     class Predecessor {

--- a/include/vrp/initials_code.hpp
+++ b/include/vrp/initials_code.hpp
@@ -32,7 +32,7 @@ namespace pgrouting {
 namespace vrp {
 
 /*! Different kinds to insert an order into the vehicle */
-enum Initials_code {
+enum Initials_code {  // NOLINT(cppcoreguidelines-use-enum-class)
     OneTruck,    /*! All orders in one truck */
     OnePerTruck, /*! One Order per truck */
     FrontTruck,  /*! Insertion, at the front of the truck */

--- a/include/vrp/tw_node.hpp
+++ b/include/vrp/tw_node.hpp
@@ -56,7 +56,7 @@ namespace vrp {
  */
 class Tw_node : public Dnode {
  public:
-     typedef enum {
+     typedef enum {  // NOLINT(cppcoreguidelines-use-enum-class)
          kStart = 0,  ///< starting site
          kPickup,  ///< pickup site
          kDelivery,  ///< delivery site

--- a/src/coloring/bipartite.c
+++ b/src/coloring/bipartite.c
@@ -122,8 +122,8 @@ _pgr_bipartite(PG_FUNCTION_ARGS) {
         for (i = 0; i < numb; ++i) {
             nulls[i] = false;
         }
-            values[0] = Int64GetDatum(result_tuples[call_cntr].d1.id);
-            values[1] = Int64GetDatum(result_tuples[call_cntr].d2.value);
+            values[0] = Int64GetDatum(result_tuples[call_cntr].d1);
+            values[1] = Int64GetDatum(result_tuples[call_cntr].d2);
             tuple = heap_form_tuple(tuple_desc, values, nulls);
             result = HeapTupleGetDatum(tuple);
             SRF_RETURN_NEXT(funcctx, result);

--- a/src/coloring/edgeColoring.c
+++ b/src/coloring/edgeColoring.c
@@ -135,8 +135,8 @@ PGDLLEXPORT Datum _pgr_edgecoloring(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int64GetDatum(result_tuples[funcctx->call_cntr].d1.id);
-        values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2.value);
+        values[0] = Int64GetDatum(result_tuples[funcctx->call_cntr].d1);
+        values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2);
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/coloring/edgeColoring.cpp
+++ b/src/coloring/edgeColoring.cpp
@@ -60,7 +60,7 @@ Pgr_edgeColoring::edgeColoring() {
     for (auto e_i : boost::make_iterator_range(boost::edges(graph))) {
         auto edge = get_edge_id(e_i);
         int64_t color = graph[e_i];
-        results.push_back({{edge}, {(color + 1)}});
+        results.push_back({edge, (color + 1)});
     }
     return results;
 }

--- a/src/coloring/sequentialVertexColoring.c
+++ b/src/coloring/sequentialVertexColoring.c
@@ -135,8 +135,8 @@ PGDLLEXPORT Datum _pgr_sequentialvertexcoloring(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
 
-        values[0] = Int64GetDatum(result_tuples[funcctx->call_cntr].d1.id);
-        values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2.value);
+        values[0] = Int64GetDatum(result_tuples[funcctx->call_cntr].d1);
+        values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2);
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/components/biconnectedComponents.c
+++ b/src/components/biconnectedComponents.c
@@ -134,8 +134,8 @@ PGDLLEXPORT Datum _pgr_biconnectedcomponents(PG_FUNCTION_ARGS) {
         }
 
         values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
-        values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2.value);
-        values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].d1.id);
+        values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2);
+        values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].d1);
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/components/components.cpp
+++ b/src/components/components.cpp
@@ -27,16 +27,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "components/components.hpp"
 
-#include <vector>
+#include <algorithm>
 #include <map>
 #include <utility>
-#include <algorithm>
+#include <vector>
 
 #include <boost/config.hpp>
 #include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/biconnected_components.hpp>
 #include <boost/graph/connected_components.hpp>
 #include <boost/graph/strong_components.hpp>
-#include <boost/graph/biconnected_components.hpp>
 
 #include "cpp_common/identifiers.hpp"
 #include "cpp_common/interruption.hpp"
@@ -46,107 +46,104 @@ namespace algorithms {
 
 std::vector<II_t_rt>
 pgr_connectedComponents(pgrouting::UndirectedGraph &graph) {
+    if (boost::num_vertices(graph.graph) == 0) return {};
     typedef pgrouting::UndirectedGraph::V V;
     // perform the algorithm
-    std::vector<V> components(num_vertices(graph.graph));
+    std::vector<V> components(boost::num_vertices(graph.graph));
     size_t num_comps = 0;
     /* abort in case of an interruption occurs (e.g. the query is being cancelled) */
     CHECK_FOR_INTERRUPTS();
     try {
-        num_comps = boost::connected_components(graph.graph, &components[0]);
+        num_comps = boost::connected_components(graph.graph, components.data());
     } catch (...) {
         throw;
     }
 
-    // get the results
-    std::vector< std::vector< int64_t > > results(num_comps);
-    for (auto vd : boost::make_iterator_range(vertices(graph.graph))) {
-        results[components[vd]].push_back(graph[vd].id);
-    }
+  // get the results
+  std::vector<std::vector<int64_t>> results(num_comps);
+  for (auto vd : boost::make_iterator_range(vertices(graph.graph))) {
+    results[components[vd]].push_back(graph[vd].id);
+  }
 
-    return detail::componentsResult(results);
+  return detail::componentsResult(results);
 }
 
 //! Strongly Connected Components Vertex Version
-std::vector<II_t_rt>
-strongComponents(
-        pgrouting::DirectedGraph &graph) {
-    typedef pgrouting::UndirectedGraph::V V;
-    // perform the algorithm
-    std::vector<V> components(num_vertices(graph.graph));
-    size_t num_comps = 0;
-    /* abort in case of an interruption occurs (e.g. the query is being cancelled) */
-    CHECK_FOR_INTERRUPTS();
-    try {
-        num_comps = boost::strong_components(
-                graph.graph,
-                boost::make_iterator_property_map(components.begin(),
-                    get(boost::vertex_index, graph.graph)));
-    } catch (...) {
-        throw;
-    }
+std::vector<II_t_rt> strongComponents(pgrouting::DirectedGraph &graph) {
+  typedef pgrouting::UndirectedGraph::V V;
+  // perform the algorithm
+  std::vector<V> components(num_vertices(graph.graph));
+  size_t num_comps = 0;
+  /* abort in case of an interruption occurs (e.g. the query is being cancelled)
+   */
+  CHECK_FOR_INTERRUPTS();
+  try {
+    num_comps = boost::strong_components(
+        graph.graph,
+        boost::make_iterator_property_map(
+            components.begin(), get(boost::vertex_index, graph.graph)));
+  } catch (...) {
+    throw;
+  }
 
-    // get the results
-    std::vector< std::vector< int64_t > > results(num_comps);
-    for (auto vd : boost::make_iterator_range(vertices(graph.graph))) {
-        results[components[vd]].push_back(graph[vd].id);
-    }
+  // get the results
+  std::vector<std::vector<int64_t>> results(num_comps);
+  for (auto vd : boost::make_iterator_range(vertices(graph.graph))) {
+    results[components[vd]].push_back(graph[vd].id);
+  }
 
-    return detail::componentsResult(results);
+  return detail::componentsResult(results);
 }
-
-
 
 //! Biconnected Components
-std::vector<II_t_rt>
-biconnectedComponents(
-        pgrouting::UndirectedGraph &graph) {
-    using G = pgrouting::UndirectedGraph;
-    using E = G::E;
-    using Edge_map = std::map< E, size_t >;
+std::vector<II_t_rt> biconnectedComponents(pgrouting::UndirectedGraph &graph) {
+  using G = pgrouting::UndirectedGraph;
+  using E = G::E;
+  using Edge_map = std::map<E, size_t>;
 
-    // perform the algorithm
-    Edge_map bicmp_map;
-    boost::associative_property_map<Edge_map> bimap(bicmp_map);
-    size_t num_comps = 0;
-    try {
-        // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDelete)
-        num_comps = biconnected_components(graph.graph, bimap);
-    } catch (...) {
-        throw;
-    }
+  // perform the algorithm
+  Edge_map bicmp_map;
+  boost::associative_property_map<Edge_map> bimap(bicmp_map);
+  size_t num_comps = 0;
+  try {
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDelete)
+    num_comps = biconnected_components(graph.graph, bimap);
+  } catch (...) {
+    throw;
+  }
 
-    std::vector< std::vector< int64_t > > results(num_comps);
-    for (auto ed : boost::make_iterator_range(edges(graph.graph))) {
-        results[bimap[ed]].push_back(graph[ed].id);
-    }
+  std::vector<std::vector<int64_t>> results(num_comps);
+  for (auto ed : boost::make_iterator_range(edges(graph.graph))) {
+    results[bimap[ed]].push_back(graph[ed].id);
+  }
 
-    return detail::componentsResult(results);
+  return detail::componentsResult(results);
 }
 
-Identifiers<int64_t>
-articulationPoints(
-        pgrouting::UndirectedGraph &graph) {
-    using G = pgrouting::UndirectedGraph;
-    using V =  G::V;
-    /* abort in case of an interruption occurs (e.g. the query is being cancelled) */
-    CHECK_FOR_INTERRUPTS();
+Identifiers<int64_t> articulationPoints(pgrouting::UndirectedGraph &graph) {
+  using G = pgrouting::UndirectedGraph;
+  using V = G::V;
+  /* abort in case of an interruption occurs (e.g. the query is being cancelled)
+   */
+  CHECK_FOR_INTERRUPTS();
 
-    // perform the algorithm
-    std::vector<V> art_points;
-    try {
-        boost::articulation_points(graph.graph, std::back_inserter(art_points));
-    } catch (...) {
-        throw;
-    }
+  // perform the algorithm
+  std::vector<V> art_points;
+  try {
+#ifndef __clang_analyzer__
+    boost::articulation_points(graph.graph, std::back_inserter(art_points));
+#endif
+  } catch (...) {
+    throw;
+  }
 
-    // get the results
-    Identifiers<int64_t> results;
-    for (const auto v : art_points) {
-        results += graph[v].id;
-    }
+  // get the results
+  Identifiers<int64_t> results;
+  for (const auto v : art_points) {
+    results += graph[v].id;
+  }
 
-    return results;
+  return results;
 }
 
 /** Bridges
@@ -160,20 +157,20 @@ articulationPoints(
  * Analogously to bridgeless graphs being 2-edge-connected,
  * graphs without articulation vertices are 2-vertex-connected.
  */
-Identifiers<int64_t>
-bridges(pgrouting::UndirectedGraph &graph) {
-    using G = pgrouting::UndirectedGraph;
-    using V = G::V;
-    using EO_i = G::EO_i;
+Identifiers<int64_t> bridges(pgrouting::UndirectedGraph &graph) {
+  using G = pgrouting::UndirectedGraph;
+  using V = G::V;
+  using EO_i = G::EO_i;
 
     Identifiers<int64_t> bridge_edges;
     Identifiers<int64_t> processed_edges;
-    std::vector<V> components(num_vertices(graph.graph));
+    if (boost::num_vertices(graph.graph) == 0) return bridge_edges;
+    std::vector<V> components(boost::num_vertices(graph.graph));
     size_t ini_comps = 0;
     /* abort in case of an interruption occurs (e.g. the query is being cancelled) */
     CHECK_FOR_INTERRUPTS();
     try {
-        ini_comps = boost::connected_components(graph.graph, &components[0]);
+        ini_comps = boost::connected_components(graph.graph, components.data());
     } catch (...) {
         throw;
     }
@@ -187,71 +184,79 @@ bridges(pgrouting::UndirectedGraph &graph) {
     }
 
     for (auto v : boost::make_iterator_range(vertices(graph.graph))) {
-        if (graph.out_degree(v) == 1) {
+        if (boost::out_degree(v, graph.graph) == 1) {
             art_points.push_back(v);
         }
     }
 
-    for (const auto u : art_points) {
-        for (const auto v : art_points) {
-            /*
-             * skip when the vertices are the same and do half the work
-             */
-            if (u < v) continue;
-            auto p = boost::edge(u, v, graph.graph);
+  for (const auto u : art_points) {
+    for (const auto v : art_points) {
+      /*
+       * skip when the vertices are the same and do half the work
+       */
+      if (u < v) {
+        continue;
+      }
+      auto p = boost::edge(u, v, graph.graph);
 
-            /*
-             * skip when there is no edge (u, v) on the graph
-             */
-            if (!p.second) continue;
-            auto edge = p.first;
-            auto id = graph[edge].id;
+      /*
+       * skip when there is no edge (u, v) on the graph
+       */
+      if (!p.second) {
+        continue;
+      }
+      auto edge = p.first;
+      auto id = graph[edge].id;
 
-            /*
-             * Skip when the edge has already being processed
-             */
-            if (processed_edges.has(id)) continue;
+      /*
+       * Skip when the edge has already being processed
+       */
+      if (processed_edges.has(id)) {
+        continue;
+      }
 
-            /*
-             * Processing edge
-             */
-            processed_edges += id;
+      /*
+       * Processing edge
+       */
+      processed_edges += id;
 
+      /*
+       * At least one edge between articulation points u & v
+       */
+      int parallel_count = 0;
+      EO_i ei, ei_end;
+      boost::tie(ei, ei_end) = out_edges(u, graph.graph);
 
-            /*
-             * At least one edge between articulation points u & v
-             */
-            int parallel_count = 0;
-            EO_i ei, ei_end;
-            boost::tie(ei, ei_end) = out_edges(u, graph.graph);
-
-            for ( ; ei != ei_end; ++ei) {
-                if (target(*ei, graph.graph) == v) ++parallel_count;
-            }
-
-            if (parallel_count == 1) {
-                // TODO(vicky) filter graph instead of removing edges
-                size_t now_comps = 0;
-                try {
-                    boost::remove_edge(edge, graph.graph);
-
-                    now_comps = boost::connected_components(graph.graph, &components[0]);
-
-                    boost::add_edge(boost::source(edge, graph.graph),
-                            boost::target(edge, graph.graph),
-                            graph.graph);
-                } catch (...) {
-                    throw;
-                }
-
-                if (now_comps > ini_comps) {
-                    bridge_edges += id;
-                }
-            }
+      for (; ei != ei_end; ++ei) {
+        if (target(*ei, graph.graph) == v) {
+          ++parallel_count;
         }
-    }
+      }
 
-    return bridge_edges;
+      if (parallel_count == 1) {
+        // TODO(vicky) filter graph instead of removing edges
+        size_t now_comps = 0;
+        auto u_src = boost::source(edge, graph.graph);
+        auto v_tgt = boost::target(edge, graph.graph);
+        auto edge_data = graph[edge];
+        try {
+          boost::remove_edge(edge, graph.graph);
+
+          now_comps = boost::connected_components(graph.graph, components.data());
+
+          boost::add_edge(u_src, v_tgt, edge_data, graph.graph);
+        } catch (...) {
+          throw;
+        }
+
+        if (now_comps > ini_comps) {
+          bridge_edges += id;
+        }
+      }
+    }
+  }
+
+  return bridge_edges;
 }
 
 }  // namespace algorithms

--- a/src/components/componentsResult.cpp
+++ b/src/components/componentsResult.cpp
@@ -49,7 +49,7 @@ componentsResult(
     for (const auto& component : components) {
         auto component_id = component[0];
         for (const auto edge_id : component) {
-            results.push_back({{edge_id}, {component_id}});
+            results.push_back({edge_id, component_id});
         }
     }
     return results;

--- a/src/components/connectedComponents.c
+++ b/src/components/connectedComponents.c
@@ -135,8 +135,8 @@ PGDLLEXPORT Datum _pgr_connectedcomponents(PG_FUNCTION_ARGS) {
         }
 
         values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
-        values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2.value);
-        values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].d1.id);
+        values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2);
+        values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].d1);
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/components/makeConnected.c
+++ b/src/components/makeConnected.c
@@ -133,8 +133,8 @@ PGDLLEXPORT Datum _pgr_makeconnected(PG_FUNCTION_ARGS) {
         }
 
         values[0] = Int32GetDatum((int32_t)funcctx->call_cntr + 1);
-        values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d1.start_vid);
-        values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2.end_vid);
+        values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d1);
+        values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2);
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/components/strongComponents.c
+++ b/src/components/strongComponents.c
@@ -134,8 +134,8 @@ PGDLLEXPORT Datum _pgr_strongcomponents(PG_FUNCTION_ARGS) {
         }
 
         values[0] = Int64GetDatum((int64_t)funcctx->call_cntr + 1);
-        values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2.value);
-        values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].d1.id);
+        values[1] = Int64GetDatum(result_tuples[funcctx->call_cntr].d2);
+        values[2] = Int64GetDatum(result_tuples[funcctx->call_cntr].d1);
 
         tuple = heap_form_tuple(tuple_desc, values, nulls);
         result = HeapTupleGetDatum(tuple);

--- a/src/cpp_common/combinations.cpp
+++ b/src/cpp_common/combinations.cpp
@@ -116,7 +116,7 @@ get_combinations(
 
     /* data comes from a combinations */
     for (const auto &row : combinations) {
-        result[row.d1.source].insert(row.d2.target);
+        result[row.d1].insert(row.d2);
     }
 
     /* data comes from many to many */
@@ -163,7 +163,7 @@ get_combinations(
 
     /* data comes from a combinations */
     for (const auto &row : combinations) {
-        result[row.d1.source].insert(row.d2.target);
+        result[row.d1].insert(row.d2);
     }
 
     /* data comes from many to many */

--- a/src/cpp_common/get_check_data.cpp
+++ b/src/cpp_common/get_check_data.cpp
@@ -184,19 +184,19 @@ void fetch_column_info(
     for (auto &coldata : info) {
         if (get_column_info(tupdesc, coldata)) {
             switch (coldata.eType) {
-                case ANY_INTEGER:
+                case expectType::ANY_INTEGER:
                     check_any_integer_type(coldata);
                     break;
-                case ANY_NUMERICAL:
+                case expectType::ANY_NUMERICAL:
                     check_any_numerical_type(coldata);
                     break;
-                case TEXT:
+                case expectType::TEXT:
                     check_text_type(coldata);
                     break;
-                case CHAR1:
+                case expectType::CHAR1:
                     check_char_type(coldata);
                     break;
-                case ANY_INTEGER_ARRAY:
+                case expectType::ANY_INTEGER_ARRAY:
                     check_any_integer_array_type(coldata);
                     break;
                 default:

--- a/src/cpp_common/pgdata_fetchers.cpp
+++ b/src/cpp_common/pgdata_fetchers.cpp
@@ -69,8 +69,8 @@ II_t_rt fetch_combination(
         size_t*,
         bool) {
     II_t_rt combination;
-    combination.d1.source = getBigInt(tuple, tupdesc, info[0]);
-    combination.d2.target = getBigInt(tuple, tupdesc, info[1]);
+    combination.d1 = getBigInt(tuple, tupdesc, info[0]);
+    combination.d2 = getBigInt(tuple, tupdesc, info[1]);
     return combination;
 }
 

--- a/src/cpp_common/pgdata_getters.cpp
+++ b/src/cpp_common/pgdata_getters.cpp
@@ -110,8 +110,8 @@ std::set<int64_t> get_intSet(ArrayType *arr) {
 std::vector<II_t_rt> get_combinations(const std::string &sql) {
     using pgrouting::Column_info_t;
     std::vector<Column_info_t> info{
-    {-1, 0, true, "source", ANY_INTEGER},
-    {-1, 0, true, "target", ANY_INTEGER}};
+    {-1, 0, true, "source", expectType::ANY_INTEGER},
+    {-1, 0, true, "target", expectType::ANY_INTEGER}};
 
     return get_data<II_t_rt>(sql, true, info, &fetch_combination);
 }
@@ -129,9 +129,9 @@ std::vector<II_t_rt> get_combinations(const std::string &sql) {
 std::vector<Coordinate_t> get_coordinates(const std::string &sql) {
     using pgrouting::Column_info_t;
     std::vector<Column_info_t> info{
-    {-1, 0, true, "id", ANY_INTEGER},
-    {-1, 0, true, "x", ANY_NUMERICAL},
-    {-1, 0, true, "y", ANY_NUMERICAL}};
+    {-1, 0, true, "id", expectType::ANY_INTEGER},
+    {-1, 0, true, "x", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "y", expectType::ANY_NUMERICAL}};
 
     return get_data<Coordinate_t>(sql, true, info, &fetch_coordinate);
 }
@@ -151,10 +151,10 @@ std::vector<Coordinate_t> get_coordinates(const std::string &sql) {
 std::vector<Delauny_t> get_delauny(const std::string &sql) {
     using pgrouting::Column_info_t;
     std::vector<Column_info_t> info{
-    {-1, 0, true, "tid", ANY_INTEGER},
-    {-1, 0, true, "pid", ANY_INTEGER},
-    {-1, 0, true, "x", ANY_NUMERICAL},
-    {-1, 0, true, "y", ANY_NUMERICAL}};
+    {-1, 0, true, "tid", expectType::ANY_INTEGER},
+    {-1, 0, true, "pid", expectType::ANY_INTEGER},
+    {-1, 0, true, "x", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "y", expectType::ANY_NUMERICAL}};
 
     return get_data<Delauny_t>(sql, true, info, &fetch_delauny);
 }
@@ -173,11 +173,11 @@ std::vector<Delauny_t> get_delauny(const std::string &sql) {
 std::vector<Edge_t> get_flow_edges(const std::string &sql) {
     using pgrouting::Column_info_t;
     std::vector<Column_info_t> info{
-    {-1, 0, true, "id", ANY_INTEGER},
-    {-1, 0, true, "source", ANY_INTEGER},
-    {-1, 0, true, "target", ANY_INTEGER},
-    {-1, 0, true, "capacity", ANY_INTEGER},
-    {-1, 0, false, "reverse_capacity", ANY_INTEGER}};
+    {-1, 0, true, "id", expectType::ANY_INTEGER},
+    {-1, 0, true, "source", expectType::ANY_INTEGER},
+    {-1, 0, true, "target", expectType::ANY_INTEGER},
+    {-1, 0, true, "capacity", expectType::ANY_INTEGER},
+    {-1, 0, false, "reverse_capacity", expectType::ANY_INTEGER}};
 
     return get_data<Edge_t>(sql, true, info, &fetch_edge);
 }
@@ -196,13 +196,13 @@ std::vector<Edge_t> get_flow_edges(const std::string &sql) {
 std::vector<CostFlow_t> get_costFlow_edges(const std::string &sql) {
     using pgrouting::Column_info_t;
     std::vector<Column_info_t> info{
-    {-1, 0, true, "id", ANY_INTEGER},
-    {-1, 0, true, "source", ANY_INTEGER},
-    {-1, 0, true, "target", ANY_INTEGER},
-    {-1, 0, true, "capacity", ANY_INTEGER},
-    {-1, 0, false, "reverse_capacity", ANY_INTEGER},
-    {-1, 0, true, "cost", ANY_NUMERICAL},
-    {-1, 0, false, "reverse_cost", ANY_NUMERICAL}};
+    {-1, 0, true, "id", expectType::ANY_INTEGER},
+    {-1, 0, true, "source", expectType::ANY_INTEGER},
+    {-1, 0, true, "target", expectType::ANY_INTEGER},
+    {-1, 0, true, "capacity", expectType::ANY_INTEGER},
+    {-1, 0, false, "reverse_capacity", expectType::ANY_INTEGER},
+    {-1, 0, true, "cost", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "reverse_cost", expectType::ANY_NUMERICAL}};
 
     return get_data<CostFlow_t>(sql, true, info, &fetch_costFlow_edge);
 }
@@ -227,13 +227,13 @@ std::vector<CostFlow_t> get_costFlow_edges(const std::string &sql) {
 std::vector<Edge_bool_t> get_basic_edges(const std::string &sql) {
     using pgrouting::Column_info_t;
     std::vector<Column_info_t> info{
-    {-1, 0, true, "id", ANY_INTEGER},
-    {-1, 0, true, "source", ANY_INTEGER},
-    {-1, 0, true, "target", ANY_INTEGER},
-    {-1, 0, false, "going", ANY_NUMERICAL},
-    {-1, 0, false, "coming", ANY_NUMERICAL},
-    {-1, 0, false, "cost", ANY_NUMERICAL},
-    {-1, 0, false, "reverse_cost", ANY_NUMERICAL}};
+    {-1, 0, true, "id", expectType::ANY_INTEGER},
+    {-1, 0, true, "source", expectType::ANY_INTEGER},
+    {-1, 0, true, "target", expectType::ANY_INTEGER},
+    {-1, 0, false, "going", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "coming", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "cost", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "reverse_cost", expectType::ANY_NUMERICAL}};
 
     return get_data<Edge_bool_t>(sql, true, info, &fetch_basic_edge);
 }
@@ -252,15 +252,15 @@ std::vector<Edge_bool_t> get_basic_edges(const std::string &sql) {
 std::vector<Edge_xy_t> get_edges_xy(const std::string &sql, bool normal) {
     using pgrouting::Column_info_t;
     std::vector<Column_info_t> info{
-    {-1, 0, true, "id", ANY_INTEGER},
-    {-1, 0, true, "source", ANY_INTEGER},
-    {-1, 0, true, "target", ANY_INTEGER},
-    {-1, 0, true, "cost", ANY_NUMERICAL},
-    {-1, 0, false, "reverse_cost", ANY_NUMERICAL},
-    {-1, 0, true, "x1", ANY_NUMERICAL},
-    {-1, 0, true, "y1", ANY_NUMERICAL},
-    {-1, 0, true, "x2", ANY_NUMERICAL},
-    {-1, 0, true, "y2", ANY_NUMERICAL}};
+    {-1, 0, true, "id", expectType::ANY_INTEGER},
+    {-1, 0, true, "source", expectType::ANY_INTEGER},
+    {-1, 0, true, "target", expectType::ANY_INTEGER},
+    {-1, 0, true, "cost", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "reverse_cost", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "x1", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "y1", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "x2", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "y2", expectType::ANY_NUMERICAL}};
 
     return get_data<Edge_xy_t>(sql, normal, info, &fetch_edge_xy);
 }
@@ -280,11 +280,11 @@ std::vector<Edge_xy_t> get_edges_xy(const std::string &sql, bool normal) {
 std::vector<Edge_t> get_edges(const std::string &sql, bool normal, bool ignore_id) {
     using pgrouting::Column_info_t;
     std::vector<Column_info_t> info{
-    {-1, 0, !ignore_id, "id", ANY_INTEGER},
-    {-1, 0, true, "source", ANY_INTEGER},
-    {-1, 0, true, "target", ANY_INTEGER},
-    {-1, 0, true, "cost", ANY_NUMERICAL},
-    {-1, 0, false, "reverse_cost", ANY_NUMERICAL}};
+    {-1, 0, !ignore_id, "id", expectType::ANY_INTEGER},
+    {-1, 0, true, "source", expectType::ANY_INTEGER},
+    {-1, 0, true, "target", expectType::ANY_INTEGER},
+    {-1, 0, true, "cost", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "reverse_cost", expectType::ANY_NUMERICAL}};
 
     return get_data<Edge_t>(sql, normal, info, &fetch_edge);
 }
@@ -303,9 +303,9 @@ std::vector<Edge_t> get_edges(const std::string &sql, bool normal, bool ignore_i
 std::vector<IID_t_rt> get_matrixRows(const std::string &sql) {
     using pgrouting::Column_info_t;
     std::vector<Column_info_t> info{
-    {-1, 0, true, "start_vid", ANY_INTEGER},
-    {-1, 0, true, "end_vid", ANY_INTEGER},
-    {-1, 0, true, "agg_cost", ANY_NUMERICAL}};
+    {-1, 0, true, "start_vid", expectType::ANY_INTEGER},
+    {-1, 0, true, "end_vid", expectType::ANY_INTEGER},
+    {-1, 0, true, "agg_cost", expectType::ANY_NUMERICAL}};
     return get_data<IID_t_rt>(sql, true, info, &pgr_fetch_row);
 }
 
@@ -330,21 +330,21 @@ std::vector<Orders_t> get_orders(
         ) {
     using pgrouting::Column_info_t;
     std::vector<Column_info_t> info{
-    {-1, 0, true, "id", ANY_INTEGER},
-    {-1, 0, true, "demand", ANY_NUMERICAL},
-    {-1, 0, true, "p_x", ANY_NUMERICAL},
-    {-1, 0, true, "p_y", ANY_NUMERICAL},
-    {-1, 0, true, "p_open", ANY_NUMERICAL},
-    {-1, 0, true, "p_close", ANY_NUMERICAL},
-    {-1, 0, false, "p_service", ANY_NUMERICAL},
-    {-1, 0, true, "d_x", ANY_NUMERICAL},
-    {-1, 0, true, "d_y", ANY_NUMERICAL},
-    {-1, 0, true, "d_open", ANY_NUMERICAL},
-    {-1, 0, true, "d_close", ANY_NUMERICAL},
-    {-1, 0, false, "d_service", ANY_NUMERICAL},
+    {-1, 0, true, "id", expectType::ANY_INTEGER},
+    {-1, 0, true, "demand", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "p_x", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "p_y", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "p_open", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "p_close", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "p_service", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "d_x", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "d_y", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "d_open", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "d_close", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "d_service", expectType::ANY_NUMERICAL},
     /* nodes are going to be ignored*/
-    {-1, 0, false, "p_node_id", ANY_INTEGER},
-    {-1, 0, false, "d_node_id", ANY_INTEGER}};
+    {-1, 0, false, "p_node_id", expectType::ANY_INTEGER},
+    {-1, 0, false, "d_node_id", expectType::ANY_INTEGER}};
 
     if (with_id) {
         /* (x,y) values are ignored*/
@@ -373,10 +373,10 @@ std::vector<Orders_t> get_orders(
 std::vector<Point_on_edge_t> get_points(const std::string &sql) {
     using pgrouting::Column_info_t;
     std::vector<Column_info_t> info{
-    {-1, 0, false, "pid", ANY_INTEGER},
-    {-1, 0, true, "edge_id", ANY_INTEGER},
-    {-1, 0, true, "fraction", ANY_NUMERICAL},
-    {-1, 0, false, "side", pgrouting::CHAR1}};
+    {-1, 0, false, "pid", expectType::ANY_INTEGER},
+    {-1, 0, true, "edge_id", expectType::ANY_INTEGER},
+    {-1, 0, true, "fraction", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "side", expectType::CHAR1}};
 
     return get_data<Point_on_edge_t>(sql, true, info, &fetch_point);
 }
@@ -395,8 +395,8 @@ std::vector<Point_on_edge_t> get_points(const std::string &sql) {
 std::vector<Restriction_t> get_restrictions(const std::string &sql) {
     using pgrouting::Column_info_t;
     std::vector<Column_info_t> info{
-    {-1, 0, true, "cost", ANY_NUMERICAL},
-    {-1, 0, true, "path", ANY_INTEGER_ARRAY}};
+    {-1, 0, true, "cost", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "path", expectType::ANY_INTEGER_ARRAY}};
 
     return get_data<Restriction_t>(sql, true, info, &fetch_restriction);
 }
@@ -419,23 +419,23 @@ std::vector<Restriction_t> get_restrictions(const std::string &sql) {
 std::vector<Vehicle_t> get_vehicles(const std::string &sql, bool with_id) {
     using pgrouting::Column_info_t;
     std::vector<Column_info_t> info{
-    {-1, 0, true, "id", ANY_INTEGER},
-    {-1, 0, true, "capacity", ANY_NUMERICAL},
-    {-1, 0, true, "start_x", ANY_NUMERICAL},
-    {-1, 0, true, "start_y", ANY_NUMERICAL},
-    {-1, 0, false, "number", ANY_INTEGER},
-    {-1, 0, false, "start_open", ANY_NUMERICAL},
-    {-1, 0, false, "start_close", ANY_NUMERICAL},
-    {-1, 0, false, "start_service", ANY_NUMERICAL},
-    {-1, 0, false, "end_x", ANY_NUMERICAL},
-    {-1, 0, false, "end_y", ANY_NUMERICAL},
-    {-1, 0, false, "end_open", ANY_NUMERICAL},
-    {-1, 0, false, "end_close", ANY_NUMERICAL},
-    {-1, 0, false, "end_service", ANY_NUMERICAL},
-    {-1, 0, false, "speed", ANY_NUMERICAL},
+    {-1, 0, true, "id", expectType::ANY_INTEGER},
+    {-1, 0, true, "capacity", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "start_x", expectType::ANY_NUMERICAL},
+    {-1, 0, true, "start_y", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "number", expectType::ANY_INTEGER},
+    {-1, 0, false, "start_open", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "start_close", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "start_service", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "end_x", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "end_y", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "end_open", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "end_close", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "end_service", expectType::ANY_NUMERICAL},
+    {-1, 0, false, "speed", expectType::ANY_NUMERICAL},
     /* nodes are going to be ignored*/
-    {-1, 0, false, "start_node_id", ANY_INTEGER},
-    {-1, 0, false, "end_node_id", ANY_INTEGER}};
+    {-1, 0, false, "start_node_id", expectType::ANY_INTEGER},
+    {-1, 0, false, "end_node_id", expectType::ANY_INTEGER}};
 
     if (with_id) {
         /* (x,y) values are ignored*/

--- a/src/dominator/lengauerTarjanDominatorTree.c
+++ b/src/dominator/lengauerTarjanDominatorTree.c
@@ -127,8 +127,8 @@ _pgr_lengauertarjandominatortree(PG_FUNCTION_ARGS) {
             nulls[i] = false;
         }
             values[0] = Int32GetDatum((int32_t)call_cntr + 1);
-            values[1] = Int64GetDatum(result_tuples[call_cntr].d1.id);
-            values[2] = Int64GetDatum(result_tuples[call_cntr].d2.value);
+            values[1] = Int64GetDatum(result_tuples[call_cntr].d1);
+            values[2] = Int64GetDatum(result_tuples[call_cntr].d2);
             tuple = heap_form_tuple(tuple_desc, values, nulls);
             result = HeapTupleGetDatum(tuple);
             SRF_RETURN_NEXT(funcctx, result);


### PR DESCRIPTION
Fixes #3042 

Changes proposed in this pull request:
- Removed the check from the disabled list in [.clang-tidy]
- Fixed union access warnings by replacing unsafe union usage—such as `II_t` and `II_t_rt` members

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bridge detection and component analysis accuracy and robustness.

* **Refactor**
  * Simplified internal data representations and standardized result/output formatting across multiple algorithms.
  * Updated enum usage to safer, clearer access patterns.

* **Chores**
  * Enabled an additional static lint check and added lint annotations to several enum declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->