### PR TITLE
docs: add doxygen documentation to get_points in pgdata_getters.hpp

### DIFF
--- a/include/cpp_common/pgdata_getters.hpp
+++ b/include/cpp_common/pgdata_getters.hpp
@@ -105,13 +105,13 @@ std::vector<Orders_t> get_orders(const std::string&, bool);
  *
  * For queries of the type:
  * ~~~~{.c}
- * SELECT pid, edge_id, fraction side FROM points;
+ * SELECT pid, edge_id, fraction, side FROM points;
  * ~~~~
  *
  * @param[in] sql The points query
  * @returns vector of `Point_on_edge_t`
  */
-std::vector<Point_on_edge_t> get_points(const std::string&);
+std::vector<Point_on_edge_t> get_points(const std::string& sql);
 
 /** @brief Read rows of matrix */
 std::vector<Restriction_t> get_restrictions(const std::string&);

--- a/include/cpp_common/pgdata_getters.hpp
+++ b/include/cpp_common/pgdata_getters.hpp
@@ -100,7 +100,17 @@ std::vector<IID_t_rt> get_matrixRows(const std::string&);
 /** @brief Reads the pick-Deliver orders */
 std::vector<Orders_t> get_orders(const std::string&, bool);
 
-/** @brief Read rows of points */
+/**
+ * @brief Read rows of points
+ *
+ * For queries of the type:
+ * ~~~~{.c}
+ * SELECT pid, edge_id, fraction side FROM points;
+ * ~~~~
+ *
+ * @param[in] sql The points query
+ * @returns vector of `Point_on_edge_t`
+ */
 std::vector<Point_on_edge_t> get_points(const std::string&);
 
 /** @brief Read rows of matrix */


### PR DESCRIPTION
Fixes #973

Adds complete Doxygen documentation (@param, @returns, and a usage
example) to get_points() in cpp_common/pgdata_getters.hpp, matching
the detail already present in pgdata_getters.cpp.

Note: points_input.c/.h referenced in the original issue no longer
exist — this functionality now lives in pgdata_getters.hpp/.cpp
alongside 13 other getter functions merged from various now-removed
files. To keep this PR focused, only get_points() is documented here.

Changes proposed in this pull request:
- Added @param and @returns tags for get_points()
- Preserved the existing SQL usage example from the .cpp file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded `get_points` documentation with a point-query example.
  * Added details about SQL parameters and the return type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->