### PR TITLE
clang-tidy: enable cppcoreguidelines-slicing and fix errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,7 +22,6 @@ Checks: >
     -cppcoreguidelines-pro-type-reinterpret-cast,
     -cppcoreguidelines-pro-type-union-access,
     -cppcoreguidelines-pro-type-vararg,
-    -cppcoreguidelines-slicing
 
 CheckOptions:
     - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor

--- a/src/pickDeliver/optimize.cpp
+++ b/src/pickDeliver/optimize.cpp
@@ -480,12 +480,12 @@ Optimize::decrease_truck(size_t cycle) {
 void
 Optimize::save_if_best() {
     if (duration() < best_solution.duration()) {
-        best_solution = (*this);
+        best_solution = static_cast<const Solution&>(*this);
         msg().log << "\n*********** best by duration"
             << best_solution.cost_str();
     }
     if (fleet.size() < best_solution.fleet.size()) {
-        best_solution = (*this);
+        best_solution = static_cast<const Solution&>(*this);
         msg().log << "\n*********** best by fleet size"
             << best_solution.cost_str();
     }

--- a/src/pickDeliver/order.cpp
+++ b/src/pickDeliver/order.cpp
@@ -53,7 +53,7 @@ Order::Order(
 std::ostream&
 operator<< (std::ostream &log, const Order &order) {
     log << "\n\nOrder "
-        << static_cast<Identifier>(order) << ": \n"
+        << static_cast<const Identifier&>(order) << ": \n"
         << "\tPickup: " << order.pickup() << "\n"
         << "\tDelivery: " << order.delivery() << "\n\n"
         << "\tTravel time: "


### PR DESCRIPTION
Enable `cppcoreguidelines-slicing` and fix warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code quality improvements to optimize memory handling and type safety in core optimization and order processing modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->