### PR TITLE
Bug Fix: Fix graph construction in pgr_edgeColoring using base_graph

### DIFF
--- a/include/coloring/edgeColoring.hpp
+++ b/include/coloring/edgeColoring.hpp
@@ -32,6 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <vector>
 #include <cstdint>
+#include <iosfwd>
 
 #include <boost/config.hpp>
 #include <boost/version.hpp>

--- a/include/coloring/edgeColoring.hpp
+++ b/include/coloring/edgeColoring.hpp
@@ -56,7 +56,7 @@ class Pgr_edgeColoring : public Pgr_messages {
 #endif
 
  private:
-    pgrouting:: UndirectedGraph graph;
+    pgrouting::UndirectedGraph graph;
 };
 
 }  // namespace functions

--- a/include/coloring/edgeColoring.hpp
+++ b/include/coloring/edgeColoring.hpp
@@ -30,35 +30,22 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #define INCLUDE_COLORING_EDGECOLORING_HPP_
 #pragma once
 
-#include <iostream>
-#include <map>
 #include <vector>
 #include <cstdint>
 
 #include <boost/config.hpp>
-#include <boost/graph/adjacency_list.hpp>
 #include <boost/version.hpp>
 
+#include "cpp_common/base_graph.hpp"
 #include "cpp_common/edge_t.hpp"
 #include "c_types/ii_t_rt.h"
-#include "cpp_common/assert.hpp"
 #include "cpp_common/messages.hpp"
 
 namespace pgrouting {
 namespace functions {
 
 class Pgr_edgeColoring : public Pgr_messages {
- public:
-    using EdgeColoring_Graph =
-        boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, boost::no_property,
-        int64_t, boost::no_property>;
-
-    using V       = boost::graph_traits<EdgeColoring_Graph>::vertex_descriptor;
-    using E       = boost::graph_traits<EdgeColoring_Graph>::edge_descriptor;
-    using V_it    = boost::graph_traits<EdgeColoring_Graph>::vertex_iterator;
-    using E_it    = boost::graph_traits<EdgeColoring_Graph>::edge_iterator;
-
- public:
+  public:
     std::vector<II_t_rt> edgeColoring();
 
     explicit Pgr_edgeColoring(const std::vector<Edge_t>&);
@@ -69,16 +56,7 @@ class Pgr_edgeColoring : public Pgr_messages {
 #endif
 
  private:
-    V get_boost_vertex(int64_t id) const;
-    int64_t get_vertex_id(V v) const;
-    int64_t get_edge_id(E e) const;
-
-
- private:
-    EdgeColoring_Graph graph;
-    std::map<int64_t, V> id_to_V;
-    std::map<V, int64_t> V_to_id;
-    std::map<E, int64_t> E_to_id;
+    pgrouting:: UndirectedGraph graph;
 };
 
 }  // namespace functions

--- a/include/cpp_common/basic_edge.hpp
+++ b/include/cpp_common/basic_edge.hpp
@@ -45,6 +45,7 @@ class Basic_edge{
 
      int64_t id;
      double cost;
+     int64_t color;
 };
 
 }  // namespace pgrouting

--- a/include/cpp_common/basic_edge.hpp
+++ b/include/cpp_common/basic_edge.hpp
@@ -45,7 +45,6 @@ class Basic_edge{
 
      int64_t id;
      double cost;
-     int64_t color;
 };
 
 }  // namespace pgrouting

--- a/src/coloring/edgeColoring.cpp
+++ b/src/coloring/edgeColoring.cpp
@@ -28,6 +28,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "coloring/edgeColoring.hpp"
 
+#include <map>
+
 #include <vector>
 #include <utility>
 #include <string>

--- a/src/coloring/edgeColoring.cpp
+++ b/src/coloring/edgeColoring.cpp
@@ -32,10 +32,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <utility>
 #include <string>
 
-#include "cpp_common/identifiers.hpp"
 #include <boost/graph/edge_coloring.hpp>
 #include <boost/graph/graph_utility.hpp>
 
+#include "cpp_common/base_graph.hpp"
 #include "cpp_common/assert.hpp"
 #include "cpp_common/interruption.hpp"
 
