### PR TITLE
fix #2583: fix negative and asymmetric edge costs in stoer wagner tests

### DIFF
--- a/pgtap/mincut/stoerWagner/compare_components.pg
+++ b/pgtap/mincut/stoerWagner/compare_components.pg
@@ -5,7 +5,7 @@
 
 BEGIN;
 
-UPDATE edges SET cost = sign(cost), reverse_cost = sign(reverse_cost);
+UPDATE edges SET cost = abs(sign(cost)), reverse_cost = abs(sign(reverse_cost));
 SELECT plan(6);
 
 PREPARE stoerWagner1 AS

--- a/pgtap/mincut/stoerWagner/edge_cases.pg
+++ b/pgtap/mincut/stoerWagner/edge_cases.pg
@@ -16,7 +16,7 @@ SELECT lives_ok(
 
 SELECT throws_ok(
     'SELECT * FROM pgr_stoerWagner(
-        ''SELECT id, source, target, cost, reverse_cost FROM edges id < 17'',
+        ''SELECT id, source, target, cost, reverse_cost FROM edges WHERE id < 17'',
         3
     )','42883','function pgr_stoerwagner(unknown, integer) does not exist',
     '6: Documentation says it does not work with 1 flags');

--- a/pgtap/mincut/stoerWagner/edge_cases.pg
+++ b/pgtap/mincut/stoerWagner/edge_cases.pg
@@ -5,7 +5,7 @@
 
 BEGIN;
 
-UPDATE edges SET cost = sign(cost), reverse_cost = sign(reverse_cost);
+UPDATE edges SET cost = abs(sign(cost)), reverse_cost = abs(sign(reverse_cost));
 SELECT plan(2);
 
 SELECT lives_ok(

--- a/pgtap/mincut/stoerWagner/inner_query.pg
+++ b/pgtap/mincut/stoerWagner/inner_query.pg
@@ -5,7 +5,7 @@
 
 BEGIN;
 
-UPDATE edges SET cost = sign(cost), reverse_cost = sign(reverse_cost);
+UPDATE edges SET cost = abs(sign(cost)), reverse_cost = abs(sign(reverse_cost));
 SELECT plan(54);
 
 SELECT style_dijkstra('pgr_stoerwagner(', ')');

--- a/pgtap/mincut/stoerWagner/types_check.pg
+++ b/pgtap/mincut/stoerWagner/types_check.pg
@@ -5,7 +5,7 @@
 
 BEGIN;
 
-UPDATE edges SET cost = sign(cost), reverse_cost = sign(reverse_cost);
+UPDATE edges SET cost = abs(sign(cost)), reverse_cost = abs(sign(reverse_cost));
 SELECT plan(5);
 
 SELECT has_function('pgr_stoerwagner');


### PR DESCRIPTION
Fixes #2583 

Changes proposed in this pull request:
- Ensures edge costs and reverse_costs are non-negative and symmetric before running Stoer-Wagner tests
- Fixes test failures caused by negative and asymmetric edge weights which violate Stoer-Wagner algorithm requirements

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated minimum-cut tests to normalize edge costs to non-negative values so negative inputs now map to positive representations.
  * Tightened a test input filter to target a smaller set of edges during an error assertion, improving test precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->