### PR TITLE
fix(drivingDistance): raise error on negative distance input

### DIFF
--- a/pgtap/dijkstra/driving_distance/edge_cases/issue_3091.pg
+++ b/pgtap/dijkstra/driving_distance/edge_cases/issue_3091.pg
@@ -1,0 +1,25 @@
+/* :file: This file is part of the pgRouting project.
+:copyright: Copyright (c) 2026 pgRouting developers
+:license: Creative Commons Attribution-Share Alike 3.0 https://creativecommons.org/licenses/by-sa/3.0 */
+
+/* Issue #3091: pgr_drivingDistance accepts negative distance without raising an error */
+
+BEGIN;
+
+SELECT plan(2);
+
+-- Negative distance should raise an error, not silently return empty result.
+SELECT throws_ok(
+    $$SELECT * FROM pgr_drivingDistance('SELECT id, source, target, cost, reverse_cost FROM edges', 1, -1.0)$$,
+    'Negative value found on ''distance''',
+    '1: pgr_drivingDistance with negative distance raises error'
+);
+
+-- Distance of 0 is valid (returns only the origin node).
+SELECT ok(
+    (SELECT count(*) = 1 FROM pgr_drivingDistance('SELECT id, source, target, cost, reverse_cost FROM edges', 1, 0.0)),
+    '2: pgr_drivingDistance with distance=0 returns only origin'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/src/driving_distance/driving_distance_driver.cpp
+++ b/src/driving_distance/driving_distance_driver.cpp
@@ -74,6 +74,12 @@ pgr_do_drivingDistance(
         pgassert(*return_count == 0);
         pgassert((*return_tuples) == NULL);
 
+        if (distance < 0) {
+            *err_msg = to_pg_msg("Negative value found on 'distance'");
+            *log_msg = to_pg_msg("distance must be non-negative");
+            return;
+        }
+
         auto roots = get_intSet(starts);
 
         hint = edges_sql;

--- a/src/driving_distance/driving_distance_withPoints_driver.cpp
+++ b/src/driving_distance/driving_distance_withPoints_driver.cpp
@@ -87,6 +87,12 @@ pgr_do_withPointsDD(
         pgassert(!(*return_tuples));
         pgassert(*return_count == 0);
 
+        if (distance < 0) {
+            *err_msg = to_pg_msg("Negative value found on 'distance'");
+            *log_msg = to_pg_msg("distance must be non-negative");
+            return;
+        }
+
         auto roots = get_intSet(starts);
 
         hint = points_sql;


### PR DESCRIPTION
## Summary

`pgr_drivingDistance` and `pgr_drivingDistanceWithPoints` silently returned an empty result set when called with a negative `distance` value. An empty result is indistinguishable from a valid empty-graph result — callers have no way to detect the misconfiguration.

The `develop` branch (4.1.0-dev) already raises `ERROR: Negative value found on 'distance'` via `src/spanningTree/spanningTree_process.cpp:105-106`. This PR backports the equivalent guard to `main`.

## Fix

Added a negative-distance guard in `pgr_do_drivingDistance` and `pgr_do_drivingDistanceWithPoints` (both C++ drivers) before graph query execution:

```cpp
if (distance < 0) {
    *err_msg = to_pg_msg("Negative value found on 'distance'");
    *log_msg = to_pg_msg("distance must be non-negative");
    return;
}
```

## Existing behavior audit (OPS-RULE-016)

- `src/driving_distance/driving_distance_driver.cpp`: no distance validation before graph construction; negative values silently traverse an empty Dijkstra result
- `src/driving_distance/driving_distance_withPoints_driver.cpp`: same pattern, same missing guard
- `src/spanningTree/spanningTree_process.cpp` (develop branch, line 105-106): contains the fix; does not exist on `main`

## Scope classification (OPS-RULE-017)

**(a) Bug fix** — missing input validation that causes silent incorrect behavior.

## Prior art consulted (OPS-RULE-018)

1. `develop` branch `src/spanningTree/spanningTree_process.cpp:82-106` — the exact validation pattern this fix mirrors for the `main` branch
2. Issue [#3091](https://github.com/pgRouting/pgrouting/issues/3091) — bug report with reproduce steps and confirmation of the develop-vs-main discrepancy
3. `pgtap/dijkstra/driving_distance/edge_cases/issue_519.pg` — existing edge-case test pattern followed for the new `issue_3091.pg` test

## Test evidence

Added `pgtap/dijkstra/driving_distance/edge_cases/issue_3091.pg`:
- Asserts `throws_ok` for `distance = -1.0`
- Asserts `distance = 0.0` returns only the origin node (valid edge case)

*AI-assisted — authored with Claude, reviewed by Komada.*