@@ -50,91 +50,30 @@ Pgr_edgeColoring::edgeColoring() {
     CHECK_FOR_INTERRUPTS();
 
     try {
-        boost::edge_coloring(graph,  boost::get(boost::edge_bundle, graph));
+        using E = pgrouting::UndirectedGraph::E;
+
+        std::map<E, int64_t> color_storage;
+        auto color_map = boost::make_assoc_property_map(color_storage);
+
+        boost::edge_coloring(graph.graph, color_map);
+
+        for (auto e_i : boost::make_iterator_range(boost::edges(graph.graph))) {
+            int64_t edge_id = graph.graph[e_i].id;
+            int64_t color = color_map[e_i];
+
+            results.push_back({{edge_id}, {(color + 1)}});
+        }
     } catch (...) {
         throw std::make_pair(
             std::string("INTERNAL: something went wrong while calling boost::edge_coloring"),
             std::string(__PGR_PRETTY_FUNCTION__));
     }
 
-    for (auto e_i : boost::make_iterator_range(boost::edges(graph))) {
-        auto edge = get_edge_id(e_i);
-        int64_t color = graph[e_i];
-        results.push_back({{edge}, {(color + 1)}});
-    }
     return results;
 }
 
 Pgr_edgeColoring::Pgr_edgeColoring(const std::vector<Edge_t> &edges) {
-    /*
-     * Inserting vertices
-     */
-    Identifiers<int64_t> ids;
-    for (const auto &e : edges) {
-        ids += e.source;
-        ids += e.target;
-    }
-
-    for (const auto id : ids) {
-        auto v = add_vertex(graph);
-        id_to_V.insert(std::make_pair(id, v));
-        V_to_id.insert(std::make_pair(v, id));
-    }
-
-    /*
-     * Inserting edges
-     */
-    bool added = false;
-    for (const auto &edge : edges) {
-        auto v1 = get_boost_vertex(edge.source);
-        auto v2 = get_boost_vertex(edge.target);
-        auto e_exists = boost::edge(v1, v2, graph);
-        // NOLINTNEXTLINE
-        if (e_exists.second) continue;
-
-        if (edge.source == edge.target) continue;
-
-        if (edge.cost < 0 && edge.reverse_cost < 0) continue;
-
-        E e;
-        // NOLINTNEXTLINE
-        boost::tie(e, added) = boost::add_edge(v1, v2, graph);
-
-        E_to_id.insert(std::make_pair(e, edge.id));
-    }
-}
-
-Pgr_edgeColoring::V
-Pgr_edgeColoring::get_boost_vertex(int64_t id) const {
-    try {
-        return id_to_V.at(id);
-    } catch (...) {
-        throw std::make_pair(
-            std::string("INTERNAL: something went wrong when getting the vertex descriptor"),
-            std::string(__PGR_PRETTY_FUNCTION__));
-    }
-}
-
-int64_t
-Pgr_edgeColoring::get_vertex_id(V v) const {
-    try {
-        return V_to_id.at(v);
-    } catch (...) {
-        throw std::make_pair(
-            std::string("INTERNAL: something went wrong when getting the vertex id"),
-            std::string(__PGR_PRETTY_FUNCTION__));
-    }
-}
-
-int64_t
-Pgr_edgeColoring::get_edge_id(E e) const {
-    try {
-        return E_to_id.at(e);
-    } catch (...) {
-        throw std::make_pair(
-            std::string("INTERNAL: something went wrong when getting the edge id"),
-            std::string(__PGR_PRETTY_FUNCTION__));
-    }
+    graph.insert_edges(edges);
 }
 
 }  // namespace functions

--- a/src/coloring/edgeColoring.cpp
+++ b/src/coloring/edgeColoring.cpp
@@ -64,7 +64,8 @@ Pgr_edgeColoring::edgeColoring() {
             results.push_back({{edge_id}, {(color + 1)}});
         }
     } catch (...) {
-        throw std::make_pair(
+        throw std::make_pair
+        (
             std::string("INTERNAL: something went wrong while calling boost::edge_coloring"),
             std::string(__PGR_PRETTY_FUNCTION__));
     }


### PR DESCRIPTION
Fixes #3101.

This PR remove graph building logicand replaces it with base_graph::insert_edges() for consistent graph building.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal edge-coloring implementation simplified to use a consolidated undirected graph representation; public API and method signatures unchanged.
  * Reduced internal mapping complexity and improved error messaging for the coloring step, aiming for easier maintenance and more reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->