### PR TITLE
get_data: fix SPI fetch order and portal leak on zero-row input

### DIFF
--- a/include/cpp_common/get_data.hpp
+++ b/include/cpp_common/get_data.hpp
@@ -134,14 +134,42 @@ std::vector<Data_type> get_data(
 
     while (moredata == true) {
         SPI_cursor_fetch(SPIportal, true, tuple_limit);
+        long fetched = SPI_processed;
         auto tuptable = SPI_tuptable;
-        auto tupdesc = SPI_tuptable->tupdesc;
-        if (total_tuples == 0) fetch_column_info(tupdesc, info);
+        auto tupdesc = tuptable ? tuptable->tupdesc : nullptr;
 
-        size_t ntuples = SPI_processed;
-        total_tuples += ntuples;
+        if (fetched <= 0) {
+            /*
+             * Zero-row batch: validate schema when a descriptor is
+             * available so typos still raise a clean error, then exit
+             * with whatever was collected so far (possibly empty).
+             */
+            if (tupdesc && total_tuples == 0) {
+                try {
+                    fetch_column_info(tupdesc, info);
+                } catch (...) {
+                    if (tuptable) SPI_freetuptable(tuptable);
+                    SPI_cursor_close(SPIportal);
+                    throw;
+                }
+            }
+            if (tuptable) SPI_freetuptable(tuptable);
+            moredata = false;
+            break;
+        }
 
-        if (ntuples > 0) {
+        if (!tuptable || !tupdesc) {
+            if (tuptable) SPI_freetuptable(tuptable);
+            moredata = false;
+            break;
+        }
+
+        try {
+            if (total_tuples == 0) fetch_column_info(tupdesc, info);
+
+            size_t ntuples = static_cast<size_t>(fetched);
+            total_tuples += ntuples;
+
             tuples.reserve(total_tuples);
             for (size_t t = 0; t < ntuples; t++) {
                 tuples.push_back(func(tuptable->vals[t], tupdesc, info,
@@ -149,8 +177,10 @@ std::vector<Data_type> get_data(
                         &valid_pgtuples, flag));
             }
             SPI_freetuptable(tuptable);
-        } else {
-            moredata = false;
+        } catch (...) {
+            SPI_freetuptable(tuptable);
+            SPI_cursor_close(SPIportal);
+            throw;
         }
     }
 

--- a/pgtap/dijkstra/dijkstra/no_crash_test.pg
+++ b/pgtap/dijkstra/dijkstra/no_crash_test.pg
@@ -7,10 +7,17 @@ BEGIN;
 
 
 UPDATE edges SET cost = sign(cost), reverse_cost = sign(reverse_cost);
-SELECT CASE WHEN min_version('3.1.0') THEN plan(82) ELSE plan(69) END;
+SELECT CASE WHEN min_version('3.1.0') THEN plan(84) ELSE plan(71) END;
 
 SELECT no_crash_dijkstra('pgr_dijkstra');
 SELECT throw_on_empty_edges_sql('pgr_dijkstra', ',1,2');
+SELECT is_empty(
+    $$SELECT * FROM pgr_dijkstra('SELECT id, source, target, cost FROM edges WHERE false', 1, 2)$$,
+    'zero-row edges_sql returns empty set without crashing');
+SELECT throws_ok(
+    $$SELECT * FROM pgr_dijkstra('SELECT id, source FROM edges WHERE false', 1, 2)$$,
+    'XX000', 'Column ''cost'' not Found',
+    'zero-row edges_sql with missing column raises a clean error');
 
 SELECT finish();
 


### PR DESCRIPTION
Fixes #3146

## Summary
Hardens the shared SPI fetch helper (`pgget::get_data` vector overload in
`include/cpp_common/get_data.hpp`) that all graph loaders (`get_edges()` +
~12 sibling getters) funnel through. Two defects, one focused patch, no
API/signature change.

## What was wrong
1. The template read `SPI_tuptable->tupdesc` before checking `SPI_processed`,
   so a valid query returning zero rows (filtered-out `edges_sql`, empty
   tenant/partition) walked an unchecked path.
2. When column validation or row conversion threw, the open SPI cursor was
   never closed, leaking the portal.

This is distinct from the empty-string `''` case (#3054), which is handled
upstream in the driver before the fetch loop.

## Changes
- `include/cpp_common/get_data.hpp` (vector overload only; the legacy `char*`
  overload has no callers and is untouched):
  - Check `SPI_processed` first, with a defensive null guard on
    `SPI_tuptable`/`tupdesc` for PG-version variance.
  - On zero-row batches, validate columns when a descriptor is available so
    typos still raise `Column 'cost' not Found` instead of returning a
    misleading empty set; otherwise exit cleanly so drivers emit the standard
    `NOTICE: No edges found`.
  - Single try/catch around validate + iterate: tuple table freed and cursor
    closed exactly once before rethrowing.
- `pgtap/dijkstra/dijkstra/no_crash_test.pg`: +2 regression assertions
  (zero-row valid schema -> empty set; zero-row missing column -> `XX000`),
  plan counts adjusted accordingly.

## Behavior after fix
- Zero rows + valid schema -> empty set + `NOTICE`, connection healthy.
- Zero rows + bad schema -> clean `ERROR XX000`, portal closed.
- `''` empty string -> unchanged `ERROR: Empty edges SQL`.

## Verification
- [x] Patched header compiles (`-std=c++17 -fsyntax-only`, template
      instantiation checked)
- [x] `git diff --check` clean; 4-space style, no lines >120
- [ ] Full `pg_prove` + live `WHERE false` repro need a PG+PostGIS box —
      requesting CI run for confirmation

Happy to adjust scope or split anything per reviewer preference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented crashes when routing queries return no rows or lack expected columns.
  - Improved error handling for invalid empty-result schemas, including clear missing-column errors.
  - Ensured resources are cleaned up when processing errors occur.

- **Tests**
  - Added coverage for empty routing results and missing required columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->