### PR TITLE
add crash message dev

### DIFF
--- a/doc/src/experimental.rst
+++ b/doc/src/experimental.rst
@@ -11,6 +11,10 @@ Experimental Functions
 
 .. admonition:: Experimental
 
+   .. warning:: Possible server crash
+
+     - These functions might create a server crash
+
    .. warning:: Experimental functions
 
      - They are not officially of the current release.

--- a/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v4.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-10 19:05+0000\n"
+"POT-Creation-Date: 2026-07-16 19:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -351,6 +351,12 @@ msgid ""
 msgstr ""
 
 msgid "Experimental"
+msgstr ""
+
+msgid "Possible server crash"
+msgstr ""
+
+msgid "These functions might create a server crash"
 msgstr ""
 
 msgid "Experimental functions"

--- a/locale/pot/pgrouting_doc_strings.pot
+++ b/locale/pot/pgrouting_doc_strings.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v4.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-10 19:05+0000\n"
+"POT-Creation-Date: 2026-07-16 19:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -335,6 +335,12 @@ msgid ":doc:`pgr_trspVia_withPoints` - Via Vertex/point routing with restriction
 msgstr ""
 
 msgid "Experimental"
+msgstr ""
+
+msgid "Possible server crash"
+msgstr ""
+
+msgid "These functions might create a server crash"
 msgstr ""
 
 msgid "Experimental functions"

--- a/src/coloring/coloring_driver.cpp
+++ b/src/coloring/coloring_driver.cpp
@@ -111,7 +111,7 @@ void do_coloring(
                     component_results = strongComponents(digraph);
                     break;
                 default:
-                    err << __FILE_NAME__ << ": Unknown function with name '" << get_name(which)
+                    err << "coloring_driver.cpp: Unknown function with name '" << get_name(which)
                         << "' for directed graph";
                     return;
             }
@@ -140,7 +140,7 @@ void do_coloring(
                     component_results = connectedComponents(undigraph);
                     break;
                 default:
-                    err << __FILE_NAME__ << ": Unknown function with name '" << get_name(which)
+                    err << "coloring_driver.cpp: Unknown function with name '" << get_name(which)
                         << "' for undirected graph";
                     return;
             }

--- a/src/ordering/ordering_driver.cpp
+++ b/src/ordering/ordering_driver.cpp
@@ -127,7 +127,7 @@ do_ordering(
                         break;
                     }
                 default:
-                    err << __FILE_NAME__ << ": Unknown function with name '" << get_name(which)
+                    err << "ordering_driver.cpp: Unknown function with name '" << get_name(which)
                         << "' for directed graph";
                     return;
             }
@@ -161,7 +161,7 @@ do_ordering(
                         break;
                     }
                 default:
-                    err << __FILE_NAME__ << ": Unknown function with name '" << get_name(which)
+                    err << "ordering_driver.cpp: Unknown function with name '" << get_name(which)
                         << "' for undirected graph";
                     return;
             }


### PR DESCRIPTION
Changes proposed in this pull request:
- Restores a message that was accidentally removed
- Fix for 22.04

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a prominent warning that experimental functions may potentially cause a server crash.
  - Updated translated documentation resources to include the new experimental-function warning.

- **Bug Fixes**
  - Improved error messages for unknown coloring and ordering functions, providing more consistent and reliable diagnostic information for directed and undirected graphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->