### PR TITLE
clang-tidy: enable cppcoreguidelines-avoid-magic-numbers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,7 @@ Checks: >
     cppcoreguidelines-*,
     -cppcoreguidelines-avoid-const-or-ref-data-members,
     -cppcoreguidelines-avoid-do-while,
-    -cppcoreguidelines-avoid-magic-numbers,
+    cppcoreguidelines-avoid-magic-numbers,
     -cppcoreguidelines-macro-usage,
     -cppcoreguidelines-narrowing-conversions,
     -cppcoreguidelines-no-malloc,


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
-
-
-

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains only internal tooling configuration updates with no user-facing changes. Code quality checks have been enhanced to better enforce development standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->