### PR TITLE
docs: add full doxygen documentation to get_check_data.hpp

### DIFF
--- a/include/cpp_common/get_check_data.hpp
+++ b/include/cpp_common/get_check_data.hpp
@@ -59,7 +59,7 @@ bool column_found(int);
 /**
  * @brief Function tells expected type of each column and then check the correspondence type of each column.
  * @param[in] tupdesc  tuple descriptor
- * @param[in] info     contain one or more column information.
+ * @param[in,out] info  contain one or more column information; populated with column type and number.
  * @throw ERROR Unknown type of column.
  */
 void fetch_column_info(const TupleDesc&, std::vector<Column_info_t>&);

--- a/include/cpp_common/get_check_data.hpp
+++ b/include/cpp_common/get_check_data.hpp
@@ -48,34 +48,117 @@ extern "C" {
 namespace pgrouting {
 using Column_info_t = struct Column_info_t;
 
-/** @brief  Function will check whether the colNumber represent any specific column or NULL (SPI_ERROR_NOATTRIBUTE).  */
+/**
+ * @brief  Function will check whether the colNumber represent any specific column or NULL (SPI_ERROR_NOATTRIBUTE).
+ * @param[in] colNumber Column number (count starts at 1).
+ * @return @b TRUE when colNumber exist.
+ *         @b FALSE when colNumber was not found.
+ */
 bool column_found(int);
 
-/** @brief Function tells expected type of each column and then check the correspondence type of each column.  */
+/**
+ * @brief Function tells expected type of each column and then check the correspondence type of each column.
+ * @param[in] tupdesc  tuple descriptor
+ * @param[in] info     contain one or more column information.
+ * @throw ERROR Unknown type of column.
+ */
 void fetch_column_info(const TupleDesc&, std::vector<Column_info_t>&);
 
-/** @brief Function return the value of specified column in char type. */
+/**
+ * @brief Function return the value of specified column in char type.
+ * @param[in] tuple         input row to be examined.
+ * @param[in] tupdesc       tuple descriptor
+ * @param[in] info          contain column information.
+ * @param[in] strict        boolean value of strict.
+ * @param[in] default_value returned when column contain NULL value.
+ * @throw ERROR Unexpected Column type. Expected column type is CHAR.
+ * @throw ERROR When value of column is NULL.
+ * @return Char type of column value is returned.
+ */
 char getChar(const HeapTuple, const TupleDesc&, const Column_info_t&, bool, char);
 
-/** @brief get postgres array into c++ set container */
+/**
+ * @brief get postgres array into c++ set container
+ * @param[in] v Pointer to the postgres C array
+ * @pre the array has to be one dimension
+ * @pre Must have elements
+ * @throw ERROR One dimension expected
+ * @throw ERROR Expected array of ANY-INTEGER
+ * @throw ERROR NULL value found in Array
+ * @return set of elements on the PostgreSQL array
+ */
 std::set<int64_t> get_pgset(ArrayType*);
 
-/** @brief get postgres array into c++ vector container */
+/**
+ * @brief get postgres array into c++ vector container
+ * @param[in] v Pointer to the postgres C array
+ * @param[in] allow_empty flag to allow empty arrays
+ * @pre the array has to be one dimension
+ * @pre Must have elements (when allow_empty is false)
+ * @throw ERROR One dimension expected
+ * @throw ERROR No elements found
+ * @throw ERROR Expected array of ANY-INTEGER
+ * @return Vector of elements of the PostgreSQL array
+ */
 std::vector<int64_t> get_pgarray(ArrayType*, bool);
 
-/** @brief Enforces the input array to be @b NOT empty */
+/**
+ * @brief Enforces the input array to be @b NOT empty
+ * @param[in] v Pointer to the postgres C array
+ * @param[out] arrlen size of the C array
+ * @param[in] allow_empty flag to allow empty arrays
+ * @pre the array has to be one dimension
+ * @pre Must have elements (when allow_empty is false)
+ * @throw ERROR One dimension expected
+ * @throw ERROR No elements found
+ * @throw ERROR Out of memory
+ * @return The resultant array
+ */
 int64_t* get_array(ArrayType*, size_t*, bool);
 
-/** @brief Function returns the values of specified columns in array. */
+/**
+ * @brief Function returns the values of specified columns in array.
+ * @param[in]  tuple    input row to be examined.
+ * @param[in]  tupdesc  input row description.
+ * @param[in]  info     contain column information.
+ * @param[out] the_size number of element in array.
+ * @throw ERROR No elements found in ARRAY.
+ * @throw ERROR Unexpected Column type. Expected column type is ANY-INTEGER-ARRAY.
+ * @throw ERROR NULL value found in Array.
+ * @return Array of columns value is returned.
+ */
 int64_t* getBigIntArr(const HeapTuple, const TupleDesc&, const Column_info_t&, size_t*);
 
-/** @brief Function returns the value of specified column in integer type.  */
+/**
+ * @brief Function returns the value of specified column in integer type.
+ * @param[in] tuple   input row to be examined.
+ * @param[in] tupdesc  tuple descriptor
+ * @param[in] info    contain column information.
+ * @throw ERROR Unexpected Column type. Expected column type is ANY-INTEGER.
+ * @throw ERROR When value of column is NULL.
+ * @return Integer type of column value is returned.
+ */
 int64_t getBigInt(const HeapTuple, const TupleDesc&, const Column_info_t&);
 
-/** @brief Function returns the value of specified column in double type.  */
+/**
+ * @brief Function returns the value of specified column in double type.
+ * @param[in] tuple   input row to be examined.
+ * @param[in] tupdesc  tuple descriptor
+ * @param[in] info    contain column information.
+ * @throw ERROR Unexpected Column type. Expected column type is ANY-NUMERICAL.
+ * @throw ERROR When value of column is NULL.
+ * @return Double type of column value is returned.
+ */
 double  getFloat8(const HeapTuple, const TupleDesc&, const Column_info_t&);
 
-/** @brief Function returns the string representation of the value of specified column.  */
+/**
+ * @brief Function returns the string representation of the value of specified column.
+ * @note under development - not used, not tested
+ * @param[in] tuple   input row to be examined.
+ * @param[in] tupdesc tuple descriptor
+ * @param[in] info    contain column information.
+ * @return Pointer of string is returned.
+ */
 char* getText(const HeapTuple, const TupleDesc&, const Column_info_t&);
 
 }  // namespace pgrouting

--- a/src/cpp_common/get_check_data.cpp
+++ b/src/cpp_common/get_check_data.cpp
@@ -139,7 +139,7 @@ check_char_type(const pgrouting::Column_info_t &info) {
     }
 }
 
