### PR TITLE
Use PG_MODULE_MAGIC_EXT in PostgreSQL 18 and later

### DIFF
--- a/src/dijkstra/dijkstra.c
+++ b/src/dijkstra/dijkstra.c
@@ -37,8 +37,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "c_types/path_rt.h"
 #include "process/shortestPath_process.h"
 
-PG_MODULE_MAGIC;
-
 PGDLLEXPORT Datum _pgr_dijkstra_v4(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(_pgr_dijkstra_v4);
 

--- a/src/version/version.c
+++ b/src/version/version.c
@@ -29,6 +29,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "c_common/postgres_connection.h"
 #include "./version.h"
 
+#ifdef PG_MODULE_MAGIC_EXT
+PG_MODULE_MAGIC_EXT(.name = "pgrouting", .version = PROJECT_VERSION);
+#else
+PG_MODULE_MAGIC;
+#endif
+
 #define UNUSED(x) (void)(x)
 
 PGDLLEXPORT Datum _pgr_boost_version(PG_FUNCTION_ARGS);


### PR DESCRIPTION
The `PG_MODULE_MAGIC_EXT` macro was added in PostgreSQL 18 and makes it possible to see which version of the library is actually loaded using `pg_get_loaded_modules()`.

This commit also moves the use of `PG_MODULE_MAGIC` to a less awkward place. While it is not 100% connected to the version functions it is much more connect to them than to Djikstra.

Changes proposed in this pull request:
- Use `PG_MODULE_MAGIC_EXT` in PostgreSQL 18
- Move `PG_MODULE_MAGIC` to `version.c`

@pgRouting/admins

Not sure if you prefer `#if PG_VERSION_NUM >= 180000` or `#ifdef PG_VERSION_MAGIC_EXT`. I personally prefer the former but found no examples of what you normally use when looking at the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal module configuration for PostgreSQL extension compatibility. No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->