### PR TITLE
Clang-Tidy: cppcoreguidelines-narrowing-conversions warning and fix

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,7 +11,6 @@ Checks: >
     -cppcoreguidelines-avoid-do-while,
     -cppcoreguidelines-avoid-magic-numbers,
     -cppcoreguidelines-macro-usage,
-    -cppcoreguidelines-narrowing-conversions,
     -cppcoreguidelines-no-malloc,
     -cppcoreguidelines-non-private-member-variables-in-classes,
     -cppcoreguidelines-owning-memory,

--- a/src/cpp_common/undirectedHasCostBG.cpp
+++ b/src/cpp_common/undirectedHasCostBG.cpp
@@ -31,7 +31,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <vector>
 #include <deque>
 #include <string>
-#include <cassert>
 #include <limits>
 #include "c_types/iid_t_rt.h"
 #include "cpp_common/coordinate_t.hpp"

--- a/src/cpp_common/undirectedHasCostBG.cpp
+++ b/src/cpp_common/undirectedHasCostBG.cpp
@@ -166,7 +166,7 @@ void
 UndirectedHasCostBG::insert_vertex(int64_t id) {
     try {
         if (has_vertex(id)) return;
-        auto v = add_vertex(m_id_to_V.size(), m_graph);
+        auto v = add_vertex(static_cast<int>(m_id_to_V.size()), m_graph);
         m_id_to_V.insert(std::make_pair(id, v));
         m_V_to_id.insert(std::make_pair(v, id));
     } catch (...) {

--- a/src/cpp_common/undirectedHasCostBG.cpp
+++ b/src/cpp_common/undirectedHasCostBG.cpp
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <vector>
 #include <deque>
 #include <string>
-#include<cassert>
+#include <cassert>
 #include <limits>
 #include "c_types/iid_t_rt.h"
 #include "cpp_common/coordinate_t.hpp"

--- a/src/cpp_common/undirectedHasCostBG.cpp
+++ b/src/cpp_common/undirectedHasCostBG.cpp
@@ -32,7 +32,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <deque>
 #include <string>
 #include <limits>
-
+#include<cassert>
+#include <limits>
 #include "c_types/iid_t_rt.h"
 #include "cpp_common/coordinate_t.hpp"
 #include "cpp_common/interruption.hpp"
@@ -166,6 +167,7 @@ void
 UndirectedHasCostBG::insert_vertex(int64_t id) {
     try {
         if (has_vertex(id)) return;
+        assert(m_id_to_V.size() <= static_cast<size_t>(std::numeric_limits<int>::max()));
         auto v = add_vertex(static_cast<int>(m_id_to_V.size()), m_graph);
         m_id_to_V.insert(std::make_pair(id, v));
         m_V_to_id.insert(std::make_pair(v, id));

--- a/src/cpp_common/undirectedHasCostBG.cpp
+++ b/src/cpp_common/undirectedHasCostBG.cpp
@@ -31,7 +31,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <vector>
 #include <deque>
 #include <string>
-#include <limits>
 #include<cassert>
 #include <limits>
 #include "c_types/iid_t_rt.h"

--- a/src/cpp_common/undirectedHasCostBG.cpp
+++ b/src/cpp_common/undirectedHasCostBG.cpp
@@ -166,12 +166,14 @@ UndirectedHasCostBG::insert_vertex(int64_t id) {
     try {
         if (has_vertex(id)) return;
         const auto vertex_count = m_id_to_V.size();
+        const auto max_int = static_cast<size_t>(std::numeric_limits<int>::max());
 
-        if (vertex_count > static_cast<size_t>(std::numeric_limits<int>::max())) {
-            throw std::overflow_error("vertex index overflow");
+        if (vertex_count > max_int) {
+            throw std::overflow_error("vertex index exceeds int range");
         }
 
         auto v = add_vertex(static_cast<int>(vertex_count), m_graph);
+
         m_id_to_V.insert(std::make_pair(id, v));
         m_V_to_id.insert(std::make_pair(v, id));
     } catch (...) {

--- a/src/cpp_common/undirectedHasCostBG.cpp
+++ b/src/cpp_common/undirectedHasCostBG.cpp
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  ********************************************************************PGR-GNU*/
 
 #include "cpp_common/undirectedHasCostBG.hpp"
-
+#include <stdexcept>
 #include <utility>
 #include <vector>
 #include <deque>
@@ -166,8 +166,13 @@ void
 UndirectedHasCostBG::insert_vertex(int64_t id) {
     try {
         if (has_vertex(id)) return;
-        assert(m_id_to_V.size() <= static_cast<size_t>(std::numeric_limits<int>::max()));
-        auto v = add_vertex(static_cast<int>(m_id_to_V.size()), m_graph);
+        const auto vertex_count = m_id_to_V.size();
+
+        if (vertex_count > static_cast<size_t>(std::numeric_limits<int>::max())) {
+            throw std::overflow_error("vertex index overflow");
+        }
+
+        auto v = add_vertex(static_cast<int>(vertex_count), m_graph);
         m_id_to_V.insert(std::make_pair(id, v));
         m_V_to_id.insert(std::make_pair(v, id));
     } catch (...) {


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- A narrowing conversion warning was shown when an unsigned long value was passed to a function expecting an int.
- I fixed it by implementing a static cast.
- adding run time check as a safety check before the static casting.


@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated static analysis configuration to re-enable narrowing-conversion checks, strengthening code-quality enforcement.
* **Bug Fixes**
  * Added runtime validation when adding vertices to guard against integer conversion/overflow during graph growth, ensuring stable behavior when many vertices are added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->