-/**
+/*
  * @brief The function check whether column type is ANY-INTEGER-ARRAY or not.
  *        Where ANY-INTEGER-ARRAY is SQL type:
  *             SMALLINT[], INTEGER[], BIGINT[]
@@ -160,7 +160,7 @@ check_any_integer_array_type(const pgrouting::Column_info_t &info) {
 
 namespace pgrouting {
 
-/**
+/*
  * @param[in] colNumber Column number (count starts at 1).
  * @return @b TRUE when colNumber exist.
  *         @b FALSE when colNumber was not found.
@@ -172,7 +172,7 @@ bool column_found(int colNumber) {
 }
 
 
-/**
+/*
  * @param[in] tupdesc  tuple descriptor
  * @param[in] info     contain one or more column information.
  *
@@ -206,7 +206,7 @@ void fetch_column_info(
     }
 }
 
-/**
+/*
  * http://doxygen.postgresql.org/include_2catalog_2pg__type_8h.html;
  * [SPI_getbinval](https://www.postgresql.org/docs/8.1/static/spi-spi-getbinval.html)
  * [Datum](https://doxygen.postgresql.org/datum_8h.html)
@@ -243,7 +243,7 @@ char getChar(
     return value;
 }
 
-/** @brief get the array contents from postgres
+/* @brief get the array contents from postgres
  *
  * @details This function generates the array inputs according to their type
  * received through @a ArrayType *v parameter and store them in @a c_array. It
@@ -328,7 +328,7 @@ get_pgset(ArrayType *v) {
     return results;
 }
 
-/** @brief get the array contents from postgres
+/* @brief get the array contents from postgres
  *
  * @details This function generates the array inputs according to their type
  * received through @a ArrayType *v parameter and store them in @a c_array. It
@@ -420,7 +420,7 @@ get_pgarray(ArrayType *v, bool allow_empty) {
     return results;
 }
 
-/** @brief get the array contents from postgres
+/* @brief get the array contents from postgres
  *
  * @details This function generates the array inputs according to their type
  * received through @a ArrayType *v parameter and store them in @a c_array. It
@@ -517,7 +517,7 @@ get_array(ArrayType *v, size_t *arrlen, bool allow_empty) {
     return c_array;
 }
 
-/**
+/*
  * [DatumGetArrayTypeP](https://doxygen.postgresql.org/array_8h.html#aa1b8e77c103863862e06a7b7c07ec532)
  * [pgrouting::get_bigIntArray](http://docs.pgrouting.org/doxy/2.2/arrays__input_8c_source.html)
  * @param[in]  tuple    input row to be examined.
@@ -545,7 +545,7 @@ int64_t* getBigIntArr(
     return get_array(pg_array, the_size, true);
 }
 
-/**
+/*
  * @param[in] tuple   input row to be examined.
  * @param[in] tupdesc  tuple descriptor
  * @param[in] info    contain column information.
@@ -579,7 +579,7 @@ int64_t getBigInt(
     return value;
 }
 
-/**
+/*
  * @param[in] tuple   input row to be examined.
  * @param[in] tupdesc  tuple descriptor
  * @param[in] info    contain column information.
@@ -622,7 +622,7 @@ double getFloat8(
     return 0.0;
 }
 
-/*!
+/*
  * [SPI_getvalue](https://doxygen.postgresql.org/spi_8c.html#ae53c12ff90592f67e4e40ad0af24205b
  which calls OidOutputFunctionCall, which calls
  OutputFunctionCall - https://doxygen.postgresql.org/fmgr_8c.html#ae19cff34818e4a6c90523e8bb02c3420


### PR DESCRIPTION
Fixes #972 .

Adds complete Doxygen documentation (@param, @throw, @return) to
get_check_data.hpp, matching the detail already present in
get_check_data.cpp. Header docs were previously limited to a single
@brief line per function.

Changes proposed in this pull request:
- Added @param tags describing each function's inputs
- Added @return tags describing what each function returns
- Added @throw tags documenting error conditions

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded API documentation with parameter, return-value, precondition, and error descriptions.
  * Clarified usage expectations for public helper functions without changing their behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->